### PR TITLE
[Extensibility Request] issue 30298: allow production scheduling direction control

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderLine.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderLine.Table.al
@@ -307,8 +307,12 @@ table 5406 "Prod. Order Line"
 
                 UpdateProdOrderComp(xRec."Qty. per Unit of Measure");
 
-                if CurrFieldNo <> 0 then
-                    Validate("Ending Time");
+                if CurrFieldNo <> 0 then begin
+                    IsHandled := false;
+                    OnValidateQuantityOnBeforeValidateEndingTime(Rec, IsHandled);
+                    if not IsHandled then
+                        Validate("Ending Time");
+                end;
                 "Cost Amount" := Round(Quantity * "Unit Cost");
             end;
         }
@@ -695,7 +699,10 @@ table 5406 "Prod. Order Line"
                 Validate(Quantity, "Quantity (Base)");
                 "Remaining Quantity" := Quantity - "Finished Quantity";
 
-                Validate("Ending Time");
+                IsHandled := false;
+                OnValidateQuantityBaseOnBeforeValidateEndingTime(Rec, IsHandled);
+                if not IsHandled then
+                    Validate("Ending Time");
 
                 "Cost Amount" := Round(Quantity * "Unit Cost");
             end;
@@ -2069,6 +2076,16 @@ table 5406 "Prod. Order Line"
 
     [IntegrationEvent(false, false)]
     local procedure OnValidateQuantityOnAfterCalcBaseQty(var ProdOrderLine: Record "Prod. Order Line"; xProdOrderLine: Record "Prod. Order Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidateQuantityOnBeforeValidateEndingTime(var ProdOrderLine: Record "Prod. Order Line"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnValidateQuantityBaseOnBeforeValidateEndingTime(var ProdOrderLine: Record "Prod. Order Line"; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Users need to control whether quantity changes reschedule production orders backward or forward so the intended start date can remain unchanged. The existing quantity validations always validate Ending Time, forcing backward scheduling. This PR adds handled events before those validations so extensions can select an alternative scheduling direction.

Source issue repository: microsoft/AlAppExtensions; issue number: 30298

## Changes Made
- `Prod. Order Line` quantity validation - Added handled events before validating Ending Time from Quantity and Quantity (Base), allowing extensions to override the hardcoded backward scheduling path in W1.

Fixes [AB#644773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644773)


