### PR TITLE
[Main]-Import of e-documents with format ZUGfERD & XRECHNUNG fail with error message You cannot insert a purchase line without a purchase header in German localisation

### DIFF
--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/ImportXRechnungDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/ImportXRechnungDocument.Codeunit.al
@@ -225,7 +225,7 @@ codeunit 13915 "Import XRechnung Document"
             RecRef.GetTable(PurchaseLine);
             EDocumentImportHelper.FindGLAccountForLine(EDocument, RecRef);
             PurchaseLine."No." := RecRef.Field(PurchaseLine.FieldNo("No.")).Value;
-            PurchaseLine.Insert();
+            PurchaseLine.Insert(true);
             LineNo += 10000;
         end;
     end;
@@ -276,7 +276,7 @@ codeunit 13915 "Import XRechnung Document"
     begin
         PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::Invoice;
         PurchaseHeader."No." := CopyStr(GetNodeByPath(TempXMLBuffer, '/' + DocumentType + '/cbc:ID'), 1, MaxStrLen(PurchaseHeader."No."));
-        PurchaseHeader.Insert();
+        PurchaseHeader.Insert(true);
 
         LastLineNo := GetLastLineNo(PurchaseHeader);
 
@@ -292,8 +292,8 @@ codeunit 13915 "Import XRechnung Document"
         AddAttachment(DocumentAttachment, DocumentAttachmentData, EDocument);
 
         // Insert last line
-        PurchaseLine.Insert();
-        PurchaseHeader.Modify();
+        PurchaseLine.Insert(true);
+        PurchaseHeader.Modify(true);
 
         CreateAllowanceChargeLines(EDocument, PurchaseHeader, PurchaseLine, TempXMLBuffer, DocumentType);
     end;
@@ -351,7 +351,7 @@ codeunit 13915 "Import XRechnung Document"
             '/' + DocumentType + '/cac:InvoiceLine':
                 begin
                     if PurchaseLine."Document No." <> '' then
-                        PurchaseLine.Insert();
+                        PurchaseLine.Insert(true);
 
                     PurchaseLine.Init();
                     PurchaseLine."Document Type" := PurchaseHeader."Document Type";
@@ -439,7 +439,7 @@ codeunit 13915 "Import XRechnung Document"
     begin
         PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::"Credit Memo";
         PurchaseHeader."No." := CopyStr(GetNodeByPath(TempXMLBuffer, '/' + DocumentType + '/cbc:ID'), 1, MaxStrLen(PurchaseHeader."No."));
-        PurchaseHeader.Insert();
+        PurchaseHeader.Insert(true);
 
         LastLineNo := GetLastLineNo(PurchaseHeader);
 
@@ -455,8 +455,8 @@ codeunit 13915 "Import XRechnung Document"
         AddAttachment(DocumentAttachment, DocumentAttachmentData, EDocument);
 
         // Insert last line
-        PurchaseLine.Insert();
-        PurchaseHeader.Modify();
+        PurchaseLine.Insert(true);
+        PurchaseHeader.Modify(true);
 
         CreateAllowanceChargeLines(EDocument, PurchaseHeader, PurchaseLine, TempXMLBuffer, DocumentType);
     end;
@@ -488,7 +488,7 @@ codeunit 13915 "Import XRechnung Document"
             '/' + DocumentType + '/cac:CreditNoteLine':
                 begin
                     if PurchaseLine."Document No." <> '' then
-                        PurchaseLine.Insert();
+                        PurchaseLine.Insert(true);
 
                     PurchaseLine.Init();
                     PurchaseLine."Document Type" := PurchaseHeader."Document Type";

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ImportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ImportZUGFeRDDocument.Codeunit.al
@@ -239,7 +239,7 @@ codeunit 13919 "Import ZUGFeRD Document"
             RecRef.GetTable(PurchaseLine);
             EDocumentImportHelper.FindGLAccountForLine(EDocument, RecRef);
             PurchaseLine."No." := RecRef.Field(PurchaseLine.FieldNo("No.")).Value;
-            PurchaseLine.Insert();
+            PurchaseLine.Insert(true);
             LineNo += 10000;
         end;
     end;
@@ -333,7 +333,7 @@ codeunit 13919 "Import ZUGFeRD Document"
     begin
         PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::Invoice;
         PurchaseHeader."No." := CopyStr(GetNodeByPath(TempXMLBuffer, '/' + DocumentElement + '/rsm:ExchangedDocument/ram:ID'), 1, MaxStrLen(PurchaseHeader."No."));
-        PurchaseHeader.Insert();
+        PurchaseHeader.Insert(true);
 
         LastLineNo := GetLastLineNo(PurchaseHeader);
 
@@ -347,8 +347,8 @@ codeunit 13919 "Import ZUGFeRD Document"
 
         // Insert last line
         if PurchaseLine."Document No." <> '' then
-            PurchaseLine.Insert();
-        PurchaseHeader.Modify();
+            PurchaseLine.Insert(true);
+        PurchaseHeader.Modify(true);
 
         CreateAllowanceChargeLines(EDocument, PurchaseHeader, PurchaseLine, TempXMLBuffer, DocumentElement);
     end;
@@ -388,7 +388,7 @@ codeunit 13919 "Import ZUGFeRD Document"
             '/' + DocumentType + '/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem':
                 begin
                     if PurchaseLine."Document No." <> '' then
-                        PurchaseLine.Insert();
+                        PurchaseLine.Insert(true);
 
                     PurchaseLine.Init();
                     PurchaseLine."Document Type" := PurchaseHeader."Document Type";
@@ -484,7 +484,7 @@ codeunit 13919 "Import ZUGFeRD Document"
     begin
         PurchaseHeader."Document Type" := PurchaseHeader."Document Type"::"Credit Memo";
         PurchaseHeader."No." := CopyStr(GetNodeByPath(TempXMLBuffer, '/' + DocumentElement + '/rsm:ExchangedDocument/ram:ID'), 1, MaxStrLen(PurchaseHeader."No."));
-        PurchaseHeader.Insert();
+        PurchaseHeader.Insert(true);
 
         LastLineNo := GetLastLineNo(PurchaseHeader);
 
@@ -498,8 +498,8 @@ codeunit 13919 "Import ZUGFeRD Document"
 
         // Insert last line
         if PurchaseLine."Document No." <> '' then
-            PurchaseLine.Insert();
-        PurchaseHeader.Modify();
+            PurchaseLine.Insert(true);
+        PurchaseHeader.Modify(true);
 
         CreateAllowanceChargeLines(EDocument, PurchaseHeader, PurchaseLine, TempXMLBuffer, DocumentElement);
     end;
@@ -539,7 +539,7 @@ codeunit 13919 "Import ZUGFeRD Document"
             '/' + DocumentType + '/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem':
                 begin
                     if PurchaseLine."Document No." <> '' then
-                        PurchaseLine.Insert();
+                        PurchaseLine.Insert(true);
 
                     PurchaseLine.Init();
                     PurchaseLine."Document Type" := PurchaseHeader."Document Type";


### PR DESCRIPTION
Workitem [Bug 636659](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/636659): [master] [All-e]Import of e-documents with format ZUGfERD & XRECHNUNG fail with error message "You cannot insert a purchase line without a purchase header" in German localisation

Fixes [AB#636659](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636659)
This pull requested is created to revert back the previous fix as Purchase and Sales Line is modified with PR https://github.com/microsoft/BCApps/issues/9566 




