### PR TITLE
Make AA0194 an error in the base ruleset

### DIFF
--- a/src/Layers/DE/BaseApp/Finance/VAT/Reporting/ECSLReport.Page.al
+++ b/src/Layers/DE/BaseApp/Finance/VAT/Reporting/ECSLReport.Page.al
@@ -224,6 +224,7 @@ page 321 "ECSL Report"
                     trigger OnAction()
                     begin
                         // MESSAGE('Show errors');
+                        exit;
                     end;
                 }
                 action(Release)
@@ -237,6 +238,7 @@ page 321 "ECSL Report"
                     trigger OnAction()
                     begin
                         // MESSAGE('Release');
+                        exit;
                     end;
                 }
                 action(Reopen)
@@ -250,6 +252,7 @@ page 321 "ECSL Report"
                     trigger OnAction()
                     begin
                         // MESSAGE('Reopen');
+                        exit;
                     end;
                 }
             }

--- a/src/Layers/DE/BaseApp/Finance/VAT/Reporting/VATReturnPeriodCard.Page.al
+++ b/src/Layers/DE/BaseApp/Finance/VAT/Reporting/VATReturnPeriodCard.Page.al
@@ -55,6 +55,11 @@ page 738 "VAT Return Period Card"
                 Image = RefreshLines;
                 ToolTip = 'Receive the VAT returns that have been submitted.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
             action("Create VAT Return")
             {
@@ -64,6 +69,11 @@ page 738 "VAT Return Period Card"
                 Image = RefreshLines;
                 ToolTip = 'Create a new VAT return from this VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(navigation)
@@ -76,6 +86,11 @@ page 738 "VAT Return Period Card"
                 Image = ShowList;
                 ToolTip = 'Open the VAT return card for this VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(Promoted)

--- a/src/Layers/DE/BaseApp/Finance/VAT/Reporting/VATReturnPeriodList.Page.al
+++ b/src/Layers/DE/BaseApp/Finance/VAT/Reporting/VATReturnPeriodList.Page.al
@@ -70,6 +70,11 @@ page 737 "VAT Return Period List"
                 Image = GetLines;
                 ToolTip = 'Load the VAT return periods that are set up in the system.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
             action("Create VAT Return")
             {
@@ -79,6 +84,11 @@ page 737 "VAT Return Period List"
                 Image = RefreshLines;
                 ToolTip = 'Create a new VAT return from the selected VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(navigation)
@@ -91,6 +101,11 @@ page 737 "VAT Return Period List"
                 Image = ShowList;
                 ToolTip = 'Open the VAT return card for the selected VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(Promoted)

--- a/src/Layers/IT/BaseApp/Finance/VAT/Reporting/VATReturnPeriodCard.Page.al
+++ b/src/Layers/IT/BaseApp/Finance/VAT/Reporting/VATReturnPeriodCard.Page.al
@@ -55,6 +55,11 @@ page 738 "VAT Return Period Card"
                 Image = RefreshLines;
                 ToolTip = 'Receive the VAT returns that have been submitted.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
             action("Create VAT Return")
             {
@@ -64,6 +69,11 @@ page 738 "VAT Return Period Card"
                 Image = RefreshLines;
                 ToolTip = 'Create a new VAT return from this VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(navigation)
@@ -76,6 +86,11 @@ page 738 "VAT Return Period Card"
                 Image = ShowList;
                 ToolTip = 'Open the VAT return card for this VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(Promoted)

--- a/src/Layers/IT/BaseApp/Finance/VAT/Reporting/VATReturnPeriodList.Page.al
+++ b/src/Layers/IT/BaseApp/Finance/VAT/Reporting/VATReturnPeriodList.Page.al
@@ -70,6 +70,11 @@ page 737 "VAT Return Period List"
                 Image = GetLines;
                 ToolTip = 'Load the VAT return periods that are set up in the system.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
             action("Create VAT Return")
             {
@@ -79,6 +84,11 @@ page 737 "VAT Return Period List"
                 Image = RefreshLines;
                 ToolTip = 'Create a new VAT return from the selected VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(navigation)
@@ -91,6 +101,11 @@ page 737 "VAT Return Period List"
                 Image = ShowList;
                 ToolTip = 'Open the VAT return card for the selected VAT return period.';
                 Visible = false;
+
+                trigger OnAction()
+                begin
+                    exit;
+                end;
             }
         }
         area(Promoted)

--- a/src/Layers/RU/BaseApp/Local/PostedFAWriteoffAct.Page.al
+++ b/src/Layers/RU/BaseApp/Local/PostedFAWriteoffAct.Page.al
@@ -158,6 +158,7 @@ page 12472 "Posted FA Writeoff Act"
                     trigger OnAction()
                     begin
                         // CurrPage.WriteoffLines.PAGE.ShowDimensions();
+                        exit;
                     end;
                 }
                 action(Comments)
@@ -169,6 +170,7 @@ page 12472 "Posted FA Writeoff Act"
                     trigger OnAction()
                     begin
                         // CurrPage.WriteoffLines.PAGE.ShowComments;
+                        exit;
                     end;
                 }
             }

--- a/src/Layers/W1/BaseApp/Modules/System/PageDesigner/PageFields.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageDesigner/PageFields.Page.al
@@ -98,6 +98,7 @@ page 9620 "Page Fields"
                     // Comment to indicate to the server that this action must be run
                     // This action is here to override the default behavior of opening the card page with this record
                     // which is not desired in this case.
+                    exit;
                 end;
             }
         }

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -260,11 +260,6 @@
       "action": "Warning"
     },
     {
-      "id": "AA0194",
-      "action": "Warning",
-      "justification": "Remember to specify either the 'OnAction' trigger or the 'RunObject' property on an action."
-    },
-    {
       "id": "AA0198",
       "action": "Warning",
       "justification": "The name of the local variable is identical to a global variable."


### PR DESCRIPTION
Removes the `AA0194` override from `src/rulesets/base.ruleset.json`.

The ruleset declares `"generalAction": "Error"`, so removing the explicit `"action": "Warning"` entry promotes AA0194 to an error for the base application.

AA0194: *Remember to specify either the `OnAction` trigger or the `RunObject` property on an action.*

[AB#646475](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646475)




