### PR TITLE
Bug 638128: Deadlock in Duplicate Management when multiple users create customers at the same time

### DIFF
--- a/src/Layers/W1/BaseApp/CRM/Duplicates/DuplicateManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/CRM/Duplicates/DuplicateManagement.Codeunit.al
@@ -140,6 +140,7 @@ codeunit 5060 DuplicateManagement
         DuplContSearchString.SetRange("Contact Company No.", Cont."No.");
         if DuplContSearchString.Find('-') then
             repeat
+                DuplContSearchString2.ReadIsolation(IsolationLevel::ReadUncommitted);
                 DuplContSearchString2.SetCurrentKey("Field No.", "Part of Field", "Search String");
                 DuplContSearchString2.SetRange("Field No.", DuplContSearchString."Field No.");
                 DuplContSearchString2.SetRange("Part of Field", DuplContSearchString."Part of Field");


### PR DESCRIPTION
When multiple users create customers (and hence contacts) at the same time, they may run into a deadlock on a simple read/check scenario.

Fixes [AB#638128](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638128)



