### PR TITLE
[Master]-Payment Reference from Purchase Order Prepayment Invoice is not Transferred to Vendor Ledger Entries.

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7663,6 +7663,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7679,6 +7681,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/APAC/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
+++ b/src/Layers/APAC/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
@@ -10,18 +10,19 @@ codeunit 134333 "ERM Purchase Prepayments"
     end;
 
     var
-        LibraryRandom: Codeunit "Library - Random";
-        LibraryPurchase: Codeunit "Library - Purchase";
-        LibraryERM: Codeunit "Library - ERM";
-        LibraryUtility: Codeunit "Library - Utility";
-        PurchasePostPrepayments: Codeunit "Purchase-Post Prepayments";
         Assert: Codeunit Assert;
-        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryERM: Codeunit "Library - ERM";
         LibraryInventory: Codeunit "Library - Inventory";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        LibraryRandom: Codeunit "Library - Random";
+        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryUtility: Codeunit "Library - Utility";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        PurchasePostPrepayments: Codeunit "Purchase-Post Prepayments";
         IsInitialized: Boolean;
         LCYCode: Code[10];
         NoAmtFoundToBePostedErr: Label 'No amount found to be posted.';
+        PaymentReferenceNotTransferredErr: Label '%1 was not transferred to the %2.', Comment = '%1 Field Caption,%2 Table Caption';
 
     local procedure Initialize()
     var
@@ -425,6 +426,49 @@ codeunit 134333 "ERM Purchase Prepayments"
 
         // [THEN] "Order Line No." in Purch. Rcpt. Line is equal to "Line No." of Purchase Line [1].
         Assert.AreEqual(PurchaseLine[1]."Line No.", PurchRcptLine."Order Line No.", '');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PaymentReferenceTransferredToVLEOnPurchasePrepaymentInvoice()
+    var
+        GLAccount: Record "G/L Account";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        Vendor: Record Vendor;
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 643383] Payment Reference from the Purchase Order is transferred to the Vendor Ledger Entry when posting a prepayment invoice.
+        Initialize();
+
+        // [GIVEN] Prepayment posting setup, an item and a vendor with a prepayment %.
+        PreparePrepaymentsPostingSetup(GLAccount);
+        PrepareItemAccordingToSetup(Item, GLAccount);
+        PrepareVendorAccordingToSetup(Vendor, GLAccount, LibraryRandom.RandInt(100));
+
+        // [GIVEN] A Purchase Order with a Payment Reference specified.
+        CreatePurchOrder(PurchaseHeader, Vendor, Item, LCYCode);
+
+        PurchaseHeader.Validate("Payment Reference", LibraryUtility.GenerateRandomCode(PurchaseHeader.FieldNo("Payment Reference"), Database::"Purchase Header"));
+        PurchaseHeader.Modify(true);
+
+        // [WHEN] Post the prepayment invoice via Purchase order page.
+        PurchaseOrder.OpenEdit();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+        PurchaseOrder.PostPrepaymentInvoice.Invoke();
+        Commit();
+        PurchaseOrder.Close();
+
+        // [THEN] The Vendor Ledger Entry created for the prepayment carries the Payment Reference from the Purchase Order.
+        CheckNumOfVendorLedgerEntries(VendorLedgerEntry, Vendor, 1);
+        VendorLedgerEntry.FindFirst();
+
+        // [THEN] The Payment Reference from the Purchase Header should be transferred to the Vendor Ledger Entry table.
+        Assert.AreEqual(
+            PurchaseHeader."Payment Reference", VendorLedgerEntry."Payment Reference",
+            StrSubstNo(
+                PaymentReferenceNotTransferredErr, PurchaseHeader.FieldCaption("Payment Reference"), VendorLedgerEntry.TableCaption()));
     end;
 
     local procedure PreparePrepaymentsPostingSetup(var GLAccount: Record "G/L Account")

--- a/src/Layers/APAC/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
+++ b/src/Layers/APAC/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
@@ -450,7 +450,7 @@ codeunit 134333 "ERM Purchase Prepayments"
         // [GIVEN] A Purchase Order with a Payment Reference specified.
         CreatePurchOrder(PurchaseHeader, Vendor, Item, LCYCode);
 
-        PurchaseHeader.Validate("Payment Reference", LibraryUtility.GenerateRandomCode(PurchaseHeader.FieldNo("Payment Reference"), Database::"Purchase Header"));
+        PurchaseHeader."Payment Reference" := LibraryUtility.GenerateRandomCode(PurchaseHeader.FieldNo("Payment Reference"), Database::"Purchase Header");
         PurchaseHeader.Modify(true);
 
         // [WHEN] Post the prepayment invoice via Purchase order page.

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7285,6 +7285,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7301,6 +7303,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7386,6 +7386,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7402,6 +7404,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/DACH/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/DACH/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7277,6 +7277,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7293,6 +7295,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7434,6 +7434,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7450,7 +7452,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
-        "Recipient Bank Account" := PurchHeader."Vendor Bank Acc. Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7452,6 +7452,7 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        "Recipient Bank Account" := PurchHeader."Vendor Bank Acc. Code";
         if PurchHeader."Payment Reference" <> '' then
             "Payment Reference" := PurchHeader."Payment Reference"
         else begin

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7318,6 +7318,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7334,6 +7336,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7298,6 +7298,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7314,6 +7316,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7254,6 +7254,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7270,6 +7272,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7934,6 +7934,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7950,6 +7952,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7401,6 +7401,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7417,6 +7419,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7294,6 +7294,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7310,6 +7312,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7518,6 +7518,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7534,6 +7536,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -8438,6 +8438,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -8454,6 +8456,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/SE/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/SE/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7265,6 +7265,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7281,6 +7283,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -7245,6 +7245,8 @@ table 81 "Gen. Journal Line"
     end;
 
     procedure CopyFromPurchHeaderPrepmtPost(PurchHeader: Record "Purchase Header"; UsePmtDisc: Boolean)
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
     begin
         "Account Type" := "Account Type"::Vendor;
         "Account No." := PurchHeader."Pay-to Vendor No.";
@@ -7261,6 +7263,13 @@ table 81 "Gen. Journal Line"
         "Due Date" := PurchHeader."Prepayment Due Date";
         "Payment Terms Code" := PurchHeader."Payment Terms Code";
         "Payment Method Code" := PurchHeader."Payment Method Code";
+        if PurchHeader."Payment Reference" <> '' then
+            "Payment Reference" := PurchHeader."Payment Reference"
+        else begin
+            PurchasesPayablesSetup.Get();
+            if PurchasesPayablesSetup."Copy Inv. No. To Pmt. Ref." then
+                "Payment Reference" := PurchHeader."Vendor Invoice No.";
+        end;
         if UsePmtDisc then begin
             "Pmt. Discount Date" := PurchHeader."Prepmt. Pmt. Discount Date";
             "Payment Discount %" := PurchHeader."Prepmt. Payment Discount %";

--- a/src/Layers/W1/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
+++ b/src/Layers/W1/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
@@ -10,18 +10,19 @@ codeunit 134333 "ERM Purchase Prepayments"
     end;
 
     var
-        LibraryRandom: Codeunit "Library - Random";
-        LibraryPurchase: Codeunit "Library - Purchase";
-        LibraryERM: Codeunit "Library - ERM";
-        LibraryUtility: Codeunit "Library - Utility";
-        PurchasePostPrepayments: Codeunit "Purchase-Post Prepayments";
         Assert: Codeunit Assert;
-        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryERM: Codeunit "Library - ERM";
         LibraryInventory: Codeunit "Library - Inventory";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        LibraryRandom: Codeunit "Library - Random";
+        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryUtility: Codeunit "Library - Utility";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        PurchasePostPrepayments: Codeunit "Purchase-Post Prepayments";
         IsInitialized: Boolean;
         LCYCode: Code[10];
         NoAmtFoundToBePostedErr: Label 'No amount found to be posted.';
+        PaymentReferenceNotTransferredErr: Label '%1 was not transferred to the %2.', Comment = '%1 Field Caption,%2 Table Caption';
 
     local procedure Initialize()
     var
@@ -424,6 +425,49 @@ codeunit 134333 "ERM Purchase Prepayments"
 
         // [THEN] "Order Line No." in Purch. Rcpt. Line is equal to "Line No." of Purchase Line [1].
         Assert.AreEqual(PurchaseLine[1]."Line No.", PurchRcptLine."Order Line No.", '');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PaymentReferenceTransferredToVLEOnPurchasePrepaymentInvoice()
+    var
+        GLAccount: Record "G/L Account";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        Vendor: Record Vendor;
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 643383] Payment Reference from the Purchase Order is transferred to the Vendor Ledger Entry when posting a prepayment invoice.
+        Initialize();
+
+        // [GIVEN] Prepayment posting setup, an item and a vendor with a prepayment %.
+        PreparePrepaymentsPostingSetup(GLAccount);
+        PrepareItemAccordingToSetup(Item, GLAccount);
+        PrepareVendorAccordingToSetup(Vendor, GLAccount, LibraryRandom.RandInt(100));
+
+        // [GIVEN] A Purchase Order with a Payment Reference specified.
+        CreatePurchOrder(PurchaseHeader, Vendor, Item, LCYCode);
+
+        PurchaseHeader.Validate("Payment Reference", LibraryUtility.GenerateRandomCode(PurchaseHeader.FieldNo("Payment Reference"), Database::"Purchase Header"));
+        PurchaseHeader.Modify(true);
+
+        // [WHEN] Post the prepayment invoice via Purchase order page.
+        PurchaseOrder.OpenEdit();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+        PurchaseOrder.PostPrepaymentInvoice.Invoke();
+        Commit();
+        PurchaseOrder.Close();
+
+        // [THEN] The Vendor Ledger Entry created for the prepayment carries the Payment Reference from the Purchase Order.
+        CheckNumOfVendorLedgerEntries(VendorLedgerEntry, Vendor, 1);
+        VendorLedgerEntry.FindFirst();
+
+        // [THEN] The Payment Reference from the Purchase Header should be transferred to the Vendor Ledger Entry table.
+        Assert.AreEqual(
+            PurchaseHeader."Payment Reference", VendorLedgerEntry."Payment Reference",
+            StrSubstNo(
+                PaymentReferenceNotTransferredErr, PurchaseHeader.FieldCaption("Payment Reference"), VendorLedgerEntry.TableCaption()));
     end;
 
     local procedure PreparePrepaymentsPostingSetup(var GLAccount: Record "G/L Account")

--- a/src/Layers/W1/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
+++ b/src/Layers/W1/Tests/Prepayment/ERMPurchasePrepayments.Codeunit.al
@@ -449,7 +449,7 @@ codeunit 134333 "ERM Purchase Prepayments"
         // [GIVEN] A Purchase Order with a Payment Reference specified.
         CreatePurchOrder(PurchaseHeader, Vendor, Item, LCYCode);
 
-        PurchaseHeader.Validate("Payment Reference", LibraryUtility.GenerateRandomCode(PurchaseHeader.FieldNo("Payment Reference"), Database::"Purchase Header"));
+        PurchaseHeader."Payment Reference" := LibraryUtility.GenerateRandomCode(PurchaseHeader.FieldNo("Payment Reference"), Database::"Purchase Header");
         PurchaseHeader.Modify(true);
 
         // [WHEN] Post the prepayment invoice via Purchase order page.


### PR DESCRIPTION
Fixes [AB#646227](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646227)

**ISSUE**: Payment Reference from Purchase Order Prepayment Invoice is not Transferred to Vendor Ledger Entries.

**CAUSE**: Payment Reference value is not transferred from the Purchase Order Prepayment Invoice to the Vendor Ledger Entry.

**SOLUTION** :- Add the required code to transfer the **Payment Reference** value from the **Purchase Order Prepayment Invoice** to the **Vendor Ledger Entry**.





