### PR TITLE
[Master]-]G/L Account Sheet with Foreign Currency report (11564) includes LCY-originated entries after enabling G/L currency revaluation feature resulting in mixed-currency totals in the Swiss version. - Copy

### DIFF
--- a/src/Layers/CH/BaseApp/Local/Finance/FinancialReports/SRGLAccSheetForeignCurr.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Finance/FinancialReports/SRGLAccSheetForeignCurr.Report.al
@@ -184,9 +184,15 @@ report 11564 "SR G/L Acc Sheet Foreign Curr"
                     else
                         BalAccType := '';
 
-                    FcyAcyAmt := "Source Currency Amount";
-                    FcyAcyBalance := FcyAcyBalance + "Source Currency Amount";
-                    Exrate := CalcExrate("Source Currency Amount", Amount, "G/L Account"."Source Currency Code");
+                    if ("Source Currency Code" <> '') and ("Source Currency Code" = "G/L Account"."Source Currency Code") then begin
+                        FcyAcyAmt := "Source Currency Amount";
+                        FcyAcyBalance := FcyAcyBalance + "Source Currency Amount";
+                        Exrate := CalcExrate("Source Currency Amount", Amount, "G/L Account"."Source Currency Code");
+                    end else begin
+                        FcyAcyAmt := 0;
+                        Exrate := 0;
+                    end;
+
                     OnAfterOnAfterGetRecord("G/L Account", "G/L Entry", FcyAcyAmt, FcyAcyBalance, Exrate);
                 end;
 

--- a/src/Layers/CH/BaseApp/Local/Finance/FinancialReports/SRGLAccSheetForeignCurr.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Finance/FinancialReports/SRGLAccSheetForeignCurr.Report.al
@@ -184,7 +184,7 @@ report 11564 "SR G/L Acc Sheet Foreign Curr"
                     else
                         BalAccType := '';
 
-                    if ("Source Currency Code" <> '') and ("Source Currency Code" = "G/L Account"."Source Currency Code") then begin
+                    if IsGLAccountSourceCurrency("Source Currency Code") then begin
                         FcyAcyAmt := "Source Currency Amount";
                         FcyAcyBalance := FcyAcyBalance + "Source Currency Amount";
                         Exrate := CalcExrate("Source Currency Amount", Amount, "G/L Account"."Source Currency Code");
@@ -614,6 +614,21 @@ report 11564 "SR G/L Acc Sheet Foreign Curr"
 
         GenJourLine2.SetRange("Bal. Account No.");
         GenJourLine2.SetRange("Bal. Account Type");
+    end;
+
+    local procedure IsGLAccountSourceCurrency(CurrencyCode: Code[10]): Boolean
+    var
+        GLAccountSourceCurrency: Record "G/L Account Source Currency";
+    begin
+        if CurrencyCode = '' then
+            exit(false);
+
+        if CurrencyCode = "G/L Account"."Source Currency Code" then
+            exit(true);
+
+        GLAccountSourceCurrency.SetRange("G/L Account No.", "G/L Account"."No.");
+        GLAccountSourceCurrency.SetRange("Currency Code", CurrencyCode);
+        exit(not GLAccountSourceCurrency.IsEmpty());
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/CH/Tests/Local/TestGLAccSheetReports.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/TestGLAccSheetReports.Codeunit.al
@@ -1157,6 +1157,81 @@ codeunit 144035 "Test G/L Acc Sheet Reports"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+     [Test]
+    [HandlerFunctions('GLAccSheetFCYReqPageHandler,GenJournalBatchesPageHandler')]
+    [Scope('OnPrem')]
+    procedure GLSheetForeignCurrExcludesMismatchedCurrencyEntries()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GLAccount: Record "G/L Account";
+        BalGLAccount: Record "G/L Account";
+        GenJournalLine: Record "Gen. Journal Line";
+        GLAccountSourceCurrency: Record "G/L Account Source Currency";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        OtherCurrencyCode: Code[10];
+    begin
+        // [FEATURE] [SR G/L Acc Sheet Foreign Curr]
+        // [SCENARIO 642513] Report 11564 must not mix amounts posted in a currency other than the
+        // G/L Account's Source Currency Code (including LCY-originated entries) into the foreign currency totals.
+        Initialize();
+
+        // [GIVEN] G/L Account set up for "Multiple Currencies" source currency posting with two registered currencies.
+        LibraryERM.CreateGenJournalTemplate(GenJournalTemplate);
+        GenJournalTemplate.Validate(Type, GenJournalTemplate.Type::General);
+        GenJournalTemplate.Modify(true);
+
+        CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), LibraryRandom.RandDec(100, 2), LibraryRandom.RandDec(100, 2));
+        OtherCurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), LibraryRandom.RandDec(100, 2), LibraryRandom.RandDec(100, 2));
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Account Type", GLAccount."Account Type"::Posting);
+        GLAccount.Validate("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.Validate("Source Currency Posting", GLAccount."Source Currency Posting"::"Multiple Currencies");
+        GLAccount.Modify(true);
+        GLAccount.SetRange("No.", GLAccount."No.");
+        GLAccount.SetRange("Date Filter", WorkDate(), WorkDate());
+
+        GLAccountSourceCurrency.Init();
+        GLAccountSourceCurrency."G/L Account No." := GLAccount."No.";
+        GLAccountSourceCurrency."Currency Code" := CurrencyCode;
+        GLAccountSourceCurrency.Insert();
+
+        GLAccountSourceCurrency.Init();
+        GLAccountSourceCurrency."G/L Account No." := GLAccount."No.";
+        GLAccountSourceCurrency."Currency Code" := OtherCurrencyCode;
+        GLAccountSourceCurrency.Insert();
+
+        LibraryERM.CreateGLAccount(BalGLAccount);
+
+        // [GIVEN] An entry posted in "CurrencyCode" ...
+        CreateGenJournalLine(GenJournalLine, GLAccount,
+          GenJournalLine."Bal. Account Type"::"G/L Account", BalGLAccount."No.", LibraryRandom.RandIntInRange(1000, 2000), CurrencyCode);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] ... and another entry posted in "OtherCurrencyCode" to the same G/L Account.
+        CreateGenJournalLine(GenJournalLine, GLAccount,
+          GenJournalLine."Bal. Account Type"::"G/L Account", BalGLAccount."No.", LibraryRandom.RandIntInRange(1000, 2000), OtherCurrencyCode);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] Run report 11564 "SR G/L Acc Sheet Foreign Curr"
+        RunSRGLAccSheetForeignCurrReport(GLAccount);
+
+        // [THEN] Neither entry is attributed to the G/L Account's (blank) Source Currency Code, so the
+        // foreign currency amount/balance columns must not mix amounts from the two different currencies.
+        LibraryReportDataset.LoadDataSetFile();
+        GLEntry.SetRange("G/L Account No.", GLAccount."No.");
+        GLEntry.FindSet();
+        repeat
+            LibraryReportDataset.Reset();
+            LibraryReportDataset.SetRange('No_GLAccount', GLAccount."No.");
+            LibraryReportDataset.SetRange('DocumentNo_GLEntry', GLEntry."Document No.");
+            LibraryReportDataset.GetNextRow();
+            LibraryReportDataset.AssertCurrentRowValueEquals('FcyAcyAmt', 0);
+            LibraryReportDataset.AssertCurrentRowValueEquals('GLEntryFcyAcyBalance', 0);
+        until GLEntry.Next() = 0;
+    end;
+
     local procedure Initialize()
     var
         GenJnlTemplate: Record "Gen. Journal Template";

--- a/src/Layers/CH/Tests/Local/TestGLAccSheetReports.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/TestGLAccSheetReports.Codeunit.al
@@ -1157,7 +1157,7 @@ codeunit 144035 "Test G/L Acc Sheet Reports"
         LibraryVariableStorage.AssertEmpty();
     end;
 
-     [Test]
+    [Test]
     [HandlerFunctions('GLAccSheetFCYReqPageHandler,GenJournalBatchesPageHandler')]
     [Scope('OnPrem')]
     procedure GLSheetForeignCurrExcludesMismatchedCurrencyEntries()
@@ -1169,20 +1169,18 @@ codeunit 144035 "Test G/L Acc Sheet Reports"
         GLAccountSourceCurrency: Record "G/L Account Source Currency";
         GLEntry: Record "G/L Entry";
         CurrencyCode: Code[10];
-        OtherCurrencyCode: Code[10];
     begin
         // [FEATURE] [SR G/L Acc Sheet Foreign Curr]
         // [SCENARIO 642513] Report 11564 must not mix amounts posted in a currency other than the
         // G/L Account's Source Currency Code (including LCY-originated entries) into the foreign currency totals.
         Initialize();
 
-        // [GIVEN] G/L Account set up for "Multiple Currencies" source currency posting with two registered currencies.
+        // [GIVEN] G/L Account set up for "Multiple Currencies" source currency posting with "CurrencyCode" registered as a source currency.
         LibraryERM.CreateGenJournalTemplate(GenJournalTemplate);
         GenJournalTemplate.Validate(Type, GenJournalTemplate.Type::General);
         GenJournalTemplate.Modify(true);
 
         CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), LibraryRandom.RandDec(100, 2), LibraryRandom.RandDec(100, 2));
-        OtherCurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), LibraryRandom.RandDec(100, 2), LibraryRandom.RandDec(100, 2));
 
         LibraryERM.CreateGLAccount(GLAccount);
         GLAccount.Validate("Account Type", GLAccount."Account Type"::Posting);
@@ -1197,28 +1195,23 @@ codeunit 144035 "Test G/L Acc Sheet Reports"
         GLAccountSourceCurrency."Currency Code" := CurrencyCode;
         GLAccountSourceCurrency.Insert();
 
-        GLAccountSourceCurrency.Init();
-        GLAccountSourceCurrency."G/L Account No." := GLAccount."No.";
-        GLAccountSourceCurrency."Currency Code" := OtherCurrencyCode;
-        GLAccountSourceCurrency.Insert();
-
         LibraryERM.CreateGLAccount(BalGLAccount);
 
-        // [GIVEN] An entry posted in "CurrencyCode" ...
+        // [GIVEN] An entry posted in "CurrencyCode" (a registered source currency for the G/L Account).
         CreateGenJournalLine(GenJournalLine, GLAccount,
           GenJournalLine."Bal. Account Type"::"G/L Account", BalGLAccount."No.", LibraryRandom.RandIntInRange(1000, 2000), CurrencyCode);
         LibraryERM.PostGeneralJnlLine(GenJournalLine);
 
-        // [GIVEN] ... and another entry posted in "OtherCurrencyCode" to the same G/L Account.
+        // [GIVEN] An LCY-originated entry (blank currency code) posted to the same G/L Account.
         CreateGenJournalLine(GenJournalLine, GLAccount,
-          GenJournalLine."Bal. Account Type"::"G/L Account", BalGLAccount."No.", LibraryRandom.RandIntInRange(1000, 2000), OtherCurrencyCode);
+          GenJournalLine."Bal. Account Type"::"G/L Account", BalGLAccount."No.", LibraryRandom.RandIntInRange(1000, 2000), '');
         LibraryERM.PostGeneralJnlLine(GenJournalLine);
 
         // [WHEN] Run report 11564 "SR G/L Acc Sheet Foreign Curr"
         RunSRGLAccSheetForeignCurrReport(GLAccount);
 
-        // [THEN] Neither entry is attributed to the G/L Account's (blank) Source Currency Code, so the
-        // foreign currency amount/balance columns must not mix amounts from the two different currencies.
+        // [THEN] Only the entry posted in the registered source currency contributes to the foreign currency
+        // amount column; the LCY-originated entry is excluded (FcyAcyAmt = 0).
         LibraryReportDataset.LoadDataSetFile();
         GLEntry.SetRange("G/L Account No.", GLAccount."No.");
         GLEntry.FindSet();
@@ -1227,8 +1220,10 @@ codeunit 144035 "Test G/L Acc Sheet Reports"
             LibraryReportDataset.SetRange('No_GLAccount', GLAccount."No.");
             LibraryReportDataset.SetRange('DocumentNo_GLEntry', GLEntry."Document No.");
             LibraryReportDataset.GetNextRow();
-            LibraryReportDataset.AssertCurrentRowValueEquals('FcyAcyAmt', 0);
-            LibraryReportDataset.AssertCurrentRowValueEquals('GLEntryFcyAcyBalance', 0);
+            if GLEntry."Source Currency Code" = CurrencyCode then
+                LibraryReportDataset.AssertCurrentRowValueEquals('FcyAcyAmt', GLEntry."Source Currency Amount")
+            else
+                LibraryReportDataset.AssertCurrentRowValueEquals('FcyAcyAmt', 0);
         until GLEntry.Next() = 0;
     end;
 


### PR DESCRIPTION
Fixes [AB#646148](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646148)




