### PR TITLE
[ExpenseAgent] Expose VatSpecifications on Expense API Page

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpensesAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpensesAPI.Page.al
@@ -311,6 +311,13 @@ page 6927 "Expenses API"
                     EntitySetName = 'expenseperdiems';
                     SubPageLink = "Expense No." = field("No.");
                 }
+                part(expenseVATSpecifications; "Expense VAT Spec. API")
+                {
+                    Caption = 'Expense VAT Specifications';
+                    EntityName = 'expenseVATSpecification';
+                    EntitySetName = 'expenseVATSpecifications';
+                    SubPageLink = "Expense No." = field("No.");
+                }
                 part(expenseRuleViolations; "Expense Rule Violations API")
                 {
                     Caption = 'Expense Rule Violations';

--- a/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapabilitiesProvider.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapabilitiesProvider.Codeunit.al
@@ -30,6 +30,8 @@ codeunit 6906 "Expense Capabilities Provider"
                 exit(IsPerDiemLocationsEnabled());
             Capability::ConsolidatedProjects:
                 exit(IsConsolidatedProjectsEnabled());
+            Capability::VATSpecifications:
+                exit(IsVATSpecificationsEnabled());
         end;
         exit(false);
     end;
@@ -51,6 +53,15 @@ codeunit 6906 "Expense Capabilities Provider"
     local procedure IsConsolidatedProjectsEnabled(): Boolean
     begin
         exit(IsProjectsEnabled());
+    end;
+
+    local procedure IsVATSpecificationsEnabled(): Boolean
+    var
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        if not ExpenseAgentSetup.Get() then
+            exit(false);
+        exit(ExpenseAgentSetup."Allow VAT Reclaim");
     end;
 
     /// <summary>

--- a/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapability.Enum.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapability.Enum.al
@@ -46,4 +46,12 @@ enum 6984 "Expense Capability"
     {
         Caption = 'Consolidated Projects', Locked = true;
     }
+
+    /// <summary>
+    /// VAT specifications are available when VAT reclaim is enabled
+    /// </summary>
+    value(3; VATSpecifications)
+    {
+        Caption = 'VAT Specifications', Locked = true;
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

The introduces a new part on the Expense API Page for VAT Specifications and it adds a new capability exposed to Expense Agent App for backwards compatibility.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#646485](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646485)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

No risks, everything is validated locally and the changes are minimal.








