### PR TITLE
Use a constant for the SignUp authentication URL

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -166,12 +166,13 @@ codeunit 6442 "SignUp Authentication"
     end;
 
     /// <summary>
-    /// The method returns the authentication URL.
+    /// The method returns the authentication URL for the given Entra tenant.
     /// </summary>
-    /// <returns>Authentication URL, where %1 is the Entra tenant ID.</returns>
-    procedure GetAuthUrl(): Text
+    /// <param name="EntraTenantId">Entra tenant ID</param>
+    /// <returns>Authentication URL</returns>
+    procedure GetAuthUrl(EntraTenantId: Text): Text
     begin
-        exit(this.AuthURLTxt);
+        exit(StrSubstNo(this.AuthURLTxt, EntraTenantId));
     end;
 
     /// <summary>
@@ -292,7 +293,7 @@ codeunit 6442 "SignUp Authentication"
         this.SignUpConnectionSetup.Get();
 
         HttpRequestMessage := this.PrepareRequest(SecretStrSubstNo(this.AuthTemplateTxt, TypeHelper.UriEscapeDataString(ClientId), ClientSecret, TypeHelper.UriEscapeDataString(ClientId)),
-                                                  StrSubstNo(this.GetAuthUrl(), ClientTenant));
+                                                  this.GetAuthUrl(ClientTenant));
 
         if not this.SendRequest(HttpRequestMessage, Response) then
             exit;

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -24,6 +24,7 @@ codeunit 6442 "SignUp Authentication"
         EnvironmentInformation: Codeunit "Environment Information";
         BearerTxt: Label 'Bearer %1', Comment = '%1 = text value', Locked = true;
         AuthURLTxt: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1 Entra Tenant Id', Locked = true;
+        SandboxAuthURLTxt: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1 Entra Tenant Id', Locked = true;
         AuthTemplateTxt: Label 'grant_type=client_credentials&client_id=%1&client_secret=%2&resource=%3', Locked = true;
         ProdMarketplaceTenantIdTxt: Label '0d725623-dc26-484f-a090-b09d2003d092', Locked = true;
         ProdClientTenantIdTxt: Label 'eef4ab2c-2b10-4380-bf4b-214157971162', Locked = true;
@@ -166,6 +167,24 @@ codeunit 6442 "SignUp Authentication"
     end;
 
     /// <summary>
+    /// The method returns the production authentication URL.
+    /// </summary>
+    /// <returns>Authentication URL, where %1 is the Entra tenant ID.</returns>
+    procedure GetAuthUrl(): Text
+    begin
+        exit(this.AuthURLTxt);
+    end;
+
+    /// <summary>
+    /// The method returns the sandbox authentication URL.
+    /// </summary>
+    /// <returns>Authentication URL, where %1 is the Entra tenant ID.</returns>
+    procedure GetSandboxAuthUrl(): Text
+    begin
+        exit(this.SandboxAuthURLTxt);
+    end;
+
+    /// <summary>
     /// The method returns the Marketplace URL.
     /// </summary>
     /// <returns></returns>
@@ -280,11 +299,9 @@ codeunit 6442 "SignUp Authentication"
         Response: Text;
     begin
         Clear(AccessToken);
-        this.SignUpConnectionSetup.Get();
-        this.SignUpConnectionSetup.TestField("Authentication URL");
 
         HttpRequestMessage := this.PrepareRequest(SecretStrSubstNo(this.AuthTemplateTxt, TypeHelper.UriEscapeDataString(ClientId), ClientSecret, TypeHelper.UriEscapeDataString(ClientId)),
-                                                  StrSubstNo(this.SignUpConnectionSetup."Authentication URL", ClientTenant));
+                                                  StrSubstNo(this.GetAuthUrl(), ClientTenant));
 
         if not this.SendRequest(HttpRequestMessage, Response) then
             exit;

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -55,7 +55,6 @@ codeunit 6442 "SignUp Authentication"
         if this.SignUpConnectionSetup.Get() then
             exit;
 
-        this.SignUpConnectionSetup."Authentication URL" := this.AuthURLTxt;
         this.SignUpConnectionSetup."Service URL" := this.GetServiceApi();
         this.StorageSet(this.SignUpConnectionSetup."Marketplace Tenant", this.GetMarketplaceTenant());
         this.StorageSet(this.SignUpConnectionSetup."Client Tenant", this.GetClientTenant());

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -289,6 +289,7 @@ codeunit 6442 "SignUp Authentication"
         Response: Text;
     begin
         Clear(AccessToken);
+        this.SignUpConnectionSetup.Get();
 
         HttpRequestMessage := this.PrepareRequest(SecretStrSubstNo(this.AuthTemplateTxt, TypeHelper.UriEscapeDataString(ClientId), ClientSecret, TypeHelper.UriEscapeDataString(ClientId)),
                                                   StrSubstNo(this.GetAuthUrl(), ClientTenant));

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpAuthentication.Codeunit.al
@@ -24,7 +24,6 @@ codeunit 6442 "SignUp Authentication"
         EnvironmentInformation: Codeunit "Environment Information";
         BearerTxt: Label 'Bearer %1', Comment = '%1 = text value', Locked = true;
         AuthURLTxt: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1 Entra Tenant Id', Locked = true;
-        SandboxAuthURLTxt: Label 'https://login.microsoftonline.com/%1/oauth2/token', Comment = '%1 Entra Tenant Id', Locked = true;
         AuthTemplateTxt: Label 'grant_type=client_credentials&client_id=%1&client_secret=%2&resource=%3', Locked = true;
         ProdMarketplaceTenantIdTxt: Label '0d725623-dc26-484f-a090-b09d2003d092', Locked = true;
         ProdClientTenantIdTxt: Label 'eef4ab2c-2b10-4380-bf4b-214157971162', Locked = true;
@@ -167,21 +166,12 @@ codeunit 6442 "SignUp Authentication"
     end;
 
     /// <summary>
-    /// The method returns the production authentication URL.
+    /// The method returns the authentication URL.
     /// </summary>
     /// <returns>Authentication URL, where %1 is the Entra tenant ID.</returns>
     procedure GetAuthUrl(): Text
     begin
         exit(this.AuthURLTxt);
-    end;
-
-    /// <summary>
-    /// The method returns the sandbox authentication URL.
-    /// </summary>
-    /// <returns>Authentication URL, where %1 is the Entra tenant ID.</returns>
-    procedure GetSandboxAuthUrl(): Text
-    begin
-        exit(this.SandboxAuthURLTxt);
     end;
 
     /// <summary>

--- a/src/Apps/W1/EDocumentConnectors/SignUp/test/src/IntegrationHelpers.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/test/src/IntegrationHelpers.Codeunit.al
@@ -35,7 +35,6 @@ codeunit 148194 IntegrationHelpers
         SignUpAuthentication.StorageSet(SignUpConnectionSetup."Client Secret", this.DummyId());
         SignUpAuthentication.StorageSet(SignUpConnectionSetup."Client Tenant", this.ClientTenantId());
 
-        SignUpConnectionSetup."Authentication URL" := this.SetMockServiceUrl('/%1/oauth2/token');
         SignUpConnectionSetup."Environment Type" := SignUpConnectionSetup."Environment Type"::Test;
         SignUpConnectionSetup.Modify(true);
     end;


### PR DESCRIPTION
Resolves the SignUp token endpoint from a constant in codeunit 6442 `SignUp Authentication` instead of reading it from the setup table.

### Changes

- Adds `GetAuthUrl(EntraTenantId)`, which formats the existing `AuthURLTxt` label for the given tenant.
- `GetAccessToken` now builds the request URI from `GetAuthUrl()` rather than from the `Authentication URL` field of table 6440 `SignUp Connection Setup`.
- Drops the corresponding assignment from `IntegrationHelpers.SetCommonConnectionSetup`, since the field is no longer read. The test HTTP handlers match the token endpoint on a pattern that the constant satisfies, so the mocked responses are unaffected.

The endpoint is a fixed Microsoft Entra URL that is the same for every tenant, so there is no reason to keep it as configurable data. Keeping it in code makes the value consistent across environments and removes a setup step from onboarding.

### Notes

- The `Authentication URL` field is left in place for compatibility; it is simply no longer read.

[AB#646373](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646373)


