### PR TITLE
[main]- Negative Shipped and Invoiced Quantities appear on Sales Order Lines after using the Copy Document from a Sales Credit Memo.

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -1028,6 +1028,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
     var
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         SalesInvoiceLine: Record "Sales Invoice Line";
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
     begin
         SalesCrMemoLine.SetLoadFields("Document No.", "No.", "Appl.-from Item Entry", Quantity, "Variant Code");
         SalesCrMemoLine.SetRange("Document No.", SalesCreditMemoNo);
@@ -1036,9 +1037,12 @@ codeunit 1303 "Correct Posted Sales Invoice"
         if SalesCrMemoLine.FindSet() then
             repeat
                 Clear(SalesInvoiceLine);
-                SalesCrMemoLine.GetSalesInvoiceLine(SalesInvoiceLine);
-                if SalesInvoiceLine."Line No." <> 0 then
+                SalesCrMemoLine.GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+                if SalesInvoiceLine."Line No." <> 0 then begin
                     UpdateSalesOrderLinesFromCreditMemo(SalesInvoiceLine, SalesCrMemoLine);
+                    TempUsedSalesInvoiceLine := SalesInvoiceLine;
+                    if TempUsedSalesInvoiceLine.Insert() then;
+                end;
             until SalesCrMemoLine.Next() = 0;
     end;
 

--- a/src/Layers/APAC/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1248,6 +1248,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1281,12 +1288,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/CH/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/CH/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1214,6 +1214,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1247,12 +1254,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/ES/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -1027,6 +1027,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
     var
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         SalesInvoiceLine: Record "Sales Invoice Line";
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
     begin
         SalesCrMemoLine.SetLoadFields("Document No.", "No.", "Appl.-from Item Entry", Quantity, "Variant Code");
         SalesCrMemoLine.SetRange("Document No.", SalesCreditMemoNo);
@@ -1035,9 +1036,12 @@ codeunit 1303 "Correct Posted Sales Invoice"
         if SalesCrMemoLine.FindSet() then
             repeat
                 Clear(SalesInvoiceLine);
-                SalesCrMemoLine.GetSalesInvoiceLine(SalesInvoiceLine);
-                if SalesInvoiceLine."Line No." <> 0 then
+                SalesCrMemoLine.GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+                if SalesInvoiceLine."Line No." <> 0 then begin
                     UpdateSalesOrderLinesFromCreditMemo(SalesInvoiceLine, SalesCrMemoLine);
+                    TempUsedSalesInvoiceLine := SalesInvoiceLine;
+                    if TempUsedSalesInvoiceLine.Insert() then;
+                end;
             until SalesCrMemoLine.Next() = 0;
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1184,6 +1184,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1217,12 +1224,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/FI/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1182,6 +1182,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1215,12 +1222,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/GB/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1199,6 +1199,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1232,12 +1239,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/IT/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/IT/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1205,6 +1205,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1238,12 +1245,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/NA/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1191,6 +1191,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1224,12 +1231,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/NO/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1200,6 +1200,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1233,12 +1240,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/RU/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1301,6 +1301,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1334,12 +1341,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/SE/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/SE/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1182,6 +1182,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1215,12 +1222,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/W1/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -1027,6 +1027,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
     var
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         SalesInvoiceLine: Record "Sales Invoice Line";
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
     begin
         SalesCrMemoLine.SetLoadFields("Document No.", "No.", "Appl.-from Item Entry", Quantity, "Variant Code");
         SalesCrMemoLine.SetRange("Document No.", SalesCreditMemoNo);
@@ -1035,9 +1036,12 @@ codeunit 1303 "Correct Posted Sales Invoice"
         if SalesCrMemoLine.FindSet() then
             repeat
                 Clear(SalesInvoiceLine);
-                SalesCrMemoLine.GetSalesInvoiceLine(SalesInvoiceLine);
-                if SalesInvoiceLine."Line No." <> 0 then
+                SalesCrMemoLine.GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+                if SalesInvoiceLine."Line No." <> 0 then begin
                     UpdateSalesOrderLinesFromCreditMemo(SalesInvoiceLine, SalesCrMemoLine);
+                    TempUsedSalesInvoiceLine := SalesInvoiceLine;
+                    if TempUsedSalesInvoiceLine.Insert() then;
+                end;
             until SalesCrMemoLine.Next() = 0;
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/History/SalesCrMemoLine.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/History/SalesCrMemoLine.Table.al
@@ -1171,6 +1171,13 @@ table 115 "Sales Cr.Memo Line"
 
     internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line")
     var
+        TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary;
+    begin
+        GetSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine);
+    end;
+
+    internal procedure GetSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary)
+    var
         ItemLedgerEntry: Record "Item Ledger Entry";
         SalesCreditMemoHeader: Record "Sales Cr.Memo Header";
         ValueEntry: Record "Value Entry";
@@ -1204,12 +1211,30 @@ table 115 "Sales Cr.Memo Line"
             SalesInvoiceLine.SetRange("Document No.", SalesCreditMemoHeader."Applies-to Doc. No.");
             SalesInvoiceLine.SetRange(Type, Type);
             SalesInvoiceLine.SetRange("No.", "No.");
+            SalesInvoiceLine.SetRange("Variant Code", "Variant Code");
+
+            SalesInvoiceLine.SetRange(Quantity, Quantity);
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
             SalesInvoiceLine.SetFilter(Quantity, '>=%1', Quantity);
-            if SalesInvoiceLine.FindFirst() then
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
                 exit;
             SalesInvoiceLine.SetRange(Quantity);
-            if SalesInvoiceLine.FindFirst() then;
+            if FindUnusedSalesInvoiceLine(SalesInvoiceLine, TempUsedSalesInvoiceLine) then
+                exit;
+
+            Clear(SalesInvoiceLine);
         end;
+    end;
+
+    local procedure FindUnusedSalesInvoiceLine(var SalesInvoiceLine: Record "Sales Invoice Line"; var TempUsedSalesInvoiceLine: Record "Sales Invoice Line" temporary): Boolean
+    begin
+        if SalesInvoiceLine.FindSet() then
+            repeat
+                if not TempUsedSalesInvoiceLine.Get(SalesInvoiceLine."Document No.", SalesInvoiceLine."Line No.") then
+                    exit(true);
+            until SalesInvoiceLine.Next() = 0;
+        exit(false);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/W1/Tests/SCM/SCMCorrectInvoice.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMCorrectInvoice.Codeunit.al
@@ -1333,6 +1333,81 @@ codeunit 137019 "SCM Correct Invoice"
             StrSubstNo(SalesOrderLineReducedErr, SalesLine[1].FieldCaption("Quantity Shipped")));
     end;
 
+    [Test]
+    procedure PostCrMemoCopyDocRevertsCorrectOrderLinesForSameItemAcrossOrders()
+    var
+        Item: Record Item;
+        Customer: Record Customer;
+        SalesHeaderOrder: array[2] of Record "Sales Header";
+        SalesLineOrder: array[2] of Record "Sales Line";
+        SalesHeaderInvoice: Record "Sales Header";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesCrMemoHeader: Record "Sales Cr.Memo Header";
+        CreditMemoHeader: Record "Sales Header";
+        SalesShipmentLine: Record "Sales Shipment Line";
+        SalesGetShipment: Codeunit "Sales-Get Shipment";
+        CopyDocMgt: Codeunit "Copy Document Mgt.";
+        OrderQty: array[2] of Decimal;
+    begin
+        // [SCENARIO 646375] Negative Shipped and Invoiced quantities no longer appear on Sales Order lines
+        // when the same item is shipped from several orders, invoiced together, and a Credit Memo is created
+        // via Copy Document from that Posted Invoice.
+        Initialize();
+
+        // [GIVEN] An item with stock.
+        CreateItemWithPrice(Item, LibraryRandom.RandDecInRange(10, 50, 2));
+        PostItemJournalPositiveAdj(Item."No.", '', 100);
+
+        // [GIVEN] Two Sales Orders for the same customer, each with a line for the same item but different quantities.
+        LibrarySales.CreateCustomer(Customer);
+        OrderQty[1] := LibraryRandom.RandIntInRange(11, 20);
+        OrderQty[2] := LibraryRandom.RandIntInRange(5, 10);
+        CreateAndShipSalesOrderWithItem(SalesHeaderOrder[1], SalesLineOrder[1], Customer."No.", Item."No.", OrderQty[1]);
+        CreateAndShipSalesOrderWithItem(SalesHeaderOrder[2], SalesLineOrder[2], Customer."No.", Item."No.", OrderQty[2]);
+
+        // [GIVEN] A single Sales Invoice created via Get Shipment Lines from both shipments, then posted.
+        LibrarySales.CreateSalesHeader(SalesHeaderInvoice, "Sales Document Type"::Invoice, Customer."No.");
+        SalesShipmentLine.SetFilter("Order No.", '%1|%2', SalesHeaderOrder[1]."No.", SalesHeaderOrder[2]."No.");
+        SalesGetShipment.SetSalesHeader(SalesHeaderInvoice);
+        SalesGetShipment.CreateInvLines(SalesShipmentLine);
+        SalesInvoiceHeader.Get(LibrarySales.PostSalesDocument(SalesHeaderInvoice, true, true));
+
+        // [GIVEN] A Credit Memo created via Copy Document from the Posted Invoice.
+        CreditMemoHeader.Init();
+        CreditMemoHeader.Validate("Document Type", CreditMemoHeader."Document Type"::"Credit Memo");
+        CreditMemoHeader.Insert(true);
+        CopyDocMgt.SetProperties(true, false, false, false, false, false, false);
+        CopyDocMgt.CopySalesDoc("Sales Document Type From"::"Posted Invoice", SalesInvoiceHeader."No.", CreditMemoHeader);
+
+        // [WHEN] Post the Credit Memo and update the linked Sales Order lines (as the Sales Credit Memo page does after posting).
+        SalesCrMemoHeader.Get(LibrarySales.PostSalesDocument(CreditMemoHeader, true, true));
+        CreditMemoHeader.UpdateSalesOrderLineIfExist();
+
+        // [THEN] Each Sales Order line is reverted to its own shipped/invoiced quantity, with no negative values.
+        SalesLineOrder[1].Find();
+        Assert.AreEqual(
+            0, SalesLineOrder[1]."Quantity Shipped",
+            StrSubstNo(SalesOrderLineReducedErr, SalesLineOrder[1].FieldCaption("Quantity Shipped")));
+        Assert.AreEqual(
+            0, SalesLineOrder[1]."Quantity Invoiced",
+            StrSubstNo(SalesOrderLineReducedErr, SalesLineOrder[1].FieldCaption("Quantity Invoiced")));
+
+        SalesLineOrder[2].Find();
+        Assert.AreEqual(
+            0, SalesLineOrder[2]."Quantity Shipped",
+            StrSubstNo(SalesOrderLineReducedErr, SalesLineOrder[2].FieldCaption("Quantity Shipped")));
+        Assert.AreEqual(
+            0, SalesLineOrder[2]."Quantity Invoiced",
+            StrSubstNo(SalesOrderLineReducedErr, SalesLineOrder[2].FieldCaption("Quantity Invoiced")));
+    end;
+
+    local procedure CreateAndShipSalesOrderWithItem(var SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line"; CustomerNo: Code[20]; ItemNo: Code[20]; Qty: Decimal)
+    begin
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, Qty);
+        LibrarySales.PostSalesDocument(SalesHeader, true, false);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";


### PR DESCRIPTION
[Bug 646375](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646375): [ALL-E] Negative Shipped and Invoiced Quantities appear on Sales Order Lines after using the Copy Document from a Sales Credit Memo.

Fixes [AB#646375](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646375)

Issue-
When a corrective Sales Credit Memo is created via Copy Document from a Posted Sales Invoice, and that invoice contains the same item on multiple lines (e.g. shipped from several sales orders and invoiced together via Get Shipment Lines), posting the credit memo produces negative Quantity Shipped / Quantity Invoiced on one sales order line while another order line is left unchanged.

Root cause-
Copy Document does not populate Appl.-from Item Entry on the credit memo lines, so SalesCrMemoLine.GetSalesInvoiceLine falls back to matching the source invoice line only by Item No. + Quantity >= X and takes FindFirst(). With duplicate items, every credit memo line resolves to the same first invoice line, so the corresponding order line is decremented repeatedly (going negative) and the other order line is never corrected.

Solution-
GetSalesInvoiceLine:
Added an overload that accepts a temporary "used invoice lines" buffer. The new FindUnusedSalesInvoiceLine helper skips invoice lines already consumed by earlier credit memo lines. Returns a blank line when no unused candidate remains.
UpdateSalesOrderLineIfExist now keeps a temporary buffer of resolved invoice lines, passes it into the resolver, and records each successfully consumed invoice line so it cannot be reused for a subsequent credit memo line.


