### PR TITLE
[Extensibility Request] issue 30400: add credit memo line filter event

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1854,6 +1854,7 @@ codeunit 444 "Purchase-Post Prepayments"
             PurchaseHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             PurchaseHeader."Prepmt. Cr. Memo No." := '';
             PurchLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader, PurchLine);
             if PurchLine.FindSet(true) then
                 repeat
                     PurchLine."Prepmt. Amt. Inv." := PurchLine."Prepmt Amt Deducted";
@@ -2472,6 +2473,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmoutns(PurchaseHeader: Record "Purchase Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1507,6 +1507,7 @@ codeunit 444 "Purchase-Post Prepayments"
             PurchaseHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             PurchaseHeader."Prepmt. Cr. Memo No." := '';
             PurchLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader, PurchLine);
             if PurchLine.FindSet(true) then
                 repeat
                     PurchLine."Prepmt. Amt. Inv." := PurchLine."Prepmt Amt Deducted";
@@ -1969,6 +1970,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmoutns(PurchaseHeader: Record "Purchase Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1612,6 +1612,7 @@ codeunit 444 "Purchase-Post Prepayments"
             PurchaseHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             PurchaseHeader."Prepmt. Cr. Memo No." := '';
             PurchLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader, PurchLine);
             if PurchLine.FindSet(true) then
                 repeat
                     PurchLine."Prepmt. Amt. Inv." := PurchLine."Prepmt Amt Deducted";
@@ -2080,6 +2081,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmoutns(PurchaseHeader: Record "Purchase Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1561,6 +1561,7 @@ codeunit 444 "Purchase-Post Prepayments"
             PurchaseHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             PurchaseHeader."Prepmt. Cr. Memo No." := '';
             PurchLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader, PurchLine);
             if PurchLine.FindSet(true) then
                 repeat
                     PurchLine."Prepmt. Amt. Inv." := PurchLine."Prepmt Amt Deducted";
@@ -1995,6 +1996,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmoutns(PurchaseHeader: Record "Purchase Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1501,6 +1501,7 @@ codeunit 444 "Purchase-Post Prepayments"
             PurchaseHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             PurchaseHeader."Prepmt. Cr. Memo No." := '';
             PurchLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader, PurchLine);
             if PurchLine.FindSet(true) then
                 repeat
                     PurchLine."Prepmt. Amt. Inv." := PurchLine."Prepmt Amt Deducted";
@@ -1931,6 +1932,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmoutns(PurchaseHeader: Record "Purchase Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1499,6 +1499,7 @@ codeunit 444 "Purchase-Post Prepayments"
             PurchaseHeader."Last Prepmt. Cr. Memo No." := GenJnlLineDocNo;
             PurchaseHeader."Prepmt. Cr. Memo No." := '';
             PurchLine.SetFilter("Prepmt. Amt. Inv.", '<>0');
+            OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader, PurchLine);
             if PurchLine.FindSet(true) then
                 repeat
                     PurchLine."Prepmt. Amt. Inv." := PurchLine."Prepmt Amt Deducted";
@@ -1929,6 +1930,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnRoundAmountsOnBeforeIncrAmoutns(PurchaseHeader: Record "Purchase Header"; var PrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBuf: Record "Prepayment Inv. Line Buffer"; var TotalPrepmtInvLineBufLCY: Record "Prepayment Inv. Line Buffer")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine(PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need to apply additional filters before credit memo purchase lines are selected while updating prepayment documents. This PR adds an integration event immediately before the credit memo line `FindSet(true)` call, allowing subscribers to refine the `Purchase Line` view without replacing standard posting logic.

Source issue repository: microsoft/AlAppExtensions; issue number: 30400

## Changes Made
- `Purchase-Post Prepayments.UpdatePurchaseDocument` - added `OnUpdatePurchaseDocumentOnBeforeFindSetCrMemoPurchLine` with the purchase header and mutable purchase line, propagated to all existing layer counterparts.

Fixes [AB#646145](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646145)



