### PR TITLE
Fixes #8851

### DIFF
--- a/src/Layers/W1/BaseApp/Warehouse/Worksheet/WhseWorksheetLine.Table.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Worksheet/WhseWorksheetLine.Table.al
@@ -1099,7 +1099,7 @@ table 7326 "Whse. Worksheet Line"
                 begin
                     WhseWkshTemplate.Init();
                     WhseWkshTemplate.Validate(Type, PageTemplate);
-                    WhseWkshTemplate.Validate("Page ID");
+                    WhseWkshTemplate.Validate("Page ID", PageID);
                     WhseWkshTemplate.Name :=
                       Format(WhseWkshTemplate.Type, MaxStrLen(WhseWkshTemplate.Name));
                     WhseWkshTemplate.Description := StrSubstNo(Text008, WhseWkshTemplate.Type);


### PR DESCRIPTION
## What & why

If the function TemplateSelection in table 7326 "Whse. Worksheet Line" is called with a page ID different from the standard Page ID. The Whse. Worksheet Template is with the standard page ID created.

## Linked work

Fixes #8851 

