### PR TITLE
Bump app version to 27.11.0.0

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -9,7 +9,7 @@
   "artifact": "bcinsider/Sandbox/27.10//latest",
   "country": "base",
   "useProjectDependencies": true,
-  "repoVersion": "27.10",
+  "repoVersion": "27.11",
   "conditionalSettings": [
     {
       "buildModes": [

--- a/src/Apps/W1/EDocumentConnectors/Avalara/App/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "E-Document Connector - Avalara",
   "description": "E-Document Connector - Avalara",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2204541",
@@ -16,7 +16,7 @@
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [
@@ -39,7 +39,7 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "target": "Cloud",
   "features": [
     "TranslationFile"

--- a/src/Apps/W1/EDocumentConnectors/Avalara/Test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Avalara/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "E-Document Connector - Avalara Tests",
   "description": "E-Document Connector - Avalara Tests",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2204541",
@@ -16,43 +16,43 @@
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f35c56a6-7c5f-4dbe-89c4-fef5145d00f4",
       "name": "E-Document Connector - Avalara",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8c",
       "name": "E-Document Core Tests",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
       "name": "Tests-TestLibraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
       "name": "System Application Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
@@ -68,7 +68,7 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "target": "OnPrem",
   "features": [
     "TranslationFile"

--- a/src/Apps/W1/EDocumentConnectors/Continia/App/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Continia/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "E-Document Connector - Continia",
   "description": "E-Document Connector - Continia",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2204541",
@@ -15,7 +15,7 @@
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [
@@ -38,7 +38,7 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "target": "OnPrem",
   "features": [
     "TranslationFile"

--- a/src/Apps/W1/EDocumentConnectors/Continia/Test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/Continia/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "E-Document Connector - Continia Tests",
   "description": "E-Document Connector - Continia Tests",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2204541",
@@ -15,37 +15,37 @@
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "31ef535a-1182-4354-98e8-e0e66a587055",
       "name": "E-Document Connector - Continia",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8c",
       "name": "E-Document Core Tests",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
       "name": "Tests-TestLibraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
       "name": "System Application Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
@@ -61,7 +61,7 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "resourceFolders": [
     "Resources"
   ],

--- a/src/Apps/W1/EDocumentConnectors/FORNAV/App/app.json
+++ b/src/Apps/W1/EDocumentConnectors/FORNAV/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "E-Document Connector - FORNAV",
   "description": "E-Document Connector - FORNAV",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2204541",
@@ -22,7 +22,7 @@
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [
@@ -33,7 +33,7 @@
     }
   ],
   "target": "Cloud",
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "platform": "27.0.0.0",
   "idRanges": [
     {

--- a/src/Apps/W1/EDocumentConnectors/FORNAV/Test/app.json
+++ b/src/Apps/W1/EDocumentConnectors/FORNAV/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test of ForNAV Peppol",
   "description": "Test of ForNAV Peppol",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2204541",
@@ -16,48 +16,48 @@
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8b",
       "name": "E-Document Core",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e1d97edc-c239-46b4-8d84-6368bdf67c8c",
       "name": "E-Document Core Tests",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
       "name": "Tests-TestLibraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
       "name": "System Application Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0addc017-80c4-40ad-bac6-5852f4fc4c55",
       "name": "E-Document Connector - FORNAV",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
   "platform": "27.0.0.0",
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "idRanges": [
     {
       "from": 148220,

--- a/src/Apps/W1/Shopify/App/app.json
+++ b/src/Apps/W1/Shopify/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Seamless connection between Shopify and Dynamics 365 Business Central will synchronize order, stock, and customer information to ensure that merchants can fulfill orders faster and better serve their customers.",
   "description": "Connecting Dynamics 365 Business Central with Shopify will help merchants implement more agile online business processes, while keeping people focused on selling. With support for multitier pricing structures and multiple currencies, companies, and entities, Business Central will support multiple Shopify store scenarios with ease. By connecting Shopify and Business Central, you will improve visibility into stock, pricing, existing customers and order history, order status, billing, and payments.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2179727",
@@ -32,7 +32,7 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "target": "OnPrem",
   "features": [
     "NoImplicitWith",

--- a/src/Apps/W1/Shopify/Test/app.json
+++ b/src/Apps/W1/Shopify/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test for the Shopify Connector extension",
   "description": "Test for the Shopify Connector extension",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2179727",
@@ -16,37 +16,37 @@
       "id": "ec255f57-31d0-4ca2-b751-f2fa7c745abb",
       "name": "Shopify Connector",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
       "name": "Tests-TestLibraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
       "name": "System Application Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
@@ -99,7 +99,7 @@
     "allowDownloadingSource": true,
     "includeSourceInSymbolFile": true
   },
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "resourceFolders": [
     ".resources"
   ],

--- a/src/Apps/W1/Subscription Billing/App/app.json
+++ b/src/Apps/W1/Subscription Billing/App/app.json
@@ -2,7 +2,7 @@
   "id": "3099ffc7-4cf7-4df6-9b96-7e4bc2bb587c",
   "name": "Subscription Billing",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Sell and manage recurring subscriptions",
   "description": "The app enables the selling of recurring subscriptions and provides accurate billing for a wide range of pricing models.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,7 +15,7 @@
       "id": "e4e86220-cac0-4ec3-b853-7c2fa610399d",
       "name": "Power BI Report embeddings for Dynamics 365 Business Central",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
@@ -33,7 +33,7 @@
     }
   ],
   "platform": "27.0.0.0",
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "idRanges": [
     {
       "from": 8000,

--- a/src/Apps/W1/Subscription Billing/Demo Data/app.json
+++ b/src/Apps/W1/Subscription Billing/Demo Data/app.json
@@ -2,7 +2,7 @@
   "id": "8a3db2bc-9378-4d0f-b89a-a7dea0555449",
   "name": "Subscription Billing Demo Data",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Demo data for Subscription Billing",
   "description": "The app provides demo data for Subscription Billing.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -16,18 +16,18 @@
       "id": "3099ffc7-4cf7-4df6-9b96-7e4bc2bb587c",
       "publisher": "Microsoft",
       "name": "Subscription Billing",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5a0b41e9-7a42-4123-d521-2265186cfb31",
       "name": "Contoso Coffee Demo Dataset",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
   "platform": "27.0.0.0",
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "idRanges": [
     {
       "from": 8101,

--- a/src/Apps/W1/Subscription Billing/Test/app.json
+++ b/src/Apps/W1/Subscription Billing/Test/app.json
@@ -2,7 +2,7 @@
   "id": "2ac317ef-11a5-4753-92f4-31c84b520c7b",
   "name": "Subscription Billing Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Test for Subscription Billing",
   "description": "The app enables the selling of recurring subscriptions and provides accurate billing for a wide range of pricing models.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -16,36 +16,36 @@
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "bee8cf2f-494a-42f4-aabd-650e87934d39",
       "name": "Business Foundation Test Libraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
       "name": "Tests-TestLibraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3099ffc7-4cf7-4df6-9b96-7e4bc2bb587c",
       "publisher": "Microsoft",
       "name": "Subscription Billing",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],
   "platform": "27.0.0.0",
-  "application": "27.10.0.0",
+  "application": "27.11.0.0",
   "idRanges": [
     {
       "from": 139685,

--- a/src/Business Foundation/App/AuditCodes/app.json
+++ b/src/Business Foundation/App/AuditCodes/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/Business Foundation/App/NoSeries/app.json
+++ b/src/Business Foundation/App/NoSeries/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/Business Foundation/App/NoSeriesCopilot/app.json
+++ b/src/Business Foundation/App/NoSeriesCopilot/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "d098b816-22fd-477f-9602-9122f5465527",
       "name": "No. Series",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/Business Foundation/App/app.json
+++ b/src/Business Foundation/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides a standard set of capabilities that serve as a foundation for developing business apps.",
   "description": "Contains an expansive set of open source modules that make it easier to build, maintain, and easily upgrade on-premises and online apps. These modules let you focus on the business logic, and the needs of your users or customers.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/Business Foundation/Test Library/NoSeries/app.json
+++ b/src/Business Foundation/Test Library/NoSeries/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test library that provide basic test setup for the No. Series tests.",
   "description": "Contains an expansive set of library methods to be used exclusively in tests.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -15,13 +15,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "d098b816-22fd-477f-9602-9122f5465527",
       "name": "No. Series",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/Business Foundation/Test Library/NoSeriesCopilot/app.json
+++ b/src/Business Foundation/Test Library/NoSeriesCopilot/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test library that provide basic test setup for the No. Series Suggestions tests.",
   "description": "Contains an expansive set of library methods to be used exclusively in tests.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -15,13 +15,13 @@
       "id": "d098b816-22fd-477f-9602-9122f5465527",
       "name": "No. Series",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7efce506-def2-4195-9d1e-bc538e729242",
       "name": "No. Series Suggestions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/Business Foundation/Test Library/app.json
+++ b/src/Business Foundation/Test Library/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test libraries that provide basic test setup for the Business Foundation tests.",
   "description": "Contains an expansive set of library methods to be used exclusively in tests.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -15,13 +15,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f3552374-a1f2-4356-848e-196002525837",
       "name": "Business Foundation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/Business Foundation/Test/NoSeries/app.json
+++ b/src/Business Foundation/Test/NoSeries/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test suite for the No. Series module",
   "description": "Contains an expansive set tests for the No. Series module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -15,43 +15,43 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "d098b816-22fd-477f-9602-9122f5465527",
       "name": "No. Series",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f7277dc2-cc73-4b81-b7c6-4a58bfb33806",
       "name": "No. Series Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/Business Foundation/Test/NoSeriesCopilot/app.json
+++ b/src/Business Foundation/Test/NoSeriesCopilot/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test suite for the No. Series Suggestions module",
   "description": "Contains an expansive set tests for the No. Series Suggestions module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -15,55 +15,55 @@
       "id": "d098b816-22fd-477f-9602-9122f5465527",
       "name": "No. Series",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7efce506-def2-4195-9d1e-bc538e729242",
       "name": "No. Series Suggestions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f7277dc2-cc73-4b81-b7c6-4a58bfb33806",
       "name": "No. Series Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ecb647bf-6fae-45b9-b136-28aa313f5e97",
       "name": "No. Series Suggestions Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2156302a-872f-4568-be0b-60968696f0d5",
       "publisher": "Microsoft",
       "name": "AI Test Toolkit",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "23de40a6-dfe8-4f80-80db-d70f83ce8caf",
       "publisher": "Microsoft",
       "name": "Test Runner",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/Business Foundation/Test/app.json
+++ b/src/Business Foundation/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test suite for the Business Foundation.",
   "description": "Contains an expansive set tests for the Business Foundation.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -15,55 +15,55 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f3552374-a1f2-4356-848e-196002525837",
       "name": "Business Foundation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "bee8cf2f-494a-42f4-aabd-650e87934d39",
       "name": "Business Foundation Test Libraries",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2156302a-872f-4568-be0b-60968696f0d5",
       "publisher": "Microsoft",
       "name": "AI Test Toolkit",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "23de40a6-dfe8-4f80-80db-d70f83ce8caf",
       "publisher": "Microsoft",
       "name": "Test Runner",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/System Application/App/AI/app.json
+++ b/src/System Application/App/AI/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "AI SDK to build AI-powered experiences",
   "description": "AI SDK to build AI-powered experiences",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,91 +15,91 @@
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b185fd4a-677b-48d3-a701-768de7563df0",
       "name": "Regex",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "daa5d70e-eaf5-4256-bf80-53545ef7629a",
       "name": "Privacy Notice",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "95025170-61fc-4808-9505-4ba1fe1d05d9",
       "name": "Azure AD Tenant",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "name": "Azure AD User",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/ActivityLog/app.json
+++ b/src/System Application/App/ActivityLog/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Activity Log to build AI-powered experiences",
   "description": "Activity Log to build AI-powered experiences",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Advanced Settings/app.json
+++ b/src/System Application/App/Advanced Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Support for Advanced Settings page",
   "description": "Support for Advanced Settings page",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "901c89b7-132b-4c59-bb3f-2bfa4fbc70b5",
       "name": "Navigation Bar Subscribers",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "872fe7e8-9893-40ae-ab94-c123ed30fdbd",
       "name": "Extension Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Agent/app.json
+++ b/src/System Application/App/Agent/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Enables managing of agents",
   "description": "Provides functionality for setting up, enabling and disabling, interacting and auditing agents.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?LinkId=847985",
   "help": "https://go.microsoft.com/fwlink/?linkid=868966",
@@ -25,67 +25,67 @@
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd4b9f8a-b018-4f69-a614-efdb744c5330",
       "name": "Page Summary Provider",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "fa2b571d-3f92-4685-9113-421ea9c0b5f5",
       "name": "Time Zone Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7b9b59f5-a68d-4271-b11a-0d3b9c0938dd",
       "name": "User Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "008c9419-0c3b-4d08-b03e-84e3adca689f",
       "name": "Data Compression",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f7964d32-7685-400f-8297-4bc17d0aab0e",
       "name": "Microsoft User Feedback",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "645965f7-95bf-4ee9-bf97-84e45dc6c6d1",
       "name": "Json",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "d3433b68-4901-445f-9547-fdfeca57575a",
       "name": "AI SDK",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "propagateDependencies": true,

--- a/src/System Application/App/AppSource Gallery/app.json
+++ b/src/System Application/App/AppSource Gallery/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "AppSource Product Gallery app provides a Gallery for navigating Microsoft AppSource apps.",
   "description": "Using AppSource Product Gallery you can explore apps from Microsoft AppSource and choose to install them on the current environment.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -16,49 +16,49 @@
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",
       "name": "Rest Client",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "872fe7e8-9893-40ae-ab94-c123ed30fdbd",
       "name": "Extension Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "95025170-61fc-4808-9505-4ba1fe1d05d9",
       "name": "Azure AD Tenant",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7b9b59f5-a68d-4271-b11a-0d3b9c0938dd",
       "name": "User Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Auto Format/app.json
+++ b/src/System Application/App/Auto Format/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Formats the appearance decimal data types.",
   "description": "Formats the appearance of decimal data types in fields of a table, report, or page. For example, you can change how amounts that include decimals appear in a Cue on a Role Center.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Azure AD Graph/app.json
+++ b/src/System Application/App/Azure AD Graph/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Retrieve information from Microsoft Entra.",
   "description": "Accesses and retrieves information from Microsoft Entra.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1a023056-d6fe-41af-a16e-da7d678cf266",
       "name": "Server Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Azure AD Licensing/app.json
+++ b/src/System Application/App/Azure AD Licensing/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Access information about the subscribed SKUs and the corresponding service plans.",
   "description": "Access information about the subscribed SKUs and the corresponding service plans. You can retrieve information such as the SKU Object ID, SKU ID, number of licenses assigned, the license state (enabled, suspended, or warning), and the SKU part number. For the corresponding service plans, you can retrieve the ID, the capability status, or the name.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Azure AD Plan/app.json
+++ b/src/System Application/App/Azure AD Plan/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Retrieve plans in Microsoft Entra and manage plans",
   "description": "Retrieve plans in Microsoft Entra and manage plans",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,73 +15,73 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "name": "Azure AD User",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "95025170-61fc-4808-9505-4ba1fe1d05d9",
       "name": "Azure AD Tenant",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "4992eeac-2fd3-4515-a50b-7336a332d47f",
       "name": "Permission Sets",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0e4ed208-7f60-4bad-a881-eeb03e09d832",
       "name": "User Details",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Azure AD Tenant/app.json
+++ b/src/System Application/App/Azure AD Tenant/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Gets information about the Microsoft Entra tenant.",
   "description": "Contains helper methods for getting information about the Microsoft Entra tenant, such as getting Microsoft Entra tenant ID and domain name.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "publisher": "Microsoft",
       "name": "Azure AD Graph",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Azure AD User Management/app.json
+++ b/src/System Application/App/Azure AD User Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Manages Microsoft Entra ID users in Business Central.",
   "description": "Manages the creation and synchronization of Microsoft Entra ID users in Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,79 +15,79 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "publisher": "Microsoft",
       "name": "Azure AD User",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "publisher": "Microsoft",
       "name": "Azure AD Graph",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "publisher": "Microsoft",
       "name": "Azure AD Plan",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "publisher": "Microsoft",
       "name": "Confirm Management",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "publisher": "Microsoft",
       "name": "User Permissions",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "publisher": "Microsoft",
       "name": "Guided Experience",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Azure AD User/app.json
+++ b/src/System Application/App/Azure AD User/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Retrieves and updates a user from Microsoft Entra.",
   "description": "Contains functions that retrieve and update a user from Microsoft Entra.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Azure Blob Services API/app.json
+++ b/src/System Application/App/Azure Blob Services API/app.json
@@ -2,7 +2,7 @@
   "id": "8047d691-d376-4570-bfe6-9e0d785b8f32",
   "name": "Azure Blob Services API",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Reproduces the Azure Blob service REST API",
   "description": "Provides a set of AL functionality and Helper libraries to make use of Azure Blob Storage in MSDyn365BC",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,31 +15,31 @@
       "id": "e409d343-14fa-42a4-a1be-fec499383e59",
       "name": "Azure Storage Services Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3f95f4c2-037f-44d4-b089-b56ffc01693f",
       "name": "OAuth",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Azure File Services API/app.json
+++ b/src/System Application/App/Azure File Services API/app.json
@@ -2,7 +2,7 @@
   "id": "a6660ad9-7675-4f68-a2f9-a938c21de68a",
   "name": "Azure File Services API",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Reproduces the Azure File Share service REST API",
   "description": "Provides a set of AL functionality and Helper libraries to make use of Azure File Share Storage in MSDyn365BC",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,37 +15,37 @@
       "id": "e409d343-14fa-42a4-a1be-fec499383e59",
       "name": "Azure Storage Services Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3f95f4c2-037f-44d4-b089-b56ffc01693f",
       "name": "OAuth",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Azure Function/app.json
+++ b/src/System Application/App/Azure Function/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Simplify using Azure Functions",
   "description": "Support for writing AL code and connecting to Azure Functions",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3f95f4c2-037f-44d4-b089-b56ffc01693f",
       "name": "OAuth",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "aa171ba9-d3b0-450d-90fb-546b61e32074",
       "name": "OAuth2",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/System Application/App/Azure Key Vault/app.json
+++ b/src/System Application/App/Azure Key Vault/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Stores Azure Key Vault secrets for deployments.",
   "description": "Azure Key Vault stores secrets for deployment. These secrets are not available for apps with \"target\" cloud. ISV solutions that are deployed in their own cluster and have their own key-vault can use this module to read shared secrets.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd7",
       "name": "Cryptography Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Azure Storage Services Authorization/app.json
+++ b/src/System Application/App/Azure Storage Services Authorization/app.json
@@ -2,7 +2,7 @@
   "id": "e409d343-14fa-42a4-a1be-fec499383e59",
   "name": "Azure Storage Services Authorization",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides means for authorizing HTTP requests to Azure Storage Services",
   "description": "Provides interfaces and authorization logic for HTTP requests to Azure Storage Services",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,19 +15,19 @@
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd7",
       "name": "Cryptography Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/BLOB Storage/app.json
+++ b/src/System Application/App/BLOB Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Stores and manages data in a binary format.",
   "description": "Provides a way to store various kinds of data. It consists of the TempBlob container to store BLOB data in-memory, the Persistent BLOB Management interface for storing BLOB data between sessions, and the TempBlob List interface for storing sequences of variables, each of which stores BLOB data. Potential uses are storing images, very long texts, PDF files, and so on.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Barcode/app.json
+++ b/src/System Application/App/Barcode/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Barcode providers for Dynamics 365 Business Central",
   "description": "Barcode encoders for easy integration of barcodes in Dynamics 365 Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -16,19 +16,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b185fd4a-677b-48d3-a701-768de7563df0",
       "name": "Regex",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "target": "OnPrem",

--- a/src/System Application/App/Base64 Convert/app.json
+++ b/src/System Application/App/Base64 Convert/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Convert to and from base-64 strings",
   "description": "The module provides functionality to convert the text to and from base 64. It may be used for dealing with large XML files, pictures etc.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Business Chart/app.json
+++ b/src/System Application/App/Business Chart/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides functionality for working with the Business Chart control add-in.",
   "description": "Provides functionality for initializing, updating and interacting with the Business Chart control add-in.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -17,19 +17,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Camera and Media Interaction/app.json
+++ b/src/System Application/App/Camera and Media Interaction/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides access to the camera and saved media on the client device.",
   "description": "Invoke the Camera page to open the camera view and take a picture on your client device. The page will communicate the availability of the camera and progress in saving the picture to the user. Invoke the Media Upload page to upload saved media from your client device. The underlying implementation uses Apache Cordova plugin.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Caption Class/app.json
+++ b/src/System Application/App/Caption Class/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Defines how the CaptionClass property displays captions.",
   "description": "Defines how the CaptionClass property displays captions for pages and tables. You can define rules for how captions display.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Client Type Management/app.json
+++ b/src/System Application/App/Client Type Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Allows testing of code relying on different client types",
   "description": "The purpose of this module is to allow testing of units that rely on client type other than the one on which the test executes. This is achieved by using the method GetCurrentClientType in the unit to compare the client type and subscribing to the event OnAfterGetCurrentClientType to alter the client type in the test.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Confirm Management/app.json
+++ b/src/System Application/App/Confirm Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Determines whether a confirm dialog displays when logic is run.",
   "description": "Contains helper methods that either display a confirm dialog when logic is run, or suppresses it if UI is not allowed, such as background sessions or webservice calls.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/ControlAddIns/app.json
+++ b/src/System Application/App/ControlAddIns/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides the System control add-ins.",
   "description": "Provides the control add-in and their resources, used throughout the application.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Cryptography Management/app.json
+++ b/src/System Application/App/Cryptography Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides cryptography helper functions.",
   "description": "Provides helper functions for encryption, hashing and signing. For encryption in an on-premises versions, use it to turn encryption on or off, and import and export the encryption key. Encryption is always turned on for online versions.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,31 +15,31 @@
       "id": "a2ca2793-e1b4-461d-8251-dbe934daec78",
       "name": "Password",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "Blob Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Cues and KPIs/app.json
+++ b/src/System Application/App/Cues and KPIs/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Sets up Cues and KPIs",
   "description": "This module provides setup pages and interface methods to manage cues in Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -22,13 +22,13 @@
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "94245fbb-b5b1-416e-b8cf-484306646e82",
       "name": "Field Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Customer Experience Survey/app.json
+++ b/src/System Application/App/Customer Experience Survey/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Customer Experince Survey",
   "description": "This module provides interface methods to connect to CES.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,49 +15,49 @@
       "id": "aa171ba9-d3b0-450d-90fb-546b61e32074",
       "name": "OAuth2",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "95025170-61fc-4808-9505-4ba1fe1d05d9",
       "name": "Azure AD Tenant",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Data Administration/app.json
+++ b/src/System Application/App/Data Administration/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides an interface for managing and cleaning up data data in the database.",
   "description": "Provides the ability to manage data in the database.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Data Archive/app.json
+++ b/src/System Application/App/Data Archive/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Enables users to archive data from Business Central.",
   "description": "Enables users to archive data from Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Data Classification/app.json
+++ b/src/System Application/App/Data Classification/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Handles data classification for objects that might contain sensitive information.",
   "description": "Helps you comply with data privacy standards by enabling you to classify data for objects that might contain sensitive information. Classifications for data sensitivity include normal, personal, company confidential, and sensitive.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Data Compression/app.json
+++ b/src/System Application/App/Data Compression/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Compresses and uncompresses data in a binary format.",
   "description": "The purpose of this module is to provide ability to create, update, read and dispose a binary data compression archive.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Date and Time/app.json
+++ b/src/System Application/App/Date and Time/app.json
@@ -2,7 +2,7 @@
   "id": "4c315253-b024-4fdc-9c3d-794036768af5",
   "name": "Date and Time",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides date and time helper functions",
   "description": "Provides helper functions for date and time, such as getting a time zone offset or giving information on daylight saving time.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Date-Time Dialog/app.json
+++ b/src/System Application/App/Date-Time Dialog/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Helper page for entering a date-time value",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Default Role Center/app.json
+++ b/src/System Application/App/Default Role Center/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Support for the default RoleCenter selection",
   "description": "Support for the default RoleCenter selection",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Device/app.json
+++ b/src/System Application/App/Device/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Access information about devices.",
   "description": "Access information such as the name, MAC address, type, and state for all devices that are connected to Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Document Sharing/app.json
+++ b/src/System Application/App/Document Sharing/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Contains the functionality for document sharing.",
   "description": "Contains the functionality for document sharing.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "574d5c26-62d4-4541-bc36-0fbbaed0072a",
       "name": "Azure AD User Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/System Application/App/DotNet Aliases/app.json
+++ b/src/System Application/App/DotNet Aliases/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Defines aliases for .NET classes.",
   "description": "Defines aliases for .NET classes so that you do not have to write the full name of the class. For example, rather than having to write \"System.Collections.Queue\", you can just use \"Queue\".",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Edit in Excel/app.json
+++ b/src/System Application/App/Edit in Excel/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Handles the edit in excel functionality",
   "description": "Contains functionality for using edit in excel.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2221526",
@@ -15,37 +15,37 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9bc20107-0927-405d-abec-ed877f67c2a3",
       "name": "Web Service Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "95025170-61fc-4808-9505-4ba1fe1d05d9",
       "name": "Azure AD Tenant",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a6444d0e-47ec-49c1-bb18-173e54b498d3",
       "name": "Document Sharing Service",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Email/app.json
+++ b/src/System Application/App/Email/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Enables user to send emails from Business Central.",
   "description": "Enables user to send emails from Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,103 +15,103 @@
       "id": "a6444d0e-47ec-49c1-bb18-173e54b498d3",
       "name": "Document Sharing Service",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "872fe7e8-9893-40ae-ab94-c123ed30fdbd",
       "name": "Extension Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b3670666-3f31-4664-8531-a1cb0bdf69fd",
       "name": "Environment Cleanup",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
       "name": "Retention Policy",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c0804406-ca14-4a8b-88a0-dd6999c550a8",
       "name": "Word Templates",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "44012bcf-22c2-40d9-bb24-410b1dfc72dc",
       "name": "Record Reference",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "008c9419-0c3b-4d08-b03e-84e3adca689f",
       "name": "Data Compression",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Encoding/app.json
+++ b/src/System Application/App/Encoding/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides helper functions for encoding.",
   "description": "Provides helper functions for converting encoded text to another type of encoding.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Entity Text/app.json
+++ b/src/System Application/App/Entity Text/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides a generic interface to handle rich text for entities",
   "description": "Contains generic functionality to enable rich text for entities.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,73 +15,73 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b185fd4a-677b-48d3-a701-768de7563df0",
       "name": "Regex",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "daa5d70e-eaf5-4256-bf80-53545ef7629a",
       "name": "Privacy Notice",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "95025170-61fc-4808-9505-4ba1fe1d05d9",
       "name": "Azure AD Tenant",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "aa171ba9-d3b0-450d-90fb-546b61e32074",
       "name": "OAuth2",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "d3433b68-4901-445f-9547-fdfeca57575a",
       "name": "AI SDK",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/System Application/App/Environment Cleanup/app.json
+++ b/src/System Application/App/Environment Cleanup/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Clean up data when copying environments",
   "description": "Provides events to subscribe to in order to clean up data when copying an environment.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Environment Information/app.json
+++ b/src/System Application/App/Environment Information/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Contains helper methods for getting information about the tenant and general settings.",
   "description": "Contains helper methods for getting information about the tenant and general settings, such as determining whether this is a production or sandbox environment, or deployed as an online or on-premises version, and so on.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1a023056-d6fe-41af-a16e-da7d678cf266",
       "name": "Server Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Extension Management/app.json
+++ b/src/System Application/App/Extension Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides the tools needed to manage an extension.",
   "description": "Provides features for installing and uninstalling, downloading and uploading, configuring and publishing extensions and their dependencies.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,67 +15,67 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1a023056-d6fe-41af-a16e-da7d678cf266",
       "name": "Server Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "66d56517-9469-4cdf-83a8-7122c54af08f",
       "name": "VS Code Integration",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/External File Storage/app.json
+++ b/src/System Application/App/External File Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Access external file storage services",
   "description": "Enables access to external file storage services from Business Central.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,37 +15,37 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "872fe7e8-9893-40ae-ab94-c123ed30fdbd",
       "name": "Extension Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Feature Configuration/app.json
+++ b/src/System Application/App/Feature Configuration/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Retrieve feature configuration values from platform",
   "description": "Retrieve feature configuration values from platform",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [],

--- a/src/System Application/App/Feature Key/app.json
+++ b/src/System Application/App/Feature Key/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Contains the functionality for selecting which features are enabled for a tenant.",
   "description": "Contains the functionality for selecting which features are enabled for a tenant.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "54911257-906e-42e5-b529-735f5b4bb244",
       "name": "Date-Time Dialog",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Field Selection/app.json
+++ b/src/System Application/App/Field Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Looks up fields.",
   "description": "Provides a page where you can look up and select one or more fields from one or more tables. For example, this is useful when you want to set up a KPI on a Role Center.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Filter Tokens/app.json
+++ b/src/System Application/App/Filter Tokens/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Helper functions to manage filter texts",
   "description": "This module enhances filtering by enabling users to enter additional filter tokens. The Code or Text filters accept the %me, %user, and %company filter tokens. The Date, Time, and DateTime filters accept the %today, %workdate, %yesterday, %tomorrow, %week, %month, %quarter filter tokens. In addition, the Date filters support date formulas. Developer can add more filter tokens by subscribing to the OnResolveDateFilterToken, OnResolveTextFilterToken, OnResolveTimeFilterToken, OnResolveDateTokenFromDateTimeFilter and OnResolveTimeTokenFromDateTimeFilter events.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Geolocation/app.json
+++ b/src/System Application/App/Geolocation/app.json
@@ -2,7 +2,7 @@
   "id": "7f03f010-1703-47eb-a3cd-c6d28b8a806c",
   "name": "Geolocation",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides access to geographical location data on client devices.",
   "description": "Open the Geolocation page and request geographical location data on your client device. The page will communicate the availability of data about the location.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Guided Experience/app.json
+++ b/src/System Application/App/Guided Experience/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides different types of guided experience for users.",
   "description": "Provides different types of guided experience for users, such as assisted setup guides, manual setup guides, and checklists.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,67 +15,67 @@
       "id": "3ade8173-2cc2-4727-8c57-eb0754f70cdc",
       "name": "Translation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "84e448ad-faa5-44c8-835a-ec4b408e8cec",
       "name": "Video",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "901c89b7-132b-4c59-bb3f-2bfa4fbc70b5",
       "name": "Navigation Bar Subscribers",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Headlines/app.json
+++ b/src/System Application/App/Headlines/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Helps with constructing the text for headlines.",
   "description": "This module provides methods for constructing headlines on Role Centers. It includes constants for the maximum allowed text length, functionality for truncating and emphasizing text, and methods related to the standard greeting headline.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Image/app.json
+++ b/src/System Application/App/Image/app.json
@@ -2,7 +2,7 @@
   "id": "b185fd4a-677b-48d3-a324-768de7563df0",
   "name": "Image",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "",
   "description": "",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,19 +15,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Json/app.json
+++ b/src/System Application/App/Json/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides tools for working with JSON data.",
   "description": "Provides tools for working with JSON data such as reading, writing and parsing JSON.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Language/app.json
+++ b/src/System Application/App/Language/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Changes the language for Windows and applications, and converts language codes to IDs, and vice versa.",
   "description": "Changes the language for Windows and applications, and converts language codes to language IDs, and vice versa. The Language table is a subset of Windows languages. You can add languages, and edit translations and descriptions in the list.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -22,7 +22,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/MCP/app.json
+++ b/src/System Application/App/MCP/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Enables managing of MCP server.",
   "description": "Provides functionality for setting up, enabling and disabling tools for the MCP server.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
       "name": "Feature Key",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Math/app.json
+++ b/src/System Application/App/Math/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides constants and static methods for trigonometric, logarithmic, and other common mathematical functions.",
   "description": "Provides constants and static methods for trigonometric, logarithmic, and other common mathematical functions.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Microsoft User Feedback/app.json
+++ b/src/System Application/App/Microsoft User Feedback/app.json
@@ -2,7 +2,7 @@
   "id": "f7964d32-7685-400f-8297-4bc17d0aab0e",
   "name": "Microsoft User Feedback",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides functionality for collecting user feedback which is sent to Microsoft.",
   "description": "Functionality to allow for AL developers to collect user feedback from the application. Since this module sends feedback to Microsoft, it should be used by Microsoft internal only.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",

--- a/src/System Application/App/MicrosoftGraph/app.json
+++ b/src/System Application/App/MicrosoftGraph/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Retrieve information from Microsoft Graph API.",
   "description": "Accesses and retrieves information from Microsoft Graph API.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,31 +15,31 @@
       "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",
       "name": "Rest Client",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Navigation Bar Subscribers/app.json
+++ b/src/System Application/App/Navigation Bar Subscribers/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Navigation Bar Subscribers and overridable integration points",
   "description": "Navigation Bar Subscribers and overridable integration points",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/OAuth/app.json
+++ b/src/System Application/App/OAuth/app.json
@@ -2,7 +2,7 @@
   "id": "3f95f4c2-037f-44d4-b089-b56ffc01693f",
   "name": "OAuth",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Contains methods supporting authentication via OAuth 1.0 protocol.",
   "description": "Contains helper methods for obtaining the authentication key and secret, or the authorization header in respect to the OAuth 1.0 authorization protocol.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/OAuth2/app.json
+++ b/src/System Application/App/OAuth2/app.json
@@ -2,7 +2,7 @@
   "id": "aa171ba9-d3b0-450d-90fb-546b61e32074",
   "name": "OAuth2",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Contains methods supporting authentication via OAuth 2.0 protocol.",
   "description": "Contains helper methods for obtaining the authentication key and secret, or the authorization header in respect to the OAuth 2.0 authorization protocol.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,31 +15,31 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Object Selection/app.json
+++ b/src/System Application/App/Object Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Look up page for all of the application objects, including objects from installed extensions.",
   "description": "",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Page Action Provider/app.json
+++ b/src/System Application/App/Page Action Provider/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides relevant actions of an AL page",
   "description": "Contains functionality for providing relevant actions for a given page.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "publisher": "Microsoft",
       "name": "Azure AD Plan",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Page Summary Provider/app.json
+++ b/src/System Application/App/Page Summary Provider/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides a summary of an AL page",
   "description": "Contains functionality for providing a summary for a given page.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Password/app.json
+++ b/src/System Application/App/Password/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Sets and verifies passwords",
   "description": "This module provides the functionality for generating and validating passwords, introduces a dialog for the user to enter a password.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Pdf/app.json
+++ b/src/System Application/App/Pdf/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides functionality for processing and extracting data from PDF documents.",
   "description": "Provides functionality for processing and extracting data from PDF documents.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b185fd4a-677b-48d3-a324-768de7563df0",
       "name": "Image",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Performance Profiler/app.json
+++ b/src/System Application/App/Performance Profiler/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides functionality for performance profiling.",
   "description": "Provides functionality for recording scenarios within the product and presenting the insights about where the time was spent.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -17,67 +17,67 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9c9b6fdc-6a1a-4cab-aa92-47ba72534897",
       "name": "Business Chart",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a6444d0e-47ec-49c1-bb18-173e54b498d3",
       "name": "Document Sharing Service",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
       "name": "Retention Policy",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Permission Sets/app.json
+++ b/src/System Application/App/Permission Sets/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Manage permission sets.",
   "description": "Manage permission sets.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2edca772-d3b5-4cfc-9ed6-b17ce4bd53c9",
       "name": "Object Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Printer Management/app.json
+++ b/src/System Application/App/Printer Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Manages printers",
   "description": "Contains functionality for managing printers available for a tenant.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Privacy Notice/app.json
+++ b/src/System Application/App/Privacy Notice/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Functionality for showing privacy notices.",
   "description": "Functionality to ensure privacy notices have been approved for integrations to other services.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Record Link Management/app.json
+++ b/src/System Application/App/Record Link Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Helper functions for RecordLinks",
   "description": "Record links features allows user to add notes and links to almost any record into the system. The current module provides APIs for developer to deal with records, for example to transfer/copy link from one record to another, transform text input into BLOB format expected by platform, clean up orphaned links.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Record Reference/app.json
+++ b/src/System Application/App/Record Reference/app.json
@@ -2,7 +2,7 @@
   "id": "44012bcf-22c2-40d9-bb24-410b1dfc72dc",
   "name": "Record Reference",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides an interface to delegate record operations.",
   "description": "Provides an interface to delegate record operations. This can be used when indirect permissions are required but the code does not support them.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",

--- a/src/System Application/App/Record Selection/app.json
+++ b/src/System Application/App/Record Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Looks up records.",
   "description": "Provides a page where you can look up and select one or more records from a table. For example, this is useful when you want to select a record from table that the user specifies.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd4b9f8a-b018-4f69-a614-efdb744c5330",
       "name": "Page Summary Provider",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Recurrence Schedule/app.json
+++ b/src/System Application/App/Recurrence Schedule/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Calculates when the next event will occur.",
   "description": "Calculates when the next event will occur. Events can recur daily, weekly, monthly or yearly.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -22,7 +22,7 @@
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Regex/app.json
+++ b/src/System Application/App/Regex/app.json
@@ -2,7 +2,7 @@
   "id": "b185fd4a-677b-48d3-a701-768de7563df0",
   "name": "Regex",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides access to the .NET regular expression engine",
   "description": "Provides access to the .NET regular expression engine.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Rest Client/app.json
+++ b/src/System Application/App/Rest Client/app.json
@@ -2,7 +2,7 @@
   "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",
   "name": "Rest Client",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides functionality to call REST services from AL",
   "description": "Provides functionality to call REST services from AL",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -14,19 +14,19 @@
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "aa171ba9-d3b0-450d-90fb-546b61e32074",
       "name": "OAuth2",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Retention Policy/app.json
+++ b/src/System Application/App/Retention Policy/app.json
@@ -2,7 +2,7 @@
   "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
   "name": "Retention Policy",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Allows setting up Retention Policies on tables.",
   "description": "Allows setting up Retention Policies on tables and deletes expired records.",
   "privacyStatement": "",
@@ -15,61 +15,61 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "94245fbb-b5b1-416e-b8cf-484306646e82",
       "name": "Field Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2edca772-d3b5-4cfc-9ed6-b17ce4bd53c9",
       "name": "Object Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "44012bcf-22c2-40d9-bb24-410b1dfc72dc",
       "name": "Record Reference",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Satisfaction Survey/app.json
+++ b/src/System Application/App/Satisfaction Survey/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Shows a satisfaction survey",
   "description": "The purpose of this module is to show a satisfaction survey.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,49 +15,49 @@
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "publisher": "Microsoft",
       "name": "DotNet Aliases",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "574d5c26-62d4-4541-bc36-0fbbaed0072a",
       "name": "Azure AD User Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Secrets/app.json
+++ b/src/System Application/App/Secrets/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Secret providers",
   "description": "This module provides access to secrets that are stored for apps in Azure Key Vault or other secret providers.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Security Groups/app.json
+++ b/src/System Application/App/Security Groups/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Manage permissions for groups of users",
   "description": "Specify the permissions different users will have depending on their Microsoft Entra security group or Windows group.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -22,43 +22,43 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "4992eeac-2fd3-4515-a50b-7336a332d47f",
       "name": "Permission Sets",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Server Settings/app.json
+++ b/src/System Application/App/Server Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Gets settings from the server.",
   "description": "Exposes methods that get settings from the server configuration file. For example, it checks whether the Excel add-in is installed, or whether online services can be installed on the server.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/SharePoint Authorization/app.json
+++ b/src/System Application/App/SharePoint Authorization/app.json
@@ -2,7 +2,7 @@
   "id": "6936a6a5-43a6-4904-855c-8dc268cd49dd",
   "name": "SharePoint Authorization",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides means for authorizing HTTP requests to SharePoint REST API",
   "description": "Provides interfaces and authorization logic for HTTP requests to SharePoint REST API",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,7 +15,7 @@
       "id": "aa171ba9-d3b0-450d-90fb-546b61e32074",
       "name": "OAuth2",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/SharePoint/app.json
+++ b/src/System Application/App/SharePoint/app.json
@@ -2,7 +2,7 @@
   "id": "1a7bfa64-c856-49ed-86b0-bb05eb5b2de4",
   "name": "SharePoint",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Reproduces the SharePoint REST API",
   "description": "Provides a set of AL functionality and Helper libraries to make use of SharePoint REST API",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,31 +15,31 @@
       "id": "6936a6a5-43a6-4904-855c-8dc268cd49dd",
       "name": "SharePoint Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3f95f4c2-037f-44d4-b089-b56ffc01693f",
       "name": "OAuth",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/SmartList Designer Subscribers/app.json
+++ b/src/System Application/App/SmartList Designer Subscribers/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "SmartList Designer Subscribers and overridable integration points",
   "description": "SmartList Designer Subscribers and overridable integration points",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/System Initialization/app.json
+++ b/src/System Application/App/System Initialization/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Executes non-business logic on user login.",
   "description": "",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "574d5c26-62d4-4541-bc36-0fbbaed0072a",
       "name": "Azure AD User Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/System Permissions/app.json
+++ b/src/System Application/App/System Permissions/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Permissions for system objects.",
   "description": "Permission sets for objects from Dynamics 365 Business Central platform.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Table Information/app.json
+++ b/src/System Application/App/Table Information/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Display information about the tables in the system",
   "description": "Display information about the tables in the system",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Table Keys/app.json
+++ b/src/System Application/App/Table Keys/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides functionality for working with table keys.",
   "description": "Provides functionality for disabling and re-enabling table keys.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Telemetry/app.json
+++ b/src/System Application/App/Telemetry/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides functionality for emitting telemetry in a universal format.",
   "description": "Provides functionality for emitting telemetry about feature usage in a universal format for automatic analysis.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/Tenant License State/app.json
+++ b/src/System Application/App/Tenant License State/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Retrieves the current state of the tenant license.",
   "description": "Retrieves the current state of the tenant license, such as trial, paid, or suspended, including the start and end dates of the license.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Time Zone Selection/app.json
+++ b/src/System Application/App/Time Zone Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Looks up and selects Time Zones.",
   "description": "Provides a page where you look up and select a Time Zone.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/Translation/app.json
+++ b/src/System Application/App/Translation/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Gets and stores translations.",
   "description": "Gets and stores language translations that users specify for values in table fields.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/URI/app.json
+++ b/src/System Application/App/URI/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Exposes functionality to work with URIs",
   "description": "Provides functionality to work with .Net Uri and UriBuilder classes.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Upgrade Tags/app.json
+++ b/src/System Application/App/Upgrade Tags/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Stores Upgrade Tags to track which methods were executed.",
   "description": "Upgrade Tags are used within upgrade codeunits to know which upgrade methods have been run and to prevent executing the same upgrade code twice. They can also be used to skip the uprade methods on a specific company or to fix the upgrade that went wrong.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/App/User Details/app.json
+++ b/src/System Application/App/User Details/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Get details about users.",
   "description": "Provides functionality for retrieving and viewing user details.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/User Login Times/app.json
+++ b/src/System Application/App/User Login Times/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Keeps track of when users sign in.",
   "description": "Records the date when users sign in for the first time, and keeps track of their two most recent sign ins.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/User Permissions/app.json
+++ b/src/System Application/App/User Permissions/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Checks whether users are assigned to the SUPER permission set or have been made capable to manage other users.",
   "description": "Checks whether users are assigned to the SUPER permission or have been made capable to manage other users. You can also remove the SUPER permission set from a user.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/User Selection/app.json
+++ b/src/System Application/App/User Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Looks up and selects registered users.",
   "description": "Provides a page where you look up and select one or more registered users. For example, this is useful for assigning a person to things like documents, processes, or items.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/User Settings/app.json
+++ b/src/System Application/App/User Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Store and retrieve User related settings.",
   "description": "Provides functionality for storing retrieving and viewing user related settings.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,67 +15,67 @@
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "21566fb3-3c6b-4cac-a70d-052f5d66ac64",
       "name": "Tenant License State",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "fa2b571d-3f92-4685-9113-421ea9c0b5f5",
       "name": "Time Zone Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "name": "Upgrade Tags",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "574d5c26-62d4-4541-bc36-0fbbaed0072a",
       "name": "Azure AD User Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "name": "Azure AD User",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/VS Code Integration/app.json
+++ b/src/System Application/App/VS Code Integration/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides the tools needed to manage Visual Studio Code requests.",
   "description": "Provides methods for constructing requests to Visual Studio Code to debug, navigate to a symbol and more.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "645965f7-95bf-4ee9-bf97-84e45dc6c6d1",
       "name": "Json",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Video/app.json
+++ b/src/System Application/App/Video/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Looks up and plays videos.",
   "description": "Provides a page where you look up and select videos. For example, use this to access video tutorials.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd8",
       "name": "Control Add-Ins",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Web Service Management/app.json
+++ b/src/System Application/App/Web Service Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides the tools needed to manage web services.",
   "description": "Provides methods for creating and modifying web services, accessing web service URLs, getting and setting web service filters and clauses.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
       "name": "Feature Key",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Word Templates/app.json
+++ b/src/System Application/App/Word Templates/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Create documents that incorporate data from Business Central using mail merge.",
   "description": "Use Word templates to create documents that incorporate data from Business Central using mail merge. For example, mail merge is a great way to personalize bulk communications with business partners by letter or email.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,61 +15,61 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "008c9419-0c3b-4d08-b03e-84e3adca689f",
       "name": "Data Compression",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2edca772-d3b5-4cfc-9ed6-b17ce4bd53c9",
       "name": "Object Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b185fd4a-677b-48d3-a701-768de7563df0",
       "name": "Regex",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "94245fbb-b5b1-416e-b8cf-484306646e82",
       "name": "Field Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "53354ca3-452d-49c4-ae76-579e7df10d6e",
       "name": "Record Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a6444d0e-47ec-49c1-bb18-173e54b498d3",
       "name": "Document Sharing Service",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/System Application/App/XML Validation/app.json
+++ b/src/System Application/App/XML Validation/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Performs XML validation",
   "description": "Validates an xml document against a xml schema.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/XmlWriter/app.json
+++ b/src/System Application/App/XmlWriter/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Write XML quickly with System.Xml.XmlTextWriter.",
   "description": "Provides a fast, non-cached, forward-only way to create streams or files with XML data that conforms to guidelines for W3C Extensible Markup Language (XML) 1.0 and Namespaces.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/app.json
+++ b/src/System Application/App/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Provides a standard set of capabilities that serve as a foundation for developing business apps.",
   "description": "Contains an expansive set of open source modules that make it easier to build, maintain, and easily upgrade on-premises and online apps. These modules let you focus on the business logic, and the needs of your users or customers.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",

--- a/src/System Application/Partner Test/AI/app.json
+++ b/src/System Application/Partner Test/AI/app.json
@@ -4,7 +4,7 @@
   "publisher": "Partner",
   "brief": "",
   "description": "Tests for the AI module for partners",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "d3433b68-4901-445f-9547-fdfeca57575a",
       "name": "AI SDK",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2d92a20-33a7-4174-a82f-666e8e2ad69e",
       "name": "AI Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "daa5d70e-eaf5-4256-bf80-53545ef7629a",
       "name": "Privacy Notice",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Partner Test/app.json
+++ b/src/System Application/Partner Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Partner",
   "brief": "Partner Test suite for the System Application.",
   "description": "Contains an partner centric tests for the System Application.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -16,37 +16,37 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
       "name": "System Application Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/AI/app.json
+++ b/src/System Application/Test Library/AI/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the AI.",
   "description": "Test objects for the AI.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "d3433b68-4901-445f-9547-fdfeca57575a",
       "name": "AI SDK",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Advanced Settings/app.json
+++ b/src/System Application/Test Library/Advanced Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Advanced Settings module.",
   "description": "Test objects for the Advanced Settings module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "87c6506c-a822-4ce9-a1c4-aba1b3822e09",
       "name": "Advanced Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/AppSource Gallery/app.json
+++ b/src/System Application/Test Library/AppSource Gallery/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the AppSource Gallery module.",
   "description": "Test objects for the AppSource Gallery module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "79952567-63d7-4586-8b47-ba13a11a8a18",
       "name": "AppSource Product Gallery",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",
       "name": "Rest Client",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7b9b59f5-a68d-4271-b11a-0d3b9c0938dd",
       "name": "User Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Azure AD Graph/app.json
+++ b/src/System Application/Test Library/Azure AD Graph/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Azure AD Graph module.",
   "description": "Test objects for the Azure AD Graph module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "815d5c15-02bd-4d58-a010-b66033de6625",
       "name": "DotNet Aliases Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Azure AD Licensing/app.json
+++ b/src/System Application/Test Library/Azure AD Licensing/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Azure AD Licensing module.",
   "description": "Test objects for the Azure AD Licensing module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "b70307d1-2c71-40ec-aeea-5deb7d0434c8",
       "name": "Azure AD Licensing",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Azure AD Plan/app.json
+++ b/src/System Application/Test Library/Azure AD Plan/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library function to initialize test data for Azure AD Plan module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "815d5c15-02bd-4d58-a010-b66033de6625",
       "name": "DotNet Aliases Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Azure AD User Management/app.json
+++ b/src/System Application/Test Library/Azure AD User Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library function to initialize test data for Azure AD User Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "574d5c26-62d4-4541-bc36-0fbbaed0072a",
       "name": "Azure AD User Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "815d5c15-02bd-4d58-a010-b66033de6625",
       "name": "DotNet Aliases Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Azure AD User/app.json
+++ b/src/System Application/Test Library/Azure AD User/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Azure AD User module.",
   "description": "Test objects for the Azure AD User module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "name": "Azure AD User",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Azure Key Vault/app.json
+++ b/src/System Application/Test Library/Azure Key Vault/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library functions to initialize test data for Azure Key Vault module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Blob Storage/app.json
+++ b/src/System Application/Test Library/Blob Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Blob Storage module.",
   "description": "Test objects for the Blob Storage module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Business Chart/app.json
+++ b/src/System Application/Test Library/Business Chart/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Business Chart module.",
   "description": "Test objects for the Business Chart module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "9c9b6fdc-6a1a-4cab-aa92-47ba72534897",
       "name": "Business Chart",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Camera and Media Interaction/app.json
+++ b/src/System Application/Test Library/Camera and Media Interaction/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library functions to initialize test data for Camera and Media Interaction module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "46992a88-9fae-4e32-948b-2b07735ea10a",
       "name": "Camera and Media Interaction",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Client Type Management/app.json
+++ b/src/System Application/Test Library/Client Type Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library functions to initialize test data for Client Type Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Confirm Management/app.json
+++ b/src/System Application/Test Library/Confirm Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library functions to initialize test data for Confirm Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Cues And KPIs/app.json
+++ b/src/System Application/Test Library/Cues And KPIs/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test Tables for the Cues And KPIs module",
   "description": "Library with Test Tables for the Cues And KPIs module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "1d643b0c-a545-46b1-8514-11196184b38f",
       "name": "Cues and KPIs",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Data Classification/app.json
+++ b/src/System Application/Test Library/Data Classification/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library function to initialize test data for the Data Classification module",
   "description": "Library function to initialize test data for the Data Classification module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "370dcef7-9c6d-4a32-94b1-754230578672",
       "name": "Data Classification",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/DotNet Aliases/app.json
+++ b/src/System Application/Test Library/DotNet Aliases/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Defines aliases for .NET classes for tests.",
   "description": "Defines aliases for .NET classes so that you do not have to write the full name of the class. For example, rather than having to write \"System.Collections.Queue\", you can just use \"Queue\".",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",

--- a/src/System Application/Test Library/Edit in Excel/app.json
+++ b/src/System Application/Test Library/Edit in Excel/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Test library for edit in excel internals.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d848063-d779-42ed-8086-5400b3380378",
       "name": "Edit in Excel",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9bc20107-0927-405d-abec-ed877f67c2a3",
       "name": "Web Service Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Email/app.json
+++ b/src/System Application/Test Library/Email/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test library for the Email module",
   "description": "Test library for the Email module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "9c4a2cf2-be3a-4aa3-833b-99a5ffd11f25",
       "name": "Email",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c0804406-ca14-4a8b-88a0-dd6999c550a8",
       "name": "Word Templates",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Environment Information/app.json
+++ b/src/System Application/Test Library/Environment Information/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library functions to initialize test data for Azure Key Vault module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/External File Storage/app.json
+++ b/src/System Application/Test Library/External File Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test library for the External File Storage module",
   "description": "Test library for the External File Storage module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,13 +15,13 @@
       "id": "c9c54414-80c3-4cc9-98c6-589158882774",
       "name": "External File Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Feature Configuration/app.json
+++ b/src/System Application/Test Library/Feature Configuration/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Test library functions for Feature Configuration module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "4c7e7094-fe3b-43da-970d-1ca056f7f3d3",
       "name": "Feature Configuration",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Feature Key/app.json
+++ b/src/System Application/Test Library/Feature Key/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Feature Key module.",
   "description": "Test objects for the Feature Key module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
       "name": "Feature Key",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Field Selection/app.json
+++ b/src/System Application/Test Library/Field Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test Tables for the Field Selection module",
   "description": "Library with Test Tables for the Field Selection module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "94245fbb-b5b1-416e-b8cf-484306646e82",
       "name": "Field Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Geolocation/app.json
+++ b/src/System Application/Test Library/Geolocation/app.json
@@ -2,7 +2,7 @@
   "id": "ca744f73-dfb4-4702-b72f-e095cac5526e",
   "name": "Geolocation Test Library",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Library functions to initialize test data for the Geolocation module.",
   "description": "Library functions to initialize test data for the Geolocation module.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,13 +15,13 @@
       "id": "7f03f010-1703-47eb-a3cd-c6d28b8a806c",
       "name": "Geolocation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test Library/Guided Experience/app.json
+++ b/src/System Application/Test Library/Guided Experience/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Test library for the Guided Experience module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "84e448ad-faa5-44c8-835a-ec4b408e8cec",
       "name": "Video",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Headlines/app.json
+++ b/src/System Application/Test Library/Headlines/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Headlines module.",
   "description": "Test objects for the Headlines module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "f3f75070-7762-41f5-9947-043a50dc9fc7",
       "name": "Headlines",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Language/app.json
+++ b/src/System Application/Test Library/Language/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Language module.",
   "description": "Test objects for the Language module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/MCP/app.json
+++ b/src/System Application/Test Library/MCP/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library function to initialize test data for the MCP module",
   "description": "Library function to initialize test data for the MCP module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "5767db24-c02e-46e8-9132-44de8be7fc57",
       "name": "MCP",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/MockGraphQuery/app.json
+++ b/src/System Application/Test Library/MockGraphQuery/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for working with MockGraphQuery .Net library.",
   "description": "Test objects for working with MockGraphQuery .Net library.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Page Action Provider/app.json
+++ b/src/System Application/Test Library/Page Action Provider/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with test objects for the Page Action Provider module",
   "description": "Library with test objects for the Page Action Provider module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "c25175d3-5f16-4f78-a1cb-e1f370e6a11e",
       "name": "Page Action Provider",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test Library/Page Summary Provider/app.json
+++ b/src/System Application/Test Library/Page Summary Provider/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test objects for the Page Summary Provider module",
   "description": "Library with Test objects for the Page Summary Provider module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "dd4b9f8a-b018-4f69-a614-efdb744c5330",
       "name": "Page Summary Provider",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Password/app.json
+++ b/src/System Application/Test Library/Password/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Password module.",
   "description": "Test objects for the Password module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "a2ca2793-e1b4-461d-8251-dbe934daec78",
       "name": "Password",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Performance Profiler/app.json
+++ b/src/System Application/Test Library/Performance Profiler/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Performance Profiler module.",
   "description": "Test objects for the Performance Profiler module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "3ed12f72-47eb-4173-87c2-42ea99d60e67",
       "name": "Performance Profiler",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Permission Sets/app.json
+++ b/src/System Application/Test Library/Permission Sets/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Permission Sets module.",
   "description": "Test objects for the Permission Sets module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "4992eeac-2fd3-4515-a50b-7336a332d47f",
       "name": "Permission Sets",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6faf3d7c-8ef2-4eef-9396-63de586532e8",
       "name": "Field Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Record Link Management/app.json
+++ b/src/System Application/Test Library/Record Link Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test objects for the Record Link Management module",
   "description": "Library with Test objects for the Record Link Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "82834e1e-bbf2-4184-b70e-ee44bca1ca10",
       "name": "Record Link Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Record Selection/app.json
+++ b/src/System Application/Test Library/Record Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with permission set for the Record Selection module",
   "description": "Library with permission set for the Record Selection module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "53354ca3-452d-49c4-ae76-579e7df10d6e",
       "name": "Record Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6faf3d7c-8ef2-4eef-9396-63de586532e8",
       "name": "Field Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Recurrence Schedule/app.json
+++ b/src/System Application/Test Library/Recurrence Schedule/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Recurrence Schedule module.",
   "description": "Test objects for the Recurrence Schedule module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "f1d7a28a-e871-4eea-916e-203361cd31d9",
       "name": "Recurrence Schedule",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Retention Policy/app.json
+++ b/src/System Application/Test Library/Retention Policy/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test tables for the Retencion Policy module",
   "description": "Library with Test tables for the Retencion Policy module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
       "name": "Retention Policy",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Satisfaction Survey/app.json
+++ b/src/System Application/Test Library/Satisfaction Survey/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Satisfaction Survey module.",
   "description": "Test objects for the Satisfaction Survey module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "5d03ef2d-13f0-4132-b941-48387b581434",
       "name": "Satisfaction Survey",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Security Groups/app.json
+++ b/src/System Application/Test Library/Security Groups/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Security Groups module.",
   "description": "Test objects for the Security Groups module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "4846d32b-e7ca-4c4c-94e0-3eee0eccd715",
       "name": "Security Groups",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/SharePoint/app.json
+++ b/src/System Application/Test Library/SharePoint/app.json
@@ -2,7 +2,7 @@
   "id": "ff0caa38-65a2-49c5-a7e2-6a0475cfc60e",
   "name": "SharePoint Test Library",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Test libraries for the SharePoint module",
   "description": "Provides a set of AL functionality and Helper libraries to make use of SharePoint REST API",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,25 +15,25 @@
       "id": "1a7bfa64-c856-49ed-86b0-bb05eb5b2de4",
       "name": "SharePoint",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6936a6a5-43a6-4904-855c-8dc268cd49dd",
       "name": "SharePoint Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/System Initialization/app.json
+++ b/src/System Application/Test Library/System Initialization/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the System Initialization module.",
   "description": "Test objects for the System Initialization module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Telemetry/app.json
+++ b/src/System Application/Test Library/Telemetry/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Telemetry module.",
   "description": "Test objects for the Telemetry module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Tenant License State/app.json
+++ b/src/System Application/Test Library/Tenant License State/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Tenant License State module.",
   "description": "Test objects for the Tenant License State module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "21566fb3-3c6b-4cac-a70d-052f5d66ac64",
       "name": "Tenant License State",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Time Zone Selection/app.json
+++ b/src/System Application/Test Library/Time Zone Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test objects for the Time Zone Selection module",
   "description": "Library with Test objects for the Time Zone Selection module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "fa2b571d-3f92-4685-9113-421ea9c0b5f5",
       "name": "Time Zone Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Translation/app.json
+++ b/src/System Application/Test Library/Translation/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test objects for the Translation module",
   "description": "Library with Test objects for the Translation module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "3ade8173-2cc2-4727-8c57-eb0754f70cdc",
       "name": "Translation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Upgrade Tags/app.json
+++ b/src/System Application/Test Library/Upgrade Tags/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Upgrade Tags module.",
   "description": "Test objects for the Upgrade Tags module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "publisher": "Microsoft",
       "name": "Upgrade Tags",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/User Details/app.json
+++ b/src/System Application/Test Library/User Details/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the User Details module.",
   "description": "Test objects for User Details module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "0e4ed208-7f60-4bad-a881-eeb03e09d832",
       "name": "User Details",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/User Login Times/app.json
+++ b/src/System Application/Test Library/User Login Times/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library function to initialize test data for User Login Times module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/User Permissions/app.json
+++ b/src/System Application/Test Library/User Permissions/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Library functions to initialize test data for User Permissions module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/User Selection/app.json
+++ b/src/System Application/Test Library/User Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the User Selection module.",
   "description": "Test objects for User Selection module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/User Settings/app.json
+++ b/src/System Application/Test Library/User Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the User Settings module.",
   "description": "Test objects for User Settings module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "7b9b59f5-a68d-4271-b11a-0d3b9c0938dd",
       "name": "User Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Video/app.json
+++ b/src/System Application/Test Library/Video/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test tables for Video module",
   "description": "Library with Test tables for Video module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,7 +15,7 @@
       "id": "84e448ad-faa5-44c8-835a-ec4b408e8cec",
       "name": "Video",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Web Service Management/app.json
+++ b/src/System Application/Test Library/Web Service Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with test objects for Web Service Management module",
   "description": "Library with test objects for Web Service Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "9bc20107-0927-405d-abec-ed877f67c2a3",
       "name": "Web Service Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
       "name": "Feature Key",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/Word Templates/app.json
+++ b/src/System Application/Test Library/Word Templates/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library with Test objects for the Word Templates module",
   "description": "Library with Test objects for the Word Templates module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "c0804406-ca14-4a8b-88a0-dd6999c550a8",
       "name": "Word Templates",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test Library/app.json
+++ b/src/System Application/Test Library/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test libraries that provide basic test setup for the System Application tests.",
   "description": "Contains an expansive set of library methods to be used exclusively in tests.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -16,13 +16,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/AI/app.json
+++ b/src/System Application/Test/AI/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the AI module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "d3433b68-4901-445f-9547-fdfeca57575a",
       "name": "AI SDK",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "daa5d70e-eaf5-4256-bf80-53545ef7629a",
       "name": "Privacy Notice",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2d92a20-33a7-4174-a82f-666e8e2ad69e",
       "name": "AI Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Advanced Settings/app.json
+++ b/src/System Application/Test/Advanced Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Advanced Settings module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "87c6506c-a822-4ce9-a1c4-aba1b3822e09",
       "name": "Advanced Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "154a0187-d979-441b-b6c1-5b7632b5a620",
       "name": "Advanced Settings Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/AppSource Gallery/app.json
+++ b/src/System Application/Test/AppSource Gallery/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the AppSource Gallery module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "ba17b564-d600-44d5-be0b-ca7ff7ac28fc",
       "name": "AppSource Gallery Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Auto Format/app.json
+++ b/src/System Application/Test/Auto Format/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Auto Format module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "34222918-6f0f-4623-a063-f716575b8529",
       "name": "Auto Format",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure AD Graph/app.json
+++ b/src/System Application/Test/Azure AD Graph/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Azure AD Graph module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "da17b564-d600-44d5-be0b-ca7ff7ac26fc",
       "name": "Azure AD Graph Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure AD Licensing/app.json
+++ b/src/System Application/Test/Azure AD Licensing/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Azure AD Licensing module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,55 +15,55 @@
       "id": "b70307d1-2c71-40ec-aeea-5deb7d0434c8",
       "name": "Azure AD Licensing",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b9663d62-d331-481d-9c06-38b6ebfb586b",
       "name": "Azure AD Licensing Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "da17b564-d600-44d5-be0b-ca7ff7ac26fc",
       "name": "Azure AD Graph Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure AD Plan/app.json
+++ b/src/System Application/Test/Azure AD Plan/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Azure AD Plan module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,73 +15,73 @@
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e63749f1-a7a5-4557-a943-0ae4745616bd",
       "name": "Azure AD Plan Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c2cb86b-321c-421b-8a76-f9ff768492d6",
       "name": "User Permission Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "da17b564-d600-44d5-be0b-ca7ff7ac26fc",
       "name": "Azure AD Graph Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "67aadf15-618d-415f-8bfe-8309b657b4fb",
       "name": "Azure AD User Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure AD User Management/app.json
+++ b/src/System Application/Test/Azure AD User Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Azure AD User Management module",
   "description": "Tests for the Azure AD User Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,91 +15,91 @@
       "id": "574d5c26-62d4-4541-bc36-0fbbaed0072a",
       "name": "Azure AD User Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc58a557-79ae-473d-9fef-3045a2289c00",
       "name": "Azure AD User Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "name": "Azure AD User",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e63749f1-a7a5-4557-a943-0ae4745616bd",
       "name": "Azure AD Plan Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9761c0ac-e4ea-4c14-8918-2f4ded158b12",
       "name": "User Login Times Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "da17b564-d600-44d5-be0b-ca7ff7ac26fc",
       "name": "Azure AD Graph Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure AD User/app.json
+++ b/src/System Application/Test/Azure AD User/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Azure AD User module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,55 +15,55 @@
       "id": "f2cc2ef8-949f-47d1-85b8-10bd6f8bc61c",
       "name": "Azure AD User",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0b52d89c-c2f9-4660-a466-02e07bb06742",
       "name": "Azure AD Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "da17b564-d600-44d5-be0b-ca7ff7ac26fc",
       "name": "Azure AD Graph Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "67aadf15-618d-415f-8bfe-8309b657b4fb",
       "name": "Azure AD User Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure Blob Services API/app.json
+++ b/src/System Application/Test/Azure Blob Services API/app.json
@@ -2,7 +2,7 @@
   "id": "1b7fba32-65f4-47ad-95ac-afd9ad108759",
   "name": "Azure Blob Services API Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Reproduces the Azure Blob service REST API",
   "description": "Provides a set of AL functionality and Helper libraries to make use of Azure Blob Storage in MSDyn365BC",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,25 +15,25 @@
       "id": "8047d691-d376-4570-bfe6-9e0d785b8f32",
       "name": "Azure Blob Services API",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e409d343-14fa-42a4-a1be-fec499383e59",
       "name": "Azure Storage Services Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure File Services API/app.json
+++ b/src/System Application/Test/Azure File Services API/app.json
@@ -2,7 +2,7 @@
   "id": "70b7015c-a198-40d7-af21-660ba444f36f",
   "name": "Azure File Services API Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Reproduces the Azure File service REST API",
   "description": "Provides a set of AL functionality and Helper libraries to make use of Azure File Storage in MSDyn365BC",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,31 +15,31 @@
       "id": "a6660ad9-7675-4f68-a2f9-a938c21de68a",
       "name": "Azure File Services API",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e409d343-14fa-42a4-a1be-fec499383e59",
       "name": "Azure Storage Services Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure Key Vault/app.json
+++ b/src/System Application/Test/Azure Key Vault/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Azure Key Vault module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "901cbabc-1217-4d4a-922f-77b4d4ef3dcf",
       "name": "Azure Key Vault Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "815d5c15-02bd-4d58-a010-b66033de6625",
       "name": "DotNet Aliases Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Azure Storage Services Authorization/app.json
+++ b/src/System Application/Test/Azure Storage Services Authorization/app.json
@@ -2,7 +2,7 @@
   "id": "d80e9dc1-c590-422c-aa4a-0b4b44848e8e",
   "name": "Azure Storage Services Authorization Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for Azure Storage Services Authorization module",
   "description": "",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,19 +15,19 @@
       "id": "e409d343-14fa-42a4-a1be-fec499383e59",
       "name": "Azure Storage Services Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/BLOB Storage/app.json
+++ b/src/System Application/Test/BLOB Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the BLOB Storage module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "29a123a2-ce97-426c-881f-d1d5b914b5ca",
       "name": "Blob Storage Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Barcode/app.json
+++ b/src/System Application/Test/Barcode/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Barcode module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b70cdbee-da69-4029-bafe-be2a1977301c",
       "name": "Barcode",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Base64 Convert/app.json
+++ b/src/System Application/Test/Base64 Convert/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Base64 Convert module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Business Chart/app.json
+++ b/src/System Application/Test/Business Chart/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Business Chart module",
   "description": "Tests for the Business Chart module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "9c9b6fdc-6a1a-4cab-aa92-47ba72534897",
       "name": "Business Chart",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "be679cd3-54a9-4d9c-9381-5ed0eeb973b8",
       "name": "Business Chart Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Camera and Media Interaction/app.json
+++ b/src/System Application/Test/Camera and Media Interaction/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for Camera and Media Interaction module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "46992a88-9fae-4e32-948b-2b07735ea10a",
       "name": "Camera and Media Interaction",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "29fa62c7-4a89-454a-b21d-f1a83d27c86e",
       "name": "Camera and Media Interaction Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Caption Class/app.json
+++ b/src/System Application/Test/Caption Class/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Caption Class module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "3d7bb555-6ce1-419f-9f11-fd3b351b0991",
       "name": "Caption Class",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Client Type Management/app.json
+++ b/src/System Application/Test/Client Type Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Client Type Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "47397d83-32ba-4ef0-8988-ef72539bfe36",
       "name": "Client Type Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Confirm Management/app.json
+++ b/src/System Application/Test/Confirm Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Confirm Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "a4584a53-9345-458a-af20-d1df2fab7bd8",
       "name": "Confirm Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "d4dcc3bc-265b-48fc-99e2-3262a6130236",
       "name": "Confirm Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Cryptography Management/app.json
+++ b/src/System Application/Test/Cryptography Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Cryptography Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "a3964a53-9345-458a-af20-d13f7eab7bd7",
       "name": "Cryptography Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test/Cues and KPIs/app.json
+++ b/src/System Application/Test/Cues and KPIs/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Cues and KPIs module",
   "description": "Tests for the Cues and KPIs module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "1d643b0c-a545-46b1-8514-11196184b38f",
       "name": "Cues and KPIs",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ae5c2cd1-89f3-4f7e-a61b-c22909f27529",
       "name": "Cues And KPIs Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Data Administration/app.json
+++ b/src/System Application/Test/Data Administration/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for Data Cleanup module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "d604b641-b148-4230-8bb7-70086b143ebf",
       "name": "Data Administration",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Data Classification/app.json
+++ b/src/System Application/Test/Data Classification/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Data Classification module",
   "description": "Tests for the Data Classification module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "370dcef7-9c6d-4a32-94b1-754230578672",
       "name": "Data Classification",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "4a81e695-54d3-44a9-b870-3797c875714a",
       "name": "Data Classification Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Data Compression/app.json
+++ b/src/System Application/Test/Data Compression/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests the Data Compression module",
   "description": "Tests for the Data Compression module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "008c9419-0c3b-4d08-b03e-84e3adca689f",
       "name": "Data Compression",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Date and Time/app.json
+++ b/src/System Application/Test/Date and Time/app.json
@@ -2,7 +2,7 @@
   "id": "93de27b1-58ac-4586-8f28-805cec92d808",
   "name": "Date and Time Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "",
   "description": "Tests for the Date and Time module",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,19 +15,19 @@
       "id": "4c315253-b024-4fdc-9c3d-794036768af5",
       "name": "Date and Time",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Date-Time Dialog/app.json
+++ b/src/System Application/Test/Date-Time Dialog/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Date-Time Dialog module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "54911257-906e-42e5-b529-735f5b4bb244",
       "name": "Date-Time Dialog",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Document Sharing/app.json
+++ b/src/System Application/Test/Document Sharing/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Document Sharing module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "a6444d0e-47ec-49c1-bb18-173e54b498d3",
       "name": "Document Sharing Service",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Edit in Excel/app.json
+++ b/src/System Application/Test/Edit in Excel/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for edit in excel.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "5d848063-d779-42ed-8086-5400b3380378",
       "name": "Edit in Excel",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c0380f61-b75f-497c-a7f6-e5a2f5f19994",
       "name": "Edit in Excel Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Email/app.json
+++ b/src/System Application/Test/Email/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Email module",
   "description": "Tests for the Email module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,73 +15,73 @@
       "id": "9c4a2cf2-be3a-4aa3-833b-99a5ffd11f25",
       "name": "Email",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "949b9041-d2cb-4e69-bf31-c1e8fcb9462b",
       "name": "Email Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "bfdf2a31-bb39-4f1a-bbb5-291e04dc8051",
       "name": "Word Templates Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "47397d83-32ba-4ef0-8988-ef72539bfe36",
       "name": "Client Type Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c0804406-ca14-4a8b-88a0-dd6999c550a8",
       "name": "Word Templates",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
       "name": "Retention Policy",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Encoding/app.json
+++ b/src/System Application/Test/Encoding/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the encoding module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "ad94bc69-99fa-4bf0-85b3-6dbc72bd1543",
       "name": "Encoding",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Environment Information/app.json
+++ b/src/System Application/Test/Environment Information/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for Enviroment Information module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Extension Management/app.json
+++ b/src/System Application/Test/Extension Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests the Extension Management module.",
   "description": "Provides tests for installing and uninstalling extensions and their dependencies. Tests the tooling for retrieving different versions of the extensions.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,43 +15,43 @@
       "id": "872fe7e8-9893-40ae-ab94-c123ed30fdbd",
       "publisher": "Microsoft",
       "name": "Extension Management",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "84e448ad-faa5-44c8-835a-ec4b408e8cec",
       "name": "Video",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/External File Storage/app.json
+++ b/src/System Application/Test/External File Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the External File Storage module",
   "description": "Tests for the External File Storage module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,49 +15,49 @@
       "id": "c9c54414-80c3-4cc9-98c6-589158882774",
       "name": "External File Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "f188754b-3ffb-443a-9507-f5fbdae3af2c",
       "name": "External File Storage Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Feature Key/app.json
+++ b/src/System Application/Test/Feature Key/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Feature Key module",
   "description": "Tests for the Feature Key module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
       "name": "Feature Key",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b5b9aea8-a0f3-4666-b755-c9996789f5bc",
       "name": "Feature Key Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Field Selection/app.json
+++ b/src/System Application/Test/Field Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Field Selection module",
   "description": "Tests for the Field Selection module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "94245fbb-b5b1-416e-b8cf-484306646e82",
       "name": "Field Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6faf3d7c-8ef2-4eef-9396-63de586532e8",
       "name": "Field Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Filter Tokens/app.json
+++ b/src/System Application/Test/Filter Tokens/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Filter Tokens module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "dcfc6d73-8259-4595-ad3e-c2574fe2a197",
       "name": "Filter Tokens",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Geolocation/app.json
+++ b/src/System Application/Test/Geolocation/app.json
@@ -2,7 +2,7 @@
   "id": "af38009d-413c-4927-acc6-1485c8f9b1f5",
   "name": "Geolocation Tests",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "",
   "description": "Tests for Geolocation module.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,19 +15,19 @@
       "id": "7f03f010-1703-47eb-a3cd-c6d28b8a806c",
       "name": "Geolocation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ca744f73-dfb4-4702-b72f-e095cac5526e",
       "name": "Geolocation Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test/Guided Experience/app.json
+++ b/src/System Application/Test/Guided Experience/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Guided Experience module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,61 +15,61 @@
       "id": "3ade8173-2cc2-4727-8c57-eb0754f70cdc",
       "name": "Translation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "84e448ad-faa5-44c8-835a-ec4b408e8cec",
       "name": "Video",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2856b1c4-3dda-4426-9403-d0313172b6c0",
       "name": "Guided Experience Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "bb4bb65a-d7ba-4054-bfe7-e2d7c4ecc133",
       "name": "System Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9761c0ac-e4ea-4c14-8918-2f4ded158b12",
       "name": "User Login Times Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Headlines/app.json
+++ b/src/System Application/Test/Headlines/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Headlines module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "f3f75070-7762-41f5-9947-043a50dc9fc7",
       "name": "Headlines",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9761c0ac-e4ea-4c14-8918-2f4ded158b12",
       "name": "User Login Times Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "32e12a85-56a3-43ca-bfbe-45d0de129d76",
       "name": "Headlines Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Image/app.json
+++ b/src/System Application/Test/Image/app.json
@@ -2,7 +2,7 @@
   "id": "c4cf59d0-e2fe-4bf8-b7ce-084aa91ba487",
   "name": "Image Tests",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "",
   "description": "Tests for Image module.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,25 +15,25 @@
       "id": "b185fd4a-677b-48d3-a324-768de7563df0",
       "name": "Image",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test/Json/app.json
+++ b/src/System Application/Test/Json/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Json module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "645965f7-95bf-4ee9-bf97-84e45dc6c6d1",
       "name": "Json",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test/Language/app.json
+++ b/src/System Application/Test/Language/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Test Module for Language",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7b9b59f5-a68d-4271-b11a-0d3b9c0938dd",
       "name": "User Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "bb4bb65a-d7ba-4054-bfe7-e2d7c4ecc133",
       "name": "System Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "79e72120-0c70-4ccf-b45c-fb75a5c7af8b",
       "name": "Language Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/MCP/app.json
+++ b/src/System Application/Test/MCP/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library function to initialize test data for the MCP module",
   "description": "Library function to initialize test data for the MCP module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5767db24-c02e-46e8-9132-44de8be7fc57",
       "name": "MCP",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ef6e70f1-8b0c-4759-b15e-d83e6ad33e45",
       "name": "MCP Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/MicrosoftGraph/app.json
+++ b/src/System Application/Test/MicrosoftGraph/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test objects for the Microsoft Graph module.",
   "description": "Test objects for the Microsoft Graph module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",
       "name": "Rest Client",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6d72c93d-164a-494c-8d65-24d7f41d7b61",
       "name": "Microsoft Graph",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Navigation Bar Subscribers/app.json
+++ b/src/System Application/Test/Navigation Bar Subscribers/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Navigation Bar Subscribers module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "901c89b7-132b-4c59-bb3f-2bfa4fbc70b5",
       "name": "Navigation Bar Subscribers",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c64d75f0-e9f1-4d0f-9949-cd453b9b1466",
       "name": "Guided Experience",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "87c6506c-a822-4ce9-a1c4-aba1b3822e09",
       "name": "Advanced Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Page Action Provider/app.json
+++ b/src/System Application/Test/Page Action Provider/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the page action provider.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "c25175d3-5f16-4f78-a1cb-e1f370e6a11e",
       "name": "Page Action Provider",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6e22c9f6-ed81-48f5-af90-2bda9799d710",
       "name": "Page Action Provider Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Page Summary Provider/app.json
+++ b/src/System Application/Test/Page Summary Provider/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the page summary provider.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "dd4b9f8a-b018-4f69-a614-efdb744c5330",
       "name": "Page Summary Provider",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "69fac4db-4559-4aa8-a2bf-d08469614599",
       "name": "Page Summary Provider Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Password/app.json
+++ b/src/System Application/Test/Password/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Password Module",
   "description": "Tests for the Password Module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a2ca2793-e1b4-461d-8251-dbe934daec78",
       "name": "Password",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "47f9b8b5-9aae-4384-8101-4519f7115381",
       "name": "Password Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Pdf/app.json
+++ b/src/System Application/Test/Pdf/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Pdf module.",
   "description": "Provides functionality for processing and extracting data from PDF documents.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,25 +15,25 @@
       "id": "2c7afcfb-9625-4ace-b972-5889d045ce8f",
       "name": "Pdf",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b185fd4a-677b-48d3-a324-768de7563df0",
       "name": "Image",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Performance Profiler/app.json
+++ b/src/System Application/Test/Performance Profiler/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Performance Profiler module",
   "description": "Tests for the Performance Profiler module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "3ed12f72-47eb-4173-87c2-42ea99d60e67",
       "name": "Performance Profiler",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b5c15eed-62f1-41e8-b053-bd733426766f",
       "name": "Performance Profiler Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
       "name": "Retention Policy",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Permission Sets/app.json
+++ b/src/System Application/Test/Permission Sets/app.json
@@ -2,7 +2,7 @@
   "id": "d996210f-839c-41bb-bfb3-dc231bf4fe86",
   "name": "Permission Sets Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for Permission Sets module",
   "description": "Tests for Permission Sets module",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,55 +15,55 @@
       "id": "4992eeac-2fd3-4515-a50b-7336a332d47f",
       "name": "Permission Sets",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6faf3d7c-8ef2-4eef-9396-63de586532e8",
       "name": "Field Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "88793a8c-a579-4c97-9739-bee458c023ee",
       "name": "Permission Sets Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c2cb86b-321c-421b-8a76-f9ff768492d6",
       "name": "User Permission Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Privacy Notice/app.json
+++ b/src/System Application/Test/Privacy Notice/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for Privacy Notice.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,19 +15,19 @@
       "id": "daa5d70e-eaf5-4256-bf80-53545ef7629a",
       "name": "Privacy Notice",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Record Link Management/app.json
+++ b/src/System Application/Test/Record Link Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Record Link Management module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "82834e1e-bbf2-4184-b70e-ee44bca1ca10",
       "name": "Record Link Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7d434875-500b-4d70-a486-82b1208e3bbc",
       "name": "Record Link Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Record Reference/app.json
+++ b/src/System Application/Test/Record Reference/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Record Reference module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "44012bcf-22c2-40d9-bb24-410b1dfc72dc",
       "name": "Record Reference",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "82834e1e-bbf2-4184-b70e-ee44bca1ca10",
       "name": "Record Link Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Record Selection/app.json
+++ b/src/System Application/Test/Record Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Record Selection module",
   "description": "Tests for the Record Selection module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "53354ca3-452d-49c4-ae76-579e7df10d6e",
       "name": "Record Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "db2105f8-986c-4af7-9273-67928941de77",
       "name": "Record Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Recurrence Schedule/app.json
+++ b/src/System Application/Test/Recurrence Schedule/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Recurrence Schedule module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "f1d7a28a-e871-4eea-916e-203361cd31d9",
       "name": "Recurrence Schedule",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "8dc27b4c-ed38-4df0-9497-2724beea0e9d",
       "name": "Recurrence Schedule Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Regex/app.json
+++ b/src/System Application/Test/Regex/app.json
@@ -2,7 +2,7 @@
   "id": "c4cf59d0-e2fe-4af8-b7ce-084aa91ba487",
   "name": "Regex Tests",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "",
   "description": "Tests for Regex module.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,13 +15,13 @@
       "id": "b185fd4a-677b-48d3-a701-768de7563df0",
       "name": "Regex",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test/Rest Client/app.json
+++ b/src/System Application/Test/Rest Client/app.json
@@ -2,7 +2,7 @@
   "id": "ae153cbb-ad55-447c-9226-5af3ef57280f",
   "name": "Rest Client Tests",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for the Rest Client module",
   "description": "Tests for the Rest Client module",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -14,25 +14,25 @@
       "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",
       "name": "Rest Client",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Retention Policy/app.json
+++ b/src/System Application/Test/Retention Policy/app.json
@@ -2,7 +2,7 @@
   "id": "489a0bcb-0619-4bd1-b626-9f30dbe8af4d",
   "name": "Retention Policy Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for the Retention Policy module",
   "description": "Tests for the Retention Policy module",
   "privacyStatement": "",
@@ -15,37 +15,37 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a8177fd4-0adb-4482-889c-2e123a13b50a",
       "publisher": "Microsoft",
       "name": "Retention Policy",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "33003b8a-f6d8-4efe-af22-1a8cb8fbacbe",
       "name": "Retencion Policy Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Satisfaction Survey/app.json
+++ b/src/System Application/Test/Satisfaction Survey/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests the Satisfaction Survey module",
   "description": "Tests for the Satisfaction Survey module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,67 +15,67 @@
       "id": "5d03ef2d-13f0-4132-b941-48387b581434",
       "name": "Satisfaction Survey",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3a56c7d2-a594-4682-bd90-b10bfb177620",
       "name": "Azure Key Vault",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "901cbabc-1217-4d4a-922f-77b4d4ef3dcf",
       "name": "Azure Key Vault Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7f3d7c69-3ffc-4201-b2b9-9f7cd56f7c50",
       "name": "Client Type Management",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "47397d83-32ba-4ef0-8988-ef72539bfe36",
       "name": "Client Type Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "815d5c15-02bd-4d58-a010-b66033de6625",
       "name": "DotNet Aliases Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "03ecb409-cce1-4f5b-b194-6ad3ad3d7378",
       "name": "Satisfaction Survey Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Secrets/app.json
+++ b/src/System Application/Test/Secrets/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Secrets module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "61626bb6-c02d-41e0-b223-85b3fba8bccc",
       "name": "Secrets",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Security Groups/app.json
+++ b/src/System Application/Test/Security Groups/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Security Groups module",
   "description": "Tests for the Security Groups module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,49 +15,49 @@
       "id": "4846d32b-e7ca-4c4c-94e0-3eee0eccd715",
       "name": "Security Groups",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1f3da4d4-84a9-4b92-8d73-24cda11cdb9d",
       "name": "Security Groups Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "7e3b999e-1182-45d2-8b82-d5127ddba9b2",
       "name": "DotNet Aliases",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "da17b564-d600-44d5-be0b-ca7ff7ac26fc",
       "name": "Azure AD Graph Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "037bf597-815e-4ca0-85a9-70d6cbcb7ee7",
       "name": "MockGraphQuery test library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/SharePoint Authorization/app.json
+++ b/src/System Application/Test/SharePoint Authorization/app.json
@@ -2,7 +2,7 @@
   "id": "d0a56ac8-6d54-4f20-a401-912d922bacc6",
   "name": "SharePoint Authorization Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for the SharePoint Authorization module",
   "description": "Tests for SharePoint Authorization Module",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,31 +15,31 @@
       "id": "1a7bfa64-c856-49ed-86b0-bb05eb5b2de4",
       "name": "SharePoint",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ff0caa38-65a2-49c5-a7e2-6a0475cfc60e",
       "name": "SharePoint Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6936a6a5-43a6-4904-855c-8dc268cd49dd",
       "name": "SharePoint Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/SharePoint/app.json
+++ b/src/System Application/Test/SharePoint/app.json
@@ -2,7 +2,7 @@
   "id": "977e6b76-d7c1-41fa-b38b-21399cd140a7",
   "name": "SharePoint Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for the SharePoint module",
   "description": "Provides a set of AL functionality and Helper libraries to make use of SharePoint REST API",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
@@ -15,37 +15,37 @@
       "id": "1a7bfa64-c856-49ed-86b0-bb05eb5b2de4",
       "name": "SharePoint",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "6936a6a5-43a6-4904-855c-8dc268cd49dd",
       "name": "SharePoint Authorization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ff0caa38-65a2-49c5-a7e2-6a0475cfc60e",
       "name": "SharePoint Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/System Initialization/app.json
+++ b/src/System Application/Test/System Initialization/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the System Initialization module",
   "description": "Tests for the System Initialization module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a2ca2793-e1b4-461d-8251-dbe934daec78",
       "name": "Password",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2955a828-6c0a-4d51-a1b8-a4cf2a040b9a",
       "name": "System Initialization",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "37419721-ec27-4f00-8e1d-22a1cfe59c39",
       "name": "System Initialization Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Telemetry/app.json
+++ b/src/System Application/Test/Telemetry/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Telemetry module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "de35f591-7216-4e60-8be1-1911d71a7fc2",
       "name": "Telemetry",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "b0b13292-6145-4cb3-b017-549dbcd82351",
       "name": "Telemetry Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Tenant License State/app.json
+++ b/src/System Application/Test/Tenant License State/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the tenant license state codeunit",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "21566fb3-3c6b-4cac-a70d-052f5d66ac64",
       "name": "Tenant License State",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "1fcac6f5-6c28-4f04-8a00-682bbc1ecadf",
       "name": "Tenant License State Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Time Zone Selection/app.json
+++ b/src/System Application/Test/Time Zone Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Time Zone Selection module",
   "description": "Tests for the API of the Time Zone Selection module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "fa2b571d-3f92-4685-9113-421ea9c0b5f5",
       "name": "Time Zone Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "43a9ec2b-a929-4c76-b60c-aaed2a6f8c50",
       "name": "Time Zone Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Translation/app.json
+++ b/src/System Application/Test/Translation/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Translation module",
   "description": "Tests for the API of the Translation module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "3ade8173-2cc2-4727-8c57-eb0754f70cdc",
       "name": "Translation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5d986913-9dd6-44b7-875b-3e8c455fac7c",
       "name": "Translation Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/URI/app.json
+++ b/src/System Application/Test/URI/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the URI module",
   "description": "Tests for the URI module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?linkid=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2103698",
@@ -15,19 +15,19 @@
       "id": "1b2efb4b-8c44-4d74-a56f-60646645bb21",
       "name": "URI",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Upgrade Tags/app.json
+++ b/src/System Application/Test/Upgrade Tags/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for Upgrade Tags module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "93b83ef6-9666-4c1d-b130-c232f4047621",
       "publisher": "Microsoft",
       "name": "Upgrade Tags",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "4313b056-0cde-4a07-a700-c984cfbb209c",
       "name": "Upgrade Tags Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/User Details/app.json
+++ b/src/System Application/Test/User Details/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the User Details module",
   "description": "Tests for the User Details module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,31 +15,31 @@
       "id": "0e4ed208-7f60-4bad-a881-eeb03e09d832",
       "name": "User Details",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9beafef7-a2fc-491c-85bd-8cd5c4650f2b",
       "name": "User Details Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "c1d53fcd-ec4f-4ac5-ba49-af91a1dea38c",
       "name": "Azure AD Plan",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e63749f1-a7a5-4557-a943-0ae4745616bd",
       "name": "Azure AD Plan Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/User Login Times/app.json
+++ b/src/System Application/Test/User Login Times/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the User Login Times module",
   "description": "Tests for the User Login Times module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "959630b2-01c5-48d8-a477-d6d40da855fb",
       "name": "User Login Times",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9761c0ac-e4ea-4c14-8918-2f4ded158b12",
       "name": "User Login Times Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/User Permissions/app.json
+++ b/src/System Application/Test/User Permissions/app.json
@@ -2,7 +2,7 @@
   "id": "d155439e-4a0a-4baf-9164-d372a1ee383f",
   "name": "User Permissions Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for User Permissions module",
   "description": "Tests for User Permissions module",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,37 +15,37 @@
       "id": "c56e3ef4-7ab0-4636-ae87-013a62f12213",
       "name": "User Permissions",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c2cb86b-321c-421b-8a76-f9ff768492d6",
       "name": "User Permission Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/User Selection/app.json
+++ b/src/System Application/Test/User Selection/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the User Selection module",
   "description": "Tests for the User Selection module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "7f850a76-a58c-4ade-a14f-7d7acff97115",
       "name": "User Selection",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "a42aa95e-45f6-4e85-bae1-26b3b89502f1",
       "name": "User Selection Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "2673d810-273e-402f-9093-2eaef7e03b83",
       "name": "Environment Information",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/User Settings/app.json
+++ b/src/System Application/Test/User Settings/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the User Settings module",
   "description": "Tests for the User Settings module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,49 +15,49 @@
       "id": "7b9b59f5-a68d-4271-b11a-0d3b9c0938dd",
       "name": "User Settings",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5c36f279-480c-451b-b513-c1af8cfb0744",
       "name": "Language",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "198640cf-2290-4f02-a9a6-05fd62cfa0e1",
       "name": "User Settings Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc58a557-79ae-473d-9fef-3045a2289c00",
       "name": "Azure AD User Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "cc441290-a967-4601-9a7d-b4209339415b",
       "name": "Environment Information Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Video/app.json
+++ b/src/System Application/Test/Video/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the Video module",
   "description": "Tests for the Video module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "84e448ad-faa5-44c8-835a-ec4b408e8cec",
       "name": "Video",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "31536cf9-f47d-42d9-95eb-b0787abf853b",
       "name": "Video Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Vs Code Integration/app.json
+++ b/src/System Application/Test/Vs Code Integration/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests for the VS Code Integration module",
   "description": "Tests for the VS Code Integration module.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,25 +15,25 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "66d56517-9469-4cdf-83a8-7122c54af08f",
       "name": "VS Code Integration",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Web Service Management/app.json
+++ b/src/System Application/Test/Web Service Management/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Tests the Web Service Management module.",
   "description": "",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,37 +15,37 @@
       "id": "9bc20107-0927-405d-abec-ed877f67c2a3",
       "publisher": "Microsoft",
       "name": "Web Service Management",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dbfc4c4f-40d1-4206-b7b4-d428054637e8",
       "name": "Web Service Management Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "ae59aed1-040c-453c-9585-fe9da2f8211e",
       "name": "Feature Key",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/Word Templates/app.json
+++ b/src/System Application/Test/Word Templates/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Test Module for Word Templates",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "",
@@ -15,43 +15,43 @@
       "id": "c0804406-ca14-4a8b-88a0-dd6999c550a8",
       "name": "Word Templates",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e31ad830-3d46-472e-afeb-1d3d35247943",
       "name": "BLOB Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "0846d207-5dec-4c1b-afd8-6a25e1e14b9d",
       "name": "Base64 Convert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "bfdf2a31-bb39-4f1a-bbb5-291e04dc8051",
       "name": "Word Templates Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/XML Validation/app.json
+++ b/src/System Application/Test/XML Validation/app.json
@@ -2,7 +2,7 @@
   "id": "e67710a1-095d-4111-879b-f2012580752b",
   "name": "XML Validation Test",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Tests for the XML Validation module",
   "description": "Tests for the XML Validation module",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -15,13 +15,13 @@
       "id": "4f3ad876-6f18-4b10-bb2c-08bb136f6919",
       "name": "XML Validation",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/Test/XmlWriter/app.json
+++ b/src/System Application/Test/XmlWriter/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "",
   "description": "Tests for the Xml Writer module",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "",
   "EULA": "",
   "help": "",
@@ -15,13 +15,13 @@
       "id": "e88f7ce1-ef3d-42c0-ba61-63699c60d12f",
       "name": "Xml Writer",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "platform": "27.0.0.0",

--- a/src/System Application/Test/app.json
+++ b/src/System Application/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test suite for the System Application.",
   "description": "Contains an expansive set tests for the System Application.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -16,37 +16,37 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",
       "name": "System Application Test Library",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "name": "Any",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "40860557-a18d-42ad-aecb-22b7dd80dc80",
       "name": "Permissions Mock",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/Tools/AI Test Toolkit/app.json
+++ b/src/Tools/AI Test Toolkit/app.json
@@ -2,7 +2,7 @@
   "id": "2156302a-872f-4568-be0b-60968696f0d5",
   "name": "AI Test Toolkit",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "propagateDependencies": true,
   "brief": "Provides tools for AI feature regression testing.",
   "description": "The AI Test Toolkit lets developers write and run automated tests for AI features. The toolkit supports running data driven tests and the ability to get the output generated from the tests.",
@@ -17,13 +17,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "23de40a6-dfe8-4f80-80db-d70f83ce8caf",
       "name": "Test Runner",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/Tools/Performance Toolkit/App/app.json
+++ b/src/Tools/Performance Toolkit/App/app.json
@@ -2,7 +2,7 @@
   "id": "75f1590f-55c5-4501-ae63-bada5534e852",
   "name": "Performance Toolkit",
   "publisher": "Microsoft",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "brief": "Provides tools for performance regression testing.",
   "description": "The Performance Toolkit lets developers use test suites during development to analyze the performance of their code by simulating the work environments in which the code will run.",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
@@ -16,13 +16,13 @@
       "id": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
       "name": "System Application",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "23de40a6-dfe8-4f80-80db-d70f83ce8caf",
       "name": "Test Runner",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/Tools/Performance Toolkit/Test/app.json
+++ b/src/Tools/Performance Toolkit/Test/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Test suite for the Business Central Performance Toolkit.",
   "description": "Contains an expansive set tests for the Business Central Performance Toolkit.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2142241",
@@ -16,13 +16,13 @@
       "id": "75f1590f-55c5-4501-ae63-bada5534e852",
       "name": "Performance Toolkit",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     },
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "name": "Library Assert",
       "publisher": "Microsoft",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/Tools/Test Framework/Test Libraries/Any/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Any/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library used to generate pseudo-random values.",
   "description": "In test code, Any should be used to generate values that should not be hardcoded to a specific values.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",

--- a/src/Tools/Test Framework/Test Libraries/Assert/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Assert/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library used in tests to verify if the values are as expected. ",
   "description": "In test code Library Assert should be used to compare the values and throw errors. TESTFIELD and ERROR must not be used in test code.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",

--- a/src/Tools/Test Framework/Test Libraries/Permissions Mock/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Permissions Mock/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library used to mock permission sets assignments on current user.",
   "description": "In test code, Permissions Mock can be used to mock the permisison sets assignment of the user.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",

--- a/src/Tools/Test Framework/Test Libraries/Variable Storage/app.json
+++ b/src/Tools/Test Framework/Test Libraries/Variable Storage/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Library used to store variables in a queue to pass values to handler functions",
   "description": "In test code, Library - Variable Storage can be used to pass values to handler and other methods",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",
@@ -16,7 +16,7 @@
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",
       "publisher": "Microsoft",
       "name": "Library Assert",
-      "version": "27.10.0.0"
+      "version": "27.11.0.0"
     }
   ],
   "screenshots": [],

--- a/src/Tools/Test Framework/Test Runner/app.json
+++ b/src/Tools/Test Framework/Test Runner/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "Executes one or more tests and gathers the results.",
   "description": "Provides options for running manual tests in the UI\u00a0or automated tests in the console. Manual tests are run from the Test Tool page, and automated tests are run from the Command Line Test Tool page. For each group of tests, you can define the test isolation by using the Test Runner Codeunit. The Test Runner - Isol. Codeunit codeunit reverts changes to the database after tests are complete. The Test Runner Isol. Disabled codeunit prevents changes from being reverted. This is useful when testing requires multiple sessions, such as when invoking web services, job queues, background\u00a0threads, and so on.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",

--- a/src/Tools/Test Framework/Test Stability Tools/Prevent Metadata Updates/app.json
+++ b/src/Tools/Test Framework/Test Stability Tools/Prevent Metadata Updates/app.json
@@ -4,7 +4,7 @@
   "publisher": "Microsoft",
   "brief": "This extension is used to prevent tests from changing specific System tables or doing any changes to metadata that may affect the test run stabilty.",
   "description": "Update to specific system tables would invalidate object metadata which may lead to the test failures with messages like - Page has expired or Administrator has updated one or more extensions, restart your activity. If a test needs do change the data in this way it needs to be isolated from other tests.",
-  "version": "27.10.0.0",
+  "version": "27.11.0.0",
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2009120",
   "help": "https://go.microsoft.com/fwlink/?linkid=2131960",


### PR DESCRIPTION
## What & why

Bump app version from 27.10.0.0 to 27.11.0.0 for the 27.x release branch.

- .github/AL-Go-Settings.json: repoVersion updated from 27.10 to 27.11
- All app.json files: version and application updated from 27.10.0.0 to 27.11.0.0

## Linked work

[AB#644817](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644817)



