### PR TITLE
[Shopify] Add cues for Skipped Records and API Errors on Activities page

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyActivities.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyActivities.Page.al
@@ -111,6 +111,27 @@ page 30100 "Shpfy Activities"
                     ToolTip = 'Specifies the number of order updates that aren''t processed.';
                     DrillDownPageId = "Shpfy Orders";
                 }
+                field(SkippedRecords; Rec."Skipped Records")
+                {
+                    ApplicationArea = All;
+                    DrillDownPageId = "Shpfy Skipped Records";
+                    StyleExpr = SkippedRecordsStyleTxt;
+                    ToolTip = 'Specifies the number of records that were skipped during synchronization.';
+                }
+                field(APIErrors; Rec."API Errors")
+                {
+                    ApplicationArea = All;
+                    StyleExpr = APIErrorsStyleTxt;
+                    ToolTip = 'Specifies the number of log entries that ended with an API error.';
+
+                    trigger OnDrillDown()
+                    var
+                        LogEntry: Record "Shpfy Log Entry";
+                    begin
+                        LogEntry.SetRange("Has Error", true);
+                        Page.Run(Page::"Shpfy Log Entries", LogEntry);
+                    end;
+                }
             }
         }
     }
@@ -138,6 +159,20 @@ page 30100 "Shpfy Activities"
         }
     }
 
+    trigger OnAfterGetRecord()
+    begin
+        Rec.CalcFields("Skipped Records", "API Errors");
+        if Rec."Skipped Records" > 0 then
+            SkippedRecordsStyleTxt := 'Ambiguous'
+        else
+            SkippedRecordsStyleTxt := 'Favorable';
+
+        if Rec."API Errors" > 0 then
+            APIErrorsStyleTxt := 'Unfavorable'
+        else
+            APIErrorsStyleTxt := 'Favorable';
+    end;
+
     trigger OnOpenPage()
     var
         Shop: Record "Shpfy Shop";
@@ -161,4 +196,7 @@ page 30100 "Shpfy Activities"
         end;
     end;
 
+    var
+        SkippedRecordsStyleTxt: Text;
+        APIErrorsStyleTxt: Text;
 }

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyCue.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyCue.Table.al
@@ -85,6 +85,18 @@ table 30100 "Shpfy Cue"
             Caption = 'Unmapped Companies';
             FieldClass = FlowField;
         }
+        field(10; "Skipped Records"; Integer)
+        {
+            CalcFormula = count("Shpfy Skipped Record");
+            Caption = 'Skipped Records';
+            FieldClass = FlowField;
+        }
+        field(11; "API Errors"; Integer)
+        {
+            CalcFormula = count("Shpfy Log Entry" where("Has Error" = const(true)));
+            Caption = 'API Errors';
+            FieldClass = FlowField;
+        }
     }
 
     keys


### PR DESCRIPTION
## What & why

Skipped records from background (Job Queue) Shopify syncs and logged API errors were invisible unless users manually opened the logs — the skipped-record notification relies on `GuiAllowed`, which is `false` in background sessions, and the Job Queue entry still shows Success. This adds two cues to the Shopify Activities page so users see issues at a glance:

- **Skipped Records** — `count("Shpfy Skipped Record")`, styled amber when > 0, drills down to the Shpfy Skipped Records page.
- **API Errors** — `count("Shpfy Log Entry" where "Has Error" = true)`, styled red when > 0, drills down to the Shpfy Log Entries page filtered to errors.

New FlowFields (10, 11) on the `Shpfy Cue` table (30100) and two cue tiles on the `Shpfy Activities` page (30100). Both cues are unfiltered by date; the Retention Policy framework (1-month period on `SystemCreatedAt`, already registered for both tables) handles cleanup. Follows the existing cue pattern (Unmapped Customers, Unprocessed Orders, Synchronization Errors).

## Linked work

Fixes [AB#646260](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646260)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Shopify Connector app locally (`al_build`) — packages with no new warnings.
- Manually validated on the Shopify Activities page: both cues render, color amber/red when counts are > 0, and drill down to the Skipped Records page and the error-filtered Log Entries page respectively.
- No automated tests added — the change is declarative cue metadata (FlowField `CalcFormula` plus page tiles and drill-downs) with no custom AL logic to unit-test; validated manually in BC.

## Risk & compatibility

Low — additive only: two new FlowFields on an internal cue table plus two cue tiles. No table schema/data changes, no breaking changes. Read permissions already cover the underlying tables (`Shpfy Skipped Record` and `Shpfy Log Entry` are `R` in `Shpfy - Read`).



