### PR TITLE
[main] features 640066 Add integration events for events for CZ Adv. Payment and CZ Cash Desk

### DIFF
--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CashDocumentLineCZZ.TableExt.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CashDocumentLineCZZ.TableExt.al
@@ -21,7 +21,13 @@ tableextension 31028 "Cash Document Line CZZ" extends "Cash Document Line CZP"
             var
                 SalesAdvLetterHeaderCZZ: Record "Sales Adv. Letter Header CZZ";
                 PurchAdvLetterHeaderCZZ: Record "Purch. Adv. Letter Header CZZ";
+                IsHandled: Boolean;
             begin
+                IsHandled := false;
+                OnBeforeValidateAdvanceLetterNoCZZ(Rec, xRec, IsHandled);
+                if IsHandled then
+                    exit;
+
                 if "Advance Letter No. CZZ" <> '' then begin
                     TestField("Gen. Document Type", "Gen. Document Type"::Payment);
                     case "Document Type" of
@@ -59,7 +65,13 @@ tableextension 31028 "Cash Document Line CZZ" extends "Cash Document Line CZP"
             var
                 SalesAdvLetterHeaderCZZ: Record "Sales Adv. Letter Header CZZ";
                 PurchAdvLetterHeaderCZZ: Record "Purch. Adv. Letter Header CZZ";
+                IsHandled: Boolean;
             begin
+                IsHandled := false;
+                OnBeforeLookupAdvanceLetterNoCZZ(Rec, IsHandled);
+                if IsHandled then
+                    exit;
+
                 TestField("Gen. Document Type", "Gen. Document Type"::Payment);
                 if not ((("Document Type" = "Document Type"::Receipt) and ("Account Type" = "Account Type"::Customer)) or
                         (("Document Type" = "Document Type"::Withdrawal) and ("Account Type" = "Account Type"::Vendor))) then
@@ -144,5 +156,15 @@ tableextension 31028 "Cash Document Line CZZ" extends "Cash Document Line CZP"
           ("Gen. Document Type" = "Gen. Document Type"::Refund) and
           ("Applies-To Doc. Type" = "Applies-To Doc. Type"::Payment) and
           ("Applies-To Doc. No." <> ''));
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeValidateAdvanceLetterNoCZZ(var CashDocumentLineCZP: Record "Cash Document Line CZP"; xCashDocumentLineCZP: Record "Cash Document Line CZP"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeLookupAdvanceLetterNoCZZ(var CashDocumentLineCZP: Record "Cash Document Line CZP"; var IsHandled: Boolean)
+    begin
     end;
 }

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CashDocumentLineCZZ.TableExt.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CashDocumentLineCZZ.TableExt.al
@@ -24,7 +24,7 @@ tableextension 31028 "Cash Document Line CZZ" extends "Cash Document Line CZP"
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
-                OnBeforeValidateAdvanceLetterNoCZZ(Rec, xRec, IsHandled);
+                OnBeforeValidateAdvanceLetterNoCZZ(Rec, IsHandled);
                 if IsHandled then
                     exit;
 
@@ -159,7 +159,7 @@ tableextension 31028 "Cash Document Line CZZ" extends "Cash Document Line CZP"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeValidateAdvanceLetterNoCZZ(var CashDocumentLineCZP: Record "Cash Document Line CZP"; xCashDocumentLineCZP: Record "Cash Document Line CZP"; var IsHandled: Boolean)
+    local procedure OnBeforeValidateAdvanceLetterNoCZZ(var CashDocumentLineCZP: Record "Cash Document Line CZP"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocLineTestHandlerCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocLineTestHandlerCZZ.Codeunit.al
@@ -1,3 +1,11 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Finance.AdvancePayments;
+
+using Microsoft.Finance.CashDesk;
+
 codeunit 148132 "Cash Doc Line Test Handler CZZ"
 {
     EventSubscriberInstance = Manual;

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocLineTestHandlerCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocLineTestHandlerCZZ.Codeunit.al
@@ -1,0 +1,32 @@
+codeunit 148132 "Cash Doc Line Test Handler CZZ"
+{
+    EventSubscriberInstance = Manual;
+
+    var
+        ValidateAdvanceLetterNoEventRaised: Boolean;
+        LookupAdvanceLetterNoEventRaised: Boolean;
+
+    [EventSubscriber(ObjectType::Table, Database::"Cash Document Line CZP", 'OnBeforeValidateAdvanceLetterNoCZZ', '', false, false)]
+    local procedure HandleOnBeforeValidateAdvanceLetterNoCZZ(var CashDocumentLineCZP: Record "Cash Document Line CZP"; var IsHandled: Boolean)
+    begin
+        ValidateAdvanceLetterNoEventRaised := true;
+        IsHandled := true;
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Cash Document Line CZP", 'OnBeforeLookupAdvanceLetterNoCZZ', '', false, false)]
+    local procedure HandleOnBeforeLookupAdvanceLetterNoCZZ(var CashDocumentLineCZP: Record "Cash Document Line CZP"; var IsHandled: Boolean)
+    begin
+        LookupAdvanceLetterNoEventRaised := true;
+        IsHandled := true;
+    end;
+
+    procedure GetValidateAdvanceLetterNoEventRaised(): Boolean
+    begin
+        exit(ValidateAdvanceLetterNoEventRaised);
+    end;
+
+    procedure GetLookupAdvanceLetterNoEventRaised(): Boolean
+    begin
+        exit(LookupAdvanceLetterNoEventRaised);
+    end;
+}

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocumentLineCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocumentLineCZZ.Codeunit.al
@@ -1,0 +1,82 @@
+codeunit 148133 "Cash Document Line CZZ"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+        CashDocLineTestHandlerCZZ: Codeunit "Cash Doc Line Test Handler CZZ";
+        LibraryCashDeskCZP: Codeunit "Library - Cash Desk CZP";
+        LibraryCashDocumentCZP: Codeunit "Library - Cash Document CZP";
+        LibraryUtility: Codeunit "Library - Utility";
+        LibrarySales: Codeunit "Library - Sales";
+
+    [Test]
+    procedure ValidateAdvanceLetterNoCanBeHandled()
+    var
+        CashDocumentLineCZP: Record "Cash Document Line CZP";
+        AdvanceLetterNo: Code[20];
+    begin
+        // [SCENARIO] Validation of the advance letter number can be handled by a subscriber
+        Initialize();
+        AdvanceLetterNo := CopyStr(LibraryUtility.GenerateRandomCode(
+                                          CashDocumentLineCZP.FieldNo("Advance Letter No. CZZ"), Database::"Cash Document Line CZP"), 1, MaxStrLen(CashDocumentLineCZP."Advance Letter No. CZZ"));
+        BindSubscription(CashDocLineTestHandlerCZZ);
+
+        // [WHEN] An advance letter number is validated on an otherwise invalid cash document line
+        CashDocumentLineCZP.Validate("Advance Letter No. CZZ", AdvanceLetterNo);
+        UnbindSubscription(CashDocLineTestHandlerCZZ);
+
+        // [THEN] The subscriber handles the validation before the standard checks are run
+        Assert.IsTrue(CashDocLineTestHandlerCZZ.GetValidateAdvanceLetterNoEventRaised(), 'The before validate event must be raised.');
+        CashDocumentLineCZP.TestField("Advance Letter No. CZZ", AdvanceLetterNo);
+    end;
+
+    [Test]
+    procedure LookupAdvanceLetterNoCanBeHandled()
+    var
+        CashDeskCZP: Record "Cash Desk CZP";
+        CashDeskUserCZP: Record "Cash Desk User CZP";
+        CashDocumentHeaderCZP: Record "Cash Document Header CZP";
+        CashDocumentLineCZP: Record "Cash Document Line CZP";
+        Customer: Record Customer;
+        CashDocumentSubformCZP: TestPage "Cash Document Subform CZP";
+    begin
+        // [SCENARIO] Lookup of the advance letter number can be handled by a subscriber
+        Initialize();
+        LibrarySales.CreateCustomer(Customer);
+        LibraryCashDeskCZP.CreateCashDeskCZP(CashDeskCZP);
+        LibraryCashDeskCZP.SetupCashDeskCZP(CashDeskCZP, false);
+        LibraryCashDeskCZP.CreateCashDeskUserCZP(CashDeskUserCZP, CashDeskCZP."No.", true, true, true);
+        LibraryCashDocumentCZP.CreateCashDocumentHeaderCZP(CashDocumentHeaderCZP, CashDocumentHeaderCZP."Document Type"::Receipt, CashDeskCZP."No.");
+        LibraryCashDocumentCZP.CreateCashDocumentLineCZP(
+            CashDocumentLineCZP, CashDocumentHeaderCZP,
+            Enum::"Cash Document Account Type CZP"::Customer, Customer."No.", 0);
+        CashDocumentLineCZP."Gen. Document Type" := CashDocumentLineCZP."Gen. Document Type"::" ";
+        CashDocumentLineCZP.Modify();
+        BindSubscription(CashDocLineTestHandlerCZZ);
+
+        // [WHEN] The advance letter number lookup is invoked on an otherwise invalid cash document line
+        CashDocumentSubformCZP.OpenEdit();
+        CashDocumentSubformCZP.GoToRecord(CashDocumentLineCZP);
+        CashDocumentSubformCZP."Advance Letter No. CZZ".Lookup();
+        CashDocumentSubformCZP.Close();
+        UnbindSubscription(CashDocLineTestHandlerCZZ);
+
+        // [THEN] The subscriber handles the lookup before the standard checks are run
+        Assert.IsTrue(CashDocLineTestHandlerCZZ.GetLookupAdvanceLetterNoEventRaised(), 'The before lookup event must be raised.');
+    end;
+
+    local procedure Initialize()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+    begin
+        Clear(CashDocLineTestHandlerCZZ);
+
+        GeneralLedgerSetup.Get();
+        if GeneralLedgerSetup."Cash Desk Nos. CZP" = '' then begin
+            GeneralLedgerSetup.Validate("Cash Desk Nos. CZP", LibraryUtility.GetGlobalNoSeriesCode());
+            GeneralLedgerSetup.Modify(true);
+        end;
+    end;
+}

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocumentLineCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/CashDocumentLineCZZ.Codeunit.al
@@ -1,3 +1,13 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Finance.AdvancePayments;
+
+using Microsoft.Finance.CashDesk;
+using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Sales.Customer;
+
 codeunit 148133 "Cash Document Line CZZ"
 {
     Subtype = Test;

--- a/src/Apps/CZ/CashDeskLocalization/app/Src/Codeunits/CashDocumentReleaseCZP.Codeunit.al
+++ b/src/Apps/CZ/CashDeskLocalization/app/Src/Codeunits/CashDocumentReleaseCZP.Codeunit.al
@@ -206,7 +206,8 @@ codeunit 11725 "Cash Document-Release CZP"
     begin
         SkipPaymentPurposeTestField := false;
         SkipAmountsTestFields := false;
-        OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP, SkipPaymentPurposeTestField, SkipAmountsTestFields);
+        OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP, SkipPaymentPurposeTestField);
+        OnBeforeCheckMandatoryFieldsSkipAmounts(CashDocumentHeaderCZP, SkipAmountsTestFields);
 
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."No.");
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Posting Date");
@@ -377,7 +378,12 @@ codeunit 11725 "Cash Document-Release CZP"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP: Record "Cash Document Header CZP"; var SkipPaymentPurposeTestField: Boolean; var SkipAmountsTestFields: Boolean)
+    local procedure OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP: Record "Cash Document Header CZP"; var SkipPaymentPurposeTestField: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckMandatoryFieldsSkipAmounts(CashDocumentHeaderCZP: Record "Cash Document Header CZP"; var SkipAmountsTestFields: Boolean)
     begin
     end;
 }

--- a/src/Apps/CZ/CashDeskLocalization/app/Src/Codeunits/CashDocumentReleaseCZP.Codeunit.al
+++ b/src/Apps/CZ/CashDeskLocalization/app/Src/Codeunits/CashDocumentReleaseCZP.Codeunit.al
@@ -211,8 +211,8 @@ codeunit 11725 "Cash Document-Release CZP"
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."No.");
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Posting Date");
         CashDocumentHeaderCZP.VATRounding();
-        CashDocumentHeaderCZP.CalcFields(CashDocumentHeaderCZP."Amount Including VAT", CashDocumentHeaderCZP."Amount Including VAT (LCY)");
         if not SkipAmountsTestFields then begin
+            CashDocumentHeaderCZP.CalcFields(CashDocumentHeaderCZP."Amount Including VAT", CashDocumentHeaderCZP."Amount Including VAT (LCY)");
             CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Amount Including VAT");
             CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Amount Including VAT (LCY)");
         end;

--- a/src/Apps/CZ/CashDeskLocalization/app/Src/Codeunits/CashDocumentReleaseCZP.Codeunit.al
+++ b/src/Apps/CZ/CashDeskLocalization/app/Src/Codeunits/CashDocumentReleaseCZP.Codeunit.al
@@ -202,16 +202,20 @@ codeunit 11725 "Cash Document-Release CZP"
     local procedure CheckMandatoryFields(CashDocumentHeaderCZP: Record "Cash Document Header CZP")
     var
         SkipPaymentPurposeTestField: Boolean;
+        SkipAmountsTestFields: Boolean;
     begin
         SkipPaymentPurposeTestField := false;
-        OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP, SkipPaymentPurposeTestField);
+        SkipAmountsTestFields := false;
+        OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP, SkipPaymentPurposeTestField, SkipAmountsTestFields);
 
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."No.");
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Posting Date");
         CashDocumentHeaderCZP.VATRounding();
         CashDocumentHeaderCZP.CalcFields(CashDocumentHeaderCZP."Amount Including VAT", CashDocumentHeaderCZP."Amount Including VAT (LCY)");
-        CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Amount Including VAT");
-        CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Amount Including VAT (LCY)");
+        if not SkipAmountsTestFields then begin
+            CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Amount Including VAT");
+            CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Amount Including VAT (LCY)");
+        end;
         CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Document Date");
         if not SkipPaymentPurposeTestField then
             CashDocumentHeaderCZP.TestField(CashDocumentHeaderCZP."Payment Purpose");
@@ -373,7 +377,7 @@ codeunit 11725 "Cash Document-Release CZP"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP: Record "Cash Document Header CZP"; var SkipPaymentPurposeTestField: Boolean)
+    local procedure OnBeforeCheckMandatoryFields(CashDocumentHeaderCZP: Record "Cash Document Header CZP"; var SkipPaymentPurposeTestField: Boolean; var SkipAmountsTestFields: Boolean)
     begin
     end;
 }

--- a/src/Apps/CZ/CashDeskLocalization/test/Src/CashDeskDocumentsCZP.Codeunit.al
+++ b/src/Apps/CZ/CashDeskLocalization/test/Src/CashDeskDocumentsCZP.Codeunit.al
@@ -19,15 +19,18 @@ codeunit 148070 "Cash Desk Documents CZP"
         LibraryRandom: Codeunit "Library - Random";
         LibraryCashDeskCZP: Codeunit "Library - Cash Desk CZP";
         LibraryCashDocumentCZP: Codeunit "Library - Cash Document CZP";
+        LibraryUtility: Codeunit "Library - Utility";
         AmountLimitErr: Label 'Cash Document Amount exceeded maximal limit (%1).', Comment = '%1 = Cash Desk Maximal Limit';
         PostCashDocNotExistErr: Label 'Posted Cash Document does not exist.';
         CashDocStatusErr: Label 'Status in Cash Document must be Released.';
         NoOfEntriesMustBeEqualErr: Label 'Number of entries must be equal.';
         AmountMustBePositiveErr: Label 'Amount Including VAT must be positive in Cash Document Header Cash Desk No.=''%1'',No.=''%2''.', Comment = '%1 = Cash Desk No., %2 = Cash Document No.';
+        LinesNotExistsErr: Label 'There are no Cash Document Lines to release.';
         isInitialized: Boolean;
 
     local procedure Initialize()
     var
+        GeneralLedgerSetup: Record "General Ledger Setup";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Cash Desk Documents CZP");
@@ -35,6 +38,11 @@ codeunit 148070 "Cash Desk Documents CZP"
         if isInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Cash Desk Documents CZP");
+        GeneralLedgerSetup.Get();
+        if GeneralLedgerSetup."Cash Desk Nos. CZP" = '' then begin
+            GeneralLedgerSetup.Validate("Cash Desk Nos. CZP", LibraryUtility.GetGlobalNoSeriesCode());
+            GeneralLedgerSetup.Modify(true);
+        end;
 
         LibraryCashDeskCZP.CreateCashDeskCZP(CashDeskCZP);
         LibraryCashDeskCZP.SetupCashDeskCZP(CashDeskCZP, true);
@@ -388,6 +396,55 @@ codeunit 148070 "Cash Desk Documents CZP"
 
         // [THEN] Error Occurs
         Assert.ExpectedError(StrSubstNo(AmountMustBePositiveErr, CashDeskCZP."No.", CashDocumentHeaderCZP."No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('YesConfirmHandler')]
+    procedure ReleaseCashDocumentChecksAmountsByDefault()
+    var
+        CashDocumentHeaderCZP: Record "Cash Document Header CZP";
+        CashDocumentLineCZP: Record "Cash Document Line CZP";
+    begin
+        // [SCENARIO] Amount mandatory fields are checked on release when no subscriber skips them
+        Initialize();
+
+        // [GIVEN] Create Receipt Cash Document with zero amount
+        CreateCashDocument(CashDocumentHeaderCZP, CashDocumentLineCZP, CashDocumentHeaderCZP."Document Type"::Receipt, CashDeskCZP."No.");
+        CashDocumentLineCZP.Validate(Amount, 0);
+        CashDocumentLineCZP.Modify();
+
+        // [WHEN] Release Cash Document
+        asserterror ReleaseCashDocumentCZP(CashDocumentHeaderCZP);
+
+        // [THEN] Error on empty Amount Including VAT occurs
+        Assert.ExpectedTestFieldError(CashDocumentHeaderCZP.FieldCaption("Amount Including VAT"), '');
+    end;
+
+    [Test]
+    [HandlerFunctions('YesConfirmHandler')]
+    procedure ReleaseCashDocumentSkipsAmountsWithSubscriber()
+    var
+        CashDocumentHeaderCZP: Record "Cash Document Header CZP";
+        CashDocumentLineCZP: Record "Cash Document Line CZP";
+        CashDocReleaseHandlerCZP: Codeunit "Cash Doc. Release Handler CZP";
+    begin
+        // [SCENARIO] Amount mandatory fields are skipped on release when a subscriber sets SkipAmountsTestFields
+        Initialize();
+
+        // [GIVEN] Create Receipt Cash Document with zero amount
+        CreateCashDocument(CashDocumentHeaderCZP, CashDocumentLineCZP, CashDocumentHeaderCZP."Document Type"::Receipt, CashDeskCZP."No.");
+        CashDocumentLineCZP.Validate(Amount, 0);
+        CashDocumentLineCZP.Modify();
+
+        // [GIVEN] Subscriber that skips the amount mandatory fields is bound
+        BindSubscription(CashDocReleaseHandlerCZP);
+
+        // [WHEN] Release Cash Document
+        asserterror ReleaseCashDocumentCZP(CashDocumentHeaderCZP);
+        UnbindSubscription(CashDocReleaseHandlerCZP);
+
+        // [THEN] Amount check is skipped and release fails later on the missing lines instead
+        Assert.ExpectedError(LinesNotExistsErr);
     end;
 
     [Test]

--- a/src/Apps/CZ/CashDeskLocalization/test/Src/CashDocReleaseHandlerCZP.Codeunit.al
+++ b/src/Apps/CZ/CashDeskLocalization/test/Src/CashDocReleaseHandlerCZP.Codeunit.al
@@ -1,0 +1,10 @@
+codeunit 148134 "Cash Doc. Release Handler CZP"
+{
+    EventSubscriberInstance = Manual;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Cash Document-Release CZP", 'OnBeforeCheckMandatoryFieldsSkipAmounts', '', false, false)]
+    local procedure SetSkipAmountsTestFieldsOnBeforeCheckMandatoryFieldsSkipAmounts(CashDocumentHeaderCZP: Record "Cash Document Header CZP"; var SkipAmountsTestFields: Boolean)
+    begin
+        SkipAmountsTestFields := true;
+    end;
+}

--- a/src/Apps/CZ/CashDeskLocalization/test/Src/CashDocReleaseHandlerCZP.Codeunit.al
+++ b/src/Apps/CZ/CashDeskLocalization/test/Src/CashDocReleaseHandlerCZP.Codeunit.al
@@ -1,3 +1,9 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Finance.CashDesk;
+
 codeunit 148134 "Cash Doc. Release Handler CZP"
 {
     EventSubscriberInstance = Manual;


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Added the OnBeforeValidateAdvanceLetterNoCZZ and OnBeforeLookupAdvanceLetterNoCZZ integration events. These events allow subscribers to override the default validation and lookup behavior of the Advance Letter No. CZZ field on cash document lines. Added the SkipAmountsTestFields parameter to the OnBeforeCheckMandatoryFields event.

To enable partners to customize selected parts of advance payment processing and better adapt the functionality to specific business requirements. Allows subscribers to skip mandatory validation of the cash document amount fields when needed.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#640066](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640066)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

## What I tested and the outcome
Tests Performed
Verified that validation of the Advance Letter No. CZZ field can be handled by an event subscriber before standard cash document line validation is executed.
Verified that the subscriber event is raised and the entered advance letter number is retained.
Verified that lookup of the Advance Letter No. CZZ field can be handled by an event subscriber before standard checks are executed.
Verified the lookup behavior on an otherwise invalid cash document line using the Cash Document Subform CZP page.
Verifies the default (unchanged) behavior: when a Cash Document line has a zero amount and no subscriber is bound, releasing the document still fails with the standard TestField error on Amount Including VAT.
ReleaseCashDocumentSkipsAmountsWithSubscriber
Verifies the new extensibility point: when a subscriber (Cash Doc. Release Handler CZP) sets SkipAmountsTestFields := true in the new event, the amount check is bypassed during release. Since the line still has an invalid (zero) amount, release then fails later for a different reason ("no lines to release"), confirming the amount check itself was actually skipped rather than the whole release logic being short-circuited.
Verified successful compilation of the test application.
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility
- Non-breaking change: The default behavior is identical
- No data migration, upgrade, or permission changes required.
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->








