### PR TITLE
[Master] [Expense Agent] Bug 641393 [AT] Recognize International Standard Code 1A as mileage UOM

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseAgentSetup.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseAgentSetup.Codeunit.al
@@ -164,7 +164,7 @@ codeunit 6970 "Create Expense Agent Setup"
 
     internal procedure GetMileageUOMStandardCodeFilter(): Text
     begin
-        exit('SMI|MI|KMT|KM');
+        exit('SMI|MI|KMT|KM|1A');
     end;
 
     local procedure CreateExpensePaymentMethod(PaymentMethodCode: Code[10]; Description: Text[100]; ReimbursementType: Enum "Expense Reimbursement Type")


### PR DESCRIPTION
Fixes [AB#641393](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641393)

## Summary
In the AT localization the "Meilen" (Miles) unit uses International Standard Code `1A`. The Default Mileage UOM selector filtered on `SMI|MI|KMT|KM`, so the AT Miles unit was not recognized. A new AT company with Expense demo data defaults Default Mileage UOM to Miles, which surfaced the issue in the "Default unit of distance" selector.

## Change
- `GetMileageUOMStandardCodeFilter` now returns `SMI|MI|KMT|KM|1A`, adding `1A` as a recognized mileage UOM standard code. Used by both the Expense Agent Setup page and Setup Wizard lookups.

## Testing
- Verified in BC UI (AT company with Expense demo data): the Units of Measure selector for "Default unit of distance" now shows both `KM` (KMT) and `MEILEN` (1A).

## Type of change
- [x] Bug fix


