### PR TITLE
[28.4] Re-enable AppSourceCop rules after Subcontracting renumbering

### DIFF
--- a/build/Packages.json
+++ b/build/Packages.json
@@ -4,7 +4,7 @@
     "Source": "NuGet.org"
   },
   "AppBaselines-BCArtifacts": {
-    "Version": "28.3.52162.53285",
+    "Version": "28.3.52162.53526",
     "Source": "BCArtifacts",
     "_comment": "Used to fetch app baselines from BC artifacts"
   }

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcFeatureFlagHandler.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcFeatureFlagHandler.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Setup;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20569 "Subc. Feature Flag Handler"
 {
     ObsoleteState = Pending;
@@ -25,5 +24,4 @@ codeunit 20569 "Subc. Feature Flag Handler"
         exit(not ManufacturingSetup."Legacy Subcontracting");
     end;
 }
-#pragma warning restore AS0072, AS0136
 #endif

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcILEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcILEntries.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Ledger;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20501 "Subc. ILEntries" extends "Item Ledger Entries"
 {
     layout
@@ -121,4 +120,3 @@ pageextension 20501 "Subc. ILEntries" extends "Item Ledger Entries"
         SubcPurchFactboxMgmt.ShowPurchaseOrder(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcItemJnlPostLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcItemJnlPostLineExt.Codeunit.al
@@ -11,7 +11,6 @@ using Microsoft.Inventory.Posting;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20515 "Subc. ItemJnlPostLine Ext"
 {
 #if not CLEAN28
@@ -135,4 +134,3 @@ codeunit 20515 "Subc. ItemJnlPostLine Ext"
             ValueEntry."Item Charge No." := ItemJournalLine."Item Charge No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcItemLedgerEntry.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcItemLedgerEntry.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Ledger;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20500 "Subc. Item Ledger Entry" extends "Item Ledger Entry"
 {
     AllowInCustomizations = AsReadOnly;
@@ -47,4 +46,3 @@ tableextension 20500 "Subc. Item Ledger Entry" extends "Item Ledger Entry"
         key(Key99001500; "Subc. Prod. Order No.", "Subc. Prod. Order Line No.", "Subc. Purch. Order No.", "Subc. Purch. Order Line No.") { }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcNotificationMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcNotificationMgmt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Environment.Configuration;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20506 "Subc. Notification Mgmt."
 {
     var
@@ -116,4 +115,3 @@ codeunit 20506 "Subc. Notification Mgmt."
         exit('{f7b10c9e-071a-4455-a048-d17b29ef764c}');
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcReportingTriggersExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcReportingTriggersExt.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Reports;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20512 "Subc. Reporting Triggers Ext"
 {
     [EventSubscriber(ObjectType::Report, Report::"Detailed Calculation", OnAfterGetRecordRoutingLineOnBeforeCalcRoutingCostPerUnit, '', false, false)]
@@ -62,4 +61,3 @@ codeunit 20512 "Subc. Reporting Triggers Ext"
         IsHandled := true;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcSessionState.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcSessionState.Codeunit.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20500 "Subc. Session State"
 {
     SingleInstance = true;
@@ -116,4 +115,3 @@ codeunit 20500 "Subc. Session State"
             ReturnRecordID := RecordIDDictionary.Get(StoredKey);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcSynchronizeManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcSynchronizeManagement.Codeunit.al
@@ -13,7 +13,6 @@ using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20511 "Subc. Synchronize Management"
 {
     var
@@ -279,4 +278,3 @@ codeunit 20511 "Subc. Synchronize Management"
         exit(IsSubcontracting);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/General/SubcontractingManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/General/SubcontractingManagement.Codeunit.al
@@ -18,7 +18,6 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using System.Utilities;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20505 "Subcontracting Management"
 {
     var
@@ -461,4 +460,3 @@ codeunit 20505 "Subcontracting Management"
     begin
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcBusinessSetupExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcBusinessSetupExt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Foundation.Company;
 using Microsoft.Manufacturing.Setup;
 using System.Environment.Configuration;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20502 "Subc. Business Setup Ext."
 {
     var
@@ -32,4 +31,3 @@ codeunit 20502 "Subc. Business Setup Ext."
         SubcontractingCompInit.CreateBasicSubcontractingMgtSetup();
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcReqWkshTemplUpgrade.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcReqWkshTemplUpgrade.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Requisition;
 using System.Upgrade;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20572 "Subc. Req Wksh Templ Upgrade"
 {
     Subtype = Upgrade;
@@ -67,4 +66,3 @@ codeunit 20572 "Subc. Req Wksh Templ Upgrade"
         exit(99001504);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcUpgradeTagDefExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcUpgradeTagDefExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Upgrade;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20570 "Subc. Upgrade Tag Def. Ext."
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", 'OnGetPerCompanyUpgradeTags', '', false, false)]
@@ -26,4 +25,3 @@ codeunit 20570 "Subc. Upgrade Tag Def. Ext."
         exit('MS-644283-SubcReqWkshTemplTypeRenumber-20260803');
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingCompInit.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Setup;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20503 "Subcontracting Comp. Init."
 {
     var
@@ -88,4 +87,3 @@ codeunit 20503 "Subcontracting Comp. Init."
         exit(DefaultCompTransferLeadTimeLbl);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingInstall.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Install/SubcontractingInstall.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Upgrade;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20501 "Subcontracting Install"
 {
     Subtype = Install;
@@ -74,4 +73,3 @@ codeunit 20501 "Subcontracting Install"
         UpgradeTag.SetUpgradeTag(SubcUpgradeTagDefExt.GetSubcontractingUpgradeTag());
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/ComponentSupplyMethod.Enum.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/ComponentSupplyMethod.Enum.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 enum 20500 "Component Supply Method"
 {
     Extensible = true;
@@ -29,4 +28,3 @@ enum 20500 "Component Supply Method"
         Caption = 'Transfer to Vendor';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/ComponentsatLocation.Enum.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/ComponentsatLocation.Enum.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 enum 20503 "Components at Location"
 {
     Extensible = true;
@@ -25,4 +24,3 @@ enum 20503 "Components at Location"
         Caption = 'Manufacturing Setup';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcBOMTreeExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcBOMTreeExt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.BOM.Tree;
 using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.Routing;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20521 "Subc. Calc BOM Tree Ext."
 {
 #if not CLEAN27
@@ -36,4 +35,3 @@ codeunit 20521 "Subc. Calc BOM Tree Ext."
         SubcSessionState.SetRecordID('OnBeforeCalcRoutingLineCosts', ParentItem.RecordId());
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcProdOrderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcProdOrderExt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20517 "Subc. Calc. Prod. Order Ext."
 {
 #if not CLEAN28
@@ -67,4 +66,3 @@ codeunit 20517 "Subc. Calc. Prod. Order Ext."
     begin
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcStandardCostExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcStandardCostExt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.StandardCost;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20514 "Subc. Calc.StandardCost Ext."
 {
 #if not CLEAN28
@@ -60,4 +59,3 @@ codeunit 20514 "Subc. Calc.StandardCost Ext."
         SubcSessionState.SetDate('OnAfterSetProperties', NewCalculationDate);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcSubcontractsExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCalcSubcontractsExt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20529 "Subc. Calc Subcontracts Ext."
 {
     [EventSubscriber(ObjectType::Report, Report::"Subc. Calculate Subcontracts", OnAfterTransferProdOrderRoutingLine, '', false, false)]
@@ -36,4 +35,3 @@ codeunit 20529 "Subc. Calc Subcontracts Ext."
         RequisitionLine.Validate("Subc. Standard Task Code", ProdOrderRoutingLine."Standard Task Code");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCapLEntries.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCapLEntries.PageExt.al
@@ -9,7 +9,6 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Utilities;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
 {
     layout
@@ -89,4 +88,3 @@ pageextension 20502 "Subc. CapLEntries" extends "Capacity Ledger Entries"
     var
         NoDocumentFoundMsg: Label 'No related document could be found for this entry.';
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCapLedgerEntryExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCapLedgerEntryExt.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.Capacity;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20504 "Subc. Cap Ledger Entry Ext." extends "Capacity Ledger Entry"
 {
     AllowInCustomizations = AsReadOnly;
@@ -33,4 +32,3 @@ tableextension 20504 "Subc. Cap Ledger Entry Ext." extends "Capacity Ledger Entr
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCarryOutActionExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCarryOutActionExt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Planning;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20523 "Subc. Carry Out Action Ext."
 {
 #if not CLEAN27
@@ -37,4 +36,3 @@ codeunit 20523 "Subc. Carry Out Action Ext."
         ProdOrderComponent."Subc. Orig. Bin Code" := PlanningComponent."Orig. Bin Code";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCompFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcCompFactboxMgmt.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Ledger;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20562 "Subc. Comp. Factbox Mgmt."
 {
 #if not CLEAN28
@@ -226,4 +225,3 @@ codeunit 20562 "Subc. Comp. Factbox Mgmt."
         ProdOrderRoutingLine.FindFirst();
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcDispatchingList.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcDispatchingList.Report.al
@@ -30,7 +30,6 @@ using System.Email;
 using System.Globalization;
 using System.Utilities;
 
-#pragma warning disable AS0072, AS0136
 report 20504 "Subc. Dispatching List"
 {
     ApplicationArea = Subcontracting;
@@ -2023,4 +2022,3 @@ report 20504 "Subc. Dispatching List"
             ShptMethodDescTxt := ShptMethodDescLbl;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrder.PageExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Ledger;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20548 "Subc. Finished Prod. Order" extends "Finished Production Order"
 {
     actions
@@ -68,4 +67,3 @@ pageextension 20548 "Subc. Finished Prod. Order" extends "Finished Production Or
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcFinishedProdOrders.PageExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Ledger;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20543 "Subc. Finished Prod. Orders" extends "Finished Production Orders"
 {
     actions
@@ -63,4 +62,3 @@ pageextension 20543 "Subc. Finished Prod. Orders" extends "Finished Production O
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningComp.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningComp.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Planning;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20511 "Subc. Planning Comp" extends "Planning Components"
 {
     layout
@@ -20,4 +19,3 @@ pageextension 20511 "Subc. Planning Comp" extends "Planning Components"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningCompExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningCompExt.Codeunit.al
@@ -10,7 +10,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20522 "Subc. Planning Comp. Ext."
 {
 #if not CLEAN28
@@ -119,4 +118,3 @@ codeunit 20522 "Subc. Planning Comp. Ext."
     end;
 
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningCompExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningCompExt.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Planning;
 using Microsoft.Warehouse.Structure;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20503 "Subc. Planning Comp Ext." extends "Planning Component"
 {
     AllowInCustomizations = AsReadOnly;
@@ -58,4 +57,3 @@ tableextension 20503 "Subc. Planning Comp Ext." extends "Planning Component"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningLineMgmtExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcPlanningLineMgmtExt.Codeunit.al
@@ -12,7 +12,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20518 "Subc. Planning Line Mgmt Ext."
 {
 #if not CLEAN28
@@ -91,4 +90,3 @@ codeunit 20518 "Subc. Planning Line Mgmt Ext."
         TransferLine.SetRange("Transfer WIP Item", false);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdBOMLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdBOMLineExt.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.ProductionBOM;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20531 "Subc. Prod BOM Line Ext." extends "Production BOM Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -42,4 +41,3 @@ tableextension 20531 "Subc. Prod BOM Line Ext." extends "Production BOM Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdBOMLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdBOMLines.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.ProductionBOM;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20510 "Subc. Prod BOM Lines" extends "Production BOM Lines"
 {
     layout
@@ -20,4 +19,3 @@ pageextension 20510 "Subc. Prod BOM Lines" extends "Production BOM Lines"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdBOMVersionLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdBOMVersionLines.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.ProductionBOM;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20514 "Subc. ProdBOMVersionLines" extends "Production BOM Version Lines"
 {
     layout
@@ -21,4 +20,3 @@ pageextension 20514 "Subc. ProdBOMVersionLines" extends "Production BOM Version 
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOFactboxMgmt.Codeunit.al
@@ -12,7 +12,6 @@ using Microsoft.Purchases.History;
 using Microsoft.Utilities;
 using System.Reflection;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20559 "Subc. ProdO. Factbox Mgmt."
 {
 #if not CLEAN28
@@ -299,4 +298,3 @@ codeunit 20559 "Subc. ProdO. Factbox Mgmt."
             exit(ProdOrderRoutingLine."Routing No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrdCompRes.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrdCompRes.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20530 "Subc. Prod. Ord. Comp. Res."
 {
     EventSubscriberInstance = Manual;
@@ -38,4 +37,3 @@ codeunit 20530 "Subc. Prod. Ord. Comp. Res."
         HasError := false;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderComp.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderComp.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20512 "Subc. Prod Order Comp" extends "Prod. Order Components"
 {
     layout
@@ -37,4 +36,3 @@ pageextension 20512 "Subc. Prod Order Comp" extends "Prod. Order Components"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderCompExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderCompExt.Codeunit.al
@@ -13,7 +13,6 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using System.Utilities;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20524 "Subc. Prod. Order Comp. Ext."
 {
     var
@@ -548,4 +547,3 @@ codeunit 20524 "Subc. Prod. Order Comp. Ext."
         exit(NetStockAtSubcLocation > 0);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderCompExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderCompExt.TableExt.al
@@ -12,7 +12,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 using Microsoft.Warehouse.Structure;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20502 "Subc. Prod Order Comp Ext." extends "Prod. Order Component"
 {
     AllowInCustomizations = AsReadOnly;
@@ -143,4 +142,3 @@ tableextension 20502 "Subc. Prod Order Comp Ext." extends "Prod. Order Component
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderCompLine.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderCompLine.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20513 "Subc. ProdOrderCompLine" extends "Prod. Order Comp. Line List"
 {
     layout
@@ -21,4 +20,3 @@ pageextension 20513 "Subc. ProdOrderCompLine" extends "Prod. Order Comp. Line Li
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderComponents.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderComponents.Page.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 page 20503 "Subc. Prod. Order Components"
 {
     ApplicationArea = Subcontracting;
@@ -182,4 +181,3 @@ page 20503 "Subc. Prod. Order Components"
     var
         SubcCompFactboxMgmt: Codeunit "Subc. Comp. Factbox Mgmt.";
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtng.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtng.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
 {
     layout
@@ -228,4 +227,3 @@ pageextension 20503 "Subc. Prod. Order Rtng." extends "Prod. Order Routing"
         end;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtngExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtngExt.Codeunit.al
@@ -10,7 +10,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20520 "Subc. Prod. Order Rtng. Ext."
 {
     var
@@ -316,4 +315,3 @@ codeunit 20520 "Subc. Prod. Order Rtng. Ext."
         exit(false);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtngLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProdOrderRtngLineExt.TableExt.al
@@ -12,7 +12,6 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20506 "Subc. ProdOrderRtngLine Ext." extends "Prod. Order Routing Line"
 {
     fields
@@ -277,4 +276,3 @@ tableextension 20506 "Subc. ProdOrderRtngLine Ext." extends "Prod. Order Routing
             until ProdOrderLine.Next() = 0;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProductionOrderExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcProductionOrderExt.TableExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20505 "Subc. Production Order Ext." extends "Production Order"
 {
     AllowInCustomizations = AsReadOnly;
@@ -20,4 +19,3 @@ tableextension 20505 "Subc. Production Order Ext." extends "Production Order"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrder.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Ledger;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
-#pragma warning disable AS0072, AS0136
 pageextension 20504 "Subc. Rel. Prod. Order" extends "Released Production Order"
 {
     actions
@@ -84,4 +83,3 @@ pageextension 20504 "Subc. Rel. Prod. Order" extends "Released Production Order"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRelProdOrders.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Ledger;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
-#pragma warning disable AS0072, AS0136
 pageextension 20505 "Subc. Rel. Prod. Orders" extends "Released Production Orders"
 {
     actions
@@ -62,4 +61,3 @@ pageextension 20505 "Subc. Rel. Prod. Orders" extends "Released Production Order
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20516 "Subc. Req. Wksh. Make Ord."
 {
 #if not CLEAN28
@@ -123,4 +122,3 @@ codeunit 20516 "Subc. Req. Wksh. Make Ord."
             until ProdOrderComponent.Next() = 0;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingFactboxMgmt.Codeunit.al
@@ -11,7 +11,6 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20561 "Subc. Routing Factbox Mgmt."
 {
 #if not CLEAN28
@@ -343,4 +342,3 @@ codeunit 20561 "Subc. Routing Factbox Mgmt."
         Page.Run(Page::"Subc. Prod. Order Components", ProdOrderComponent);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingInfoFactbox.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingInfoFactbox.Page.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 page 20502 "Subc. Routing Info Factbox"
 {
     ApplicationArea = Subcontracting;
@@ -125,4 +124,3 @@ page 20502 "Subc. Routing Info Factbox"
         SubcRoutingFactboxMgmt: Codeunit "Subc. Routing Factbox Mgmt.";
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLine.TableExt.al
@@ -8,7 +8,6 @@ using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20560 "Subc. Routing Line" extends "Routing Line"
 {
     AllowInCustomizations = AsReadWrite;
@@ -118,4 +117,3 @@ tableextension 20560 "Subc. Routing Line" extends "Routing Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingLines.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Routing;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20508 "Subc. Routing Lines" extends "Routing Lines"
 {
     layout
@@ -135,4 +134,3 @@ pageextension 20508 "Subc. Routing Lines" extends "Routing Lines"
         Page.Run(Page::"Subcontractor Prices", SubcontractorPrice);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingVersionLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcRoutingVersionLines.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Routing;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20509 "Subc. Routing Version Lines" extends "Routing Version Lines"
 {
     layout
@@ -128,4 +127,3 @@ pageextension 20509 "Subc. Routing Version Lines" extends "Routing Version Lines
         Page.Run(Page::"Subcontractor Prices", SubcontractorPrice);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterCard.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20506 "Subc. Work Center Card" extends "Work Center Card"
 {
     layout
@@ -98,4 +97,3 @@ pageextension 20506 "Subc. Work Center Card" extends "Work Center Card"
 #endif
         IsSubcontractingWorkCenter: Boolean;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterExtension.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20519 "Subc. Work Center Extension"
 {
     [EventSubscriber(ObjectType::Table, Database::"Work Center", OnAfterDeleteEvent, '', false, false)]
@@ -34,4 +33,3 @@ codeunit 20519 "Subc. Work Center Extension"
         SubcontractorPrice.DeletePricesForWorkCenter(Rec."No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcWorkCenterList.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20507 "Subc. Work Center List" extends "Work Center List"
 {
     actions
@@ -75,4 +74,3 @@ pageextension 20507 "Subc. Work Center List" extends "Work Center List"
 #endif
         IsSubcontractingWorkCenter: Boolean;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemCard.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Item;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20518 "Subc. Item Card" extends "Item Card"
 {
     actions
@@ -26,4 +25,3 @@ pageextension 20518 "Subc. Item Card" extends "Item Card"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemExtension.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Item;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20532 "Subc. Item Extension"
 {
     [EventSubscriber(ObjectType::Table, Database::Item, OnAfterDeleteEvent, '', false, false)]
@@ -34,4 +33,3 @@ codeunit 20532 "Subc. Item Extension"
         SubcontractorPrice.DeletePricesForItem(Rec."No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemJournalLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemJournalLineExt.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Journal;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20508 "Subc. Item Journal Line Ext." extends "Item Journal Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -48,4 +47,3 @@ tableextension 20508 "Subc. Item Journal Line Ext." extends "Item Journal Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcItemList.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Item;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20519 "Subc. Item List" extends "Item List"
 {
     actions
@@ -38,4 +37,3 @@ pageextension 20519 "Subc. Item List" extends "Item List"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendor.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendor.TableExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Location;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20507 "Subc. Vendor" extends Vendor
 {
     AllowInCustomizations = AsReadOnly;
@@ -74,4 +73,3 @@ tableextension 20507 "Subc. Vendor" extends Vendor
         ShowLocationCardLbl: Label 'Show Location Card';
         BinWarehouseEnabledOnLocationErr: Label 'Location %1 cannot be used as a subcontracting location because Bin Mandatory or warehouse handling is enabled on the location.', Comment = '%1 = Location Code';
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendorCard.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendorCard.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20516 "Subc. Vendor Card" extends "Vendor Card"
 {
     layout
@@ -42,4 +41,3 @@ pageextension 20516 "Subc. Vendor Card" extends "Vendor Card"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendorExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendorExtension.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20531 "Subc. Vendor Extension"
 {
     [EventSubscriber(ObjectType::Table, Database::Vendor, OnAfterDeleteEvent, '', false, false)]
@@ -34,4 +33,3 @@ codeunit 20531 "Subc. Vendor Extension"
         SubcontractorPrice.DeletePricesForVendor(Rec."No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendorList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/MasterData/SubcVendorList.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20517 "Subc. Vendor List" extends "Vendor List"
 {
     actions
@@ -26,4 +25,3 @@ pageextension 20517 "Subc. Vendor List" extends "Vendor List"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Permissions/D365BasicSubcontracting.PermissionSetExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Permissions/D365BasicSubcontracting.PermissionSetExt.al
@@ -6,9 +6,7 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Security.AccessControl;
 
-#pragma warning disable AS0072, AS0136
 permissionsetextension 20502 "D365 BASIC - Subcontracting" extends "D365 BASIC"
 {
     IncludedPermissionSets = "Subcontract. - Read";
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Permissions/D365BusFullAccessSubcontracting.PermissionSetExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Permissions/D365BusFullAccessSubcontracting.PermissionSetExt.al
@@ -6,9 +6,7 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Security.AccessControl;
 
-#pragma warning disable AS0072, AS0136
 permissionsetextension 20501 "D365 BUS FULL ACCESS - Subcontracting" extends "D365 BUS FULL ACCESS"
 {
     IncludedPermissionSets = "Subcontract. - Edit";
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Permissions/D365ReadSubcontracting.PermissionSetExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Permissions/D365ReadSubcontracting.PermissionSetExt.al
@@ -6,9 +6,7 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Security.AccessControl;
 
-#pragma warning disable AS0072, AS0136
 permissionsetextension 20500 "D365 READ - Subcontracting" extends "D365 READ"
 {
     IncludedPermissionSets = "Subcontract. - Read";
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Permissions/SubcontractEdit.PermissionSet.al
+++ b/src/Apps/W1/Subcontracting/App/src/Permissions/SubcontractEdit.PermissionSet.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 permissionset 20503 "Subcontract. - Edit"
 {
     Caption = 'Subcontracting - Edit';
@@ -17,4 +16,3 @@ permissionset 20503 "Subcontract. - Edit"
         tabledata "Subcontractor Price" = IMD,
         tabledata "Subcontractor WIP Ledger Entry" = IMD;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Permissions/SubcontractObjs.PermissionSet.al
+++ b/src/Apps/W1/Subcontracting/App/src/Permissions/SubcontractObjs.PermissionSet.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 permissionset 20501 "Subcontract. - Objs"
 {
     Caption = 'Subcontracting - Objects';
@@ -95,4 +94,3 @@ permissionset 20501 "Subcontract. - Objs"
         report "Subc. Create SubCReturnOrder" = X,
         report "Subc. Dispatching List" = X;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Permissions/SubcontractRead.PermissionSet.al
+++ b/src/Apps/W1/Subcontracting/App/src/Permissions/SubcontractRead.PermissionSet.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 permissionset 20502 "Subcontract. - Read"
 {
     Caption = 'Subcontracting - Read';
@@ -17,4 +16,3 @@ permissionset 20502 "Subcontract. - Read"
         tabledata "Subcontractor Price" = R,
         tabledata "Subcontractor WIP Ledger Entry" = R;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCalculateSubcontracts.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCalculateSubcontracts.Report.al
@@ -15,7 +15,6 @@ using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 report 20505 "Subc. Calculate Subcontracts"
 {
     ApplicationArea = Subcontracting;
@@ -370,4 +369,3 @@ report 20505 "Subc. Calculate Subcontracts"
     begin
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
@@ -12,7 +12,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 report 20502 "Subc. Create SubCReturnOrder"
 {
     ApplicationArea = Subcontracting;
@@ -418,4 +417,3 @@ report 20502 "Subc. Create SubCReturnOrder"
         exit(not TransferLineToCheck.IsEmpty());
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcItemChargeAssPurchExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcItemChargeAssPurchExt.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20536 "Subc. ItemChargeAssPurchExt"
 {
     var
@@ -60,4 +59,3 @@ codeunit 20536 "Subc. ItemChargeAssPurchExt"
         until FromPurchRcptLine.Next() = 0;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPOSubform.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPOSubform.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20524 "Subc. PO Subform" extends "Purchase Order Subform"
 {
     layout
@@ -129,4 +128,3 @@ pageextension 20524 "Subc. PO Subform" extends "Purchase Order Subform"
         SubcProdOrderFactboxMgmt.ShowProductionOrderRouting(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -19,7 +19,6 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20508 "Subc. Price Management"
 {
     var
@@ -591,4 +590,3 @@ codeunit 20508 "Subc. Price Management"
         exit(Round(PurchaseLine.Quantity * ItemUnitofMeasure."Qty. per Unit of Measure", 0.00001));
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchCrMemoLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchCrMemoLine.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.History;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20515 "Subc. Purch. CrMemo Line" extends "Purch. Cr. Memo Line"
 {
     fields
@@ -61,4 +60,3 @@ tableextension 20515 "Subc. Purch. CrMemo Line" extends "Purch. Cr. Memo Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchFactboxMgmt.Codeunit.al
@@ -14,7 +14,6 @@ using Microsoft.Utilities;
 using System.Reflection;
 using System.Text;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20560 "Subc. Purch. Factbox Mgmt."
 {
     var
@@ -640,4 +639,3 @@ codeunit 20560 "Subc. Purch. Factbox Mgmt."
         TransferLine.SetRange("Derived From Line No.", 0);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchInvLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchInvLine.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.History;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20514 "Subc. Purch. Inv. Line" extends "Purch. Inv. Line"
 {
     fields
@@ -61,4 +60,3 @@ tableextension 20514 "Subc. Purch. Inv. Line" extends "Purch. Inv. Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchOrder.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20523 "Subc. Purch. Order" extends "Purchase Order"
 {
     layout
@@ -129,4 +128,3 @@ pageextension 20523 "Subc. Purch. Order" extends "Purchase Order"
         HasSubcontractingContext := SubcontractingManagement.IsSubcontractingPurchaseDocument(Rec);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchOrderList.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchOrderList.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20525 "Subc. PurchOrderList" extends "Purchase Order List"
 {
     layout
@@ -86,4 +85,3 @@ pageextension 20525 "Subc. PurchOrderList" extends "Purchase Order List"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchPostExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchPostExt.Codeunit.al
@@ -16,7 +16,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Posting;
-#pragma warning disable AS0072, AS0136
 codeunit 20535 "Subc. Purch. Post Ext"
 {
     var
@@ -283,4 +282,3 @@ codeunit 20535 "Subc. Purch. Post Ext"
     end;
 
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchRcptLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchRcptLine.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.History;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20513 "Subc. Purch. Rcpt. Line" extends "Purch. Rcpt. Line"
 {
     fields
@@ -61,4 +60,3 @@ tableextension 20513 "Subc. Purch. Rcpt. Line" extends "Purch. Rcpt. Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeader.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeader.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Location;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20509 "Subc. Purchase Header" extends "Purchase Header"
 {
     AllowInCustomizations = AsReadOnly;
@@ -43,4 +42,3 @@ tableextension 20509 "Subc. Purchase Header" extends "Purchase Header"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderArch.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderArch.TableExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Location;
 using Microsoft.Purchases.Archive;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20511 "Subc. Purchase Header Arch" extends "Purchase Header Archive"
 {
     AllowInCustomizations = AsReadOnly;
@@ -33,4 +32,3 @@ tableextension 20511 "Subc. Purchase Header Arch" extends "Purchase Header Archi
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Utilities;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20533 "Subc. Purchase Header Ext"
 {
     var
@@ -99,4 +98,3 @@ codeunit 20533 "Subc. Purchase Header Ext"
         ToPurchaseHeader."Subc. Location Code" := '';
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLine.TableExt.al
@@ -13,7 +13,6 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20512 "Subc. Purchase Line" extends "Purchase Line"
 {
     fields
@@ -251,4 +250,3 @@ tableextension 20512 "Subc. Purchase Line" extends "Purchase Line"
         end;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineArchive.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineArchive.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Archive;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20516 "Subc. Purchase Line Archive" extends "Purchase Line Archive"
 {
     fields
@@ -61,4 +60,3 @@ tableextension 20516 "Subc. Purchase Line Archive" extends "Purchase Line Archiv
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -11,7 +11,6 @@ using Microsoft.Purchases.Document;
 using Microsoft.Utilities;
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20534 "Subc. Purchase Line Ext"
 {
     var
@@ -458,4 +457,3 @@ codeunit 20534 "Subc. Purchase Line Ext"
         OpenItemTrackingOfProdOrderLine(PurchaseLine, true);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineFactbox.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineFactbox.Page.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 page 20518 "Subc. Purchase Line Factbox"
 {
     ApplicationArea = Subcontracting;
@@ -140,4 +139,3 @@ page 20518 "Subc. Purchase Line Factbox"
     var
         PlaceholderLbl: Label '%1', Locked = true;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineType.Enum.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineType.Enum.al
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
-#pragma warning disable AS0072, AS0136
 enum 20507 "Subc. Purchase Line Type"
 {
     Extensible = true;
@@ -21,4 +20,3 @@ enum 20507 "Subc. Purchase Line Type"
         Caption = 'Not Last Operation';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseOrderCreator.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseOrderCreator.Codeunit.al
@@ -22,7 +22,6 @@ using Microsoft.Purchases.Vendor;
 using Microsoft.Utilities;
 using System.Utilities;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20557 "Subc. Purchase Order Creator"
 {
     var
@@ -664,4 +663,3 @@ codeunit 20557 "Subc. Purchase Order Creator"
     begin
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcReqLineExtension.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcReqLineExtension.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Requisition;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20513 "Subc. Req.Line Extension"
 {
 #if not CLEAN28
@@ -80,4 +79,3 @@ codeunit 20513 "Subc. Req.Line Extension"
             end;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcRequisitionLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcRequisitionLine.TableExt.al
@@ -11,7 +11,6 @@ using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Routing;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20510 "Subc. RequisitionLine" extends "Requisition Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -190,4 +189,3 @@ tableextension 20510 "Subc. RequisitionLine" extends "Requisition Line"
             SubcPriceManagement.GetSubcPriceForReqLine(Rec, "Subc. UoM for Pricelist");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcontractorPrice.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcontractorPrice.Table.al
@@ -10,7 +10,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 table 20500 "Subcontractor Price"
 {
     AllowInCustomizations = AsReadOnly;
@@ -260,4 +259,3 @@ table 20500 "Subcontractor Price"
     end;
 
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcontractorPrices.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcontractorPrices.Page.al
@@ -11,7 +11,6 @@ using Microsoft.Purchases.Vendor;
 using System.Globalization;
 using System.Text;
 
-#pragma warning disable AS0072, AS0136
 page 20500 "Subcontractor Prices"
 {
     ApplicationArea = Subcontracting;
@@ -412,4 +411,3 @@ page 20500 "Subcontractor Prices"
         CurrPage.SetSelectionFilter(SubcontractorPrice);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcManufacturingCue.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcManufacturingCue.TableExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.RoleCenters;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20529 "Subc. Manufacturing Cue" extends "Manufacturing Cue"
 {
     fields
@@ -66,4 +65,3 @@ tableextension 20529 "Subc. Manufacturing Cue" extends "Manufacturing Cue"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcManufacturingManagerRC.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcManufacturingManagerRC.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.RoleCenters;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20536 "Subc. Manufacturing Manager RC" extends "Manufacturing Manager RC"
 {
     actions
@@ -34,4 +33,3 @@ pageextension 20536 "Subc. Manufacturing Manager RC" extends "Manufacturing Mana
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcProdPlannerActivities.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcProdPlannerActivities.PageExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.RoleCenters;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20537 "Subc. Prod. Planner Activities" extends "Production Planner Activities"
 {
     layout
@@ -67,4 +66,3 @@ pageextension 20537 "Subc. Prod. Planner Activities" extends "Production Planner
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcProdPlannerRoleCenter.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcProdPlannerRoleCenter.PageExt.al
@@ -9,7 +9,6 @@ using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.RoleCenters;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20538 "Subc. Prod. Planner RoleCenter" extends "Production Planner Role Center"
 {
     actions
@@ -61,4 +60,3 @@ pageextension 20538 "Subc. Prod. Planner RoleCenter" extends "Production Planner
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcPurchAgentRoleCenter.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcPurchAgentRoleCenter.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Purchases.RoleCenters;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20541 "Subc. Purch. Agent Role Center" extends "Purchasing Agent Role Center"
 {
     actions
@@ -26,4 +25,3 @@ pageextension 20541 "Subc. Purch. Agent Role Center" extends "Purchasing Agent R
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcPurchasingManagerRC.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcPurchasingManagerRC.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.RoleCenters;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20535 "Subc. Purchasing Manager RC" extends "Purchasing Manager Role Center"
 {
     actions
@@ -23,4 +22,3 @@ pageextension 20535 "Subc. Purchasing Manager RC" extends "Purchasing Manager Ro
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSMfgFoundation.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSMfgFoundation.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.RoleCenters;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20539 "Subc. Shop S. Mfg Foundation" extends "Shop Supervisor Mfg Foundation"
 {
     actions
@@ -26,4 +25,3 @@ pageextension 20539 "Subc. Shop S. Mfg Foundation" extends "Shop Supervisor Mfg 
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSuperActivities.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSuperActivities.PageExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.RoleCenters;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20549 "Subc. Shop Super. Activities" extends "Shop Supervisor Activities"
 {
     layout
@@ -67,4 +66,3 @@ pageextension 20549 "Subc. Shop Super. Activities" extends "Shop Supervisor Acti
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSuperRoleCenter.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSuperRoleCenter.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.RoleCenters;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20540 "Subc. Shop Super. Role Center" extends "Shop Supervisor Role Center"
 {
     actions
@@ -26,4 +25,3 @@ pageextension 20540 "Subc. Shop Super. Role Center" extends "Shop Supervisor Rol
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSuperbasicActivity.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/RoleCenters/SubcShopSuperbasicActivity.PageExt.al
@@ -8,7 +8,6 @@ using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.RoleCenters;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20550 "Subc. ShopSuperbasicActivity" extends "Shop Super. basic Activities"
 {
     layout
@@ -67,4 +66,3 @@ pageextension 20550 "Subc. ShopSuperbasicActivity" extends "Shop Super. basic Ac
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Setup/SubcApplicationAreaMgmt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/SubcApplicationAreaMgmt.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Setup;
 #endif
 using System.Environment.Configuration;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20571 "Subc. Application Area Mgmt."
 {
     Access = Internal;
@@ -48,4 +47,3 @@ codeunit 20571 "Subc. Application Area Mgmt."
 
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Setup/SubcApplicationAreaSetup.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/SubcApplicationAreaSetup.TableExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using System.Environment.Configuration;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20571 "Subc. Application Area Setup" extends "Application Area Setup"
 {
     fields
@@ -18,4 +17,3 @@ tableextension 20571 "Subc. Application Area Setup" extends "Application Area Se
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Setup/SubcManufacturingSetup.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/SubcManufacturingSetup.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Setup;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20542 "Subc. Manufacturing Setup" extends "Manufacturing Setup"
 {
     layout
@@ -50,4 +49,3 @@ pageextension 20542 "Subc. Manufacturing Setup" extends "Manufacturing Setup"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Setup/SubcManufacturingSetup.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Setup/SubcManufacturingSetup.TableExt.al
@@ -8,7 +8,6 @@ using Microsoft.Foundation.Company;
 using Microsoft.Inventory.Requisition;
 using Microsoft.Manufacturing.Setup;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20501 "Subc. Manufacturing Setup" extends "Manufacturing Setup"
 {
     fields
@@ -88,4 +87,3 @@ tableextension 20501 "Subc. Manufacturing Setup" extends "Manufacturing Setup"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -13,7 +13,6 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 report 20501 "Subc. Create Transf. Order"
 {
     ApplicationArea = Subcontracting;
@@ -599,4 +598,3 @@ report 20501 "Subc. Create Transf. Order"
         exit(SubcontractorWIPLedgerEntry."Quantity (Base)");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcDirectTransHeaderExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcDirectTransHeaderExt.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20524 "Subc. DirectTransHeader Ext." extends "Direct Trans. Header"
 {
     AllowInCustomizations = AsReadOnly;
@@ -79,4 +78,3 @@ tableextension 20524 "Subc. DirectTransHeader Ext." extends "Direct Trans. Heade
     end;
 
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcDirectTransLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcDirectTransLineExt.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20523 "Subc. DirectTrans. Line Ext" extends "Direct Trans. Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -86,4 +85,3 @@ tableextension 20523 "Subc. DirectTrans. Line Ext" extends "Direct Trans. Line"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcDirectTransferLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcDirectTransferLineExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20548 "Subc. DirectTransferLine Ext."
 {
     [EventSubscriber(ObjectType::Table, Database::"Direct Trans. Line", OnAfterCopyFromTransferLine, '', false, false)]
@@ -35,4 +34,3 @@ codeunit 20548 "Subc. DirectTransferLine Ext."
         DirectTransLine."Operation No." := TransferLine."Subc. Operation No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdDirectTrans.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdDirectTrans.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20531 "Subc. Pstd. Direct Trans." extends "Posted Direct Transfer"
 {
     layout
@@ -58,4 +57,3 @@ pageextension 20531 "Subc. Pstd. Direct Trans." extends "Posted Direct Transfer"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdDirectTransfSub.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdDirectTransfSub.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20532 "Subc. PstdDirectTransfSub" extends "Posted Direct Transfer Subform"
 {
     layout
@@ -152,4 +151,3 @@ pageextension 20532 "Subc. PstdDirectTransfSub" extends "Posted Direct Transfer 
         SubcPurchFactboxMgmt.ShowPurchaseOrder(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdDirectTransfers.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdDirectTransfers.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20554 "Subc. Pstd. Direct Transfers" extends "Posted Direct Transfers"
 {
     views
@@ -21,4 +20,3 @@ pageextension 20554 "Subc. Pstd. Direct Transfers" extends "Posted Direct Transf
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferRcpt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferRcpt.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20528 "Subc. Pstd. Transfer Rcpt" extends "Posted Transfer Receipt"
 {
     layout
@@ -58,4 +57,3 @@ pageextension 20528 "Subc. Pstd. Transfer Rcpt" extends "Posted Transfer Receipt
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferRcpts.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferRcpts.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20553 "Subc. Pstd. Transfer Rcpts." extends "Posted Transfer Receipts"
 {
     views
@@ -21,4 +20,3 @@ pageextension 20553 "Subc. Pstd. Transfer Rcpts." extends "Posted Transfer Recei
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferShpt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferShpt.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20527 "Subc. Pstd. Transfer Shpt" extends "Posted Transfer Shipment"
 {
     layout
@@ -52,4 +51,3 @@ pageextension 20527 "Subc. Pstd. Transfer Shpt" extends "Posted Transfer Shipmen
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferShpts.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcPstdTransferShpts.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20552 "Subc. Pstd. Transfer Shpts." extends "Posted Transfer Shipments"
 {
     views
@@ -21,4 +20,3 @@ pageextension 20552 "Subc. Pstd. Transfer Shpts." extends "Posted Transfer Shipm
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderPostRcptExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderPostRcptExt.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20540 "Subc. TransOrderPostRcpt Ext"
 {
 #if not CLEAN28
@@ -80,4 +79,3 @@ codeunit 20540 "Subc. TransOrderPostRcpt Ext"
         end;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderPostShptExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderPostShptExt.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20539 "Subc. TransOrderPostShpt Ext"
 {
 #if not CLEAN28
@@ -55,4 +54,3 @@ codeunit 20539 "Subc. TransOrderPostShpt Ext"
         TransShptLine."Subc. Routing Reference No." := TransLine."Subc. Routing Reference No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderPostTransExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderPostTransExt.Codeunit.al
@@ -12,7 +12,6 @@ using Microsoft.Inventory.Tracking;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20547 "Subc. TransOrderPostTrans Ext"
 {
 #if not CLEAN28
@@ -317,4 +316,3 @@ codeunit 20547 "Subc. TransOrderPostTrans Ext"
         exit(true);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderSub.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransOrderSub.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20529 "Subc. Trans. Order Sub." extends "Transfer Order Subform"
 {
     layout
@@ -203,4 +202,3 @@ pageextension 20529 "Subc. Trans. Order Sub." extends "Transfer Order Subform"
         SubcPurchFactboxMgmt.ShowPurchaseOrder(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransRcptHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransRcptHeaderExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20542 "Subc. Trans Rcpt Header Ext"
 {
     [EventSubscriber(ObjectType::Table, Database::"Transfer Receipt Header", OnAfterCopyFromTransferHeader, '', false, false)]
@@ -32,4 +31,3 @@ codeunit 20542 "Subc. Trans Rcpt Header Ext"
         TransferReceiptHeader."Subcontr. PO Line No." := TransferHeader."Subcontr. PO Line No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransRcptHeaderExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransRcptHeaderExt.TableExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20521 "Subc. Trans Rcpt Header Ext." extends "Transfer Receipt Header"
 {
     AllowInCustomizations = AsReadOnly;
@@ -51,4 +50,3 @@ tableextension 20521 "Subc. Trans Rcpt Header Ext." extends "Transfer Receipt He
         key(Key99001501; "Source ID", "Subc. Source Type") { }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransShptHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransShptHeaderExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20543 "Subc. Trans Shpt Header Ext"
 {
     [EventSubscriber(ObjectType::Table, Database::"Transfer Shipment Header", OnAfterCopyFromTransferHeader, '', false, false)]
@@ -32,4 +31,3 @@ codeunit 20543 "Subc. Trans Shpt Header Ext"
         TransferShipmentHeader."Subcontr. PO Line No." := TransferHeader."Subcontr. PO Line No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransShptHeaderExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransShptHeaderExt.TableExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20522 "Subc. Trans Shpt Header Ext." extends "Transfer Shipment Header"
 {
     AllowInCustomizations = AsReadOnly;
@@ -57,4 +56,3 @@ tableextension 20522 "Subc. Trans Shpt Header Ext." extends "Transfer Shipment H
         key(Key99001501; "Source ID", "Subc. Source Type") { }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferHeader.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferHeader.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Purchases.Vendor;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20520 "Subc. Transfer Header" extends "Transfer Header"
 {
     AllowInCustomizations = AsReadOnly;
@@ -95,4 +94,3 @@ tableextension 20520 "Subc. Transfer Header" extends "Transfer Header"
         TestField("Transfer-to Code");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferHeaderExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20507 "Subc. Transfer Header Ext."
 {
 #if not CLEAN28
@@ -61,4 +60,3 @@ codeunit 20507 "Subc. Transfer Header Ext."
         SubcTransferManagement.CheckSubcTransferHeaderCanBeModified(Rec, Rec.FieldCaption("Transfer-to Code"));
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLine.TableExt.al
@@ -14,7 +14,6 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20517 "Subc. Transfer Line" extends "Transfer Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -250,4 +249,3 @@ tableextension 20517 "Subc. Transfer Line" extends "Transfer Line"
             end;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLineExt.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20544 "Subc. Transfer Line Ext."
 {
 #if not CLEAN28
@@ -157,4 +156,3 @@ codeunit 20544 "Subc. Transfer Line Ext."
         TransferLine."Subc. Return Order" := TempTransferLine."Subc. Return Order";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLineFactbox.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLineFactbox.Page.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 page 20501 "Subc. Transfer Line Factbox"
 {
     ApplicationArea = Subcontracting;
@@ -92,4 +91,3 @@ page 20501 "Subc. Transfer Line Factbox"
         SubcPurchFactboxMgmt.ShowPurchaseOrder(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLines.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferLines.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20530 "Subc. Transfer Lines" extends "Transfer Lines"
 {
     layout
@@ -27,4 +26,3 @@ pageextension 20530 "Subc. Transfer Lines" extends "Transfer Lines"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferManagement.Codeunit.al
@@ -13,7 +13,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20504 "Subc. Transfer Management"
 {
     var
@@ -474,4 +473,3 @@ codeunit 20504 "Subc. Transfer Management"
             Error(RoutingOperationNotFoundErr, PurchaseLine."Operation No.", PurchaseLine."Document No.", PurchaseLine."Routing No.", PurchaseLine."Prod. Order No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferOrder.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20526 "Subc. Transfer Order" extends "Transfer Order"
 {
     layout
@@ -126,4 +125,3 @@ pageextension 20526 "Subc. Transfer Order" extends "Transfer Order"
         exit(not TransferLine.IsEmpty());
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferOrders.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferOrders.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20551 "Subc. Transfer Orders" extends "Transfer Orders"
 {
     views
@@ -26,4 +25,3 @@ pageextension 20551 "Subc. Transfer Orders" extends "Transfer Orders"
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferRcptLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferRcptLineExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20538 "Subc. Transfer Rcpt Line Ext."
 {
     [EventSubscriber(ObjectType::Table, Database::"Transfer Receipt Line", OnAfterCopyFromTransferLine, '', false, false)]
@@ -35,4 +34,3 @@ codeunit 20538 "Subc. Transfer Rcpt Line Ext."
         TransferReceiptLine."Subc. Operation No." := TransferLine."Subc. Operation No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferRcptLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferRcptLineExt.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20518 "Subc. Transfer Rcpt. Line Ext" extends "Transfer Receipt Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -86,4 +85,3 @@ tableextension 20518 "Subc. Transfer Rcpt. Line Ext" extends "Transfer Receipt L
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferShptLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferShptLineExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Transfer;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20537 "Subc. Transfer Shpt Line Ext."
 {
     [EventSubscriber(ObjectType::Table, Database::"Transfer Shipment Line", OnAfterCopyFromTransferLine, '', false, false)]
@@ -35,4 +34,3 @@ codeunit 20537 "Subc. Transfer Shpt Line Ext."
         TransferShipmentLine."Subc. Operation No." := TransferLine."Subc. Operation No.";
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferShptLineExt.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcTransferShptLineExt.TableExt.al
@@ -9,7 +9,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20519 "Subc. Transfer Shpt. Line Ext" extends "Transfer Shipment Line"
 {
     AllowInCustomizations = AsReadOnly;
@@ -86,4 +85,3 @@ tableextension 20519 "Subc. Transfer Shpt. Line Ext" extends "Transfer Shipment 
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/TransferSourceType.Enum.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/TransferSourceType.Enum.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 enum 20501 "Transfer Source Type"
 {
     Extensible = true;
@@ -17,4 +16,3 @@ enum 20501 "Transfer Source Type"
         Caption = 'Subcontracting';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcChangeProdOrderStatus.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcChangeProdOrderStatus.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20549 "Subc. Change Prod.Order Status"
 {
     Permissions = TableData "Subcontractor WIP Ledger Entry" = RIMD;
@@ -123,4 +122,3 @@ Comment = '%1=Transfer Header No';
         SubcontractorWIPLedgerEntry.ModifyAll("Prod. Order No.", ToProdOrder."No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcChangeStatusProdOrder.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcChangeStatusProdOrder.PageExt.al
@@ -5,7 +5,6 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
-#pragma warning disable AS0072, AS0136
 pageextension 20544 "Subc.Change Status Prod. Order" extends "Change Status on Prod. Order"
 {
     layout
@@ -110,4 +109,3 @@ pageextension 20544 "Subc.Change Status Prod. Order" extends "Change Status on P
             WIPQuantityCleanUp := false;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcPostingPreviewBinding.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcPostingPreviewBinding.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Finance.GeneralLedger.Preview;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20565 "Subc. Posting Preview Binding"
 {
 #if not CLEAN28
@@ -55,4 +54,3 @@ codeunit 20565 "Subc. Posting Preview Binding"
         exit(UnbindSubscription(SubcPostingPreviewHandler));
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcPostingPreviewSubscr.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcPostingPreviewSubscr.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Finance.GeneralLedger.Preview;
 using Microsoft.Foundation.Navigate;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20566 "Subc. Posting Preview Subscr."
 {
     var
@@ -71,4 +70,3 @@ codeunit 20566 "Subc. Posting Preview Subscr."
         SubcPostingPreviewHandler.GetTempSubcontractorWIPLedgerEntry(TempSubcontractorWIPLedgerEntry);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcPstPrevEventHandler.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcPstPrevEventHandler.Codeunit.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20567 "Subc. Pst. Prev. Event Handler"
 {
     EventSubscriberInstance = Manual;
@@ -62,4 +61,3 @@ codeunit 20567 "Subc. Pst. Prev. Event Handler"
         OutTempSubcontractorWIPLedgerEntry.Copy(TempSubcontractorWIPLedgerEntry, true);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcTransferWIPPosting.Codeunit.al
@@ -17,7 +17,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20541 "Subc. Transfer WIP Posting"
 {
 
@@ -522,4 +521,3 @@ codeunit 20541 "Subc. Transfer WIP Posting"
     begin
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcWIPAdjustment.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcWIPAdjustment.Page.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 page 20561 "Subc. WIP Adjustment"
 {
     ApplicationArea = Subcontracting;
@@ -439,4 +438,3 @@ page 20561 "Subc. WIP Adjustment"
             Error(NewQuantityExceedsProdOrderQtyErr, ProdOrderLine."Quantity (Base)");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcWIPItemLedgFindEntry.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcWIPItemLedgFindEntry.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Foundation.Navigate;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20564 "Subc. WIP Item Ledg Find Entry"
 {
 
@@ -65,4 +64,3 @@ codeunit 20564 "Subc. WIP Item Ledg Find Entry"
         end;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcWIPLedgerEntries.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcWIPLedgerEntries.Page.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Manufacturing.Document;
 
-#pragma warning disable AS0072, AS0136
 page 20560 "Subc. WIP Ledger Entries"
 {
     ApplicationArea = Subcontracting;
@@ -152,4 +151,3 @@ page 20560 "Subc. WIP Ledger Entries"
         WIPAdjustmentEnabled := ProductionOrder.Get(Rec."Prod. Order Status", Rec."Prod. Order No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcontractorWIPLedgerEntry.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/SubcontractorWIPLedgerEntry.Table.al
@@ -11,7 +11,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.WorkCenter;
 
-#pragma warning disable AS0072, AS0136
 table 20560 "Subcontractor WIP Ledger Entry"
 {
     AllowInCustomizations = AsReadOnly;
@@ -248,4 +247,3 @@ table 20560 "Subcontractor WIP Ledger Entry"
         exit(SequenceNoMgt.GetNextSeqNo(DATABASE::"Subcontractor WIP Ledger Entry"));
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/WIPDocumentType.Enum.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/WIPDocumentType.Enum.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 enum 20509 "WIP Document Type"
 {
     Extensible = true;
@@ -21,4 +20,3 @@ enum 20509 "WIP Document Type"
         Caption = 'Adjustment (Finish Prod Order)';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/WIPItem/WIPLedgerEntryType.Enum.al
+++ b/src/Apps/W1/Subcontracting/App/src/WIPItem/WIPLedgerEntryType.Enum.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Manufacturing.Subcontracting;
 
-#pragma warning disable AS0072, AS0136
 enum 20508 "WIP Ledger Entry Type"
 {
     Extensible = true;
@@ -17,4 +16,3 @@ enum 20508 "WIP Ledger Entry Type"
         Caption = 'Negative Adjustment';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPostedWhseReceiptLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPostedWhseReceiptLine.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.History;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20526 "Subc. Posted Whse Receipt Line" extends "Posted Whse. Receipt Line"
 {
     fields
@@ -28,4 +27,3 @@ tableextension 20526 "Subc. Posted Whse Receipt Line" extends "Posted Whse. Rece
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPstdWhseRcptSub.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPstdWhseRcptSub.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.History;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20545 "Subc. Pstd. Whse Rcpt Sub" extends "Posted Whse. Receipt Subform"
 {
     layout
@@ -21,4 +20,3 @@ pageextension 20545 "Subc. Pstd. Whse Rcpt Sub" extends "Posted Whse. Receipt Su
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPstdWhseShipmSub.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPstdWhseShipmSub.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.History;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20546 "Subc. Pstd. Whse Shipm Sub" extends "Posted Whse. Shipment Subform"
 {
     layout
@@ -21,4 +20,3 @@ pageextension 20546 "Subc. Pstd. Whse Shipm Sub" extends "Posted Whse. Shipment 
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPstdWhseShipmentLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcPstdWhseShipmentLine.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.History;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20528 "Subc. Pstd. Whse Shipment Line" extends "Posted Whse. Shipment Line"
 {
     fields
@@ -21,4 +20,3 @@ tableextension 20528 "Subc. Pstd. Whse Shipment Line" extends "Posted Whse. Ship
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWarehouseReceiptLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWarehouseReceiptLine.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20525 "Subc. Warehouse Receipt Line" extends "Warehouse Receipt Line"
 {
     fields
@@ -28,4 +27,3 @@ tableextension 20525 "Subc. Warehouse Receipt Line" extends "Warehouse Receipt L
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWarehouseShipmentLine.TableExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWarehouseShipmentLine.TableExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 tableextension 20527 "Subc. Warehouse Shipment Line" extends "Warehouse Shipment Line"
 {
     fields
@@ -21,4 +20,3 @@ tableextension 20527 "Subc. Warehouse Shipment Line" extends "Warehouse Shipment
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhsePostReceiptExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhsePostReceiptExt.Codeunit.al
@@ -15,7 +15,6 @@ using Microsoft.Warehouse.Document;
 using Microsoft.Warehouse.History;
 using Microsoft.Warehouse.Journal;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20551 "Subc. WhsePostReceipt Ext"
 {
     var
@@ -398,4 +397,3 @@ codeunit 20551 "Subc. WhsePostReceipt Ext"
         exit(WarehouseReceiptLineSystemIdCustomDimensionTok);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhsePostShipmentExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhsePostShipmentExt.Codeunit.al
@@ -11,7 +11,6 @@ using Microsoft.Warehouse.Document;
 using Microsoft.Warehouse.History;
 using Microsoft.Warehouse.Request;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20563 "Subc. WhsePostShipment Ext"
 {
 #if not CLEAN28
@@ -144,4 +143,3 @@ codeunit 20563 "Subc. WhsePostShipment Ext"
         IsHandled := true;
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhsePurchReleaseExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhsePurchReleaseExt.Codeunit.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Purchases.Document;
 
-#pragma warning disable AS0072, AS0136
 codeunit 20550 "Subc. WhsePurchRelease Ext"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Whse.-Purch. Release", OnAfterReleaseSetFilters, '', false, false)]
@@ -29,4 +28,3 @@ codeunit 20550 "Subc. WhsePurchRelease Ext"
             PurchaseLine.SetRange("Work Center No.");
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhseRcptLinesExt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhseRcptLinesExt.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Purchases.Document;
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines"
 {
     layout
@@ -123,4 +122,3 @@ pageextension 20534 "Subc. Whse Rcpt Lines Ext." extends "Whse. Receipt Lines"
         SubcProdOrderFactboxMgmt.ShowProductionOrderRouting(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhseRcptSubformExt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhseRcptSubformExt.PageExt.al
@@ -7,7 +7,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Purchases.Document;
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Subform"
 {
     layout
@@ -126,4 +125,3 @@ pageextension 20533 "Subc. Whse Rcpt Subform Ext." extends "Whse. Receipt Subfor
         SubcProdOrderFactboxMgmt.ShowProductionOrderRouting(RecRelatedVariant);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhseShipmSubformExt.PageExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Warehouse/SubcWhseShipmSubformExt.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Warehouse.Document;
 
-#pragma warning disable AS0072, AS0136
 pageextension 20547 "Subc. Whse Shipm. Subform Ext." extends "Whse. Shipment Subform"
 {
     layout
@@ -28,4 +27,3 @@ pageextension 20547 "Subc. Whse Shipm. Subform Ext." extends "Whse. Shipment Sub
         }
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Worksheet/SubcReqWkshTempTypeExt.EnumExt.al
+++ b/src/Apps/W1/Subcontracting/App/src/Worksheet/SubcReqWkshTempTypeExt.EnumExt.al
@@ -5,7 +5,6 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Requisition;
-#pragma warning disable AS0072, AS0136
 enumextension 20500 "Subc. ReqWkshTempType Ext." extends "Req. Worksheet Template Type"
 {
     value(20500; Subcontracting)
@@ -13,4 +12,3 @@ enumextension 20500 "Subc. ReqWkshTempType Ext." extends "Req. Worksheet Templat
         Caption = 'Subcontracting';
     }
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Worksheet/SubcSubcontractingWorksheet.Page.al
+++ b/src/Apps/W1/Subcontracting/App/src/Worksheet/SubcSubcontractingWorksheet.Page.al
@@ -10,7 +10,6 @@ using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Requisition;
 using System.Security.User;
 
-#pragma warning disable AS0072, AS0136
 page 20504 "Subc. Subcontracting Worksheet"
 {
     ApplicationArea = Subcontracting;
@@ -447,4 +446,3 @@ page 20504 "Subc. Subcontracting Worksheet"
     begin
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/Apps/W1/Subcontracting/App/src/Worksheet/SubcWorksheetHandler.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Worksheet/SubcWorksheetHandler.Codeunit.al
@@ -5,7 +5,6 @@
 namespace Microsoft.Manufacturing.Subcontracting;
 
 using Microsoft.Inventory.Requisition;
-#pragma warning disable AS0072, AS0136
 codeunit 20558 "Subc. Worksheet Handler"
 {
     [EventSubscriber(ObjectType::Codeunit, Codeunit::ReqJnlManagement, OnOpenJnlBatchOnBeforeTemplateSelection, '', false, false)]
@@ -26,4 +25,3 @@ codeunit 20558 "Subc. Worksheet Handler"
         ReqWorksheetTemplateTypeList.Add(Enum::"Req. Worksheet Template Type"::Subcontracting);
     end;
 }
-#pragma warning restore AS0072, AS0136

--- a/src/rulesets/AppSourceCop.ruleset.json
+++ b/src/rulesets/AppSourceCop.ruleset.json
@@ -3,8 +3,7 @@
     "rules":  [
                   {
                       "id":  "AS0001",
-                      "action":  "None",
-                      "justification": "Temporarily disabled to allow renumbering of Subcontracting App"
+                      "action":  "Error"
                   },
                   {
                       "id":  "AS0002",
@@ -73,8 +72,7 @@
                   },
                   {
                       "id":  "AS0018",
-                      "action":  "None",
-                      "justification": "Temporarily disabled to allow renumbering of Subcontracting App"
+                      "action":  "Error"
                   },
                   {
                       "id":  "AS0019",
@@ -118,8 +116,7 @@
                   },
                   {
                       "id":  "AS0029",
-                      "action":  "None",
-                      "justification": "Temporarily disabled to allow renumbering of Subcontracting App"
+                      "action":  "Error"
                   },
                   {
                       "id":  "AS0030",
@@ -362,8 +359,7 @@
                   },
                   {
                       "id":  "AS0088",
-                      "action":  "None",
-                      "justification": "Temporarily disabled to allow renumbering of Subcontracting App"
+                      "action":  "Error"
                   },
                   {
                       "id":  "AS0089",
@@ -437,8 +433,7 @@
                   },
                   {
                       "id":  "AS0106",
-                      "action":  "None",
-                      "justification": "Temporarily disabled to allow renumbering of Subcontracting App"
+                      "action":  "Error"
                   },
                   {
                       "id":  "AS0107",


### PR DESCRIPTION
## What & why

Re-enables the AppSourceCop rules that were temporarily disabled for the Subcontracting object renumbering and removes the temporary `AS0072`/`AS0136` pragmas added to the Subcontracting app.

This PR contains only ruleset and pragma cleanup. It does not change application behavior.

## Rules re-enabled

- AS0001
- AS0018
- AS0029
- AS0088
- AS0106

## Linked work

Fixes [AB#646188](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646188)



