### PR TITLE
[Extensibility Request] issue 30379: enable grouped pick printing

### DIFF
--- a/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Report.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Report.al
@@ -298,7 +298,6 @@ report 5754 "Create Pick"
     local procedure CreateTempLine()
     var
         WarehouseShipmentLine: Record "Warehouse Shipment Line";
-        PickWhseActivHeader: Record "Warehouse Activity Header";
         TempWhseItemTrkgLine: Record "Whse. Item Tracking Line" temporary;
         ItemTrackingMgt: Codeunit "Item Tracking Management";
         PickQty: Decimal;
@@ -434,20 +433,22 @@ report 5754 "Create Pick"
             Commit();
         end;
 
-        PickWhseActivHeader.SetRange(Type, PickWhseActivHeader.Type::Pick);
-        PickWhseActivHeader.SetRange("No.", FirstSetPickNo, LastPickNo);
-        IsHandled := false;
-        OnCreateTempLineOnBeforeFindAndPrintPickHeaders(PickWhseActivHeader, PrintPick, IsHandled);
-        if not IsHandled then
-            FindAndPrintPickHeaders(PickWhseActivHeader, PrintPick, SortActivity);
+        FindAndPrintPickHeaders();
     end;
 
-    local procedure FindAndPrintPickHeaders(var PickWhseActivHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; SortActivity: Enum "Whse. Activity Sorting Method")
+    local procedure FindAndPrintPickHeaders()
     var
+        PickWhseActivHeader: Record "Warehouse Activity Header";
         WarehouseDocumentPrint: Codeunit "Warehouse Document-Print";
         PickListReportID: Integer;
         IsHandled: Boolean;
     begin
+        PickWhseActivHeader.SetRange(Type, PickWhseActivHeader.Type::Pick);
+        PickWhseActivHeader.SetRange("No.", FirstSetPickNo, LastPickNo);
+        OnBeforeFindAndPrintPickHeaders(PickWhseActivHeader, PrintPick, IsHandled);
+        if IsHandled then
+            exit;
+
         PickWhseActivHeader.Find('-');
         repeat
             if SortActivity <> SortActivity::None then
@@ -681,7 +682,7 @@ report 5754 "Create Pick"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCreateTempLineOnBeforeFindAndPrintPickHeaders(var WarehouseActivityHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeFindAndPrintPickHeaders(var WarehouseActivityHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Report.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Report.al
@@ -433,10 +433,10 @@ report 5754 "Create Pick"
             Commit();
         end;
 
-        FindAndPrintPickHeaders();
+        FindSortAndPrintPickHeaders();
     end;
 
-    local procedure FindAndPrintPickHeaders()
+    local procedure FindSortAndPrintPickHeaders()
     var
         PickWhseActivHeader: Record "Warehouse Activity Header";
         WarehouseDocumentPrint: Codeunit "Warehouse Document-Print";
@@ -445,7 +445,8 @@ report 5754 "Create Pick"
     begin
         PickWhseActivHeader.SetRange(Type, PickWhseActivHeader.Type::Pick);
         PickWhseActivHeader.SetRange("No.", FirstSetPickNo, LastPickNo);
-        OnBeforeFindAndPrintPickHeaders(PickWhseActivHeader, PrintPick, IsHandled);
+        IsHandled := false;
+        OnBeforeFindSortAndPrintPickHeaders(PickWhseActivHeader, PrintPick, IsHandled);
         if IsHandled then
             exit;
 
@@ -682,7 +683,7 @@ report 5754 "Create Pick"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeFindAndPrintPickHeaders(var WarehouseActivityHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeFindSortAndPrintPickHeaders(var WarehouseActivityHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Report.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Activity/CreatePick.Report.al
@@ -301,12 +301,10 @@ report 5754 "Create Pick"
         PickWhseActivHeader: Record "Warehouse Activity Header";
         TempWhseItemTrkgLine: Record "Whse. Item Tracking Line" temporary;
         ItemTrackingMgt: Codeunit "Item Tracking Management";
-        WarehouseDocumentPrint: Codeunit "Warehouse Document-Print";
         PickQty: Decimal;
         PickQtyBase: Decimal;
         OldFirstSetPickNo: Code[20];
         TotalQtyPickedBase: Decimal;
-        PickListReportID: Integer;
         IsHandled: Boolean;
     begin
         PickWhseWkshLine.LockTable();
@@ -438,6 +436,18 @@ report 5754 "Create Pick"
 
         PickWhseActivHeader.SetRange(Type, PickWhseActivHeader.Type::Pick);
         PickWhseActivHeader.SetRange("No.", FirstSetPickNo, LastPickNo);
+        IsHandled := false;
+        OnCreateTempLineOnBeforeFindAndPrintPickHeaders(PickWhseActivHeader, PrintPick, IsHandled);
+        if not IsHandled then
+            FindAndPrintPickHeaders(PickWhseActivHeader, PrintPick, SortActivity);
+    end;
+
+    local procedure FindAndPrintPickHeaders(var PickWhseActivHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; SortActivity: Enum "Whse. Activity Sorting Method")
+    var
+        WarehouseDocumentPrint: Codeunit "Warehouse Document-Print";
+        PickListReportID: Integer;
+        IsHandled: Boolean;
+    begin
         PickWhseActivHeader.Find('-');
         repeat
             if SortActivity <> SortActivity::None then
@@ -670,6 +680,11 @@ report 5754 "Create Pick"
     begin
     end;
 
+    [IntegrationEvent(false, false)]
+    local procedure OnCreateTempLineOnBeforeFindAndPrintPickHeaders(var WarehouseActivityHeader: Record "Warehouse Activity Header"; PrintPick: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
     [IntegrationEvent(true, false)]
     local procedure OnCreateTempLineOnBeforeSetTempWhseItemTrackingLine(var PickWhseWorksheetLine: Record "Whse. Worksheet Line"; var PickQty: Decimal; var PickQtyBase: Decimal; var IsHandled: Boolean)
     begin
@@ -685,4 +700,3 @@ report 5754 "Create Pick"
     begin
     end;
 }
-


### PR DESCRIPTION
## Summary
Extensions need to print all picks generated by Report 5754 in one consolidated report run instead of invoking the request page once per pick. This change exposes the filtered pick-header set before standard enumeration so a subscriber can replace the individual printing flow while preserving the existing default behavior.

Source issue repository: microsoft/AlAppExtensions; issue number: 30379

## Changes Made
- `CreateTempLine` / `FindAndPrintPickHeaders` - extracted the standard pick-header enumeration and printing flow, then added an `IsHandled` event before it so extensions can provide grouped printing

Fixes [AB#646350](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646350)


