### PR TITLE
[Extensibility Request] issue 30342: allow skipping blocked item checks

### DIFF
--- a/src/Layers/W1/BaseApp/Service/Contract/ServContractManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Contract/ServContractManagement.Codeunit.al
@@ -2620,7 +2620,13 @@ codeunit 5940 ServContractManagement
     procedure CheckServiceItemBlockedForAll(var ServiceContractLine: Record "Service Contract Line")
     var
         ServiceItem: Record "Service Item";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeCheckServiceItemBlockedForAll(ServiceContractLine, IsHandled);
+        if IsHandled then
+            exit;
+
         if ServiceContractLine."Service Item No." = '' then
             exit;
 
@@ -2635,7 +2641,13 @@ codeunit 5940 ServContractManagement
     var
         Item: Record Item;
         ItemVariant: Record "Item Variant";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeCheckItemServiceBlocked(ServiceContractLine, IsHandled);
+        if IsHandled then
+            exit;
+
         if ServiceContractLine."Item No." = '' then
             exit;
 
@@ -2652,6 +2664,16 @@ codeunit 5940 ServContractManagement
         end;
     end;
     # endregion Item Service Blocked checks
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckServiceItemBlockedForAll(var ServiceContractLine: Record "Service Contract Line"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckItemServiceBlocked(var ServiceContractLine: Record "Service Contract Line"; var IsHandled: Boolean)
+    begin
+    end;
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterCalcContractLineAmount(AnnualAmount: Decimal; PeriodStarts: Date; PeriodEnds: Date; var AmountCalculated: Decimal)


### PR DESCRIPTION
## Summary
Service contract invoicing currently stops when a contract line references a service item, item, or item variant that was later blocked or deleted. This change lets extensions independently bypass each blocked-item validation so active contracts can continue to be invoiced when appropriate.

Source issue repository: microsoft/AlAppExtensions; issue number: 30342

## Changes Made
- `ServContractManagement.CheckServiceItemBlockedForAll` - added an `IsHandled` event before the service-item validation so extensions can skip the check.
- `ServContractManagement.CheckItemServiceBlocked` - added an independent `IsHandled` event before item and variant validation so extensions can skip that check.

Fixes [AB#646130](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646130)


