### PR TITLE
[Main]- Standard-cost purchase receipts use Direct Unit Cost instead of Standard Cost when cumulative expected-cost rounding is enabled

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -7957,6 +7957,9 @@ codeunit 22 "Item Jnl.-Post Line"
         if ItemJnlLine."Entry Type" <> ItemJnlLine."Entry Type"::Purchase then
             exit(false);
 
+        if Item."Costing Method" = Item."Costing Method"::Standard then
+            exit(false);
+
         if not (InvtSetup."Automatic Cost Posting") or not (InvtSetup."Expected Cost Posting to G/L") then
             exit(false);
 

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -7928,6 +7928,9 @@ codeunit 22 "Item Jnl.-Post Line"
         if ItemJnlLine."Entry Type" <> ItemJnlLine."Entry Type"::Purchase then
             exit(false);
 
+        if Item."Costing Method" = Item."Costing Method"::Standard then
+            exit(false);
+
         if not (InvtSetup."Automatic Cost Posting") or not (InvtSetup."Expected Cost Posting to G/L") then
             exit(false);
 

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -7938,6 +7938,9 @@ codeunit 22 "Item Jnl.-Post Line"
         if ItemJnlLine."Entry Type" <> ItemJnlLine."Entry Type"::Purchase then
             exit(false);
 
+        if Item."Costing Method" = Item."Costing Method"::Standard then
+            exit(false);
+
         if not (InvtSetup."Automatic Cost Posting") or not (InvtSetup."Expected Cost Posting to G/L") then
             exit(false);
 

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -7955,6 +7955,9 @@ codeunit 22 "Item Jnl.-Post Line"
         if ItemJnlLine."Entry Type" <> ItemJnlLine."Entry Type"::Purchase then
             exit(false);
 
+        if Item."Costing Method" = Item."Costing Method"::Standard then
+            exit(false);
+
         if not (InvtSetup."Automatic Cost Posting") or not (InvtSetup."Expected Cost Posting to G/L") then
             exit(false);
 

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -8273,6 +8273,9 @@ codeunit 22 "Item Jnl.-Post Line"
         if ItemJnlLine."Entry Type" <> ItemJnlLine."Entry Type"::Purchase then
             exit(false);
 
+        if Item."Costing Method" = Item."Costing Method"::Standard then
+            exit(false);
+
         if not (InvtSetup."Automatic Cost Posting") or not (InvtSetup."Expected Cost Posting to G/L") then
             exit(false);
 

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -7924,6 +7924,9 @@ codeunit 22 "Item Jnl.-Post Line"
         if ItemJnlLine."Entry Type" <> ItemJnlLine."Entry Type"::Purchase then
             exit(false);
 
+        if Item."Costing Method" = Item."Costing Method"::Standard then
+            exit(false);
+
         if not (InvtSetup."Automatic Cost Posting") or not (InvtSetup."Expected Cost Posting to G/L") then
             exit(false);
 

--- a/src/Layers/W1/Tests/SCM-Costing/SCMAdjmtofExpectedCost.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Costing/SCMAdjmtofExpectedCost.Codeunit.al
@@ -14,10 +14,12 @@ codeunit 137018 "SCM Adjmt. of Expected Cost"
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibrarySales: Codeunit "Library - Sales";
+        LibraryRandom: Codeunit "Library - Random";
         Assert: Codeunit Assert;
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         IsInitialized: Boolean;
         GLEntryTotalMismatchErr: Label 'GL Entry total for account %1 is %2, expected %3.', Comment = '%1 = G/L Account No., %2 = Actual Amount, %3 = Expected Amount';
+        ExpectedCostMismatchErr: Label 'Cost Amount (Expected) is %1, expected %2.', Comment = '%1 = Actual Amount, %2 = Expected Amount';
 
     [Test]
     [Scope('OnPrem')]
@@ -151,6 +153,84 @@ codeunit 137018 "SCM Adjmt. of Expected Cost"
         Assert.AreEqual(
             ExpectedTotalAmount, ActualTotalAmount,
             StrSubstNo(GLEntryTotalMismatchErr, InventoryPostingSetup."Inventory Account (Interim)", ActualTotalAmount, ExpectedTotalAmount));
+
+        // Teardown
+        SetInventorySetup(
+            OldInventorySetup, false,
+            OldInventorySetup."Automatic Cost Posting",
+            OldInventorySetup."Expected Cost Posting to G/L",
+            OldInventorySetup."Automatic Cost Adjustment");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure StandardCostItemExpectedCostUsesStandardCostOnReceipt()
+    var
+        Item: Record Item;
+        OldInventorySetup: Record "Inventory Setup";
+        GLAccount: Record "G/L Account";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ValueEntry: Record "Value Entry";
+        DirectUnitCost: Decimal;
+        ExpectedCostAmount: Decimal;
+        Qty: Decimal;
+        StandardCost: Decimal;
+    begin
+        // [FEATURE] [Standard Cost] [Expected Cost] [AI Test]
+        // [SCENARIO 645071] Expected cost of a purchase receipt for a Standard cost item is Standard Cost x Quantity, not Direct Unit Cost x Quantity.
+        Initialize();
+
+        // [GIVEN] Inventory Setup with Automatic Cost Posting and Expected Cost Posting to G/L enabled.
+        OldInventorySetup.Get();
+        SetInventorySetup(
+            OldInventorySetup, true, true, true,
+            OldInventorySetup."Automatic Cost Adjustment"::Never);
+
+        // [GIVEN] Item "I" with Costing Method = Standard and a random 3-decimal Standard Cost.
+        StandardCost := LibraryRandom.RandDecInDecimalRange(0.1, 0.2, 3);
+        DirectUnitCost := LibraryRandom.RandDecInDecimalRange(0.2, 0.3, 3);
+        Qty := 1000;
+        ExpectedCostAmount := StandardCost * Qty;
+
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Costing Method", Item."Costing Method"::Standard);
+        Item.Validate("Standard Cost", StandardCost);
+        Item.Modify(true);
+
+        // [GIVEN] The item matches the conditions of the cumulative expected cost rounding path.
+        Item.Get(Item."No.");
+        Item.Validate("Cost is Adjusted", false);
+        Item.Validate("Allow Online Adjustment", false);
+        Item.Validate("Flushing Method", Item."Flushing Method"::Manual);
+        Item.Modify(true);
+
+        // [GIVEN] Create new interim accounts.
+        InventoryPostingSetup.Get('', Item."Inventory Posting Group");
+        if InventoryPostingSetup."Inventory Account (Interim)" = '' then begin
+            LibraryERM.CreateGLAccount(GLAccount);
+            InventoryPostingSetup.Validate("Inventory Account (Interim)", GLAccount."No.");
+            InventoryPostingSetup.Modify(true);
+        end;
+
+        // [GIVEN] Purchase Order "PO" with Quantity = 1000 and a random Direct Unit Cost.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, '');
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Qty);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] Post the purchase receipt.
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] Cost Amount (Expected) = Standard Cost x Quantity, not Direct Unit Cost x Quantity.
+        ValueEntry.SetRange("Item No.", Item."No.");
+        ValueEntry.SetRange("Entry Type", ValueEntry."Entry Type"::"Direct Cost");
+        ValueEntry.SetRange("Expected Cost", true);
+        ValueEntry.CalcSums("Cost Amount (Expected)");
+        Assert.AreEqual(
+            ExpectedCostAmount, ValueEntry."Cost Amount (Expected)",
+            StrSubstNo(ExpectedCostMismatchErr, ValueEntry."Cost Amount (Expected)", ExpectedCostAmount));
 
         // Teardown
         SetInventorySetup(


### PR DESCRIPTION
[Bug 646424](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646424): [master] [Repair Item] [ALL-E] Standard-cost purchase receipts use Direct Unit Cost instead of Standard Cost when cumulative expected-cost rounding is enabled

[AB#646424](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646424)

**Issue**: When posting a purchase receipt (receive only, no invoice) for an item with Costing Method = Standard, the Cost Amount (Expected) on the Value Entry is calculated from the Direct Unit Cost on the purchase line instead of the item's Standard Cost (e.g. Standard Cost 0.134 × 1000 posts 136.00 instead of 134.00). This overstates the interim inventory value and the Inventory Accrual (Interim) G/L amount, breaking the standard costing principle that inventory is always valued at Standard Cost.

**Cause**: In CalcPosShares in [ItemJnlPostLine.Codeunit.al](vscode-file://vscode-app/c:/Users/v-dhavalmore/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the fix for Bug 631139 (PR 245490) introduced ShouldUseCumulativeRoundingForExpectedCost to switch the expected-cost basis from ItemJnlLine."Unit Cost" * ItemJnlLine.Quantity to ItemJnlLine.Amount in order to eliminate a 0.01 rounding residual across partial receipts. For FIFO/Average items these two expressions are equivalent, but the guard did not exclude Standard costing, where ItemJnlLine.Amount carries the vendor's Direct Unit Cost and legitimately differs from Standard Cost — so the price difference was silently capitalised into inventory instead of being recognised as Purchase Variance on invoicing.

**Solution**: Added an early if Item."Costing Method" = Item."Costing Method"::Standard then exit(false); check to ShouldUseCumulativeRoundingForExpectedCost in [ItemJnlPostLine.Codeunit.al](vscode-file://vscode-app/c:/Users/v-dhavalmore/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (W1 plus the APAC, CH, ES, IT and RU layers), so Standard-cost items fall back to the Unit Cost * Quantity basis and post expected cost at Standard Cost. The two scenarios are mutually exclusive on Costing Method, so Bug 631139's cumulative-rounding behaviour is fully preserved for FIFO/Average/LIFO/Specific items, and the price difference is correctly posted to Purchase Variance when the receipt is invoiced. Added regression test StandardCostItemExpectedCostUsesStandardCostOnReceipt to codeunit 137018.

