### PR TITLE
Enable PSSession again

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -6,6 +6,8 @@
   "runs-on": "windows-latest",
   "cacheImageName": "",
   "UsePsSession": false,
+  "usePsSessionForBc28": true,
+  "debugMode": true,
   "gitHubRunner": "windows-latest",
   "githubRunnerShell": "pwsh",
   "artifact": "bcinsider/Sandbox/29.0.53396.0//latest",

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -7,7 +7,6 @@
   "cacheImageName": "",
   "UsePsSession": true,
   "usePsSessionForBc28": true,
-  "debugMode": true,
   "gitHubRunner": "windows-latest",
   "githubRunnerShell": "pwsh",
   "artifact": "bcinsider/Sandbox/29.0.53396.0//latest",

--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -5,7 +5,7 @@
   "bcContainerHelperVersion": "preview",
   "runs-on": "windows-latest",
   "cacheImageName": "",
-  "UsePsSession": false,
+  "UsePsSession": true,
   "usePsSessionForBc28": true,
   "debugMode": true,
   "gitHubRunner": "windows-latest",

--- a/build/scripts/NewBcContainer.ps1
+++ b/build/scripts/NewBcContainer.ps1
@@ -22,13 +22,6 @@ if ($platformVersion) {
     $parameters.platformArtifactUrl = "$platformUrl/platform"
 }
 
-$genericImageName = Get-BestGenericImageName
-Write-Host "Pulling latest generic Business Central container image '$genericImageName'"
-docker pull $genericImageName
-if ($LASTEXITCODE -ne 0) {
-    throw "Failed to pull Docker image '$genericImageName'"
-}
-
 New-BcContainer @parameters
 
 Set-BcContainerServerConfiguration -containerName $parameters.ContainerName -keyName "EnforceUserPathForAlFileOperations" -keyValue "false"

--- a/build/scripts/NewBcContainer.ps1
+++ b/build/scripts/NewBcContainer.ps1
@@ -22,6 +22,13 @@ if ($platformVersion) {
     $parameters.platformArtifactUrl = "$platformUrl/platform"
 }
 
+$genericImageName = Get-BestGenericImageName
+Write-Host "Pulling latest generic Business Central container image '$genericImageName'"
+docker pull $genericImageName
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to pull Docker image '$genericImageName'"
+}
+
 New-BcContainer @parameters
 
 Set-BcContainerServerConfiguration -containerName $parameters.ContainerName -keyName "EnforceUserPathForAlFileOperations" -keyValue "false"


### PR DESCRIPTION
## What & why

Enable AL-Go PowerShell sessions for BCApps PR builds so container script invocations can use remote PowerShell sessions instead of the slower `docker exec` path where supported. This keeps the BC28-specific opt-in setting in place while enabling PSSessions generally for the repo.

## Linked work

[AB#646705](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646705)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

- Parsed `.github\AL-Go-Settings.json` as JSON successfully.
- Created a local BC29 container with PSSessions enabled and confirmed `Invoke script using remote session`.
- Reviewed PR build logs and confirmed container jobs used cached PowerShell 7 WinRM sessions.
- No tests added because this only updates repository workflow/container setup.

## Risk & compatibility

BC28 still depends on the existing `usePsSessionForBc28` opt-in behavior. Runners must have working WinRM/PowerShell remoting for PSSessions; otherwise BcContainerHelper can fall back to `docker exec`.


