### PR TITLE
[PEPPOL] Handle unknown persisted PEPPOL format values

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Format.Enum.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Format.Enum.al
@@ -23,6 +23,16 @@ enum 37200 "PEPPOL 3.0 Format" implements "PEPPOL Attachment Provider",
                             "PEPPOL Party Info Provider" = "PEPPOL30",
                             "PEPPOL Payment Info Provider" = "PEPPOL30",
                             "PEPPOL Tax Info Provider" = "PEPPOL30";
+    UnknownValueImplementation = "PEPPOL Attachment Provider" = "PEPPOL30",
+                                 "PEPPOL Delivery Info Provider" = "PEPPOL30",
+                                 "PEPPOL Document Info Provider" = "PEPPOL30",
+                                 "PEPPOL Line Info Provider" = "PEPPOL30",
+                                 "PEPPOL Monetary Info Provider" = "PEPPOL30",
+                                 "PEPPOL Party Info Provider" = "PEPPOL30",
+                                 "PEPPOL Payment Info Provider" = "PEPPOL30",
+                                 "PEPPOL Posted Document Iterator" = "PEPPOL30 Unknown Format",
+                                 "PEPPOL Tax Info Provider" = "PEPPOL30",
+                                 "PEPPOL30 Validation" = "PEPPOL30 Unknown Format";
     Extensible = true;
 
     value(0; "PEPPOL 3.0 - Sales")

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30UnknownFormat.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30UnknownFormat.Codeunit.al
@@ -11,40 +11,53 @@ codeunit 37223 "PEPPOL30 Unknown Format" implements "PEPPOL30 Validation", "PEPP
     Access = Internal;
 
     var
-        UnknownFormatErr: Label 'The selected PEPPOL 3.0 format is no longer available. Open the PEPPOL 3.0 Setup page and select an available format.';
+        UnknownFormatErr: Label 'The selected PEPPOL 3.0 format is no longer available. Select an available format.';
+        UnknownFormatTitleErr: Label 'PEPPOL 3.0 format unavailable';
+        OpenPEPPOLSetupLbl: Label 'Open PEPPOL 3.0 Setup';
 
     procedure ValidateDocument(RecordVariant: Variant)
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
     end;
 
     procedure ValidateDocumentLines(RecordVariant: Variant)
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
     end;
 
     procedure ValidateDocumentLine(RecordVariant: Variant)
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
     end;
 
     procedure ValidateLineTypeAndDescription(RecordVariant: Variant): Boolean
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
     end;
 
     procedure ValidatePostedDocument(RecordVariant: Variant)
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
     end;
 
     procedure GetNextPostedHeaderAsSalesHeader(var PostedRecRef: RecordRef; var SalesHeader: Record "Sales Header") Found: Boolean
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
     end;
 
     procedure GetNextPostedLineAsSalesLine(var PostedLineRecRef: RecordRef; var SalesLine: Record "Sales Line") Found: Boolean
     begin
-        Error(UnknownFormatErr);
+        RaiseUnknownFormatError();
+    end;
+
+    local procedure RaiseUnknownFormatError()
+    var
+        UnknownFormatErrorInfo: ErrorInfo;
+    begin
+        UnknownFormatErrorInfo.Title := UnknownFormatTitleErr;
+        UnknownFormatErrorInfo.Message := UnknownFormatErr;
+        UnknownFormatErrorInfo.PageNo := Page::"PEPPOL 3.0 Setup";
+        UnknownFormatErrorInfo.AddNavigationAction(OpenPEPPOLSetupLbl);
+        Error(UnknownFormatErrorInfo);
     end;
 }

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30UnknownFormat.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30UnknownFormat.Codeunit.al
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Peppol;
+
+using Microsoft.Sales.Document;
+
+codeunit 37223 "PEPPOL30 Unknown Format" implements "PEPPOL30 Validation", "PEPPOL Posted Document Iterator"
+{
+    Access = Internal;
+
+    var
+        UnknownFormatErr: Label 'The selected PEPPOL 3.0 format is no longer available. Open the PEPPOL 3.0 Setup page and select an available format.';
+
+    procedure ValidateDocument(RecordVariant: Variant)
+    begin
+        Error(UnknownFormatErr);
+    end;
+
+    procedure ValidateDocumentLines(RecordVariant: Variant)
+    begin
+        Error(UnknownFormatErr);
+    end;
+
+    procedure ValidateDocumentLine(RecordVariant: Variant)
+    begin
+        Error(UnknownFormatErr);
+    end;
+
+    procedure ValidateLineTypeAndDescription(RecordVariant: Variant): Boolean
+    begin
+        Error(UnknownFormatErr);
+    end;
+
+    procedure ValidatePostedDocument(RecordVariant: Variant)
+    begin
+        Error(UnknownFormatErr);
+    end;
+
+    procedure GetNextPostedHeaderAsSalesHeader(var PostedRecRef: RecordRef; var SalesHeader: Record "Sales Header") Found: Boolean
+    begin
+        Error(UnknownFormatErr);
+    end;
+
+    procedure GetNextPostedLineAsSalesLine(var PostedLineRecRef: RecordRef; var SalesLine: Record "Sales Line") Found: Boolean
+    begin
+        Error(UnknownFormatErr);
+    end;
+}

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30UnknownFormat.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30UnknownFormat.Codeunit.al
@@ -56,6 +56,7 @@ codeunit 37223 "PEPPOL30 Unknown Format" implements "PEPPOL30 Validation", "PEPP
     begin
         UnknownFormatErrorInfo.Title := UnknownFormatTitleErr;
         UnknownFormatErrorInfo.Message := UnknownFormatErr;
+        UnknownFormatErrorInfo.DataClassification := DataClassification::SystemMetadata;
         UnknownFormatErrorInfo.PageNo := Page::"PEPPOL 3.0 Setup";
         UnknownFormatErrorInfo.AddNavigationAction(OpenPEPPOLSetupLbl);
         Error(UnknownFormatErrorInfo);

--- a/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
@@ -75,7 +75,67 @@ codeunit 139235 "PEPPOL30 Management Tests"
         asserterror PEPPOL30Validation.ValidateDocument('');
 
         Assert.ExpectedErrorCode('Dialog');
-        Assert.IsSubstring(GetLastErrorText(), 'no longer available');
+        Assert.ExpectedError('no longer available');
+    end;
+
+    [Test]
+    procedure UnknownFormatDocumentLinesValidationRaisesControlledError()
+    var
+        PEPPOL30Validation: Interface "PEPPOL30 Validation";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOL30Validation := UnknownFormat;
+
+        asserterror PEPPOL30Validation.ValidateDocumentLines('');
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError('no longer available');
+    end;
+
+    [Test]
+    procedure UnknownFormatDocumentLineValidationRaisesControlledError()
+    var
+        PEPPOL30Validation: Interface "PEPPOL30 Validation";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOL30Validation := UnknownFormat;
+
+        asserterror PEPPOL30Validation.ValidateDocumentLine('');
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError('no longer available');
+    end;
+
+    [Test]
+    procedure UnknownFormatLineTypeValidationRaisesControlledError()
+    var
+        PEPPOL30Validation: Interface "PEPPOL30 Validation";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOL30Validation := UnknownFormat;
+
+        asserterror PEPPOL30Validation.ValidateLineTypeAndDescription('');
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError('no longer available');
+    end;
+
+    [Test]
+    procedure UnknownFormatPostedDocumentValidationRaisesControlledError()
+    var
+        PEPPOL30Validation: Interface "PEPPOL30 Validation";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOL30Validation := UnknownFormat;
+
+        asserterror PEPPOL30Validation.ValidatePostedDocument('');
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError('no longer available');
     end;
 
     [Test]
@@ -92,7 +152,24 @@ codeunit 139235 "PEPPOL30 Management Tests"
         asserterror PEPPOLPostedDocumentIterator.GetNextPostedHeaderAsSalesHeader(PostedRecRef, SalesHeader);
 
         Assert.ExpectedErrorCode('Dialog');
-        Assert.IsSubstring(GetLastErrorText(), 'no longer available');
+        Assert.ExpectedError('no longer available');
+    end;
+
+    [Test]
+    procedure UnknownFormatLineIteratorRaisesControlledError()
+    var
+        SalesLine: Record "Sales Line";
+        PostedLineRecRef: RecordRef;
+        PEPPOLPostedDocumentIterator: Interface "PEPPOL Posted Document Iterator";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOLPostedDocumentIterator := UnknownFormat;
+
+        asserterror PEPPOLPostedDocumentIterator.GetNextPostedLineAsSalesLine(PostedLineRecRef, SalesLine);
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError('no longer available');
     end;
 
     [Test]

--- a/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/Test/src/PEPPOL30ManagementTests.Codeunit.al
@@ -64,6 +64,38 @@ codeunit 139235 "PEPPOL30 Management Tests"
         SalespersonTxt: Label 'Salesperson';
 
     [Test]
+    procedure UnknownFormatValidationRaisesControlledError()
+    var
+        PEPPOL30Validation: Interface "PEPPOL30 Validation";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOL30Validation := UnknownFormat;
+
+        asserterror PEPPOL30Validation.ValidateDocument('');
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.IsSubstring(GetLastErrorText(), 'no longer available');
+    end;
+
+    [Test]
+    procedure UnknownFormatIteratorRaisesControlledError()
+    var
+        SalesHeader: Record "Sales Header";
+        PostedRecRef: RecordRef;
+        PEPPOLPostedDocumentIterator: Interface "PEPPOL Posted Document Iterator";
+        UnknownFormat: Enum "PEPPOL 3.0 Format";
+    begin
+        UnknownFormat := Enum::"PEPPOL 3.0 Format".FromInteger(10995);
+        PEPPOLPostedDocumentIterator := UnknownFormat;
+
+        asserterror PEPPOLPostedDocumentIterator.GetNextPostedHeaderAsSalesHeader(PostedRecRef, SalesHeader);
+
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.IsSubstring(GetLastErrorText(), 'no longer available');
+    end;
+
+    [Test]
     procedure GeneralInfo()
     var
         Cust: Record Customer;


### PR DESCRIPTION
## Why

A PEPPOL format enum ordinal can remain in the persisted PEPPOL 3.0 Setup after the enum extension that declared it is uninstalled. Converting that unknown ordinal to a PEPPOL interface currently produces a technical runtime error because the base enum has no unknown-value implementation.

## Summary

- **Added** unknown-value mappings for every interface implemented by the PEPPOL 3.0 Format enum.
- **Added** a controlled handler that tells users to select an available format when validation or document iteration encounters an unavailable format.
- **Added** regression coverage for validation and iterator conversion of a persisted unknown ordinal.


https://github.com/microsoft/BCQuality/blob/712dee9ec1f0b098f859753e083e8c6efa903d01/microsoft/knowledge/interfaces/handle-unknown-enum-ordinals-with-unknownvalueimplementation.md





Fixes [AB#646302](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646302)






