### PR TITLE
Fix Agent List and Agent Task List filter and refresh issues (AB#646062)

### DIFF
--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
@@ -329,11 +329,12 @@ page 4300 "Agent Task List"
 
     local procedure SetAgentSubstateFilter()
     begin
+        Rec.FilterGroup(2);
         if ShouldShowAllAgents then
             Rec.SetRange("Agent Substate")
         else
-            // "Agent Substate" is a FlowField of the agent, filtered in-memory to hide archived tasks by default.
             Rec.SetRange("Agent Substate", Rec."Agent Substate"::None);
+        Rec.FilterGroup(0);
         CurrPage.Update(false);
     end;
 

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
@@ -288,7 +288,7 @@ page 4300 "Agent Task List"
     trigger OnOpenPage()
     begin
         Rec.SetRange(Archived, false);
-        ShouldShowAllAgents := false;
+        ShouldShowAllAgents := Rec.GetFilter("Agent User Security ID") <> '';
         SetAgentSubstateFilter();
     end;
 

--- a/src/System Application/App/Agent/Setup/AgentList.Page.al
+++ b/src/System Application/App/Agent/Setup/AgentList.Page.al
@@ -99,7 +99,7 @@ page 4316 "Agent List"
                     if Rec.IsEmpty() then
                         Error(NoAgentSetupErr);
 
-                    if Rec.State <> Rec.State::Disabled then
+                    if Agent.IsActive(Rec."User Security ID") then
                         Error(DeactivateBeforeArchivingErr);
 
                     Rec.TestField("Display Name");
@@ -274,20 +274,23 @@ page 4316 "Agent List"
 
     local procedure SetCompanyFilter()
     begin
+        Rec.FilterGroup(2);
         if ShouldShowAllCompanies then
             Rec.SetRange("Can Access Current Company")
         else
             Rec.SetRange("Can Access Current Company", true);
+        Rec.FilterGroup(0);
         CurrPage.Update(false);
     end;
 
     local procedure SetAgentSubstateFilter()
     begin
-        // Hide archived agents from the default list; the Show all agents action reveals them.
+        Rec.FilterGroup(2);
         if ShouldShowAllAgents then
             Rec.SetRange(Substate)
         else
             Rec.SetRange(Substate, Rec.Substate::None);
+        Rec.FilterGroup(0);
         CurrPage.Update(false);
     end;
 


### PR DESCRIPTION
Fixes the UX defects reported in [AB#646062](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646062) on the agent list and agent task list pages.

Three of the four come from the same root cause: the page set a filter in **filter group 0**, the *user* filter group. The client owns that group, surfaces it in the filter pane, and re-applies its own copy on every query — so clearing or widening the filter server-side never changed the result set. The actions looked like they worked (caption flipped, column appeared) but no rows were ever added. Pressing F5 fixed it.

The fix in each case is to move the filter to **filter group 2** (`PredefinedFilterGroupNo.Form`), which is server-owned and not round-tripped by the client.

## Page 4316 "Agent List"

**1. "Show all agents" and "Show agents for all companies" had no effect.** Both toggles now set their filter in group 2.

**2. "Deactivate the agent before archiving it" kept appearing after the agent had been deactivated.** The Archive action tested `Rec.State`. `Agent` is a virtual table, so that is the value cached in the page dataset when the row was materialised; after deactivating on the Agent Card and returning to the list, the cached `State` was still `Enabled`. The guard now calls `Agent.IsActive`, which re-reads the agent record, so it is correct regardless of what the page dataset holds.

## Page 4300 "Agent Task List"

**3. An archived agent's tasks did not show when the list was opened for that agent.** The page hides tasks whose owning agent is archived by filtering the `Agent Substate` flowfield to `None`. That default is right for the unfiltered list, but it also applied when the page was opened for one specific agent from the Agent Card or Agent List, which filtered out every one of that agent's tasks and produced an empty list with no indication why. `OnOpenPage` now treats a caller-supplied `"Agent User Security ID"` filter as an explicit request for that agent's tasks and skips the substate filter in that case.

**4. "Show tasks from all agents" / "Hide tasks from archived agents" had no effect** — same group 0 problem as issue 1, same fix.

## Reviewer notes

**The substate and company filters are now invisible and non-removable in the filter pane.** The actions become the only way to toggle them. That is intended for these system-managed filters, but it is a deliberate behaviour change worth a look.

**The `views` block on page 4300 is unaffected.** Its filters are applied in group 0 and stay visible and editable in the filter pane, so they do not collide with the group 2 filter. Verified by selecting the Archived view after the change: the filter appears in the pane as expected and the list filters correctly.

**`RefreshOnActivate` was considered and rejected for issue 2.** It does fix the symptom, and it is what `AgentCard.Page.al:17` uses, but it is timing-dependent — it only works because focus happens to leave and return. It also introduced a hang: it fires when the archive confirmation modal closes, at which point the just-archived row no longer passes the `Substate = None` filter, so the client refreshed from a now-invalid bookmark, hung, and then reported *"The record that you tried to open is not available."* Re-reading in the guard fixes issue 2 deterministically, avoids that failure mode, and costs nothing on every other modal close.

## Testing

Verified manually on a local environment (platform 29.0.53287) with an archived Payables agent that owns one non-archived task:

- Deactivate an agent on the Agent Card, return to the list, Archive succeeds with no reload; the State column shows Inactive.
- Archiving completes without hanging and the row leaves the list.
- "Show all agents" reveals archived agents; "Show agents for all companies" reveals cross-company agents.
- Agent Task List opened from Tell Me hides the archived agent's task; "Show tasks from all agents" reveals it.
- Agent Task List opened from the Agent Card shows the archived agent's task immediately.
- The Archived view still applies its filter correctly.

No automated test is included. `TestPage` does not perform the client/server filter round-trip that issues 1 and 4 depend on, so the existing `ArchivedAgentRevealedByShowAllAgentsToggle` test passes both with and without the fix. Suggestions for a workable regression test are welcome.

[AB#646062](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646062)



