### PR TITLE
[Extensibility Request] issue 30389: allow skipping service item confirmation

### DIFF
--- a/src/Layers/W1/BaseApp/Service/Item/ServItemManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Item/ServItemManagement.Codeunit.al
@@ -419,6 +419,7 @@ codeunit 5920 ServItemManagement
         ConfirmManagement: Codeunit "Confirm Management";
         NoSeries: Codeunit "No. Series";
         IsHandled: Boolean;
+        SkipConfirm: Boolean;
     begin
         OnBeforeCreateServItemOnServItemLine(ServItemLine);
         ServItemLine.TestField("Service Item No.", '');
@@ -426,11 +427,12 @@ codeunit 5920 ServItemManagement
         ServItemLine.TestField(Description);
 
         IsHandled := false;
-        OnCreateServItemOnServItemLineOnBeforeConfirmCreateServItem(ServItemLine, IsHandled);
+        SkipConfirm := false;
+        OnCreateServItemOnServItemLineOnBeforeConfirmCreateServItem(ServItemLine, IsHandled, SkipConfirm);
         if IsHandled then
             exit;
 
-        if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(Text000), true) then
+        if (not SkipConfirm) and (not ConfirmManagement.GetResponseOrDefault(StrSubstNo(Text000), true)) then
             exit;
 
         Clear(ServItem);
@@ -777,7 +779,7 @@ codeunit 5920 ServItemManagement
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCreateServItemOnServItemLineOnBeforeConfirmCreateServItem(var ServiceItemLine: Record "Service Item Line"; var IsHandled: Boolean)
+    local procedure OnCreateServItemOnServItemLineOnBeforeConfirmCreateServItem(var ServiceItemLine: Record "Service Item Line"; var IsHandled: Boolean; var SkipConfirm: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Service/Item/ServItemManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Item/ServItemManagement.Codeunit.al
@@ -432,8 +432,9 @@ codeunit 5920 ServItemManagement
         if IsHandled then
             exit;
 
-        if (not SkipConfirm) and (not ConfirmManagement.GetResponseOrDefault(StrSubstNo(Text000), true)) then
-            exit;
+        if not SkipConfirm then
+            if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(Text000), true) then
+                exit;
 
         Clear(ServItem);
         ServItem.Init();


### PR DESCRIPTION
## Summary
Extensions need to create service items with the standard application logic without displaying the interactive confirmation dialog. This change extends the existing pre-confirmation event so subscribers can skip only the dialog while preserving service item creation and the existing full-bypass behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30389

## Changes Made
- `ServItemManagement.CreateServItemOnServItemLine` - appended a `SkipConfirm` event parameter and used it to bypass the confirmation without exiting the standard creation flow

Fixes [AB#646064](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646064)



