### PR TITLE
Make AA0189 an error in the base ruleset

### DIFF
--- a/src/Apps/IN/INGST/app/GSTSubcontracting/src/Page/SubcontractingOrderSubform.Page.al
+++ b/src/Apps/IN/INGST/app/GSTSubcontracting/src/Page/SubcontractingOrderSubform.Page.al
@@ -511,7 +511,7 @@ page 18493 "Subcontracting Order Subform"
                 }
                 field("Qty. Rejected (Rework)"; Rec."Qty. Rejected (Rework)")
                 {
-                    ApplicationArea = Basic, suite;
+                    ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the quantity rejected for rework';
                     Visible = false;
                 }

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -256,10 +256,6 @@
       "justification": "The FindSet() or Find() method on the record must be used only in connection with the Next() method."
     },
     {
-      "id": "AA0189",
-      "action": "Warning"
-    },
-    {
       "id": "AA0194",
       "action": "Warning",
       "justification": "Remember to specify either the 'OnAction' trigger or the 'RunObject' property on an action."


### PR DESCRIPTION
Removes the `AA0189` override from `src/rulesets/base.ruleset.json`.

The ruleset declares `"generalAction": "Error"`, so removing the explicit `"action": "Warning"` entry promotes AA0189 to an error for the base application.

