### PR TITLE
Remove two redundant overrides from the base ruleset

### DIFF
--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -49,10 +49,6 @@
       "action": "Warning"
     },
     {
-      "id": "AL0640",
-      "action": "Error"
-    },
-    {
       "id": "AL0659",
       "action": "Warning",
       "justification": "The length of the enum identifier 'Acc. Schedule Line Totaling Type' should not exceed 30 characters as it may result in runtime issues in cases where there are other enums with the same first 30 characters."
@@ -429,11 +425,6 @@
     {
       "id": "PTE0018",
       "action": "Warning"
-    },
-    {
-      "id": "AD0001",
-      "action": "Error",
-      "justification": "Analyzer exceptions should be an error as they can prevent other rules from being validated properly."
     },
     {
       "id": "AL0468",


### PR DESCRIPTION
## Why

Follows on from #10088, under [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773).

## What changed

`AD0001` and `AL0640` are overridden to `Error` in `base.ruleset.json` — which is already their effective severity. `base.ruleset.json` sets `generalAction: "Error"`, and neither rule is downgraded by the included `ruleset.json`.

Removing the two entries is a **no-op for analysis behaviour** and simply reduces the override list from 105 to 103. Single file, deletions only.

## Note on the original scope

This PR originally proposed promoting 14 rules that appeared to have zero violations. That analysis was wrong, and the CI failures on this branch showed why.

Twelve of those rules were not downgraded to `Warning` — they were set to `None` or `Hidden`, i.e. switched off entirely. A disabled rule emits no diagnostics, so "zero violations in the build logs" was true by construction rather than evidence of a clean codebase.

Two CI rounds confirmed this. Promoting them surfaced real violations:

| Rule | Hits | Diagnostic |
|---|---|---|
| `AA0219` | 6904 | Tooltip should start with 'Specifies' |
| `AL0432` | 149 | Obsolete `Permission` table |
| `AL0684` | 98 | Permission set references objects from other modules |
| `AS0112` | 44 (1 per build) | Permission set extension includes objects from another application |

The failures also revealed that the build **stops at the first app that fails to compile**, so each round only exposes one layer of violations. The first round showed `AL0432`/`AL0684` and never reached the apps that produce `AA0219`.

Consequently the disabled rules cannot be validated by mining build logs, and the remaining candidates (`AA0471`–`AA0474` on AutoformatType, and `AL0605` on implicit `with`) are exactly the kind of rules that tend to have large violation counts. They are left alone here and tracked separately.




