### PR TITLE
[Extensibility Request] issue 30401: add credit memo sales line filter event

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1986,6 +1986,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -3137,6 +3138,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/BE/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1704,6 +1704,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2639,6 +2640,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1738,6 +1738,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2669,6 +2670,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1700,6 +1700,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2633,6 +2634,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/FI/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1696,6 +1696,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2630,6 +2631,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1766,6 +1766,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2733,6 +2734,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1740,6 +1740,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2710,6 +2711,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1695,6 +1695,7 @@ UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineB
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2626,6 +2627,16 @@ UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineB
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1693,6 +1693,7 @@ codeunit 442 "Sales-Post Prepayments"
             SalesHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             SalesHeader."Prepmt. Cr. Memo No." := '';
             SalesLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader, SalesLine);
             if SalesLine.FindSet(true) then
                 repeat
                     SalesLine."Prepmt. Amt. Inv." := SalesLine."Prepmt Amt Deducted";
@@ -2624,6 +2625,16 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="TotalPrepmtInvLineBufLCY">The total prepayment invoice line buffer in LCY.</param>
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmounts(SalesHeader: Record "Sales Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the credit memo sales lines during prepayment document update.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="SalesLine">The sales lines to be filtered.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine(SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line")
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need to refine which credit memo sales lines are processed when a prepayment document updates the originating sales document. This PR adds an integration event immediately before the credit memo line `FindSet`, allowing subscribers to add filters while retaining the existing prepayment filter.

Source issue repository: microsoft/AlAppExtensions; issue number: 30401

## Changes Made
- `Sales-Post Prepayments.UpdateSalesDocument` - Added `OnUpdateSalesDocumentOnBeforeFindSetCreditMemoSalesLine` before credit memo lines are read, and propagated the event to all existing layer counterparts.

Fixes [AB#646144](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646144)



