### PR TITLE
[Extensibility Request] issue 30395: expose production pick grouping number

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Warehouse/Request/MfgWhseSourceCreateDocument.ReportExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Warehouse/Request/MfgWhseSourceCreateDocument.ReportExt.al
@@ -27,6 +27,7 @@ reportextension 7305 "Mfg. WhseSourceCreateDocument" extends "Whse.-Source - Cre
                     WMSMgt: Codeunit "WMS Management";
                     QtyToPick: Decimal;
                     QtyToPickBase: Decimal;
+                    GroupingNumber: Integer;
                     SkipProdOrderComp: Boolean;
                     EmptyGuid: Guid;
                 begin
@@ -64,8 +65,10 @@ reportextension 7305 "Mfg. WhseSourceCreateDocument" extends "Whse.-Source - Cre
                         QtyToPickBase := UOMMgt.CalcBaseQty("Item No.", "Variant Code", "Unit of Measure Code", QtyToPick, "Qty. per Unit of Measure");
 
                         if QtyToPick > 0 then begin
+                            GroupingNumber := 1;
+                            OnAfterGetRecordProdOrderComponentOnBeforeSetCustomWhseSourceLine("Prod. Order Component", GroupingNumber);
                             CreatePick.SetCustomWhseSourceLine(
-                                "Prod. Order Component", 1,
+                                "Prod. Order Component", GroupingNumber,
                                 Database::"Prod. Order Component", Status.AsInteger(), "Prod. Order No.", "Prod. Order Line No.", "Line No.");
                             CreatePick.SetTempWhseItemTrkgLine(
                                 "Prod. Order No.", Database::"Prod. Order Component", '', "Prod. Order Line No.", "Line No.", "Location Code");
@@ -150,6 +153,11 @@ reportextension 7305 "Mfg. WhseSourceCreateDocument" extends "Whse.-Source - Cre
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterGetRecordProdOrderComponent(var ProdOrderComponent: Record "Prod. Order Component"; var SkipProdOrderComp: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterGetRecordProdOrderComponentOnBeforeSetCustomWhseSourceLine(var ProdOrderComponent: Record "Prod. Order Component"; var GroupingNumber: Integer)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Production order components currently all use the same warehouse pick grouping number, preventing extensions from creating separate activity lines for each component. This change exposes the grouping number immediately before the source line is configured so subscribers can control how production order pick lines are grouped.

Source issue repository: microsoft/AlAppExtensions; issue number: 30395

## Changes Made
- `Mfg. WhseSourceCreateDocument.OnAfterGetRecord()` - initializes the existing grouping value and publishes it by reference before calling `SetCustomWhseSourceLine`
- `OnAfterGetRecordProdOrderComponentOnBeforeSetCustomWhseSourceLine` - lets subscribers adjust the production component pick grouping number

Fixes [AB#645233](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645233)



