### PR TITLE
Fix the shadowed header cache in reminder line GetCurrencyCodeFromHeader

### DIFF
--- a/src/Layers/ES/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -667,6 +667,9 @@ table 296 "Reminder Line"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         ReminderHeader: Record "Reminder Header";
+        // Used only by GetCurrencyCodeFromHeader(). The shared ReminderHeader global cannot be reused there:
+        // GetReminderHeader() takes a matching "No." as proof that ProcessReminderHeader() already ran.
+        CurrencyCodeReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
         ReminderEntry: Record "Reminder/Fin. Charge Entry";
@@ -893,14 +896,12 @@ table 296 "Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or blank if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        ReminderHeader: Record "Reminder Header";
     begin
-        if "Reminder No." = ReminderHeader."No." then
-            exit(ReminderHeader."Currency Code");
+        if "Reminder No." = CurrencyCodeReminderHeader."No." then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
-        if ReminderHeader.Get("Reminder No.") then
-            exit(ReminderHeader."Currency Code");
+        if CurrencyCodeReminderHeader.Get("Reminder No.") then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
         exit('');
     end;

--- a/src/Layers/FI/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
@@ -351,8 +351,6 @@ table 298 "Issued Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or empty string if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        IssuedReminderHeader: Record "Issued Reminder Header";
     begin
         if "Reminder No." = IssuedReminderHeader."No." then
             exit(IssuedReminderHeader."Currency Code");

--- a/src/Layers/FI/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -671,6 +671,9 @@ table 296 "Reminder Line"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         ReminderHeader: Record "Reminder Header";
+        // Used only by GetCurrencyCodeFromHeader(). The shared ReminderHeader global cannot be reused there:
+        // GetReminderHeader() takes a matching "No." as proof that ProcessReminderHeader() already ran.
+        CurrencyCodeReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
         ReminderEntry: Record "Reminder/Fin. Charge Entry";
@@ -897,14 +900,12 @@ table 296 "Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or blank if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        ReminderHeader: Record "Reminder Header";
     begin
-        if "Reminder No." = ReminderHeader."No." then
-            exit(ReminderHeader."Currency Code");
+        if "Reminder No." = CurrencyCodeReminderHeader."No." then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
-        if ReminderHeader.Get("Reminder No.") then
-            exit(ReminderHeader."Currency Code");
+        if CurrencyCodeReminderHeader.Get("Reminder No.") then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
         exit('');
     end;

--- a/src/Layers/GB/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
@@ -349,8 +349,6 @@ table 298 "Issued Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or empty string if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        IssuedReminderHeader: Record "Issued Reminder Header";
     begin
         if "Reminder No." = IssuedReminderHeader."No." then
             exit(IssuedReminderHeader."Currency Code");

--- a/src/Layers/GB/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -669,6 +669,9 @@ table 296 "Reminder Line"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         ReminderHeader: Record "Reminder Header";
+        // Used only by GetCurrencyCodeFromHeader(). The shared ReminderHeader global cannot be reused there:
+        // GetReminderHeader() takes a matching "No." as proof that ProcessReminderHeader() already ran.
+        CurrencyCodeReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
         ReminderEntry: Record "Reminder/Fin. Charge Entry";
@@ -895,14 +898,12 @@ table 296 "Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or blank if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        ReminderHeader: Record "Reminder Header";
     begin
-        if "Reminder No." = ReminderHeader."No." then
-            exit(ReminderHeader."Currency Code");
+        if "Reminder No." = CurrencyCodeReminderHeader."No." then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
-        if ReminderHeader.Get("Reminder No.") then
-            exit(ReminderHeader."Currency Code");
+        if CurrencyCodeReminderHeader.Get("Reminder No.") then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
         exit('');
     end;

--- a/src/Layers/NO/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
@@ -361,8 +361,6 @@ table 298 "Issued Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or empty string if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        IssuedReminderHeader: Record "Issued Reminder Header";
     begin
         if "Reminder No." = IssuedReminderHeader."No." then
             exit(IssuedReminderHeader."Currency Code");

--- a/src/Layers/NO/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -698,6 +698,9 @@ table 296 "Reminder Line"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         ReminderHeader: Record "Reminder Header";
+        // Used only by GetCurrencyCodeFromHeader(). The shared ReminderHeader global cannot be reused there:
+        // GetReminderHeader() takes a matching "No." as proof that ProcessReminderHeader() already ran.
+        CurrencyCodeReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
         ReminderEntry: Record "Reminder/Fin. Charge Entry";
@@ -927,14 +930,12 @@ table 296 "Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or blank if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        ReminderHeader: Record "Reminder Header";
     begin
-        if "Reminder No." = ReminderHeader."No." then
-            exit(ReminderHeader."Currency Code");
+        if "Reminder No." = CurrencyCodeReminderHeader."No." then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
-        if ReminderHeader.Get("Reminder No.") then
-            exit(ReminderHeader."Currency Code");
+        if CurrencyCodeReminderHeader.Get("Reminder No.") then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
         exit('');
     end;

--- a/src/Layers/W1/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/IssuedReminderLine.Table.al
@@ -347,8 +347,6 @@ table 298 "Issued Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or empty string if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        IssuedReminderHeader: Record "Issued Reminder Header";
     begin
         if "Reminder No." = IssuedReminderHeader."No." then
             exit(IssuedReminderHeader."Currency Code");

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -667,6 +667,9 @@ table 296 "Reminder Line"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         ReminderHeader: Record "Reminder Header";
+        // Used only by GetCurrencyCodeFromHeader(). The shared ReminderHeader global cannot be reused there:
+        // GetReminderHeader() takes a matching "No." as proof that ProcessReminderHeader() already ran.
+        CurrencyCodeReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
         ReminderEntry: Record "Reminder/Fin. Charge Entry";
@@ -893,14 +896,12 @@ table 296 "Reminder Line"
     /// </summary>
     /// <returns>The currency code from the header, or blank if not found.</returns>
     procedure GetCurrencyCodeFromHeader(): Code[10]
-    var
-        ReminderHeader: Record "Reminder Header";
     begin
-        if "Reminder No." = ReminderHeader."No." then
-            exit(ReminderHeader."Currency Code");
+        if "Reminder No." = CurrencyCodeReminderHeader."No." then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
-        if ReminderHeader.Get("Reminder No.") then
-            exit(ReminderHeader."Currency Code");
+        if CurrencyCodeReminderHeader.Get("Reminder No.") then
+            exit(CurrencyCodeReminderHeader."Currency Code");
 
         exit('');
     end;


### PR DESCRIPTION
## What & why

`GetCurrencyCodeFromHeader()` on table 296 "Reminder Line" and table 298 "Issued Reminder Line" declares a local record that shadows the same-named global. The cache check on the first line therefore always compares against a freshly initialized local, never matches, and the header is re-read from the database on every single call (issue #8850).

The procedure is not called occasionally. It is the `AutoFormatExpression` of the amount fields on both tables and of the amount columns on the reminder reports: **230 usages across 26 files**, covering the W1, ES, FI, GB and NO copies of the two tables, the `Reminder` and `Reminder Test` reports in APAC, BE, DACH, ES, FI, FR, GB, NA, NO and W1, and report extension 10584 in the GB `ReportsGB` app. Every amount rendered on a reminder line or a reminder report triggers one `Get`, so a reminder with N lines costs roughly 4N header reads to display where 1 would do.

**The fix is not the same on the two tables, and that is deliberate.**

- **Table 298 "Issued Reminder Line"** (W1, FI, GB, NO): the shadowing local is simply deleted, so the existing global finally does its job. This is the fix proposed in the issue and it matches Microsoft's own pattern on posted tables that already have no shadow, for example `PurchRcptLine.GetCurrencyCodeFromHeader()` and `SalesShipmentLine.GetCurrencyCodeFromHeader()`. It is safe here because the `IssuedReminderHeader` global on this table carries no contract: it is only ever read straight after an unconditional `Get`, and every writer of Issued Reminder Header after issuance touches non-currency fields.

- **Table 296 "Reminder Line"** (W1, ES, FI, GB, NO): the same plain deletion would introduce a real defect, so this fix adds a dedicated global used only by this procedure instead. On the editable table the `ReminderHeader` global is a shared cache with an invariant: `GetReminderHeader()` treats a matching `"Reminder No."` as proof that `ProcessReminderHeader()` has already run, and `ProcessReminderHeader()` is the only writer of the `Currency` global and the only place four header `TestField` checks are made. Letting the display path populate that shared global would break the invariant: the lines part formats amounts before any validation runs, `GetReminderHeader()` would then hit the cache, `ProcessReminderHeader()` would be skipped, and the subsequent `Amount` validation would round with an `"Amount Rounding Precision"` of 0 while the four header checks silently never fire. A separate `CurrencyCodeReminderHeader` global gives the identical fetch-count win with no coupling to that contract, and a short comment in the variable block records why it exists.

Implementing this through `GetReminderHeader()` was also considered and rejected: it hard-`Get`s, so a missing header would raise an error during rendering where the procedure currently returns a blank string, and its `TestField` checks would fire while merely formatting a list.

Credit to @FSchneiderYav, who reported this and had already written the plain-deletion fix as PR #1894 in the BusinessCentralApps repository, closed by that repository's retirement rather than on its merits. I offered to carry it forward in the issue thread and am doing so here, with the table 296 shape changed for the reason above.

## Linked work

Fixes #8850

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- **Why no new test.** Under the dedicated-cache shape on table 296 the change is behavior-preserving by construction: the procedure's return value is the same in every reachable state, and the new global is touched by nothing else. The behavior actually worth protecting is an ordering property (format the lines part, then edit an amount, and observe that rounding precision is still initialized), and the repository has no existing coverage of that ordering to extend. I did not want to claim the existing reminder suites cover this, because they do not: `ERMFinancialReportsII` and `ERMInvoiceandReminder` drive fresh record variables and cannot reach the format-then-validate sequence. If you would like a regression test anyway, the shape I would write is a `TestPage` test on page 434 "Reminder" driving the `ReminderLines` host control, since page 435 is a ListPart and cannot be opened standalone. Happy to add it if you prefer that over the argument above.
- **How the behavior was verified.** I have no local Business Central environment for this repository, so I checked the reasoning by tracing the code rather than by running it. The chain the table 296 shape protects is: `GetReminderHeader()` treats a matching `"Reminder No."` as proof that `ProcessReminderHeader()` has already run; `ProcessReminderHeader()` is the only writer of the `Currency` record and the only place the four header `TestField` checks happen; and the `Amount`, `Remaining Amount` and line fee validations each round against `Currency."Amount Rounding Precision"` immediately after calling `GetReminderHeader()`. Since page 435 renders the `AutoFormatExpression` fields before any of those validations run, that is the ordering a shared-global fix would break and the dedicated global leaves untouched. If you would like this confirmed on a live environment before merging, I am glad to run whichever repro you prefer.
- **Layer-copy verification, since CI does not cover it.** This repository's build compiles `src/Layers/W1/BaseApp` only; the ES, FI, GB and NO copies have no app.json and no AL-Go project references them, and `VerifyMiappSync` checks that the files exist, not what they contain. So the eight country files in this PR get **no compiler coverage from the PR build** and I verified them by hand instead. Each file was edited independently at its own offsets, never by copying W1 over a country copy, because the copies carry exclusive content (NO field 10601 "Account Code", FI field 32000000 "Reference No.", the GB key guard, the ES "VAT+EC %" field). To prove no country content was disturbed, I captured `diff -u` of W1 against each country copy before and after the edit and asserted the divergence is unchanged:

  | Country copy | Divergent lines before | After |
  |---|---:|---:|
  | ES Reminder Line | 2 | 2 |
  | FI Reminder Line | 4 | 4 |
  | GB Reminder Line | 2 | 2 |
  | NO Reminder Line | 33 | 33 |
  | FI Issued Reminder Line | 4 | 4 |
  | GB Issued Reminder Line | 2 | 2 |
  | NO Issued Reminder Line | 14 | 14 |

  I also asserted that each of the nine files loses exactly one header-record declaration (the shadowing local) and that the five table 296 files gain exactly one `CurrencyCodeReminderHeader` declaration, in the global variable block.
- All nine files are required. `VerifyMiappSync` fails a W1-only changelist for these tables, so trimming this to W1 is not an option.

## Risk & compatibility

- I am deliberately not claiming "no observable behavior change". The precise statement is: the procedure returns the same value in every reachable state, and on table 296 the dedicated global keeps the display path from touching business state. What does change is how often the header is read, which is the point of the fix.
- **One accepted cosmetic limitation.** Any key-only cache, including Microsoft's existing `GetReminderHeader()`, keeps returning the cached header until the key changes. The reachable consequence: after changing a header's currency and running Suggest Reminder Lines, an already-open lines part can format amounts with the previous currency until the page instance is rebuilt. This is display formatting only, and every validation path stays protected, because `OnInsert` performs a raw `Get` and a currency change deletes the lines through Undo. I chose to document this rather than add invalidation, since fixing it would mean a broader change than the issue asks for. Say the word if you would rather have it addressed here.
- The fix assumes the platform reuses the record instance across `AutoFormatExpression` evaluations, which is the issue's own premise and what the reporter observed. If some path formats on throwaway instances, the change degrades to a harmless no-op there.
- **Out of scope, flagged for transparency.** Tables 303 "Finance Charge Memo Line" and 305 "Issued Fin. Charge Memo Line" carry the identical shadowed local in their `GetCurrencyCode()`, across six more files (W1 for both, plus CZ, ES and NO Finance Charge Memo Line and NO Issued Fin. Charge Memo Line). Table 303 has the same shared-global invariant as 296 and would need the dedicated-cache treatment; table 305 is a plain win like 298. I left them out because #8850 is scoped to the reminder tables. Happy to file a follow-up issue and fix them the same way if you want them covered.
- Area: Finance, matching the issue. I cannot set labels myself.

