### PR TITLE
[Extensibility Request] issue 30357: add prepayment credit memo confirmation event

### DIFF
--- a/src/Layers/W1/BaseApp/Sales/Posting/SalesPostPrepaymentYesNo.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Posting/SalesPostPrepaymentYesNo.Codeunit.al
@@ -70,10 +70,14 @@ codeunit 443 "Sales-Post Prepayment (Yes/No)"
     procedure PostPrepmtCrMemoYN(var SalesHeader2: Record "Sales Header"; Print: Boolean)
     var
         SalesHeader: Record "Sales Header";
+        IsHandled: Boolean;
     begin
         SalesHeader.Copy(SalesHeader2);
-        if not ConfirmForDocument(SalesHeader, Text001) then
-            exit;
+        IsHandled := false;
+        OnPostPrepmtCrMemoYNOnBeforeConfirm(SalesHeader, IsHandled);
+        if not IsHandled then
+            if not ConfirmForDocument(SalesHeader, Text001) then
+                exit;
 
         PostPrepmtDocument(SalesHeader, SalesHeader."Document Type"::"Credit Memo");
 
@@ -254,6 +258,16 @@ codeunit 443 "Sales-Post Prepayment (Yes/No)"
     end;
 
     /// <summary>
+    /// Raised before confirming the posting of the prepayment credit memo.
+    /// </summary>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="IsHandled">Set to true to skip the default confirmation dialog.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnPostPrepmtCrMemoYNOnBeforeConfirm(var SalesHeader: Record "Sales Header"; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
     /// Raised before running the Sales-Post Prepayments codeunit.
     /// </summary>
     /// <param name="SalesHeader">The sales header to be posted.</param>
@@ -263,4 +277,3 @@ codeunit 443 "Sales-Post Prepayment (Yes/No)"
     begin
     end;
 }
-


### PR DESCRIPTION
## Summary
Extensions need to replace the standard confirmation when posting sales prepayment credit memos, matching the customization already available for prepayment invoices. This PR adds a handled event before the credit memo confirmation so subscribers can provide their own confirmation experience without changing the posting flow.

Source issue repository: microsoft/AlAppExtensions; issue number: 30357

## Changes Made
- `PostPrepmtCrMemoYN` - Added a handled event before the standard confirmation so extensions can replace the dialog for prepayment credit memos.

Fixes [AB#644070](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644070)



