### PR TITLE
[Shopify] Don't block Shops page when user lacks extension permissions

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyShopMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyShopMgt.Codeunit.al
@@ -121,13 +121,16 @@ codeunit 30211 "Shpfy Shop Mgt."
     var
         MyNotifications: Record "My Notifications";
         EnvironmentInformation: Codeunit "Environment Information";
-        ExtensionManagement: Codeunit "Extension Management";
         BelgianLocalizationNotification: Notification;
+        IsInstalled: Boolean;
     begin
         if EnvironmentInformation.GetApplicationFamily() <> BelgianCountryCodeTok then
             exit;
 
-        if ExtensionManagement.IsInstalledByAppId(GetBelgianLocalizationAppId()) then
+        if not TryIsBelgianLocalizationInstalled(IsInstalled) then
+            exit;
+
+        if IsInstalled then
             exit;
 
         if not MyNotifications.IsEnabled(GetBelgianLocalizationNotificationId()) then
@@ -139,6 +142,14 @@ codeunit 30211 "Shpfy Shop Mgt."
         BelgianLocalizationNotification.AddAction(InstallActionLbl, Codeunit::"Shpfy Shop Mgt.", 'InstallBelgianLocalization');
         BelgianLocalizationNotification.AddAction(DontShowThisAgainLbl, Codeunit::"Shpfy Shop Mgt.", 'DisableBelgianLocalizationNotification');
         BelgianLocalizationNotification.Send();
+    end;
+
+    [TryFunction]
+    local procedure TryIsBelgianLocalizationInstalled(var IsInstalled: Boolean)
+    var
+        ExtensionManagement: Codeunit "Extension Management";
+    begin
+        IsInstalled := ExtensionManagement.IsInstalledByAppId(GetBelgianLocalizationAppId());
     end;
 
     procedure InstallBelgianLocalization(Notification: Notification)


### PR DESCRIPTION
## What & why

On Belgian (BE) environments, the **Shopify Shops** list (Page 30102) failed to open entirely for any user without extension-install permissions.

`OnOpenPage` unconditionally calls `Shpfy Shop Mgt.SendBelgianLocalizationNotification`, which calls `ExtensionManagement.IsInstalledByAppId`. That check (via `Extension Installation Impl`, CU 2500) requires **both Read and Write permission** on the `NAV App Installed App` table and raises `PermissionErr` ("You do not have the required permissions to install the selected app…") otherwise — aborting the whole page.

This wraps the install-status check in a `[TryFunction]` so a permission (or any) error simply **skips the notification** instead of blocking the page. A user who can't check installation status also can't install the app, so the prompt would not be actionable for them anyway.

Regression from the notification added in [AB#640073](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640073).

## Linked work

Fixes [AB#646122](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646122)

**What I tested and the outcome**

- Built `Shopify Connector` locally via the AL toolchain — package generated successfully; `al_getdiagnostics` on `ShpfyShopMgt.Codeunit.al` returns 0 errors / 0 warnings.
- No tests added: the change is a defensive guard around a platform permission error that only reproduces on a BE localization with a permission-restricted user; the notification feature ([AB#640073](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640073)) shipped without unit coverage and there is no existing harness for this `OnOpenPage` path.
- **Recommended before merge:** manual runtime check — open the Shopify Shops page on a BE environment as a user lacking `NAV App Installed App` permissions and confirm the page opens with no error and no notification.

## Risk & compatibility

Low. The behavior change is limited to the BE localization notification path: when the installation check can't be performed, the notification is silently skipped (previously it errored and closed the page). No schema, API, or permission changes.





