### PR TITLE
[CH][SEPA CT] Export requires both IBAN and Clearing No. for domestic payments and refunds

### DIFF
--- a/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTCheckLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTCheckLine.Codeunit.al
@@ -48,7 +48,6 @@ codeunit 1223 "SEPA CT-Check Line"
         IBANTypeErr: Label 'The IBAN type on the recipient bank account must match the payment reference type.';
         QRIBANErr: Label 'The recipient bank account has an IBAN that is of type QR-IBAN. This type requires that the recipient bank account has a SEPA CT export payment type that is type 2.2 or 3.';
         QRRefErr: Label 'The payment reference is a QR reference. This type requires that the recipient bank account has a SEPA CT export payment type that is type 2.2 or 3.';
-        CustomerIBANNoClearingErr: Label 'The IBAN on customer bank account %1 does not contain a valid Swiss bank clearing number, which is required for a domestic (payment type 2.2) transfer.', Comment = '%1 - customer bank account code';
         IBANTypeHelpLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2210475', Locked = true;
         QRIBANHelpLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2210564', Locked = true;
         QRRefHelpLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2210811', Locked = true;
@@ -270,27 +269,18 @@ codeunit 1223 "SEPA CT-Check Line"
     var
         DummyPaymentExportData: Record "Payment Export Data";
         BankAccount: Record "Bank Account";
-        CHMgt: Codeunit CHMgt;
         SwissPaymentType: Option;
     begin
         if not SwissExport then
             exit;
 
-        if not CustomerBankAccount.GetPaymentType(SwissPaymentType, GenJnlLine."Currency Code") then
-            exit;
-
-        case SwissPaymentType of
-            DummyPaymentExportData."Swiss Payment Type"::"2.2":
-                if CHMgt.GetClearingNoFromIBAN(CustomerBankAccount.IBAN) = '' then
-                    GenJnlLine.InsertPaymentFileError(StrSubstNo(CustomerIBANNoClearingErr, GenJnlLine."Recipient Bank Account"));
-            DummyPaymentExportData."Swiss Payment Type"::"6":
-                begin
-                    BankAccount.Get(GenJnlLine."Bal. Account No.");
-                    if BankAccount."SWIFT Code" = '' then
-                        AddFieldEmptyError(
-                          GenJnlLine, BankAccount.TableCaption(), BankAccount.FieldCaption("SWIFT Code"), GenJnlLine."Bal. Account No.");
-                end;
-        end;
+        if CustomerBankAccount.GetPaymentType(SwissPaymentType, GenJnlLine."Currency Code") then
+            if SwissPaymentType = DummyPaymentExportData."Swiss Payment Type"::"6" then begin
+                BankAccount.Get(GenJnlLine."Bal. Account No.");
+                if BankAccount."SWIFT Code" = '' then
+                    AddFieldEmptyError(
+                      GenJnlLine, BankAccount.TableCaption(), BankAccount.FieldCaption("SWIFT Code"), GenJnlLine."Bal. Account No.");
+            end;
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTCheckLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Bank/DirectDebit/SEPACTCheckLine.Codeunit.al
@@ -48,6 +48,7 @@ codeunit 1223 "SEPA CT-Check Line"
         IBANTypeErr: Label 'The IBAN type on the recipient bank account must match the payment reference type.';
         QRIBANErr: Label 'The recipient bank account has an IBAN that is of type QR-IBAN. This type requires that the recipient bank account has a SEPA CT export payment type that is type 2.2 or 3.';
         QRRefErr: Label 'The payment reference is a QR reference. This type requires that the recipient bank account has a SEPA CT export payment type that is type 2.2 or 3.';
+        CustomerIBANNoClearingErr: Label 'The IBAN on customer bank account %1 does not contain a valid Swiss bank clearing number, which is required for a domestic (payment type 2.2) transfer.', Comment = '%1 - customer bank account code';
         IBANTypeHelpLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2210475', Locked = true;
         QRIBANHelpLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2210564', Locked = true;
         QRRefHelpLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=2210811', Locked = true;
@@ -269,18 +270,27 @@ codeunit 1223 "SEPA CT-Check Line"
     var
         DummyPaymentExportData: Record "Payment Export Data";
         BankAccount: Record "Bank Account";
+        CHMgt: Codeunit CHMgt;
         SwissPaymentType: Option;
     begin
         if not SwissExport then
             exit;
 
-        if CustomerBankAccount.GetPaymentType(SwissPaymentType, GenJnlLine."Currency Code") then
-            if SwissPaymentType = DummyPaymentExportData."Swiss Payment Type"::"6" then begin
-                BankAccount.Get(GenJnlLine."Bal. Account No.");
-                if BankAccount."SWIFT Code" = '' then
-                    AddFieldEmptyError(
-                      GenJnlLine, BankAccount.TableCaption(), BankAccount.FieldCaption("SWIFT Code"), GenJnlLine."Bal. Account No.");
-            end;
+        if not CustomerBankAccount.GetPaymentType(SwissPaymentType, GenJnlLine."Currency Code") then
+            exit;
+
+        case SwissPaymentType of
+            DummyPaymentExportData."Swiss Payment Type"::"2.2":
+                if CHMgt.GetClearingNoFromIBAN(CustomerBankAccount.IBAN) = '' then
+                    GenJnlLine.InsertPaymentFileError(StrSubstNo(CustomerIBANNoClearingErr, GenJnlLine."Recipient Bank Account"));
+            DummyPaymentExportData."Swiss Payment Type"::"6":
+                begin
+                    BankAccount.Get(GenJnlLine."Bal. Account No.");
+                    if BankAccount."SWIFT Code" = '' then
+                        AddFieldEmptyError(
+                          GenJnlLine, BankAccount.TableCaption(), BankAccount.FieldCaption("SWIFT Code"), GenJnlLine."Bal. Account No.");
+                end;
+        end;
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/CH/BaseApp/Bank/Payment/PaymentExportData.Table.al
+++ b/src/Layers/CH/BaseApp/Bank/Payment/PaymentExportData.Table.al
@@ -827,18 +827,23 @@ table 1226 "Payment Export Data"
     end;
 
     local procedure FillSwissFieldsFromCustomerBankAccount(CustomerBankAccount: Record "Customer Bank Account")
+    var
+        CHMgt: Codeunit CHMgt;
     begin
         if not SwissExport then
             exit;
 
         CustomerBankAccount.GetPaymentType("Swiss Payment Type", "Currency Code");
         if "Swiss Payment Type" = "Swiss Payment Type"::"2.2" then
-            "Recipient Bank BIC" := CopyStr("Recipient Bank Acc. No.", 1, MaxStrLen("Recipient Bank BIC"));
+            // MmbId must be the bank clearing number (IID), not the IBAN. Customer bank accounts have no
+            // Clearing No. field, so derive it from the domestic IBAN.
+            "Recipient Bank BIC" := CHMgt.GetClearingNoFromIBAN(CustomerBankAccount.IBAN);
     end;
 
     local procedure FillSwissFieldsFromVendorBankAccount(VendorBankAccount: Record "Vendor Bank Account")
     var
         DtaMgt: Codeunit DtaMgt;
+        CHMgt: Codeunit CHMgt;
     begin
         if not SwissExport then
             exit;
@@ -853,7 +858,12 @@ table 1226 "Payment Export Data"
                 end;
             "Swiss Payment Type"::"2.2":
                 begin
-                    "Recipient Bank BIC" := CopyStr("Recipient Bank Acc. No.", 1, MaxStrLen("Recipient Bank BIC"));
+                    // The clearing member id (MmbId) is the bank clearing number. Use the Clearing No. when set,
+                    // otherwise derive it from the domestic IBAN so it is not left as the full IBAN.
+                    if VendorBankAccount."Clearing No." <> '' then
+                        "Recipient Bank BIC" := VendorBankAccount."Clearing No."
+                    else
+                        "Recipient Bank BIC" := CHMgt.GetClearingNoFromIBAN(VendorBankAccount.IBAN);
                     "Recipient Bank Acc. No." := DtaMgt.IBANDELCHR(VendorBankAccount.IBAN);
                 end;
             "Swiss Payment Type"::"6":

--- a/src/Layers/CH/BaseApp/Bank/Payment/PaymentExportData.Table.al
+++ b/src/Layers/CH/BaseApp/Bank/Payment/PaymentExportData.Table.al
@@ -827,17 +827,13 @@ table 1226 "Payment Export Data"
     end;
 
     local procedure FillSwissFieldsFromCustomerBankAccount(CustomerBankAccount: Record "Customer Bank Account")
-    var
-        CHMgt: Codeunit CHMgt;
     begin
         if not SwissExport then
             exit;
 
         CustomerBankAccount.GetPaymentType("Swiss Payment Type", "Currency Code");
         if "Swiss Payment Type" = "Swiss Payment Type"::"2.2" then
-            // MmbId must be the bank clearing number (IID), not the IBAN. Customer bank accounts have no
-            // Clearing No. field, so derive it from the domestic IBAN.
-            "Recipient Bank BIC" := CHMgt.GetClearingNoFromIBAN(CustomerBankAccount.IBAN);
+            "Recipient Bank BIC" := CopyStr("Recipient Bank Acc. No.", 1, MaxStrLen("Recipient Bank BIC"));
     end;
 
     local procedure FillSwissFieldsFromVendorBankAccount(VendorBankAccount: Record "Vendor Bank Account")

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
@@ -254,7 +254,8 @@ codeunit 11503 CHMgt
         if not IsDomesticIBAN(IBAN) then
             exit('');
 
-        PureIBAN := DtaMgt.IBANDELCHR(IBAN);
+        // IBANDELCHR expects Code[37]; IBANs are at most 34 characters, so this never truncates real data.
+        PureIBAN := DtaMgt.IBANDELCHR(CopyStr(IBAN, 1, 37));
         if StrLen(PureIBAN) < 9 then
             exit('');
 

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
@@ -239,6 +239,23 @@ codeunit 11503 CHMgt
         exit(CopyStr(DtaMgt.IBANDELCHR(IBAN), 1, 2) in ['CH', 'LI']);
     end;
 
+    procedure GetClearingNoFromIBAN(IBAN: Code[50]) ClearingNo: Code[5]
+    var
+        DtaMgt: Codeunit DtaMgt;
+        PureIBAN: Text;
+    begin
+        // Swiss/Liechtenstein IBANs carry the 5-digit bank clearing number (IID) in positions 5-9,
+        // so it can be derived from the IBAN without a separately maintained Clearing No.
+        if not IsDomesticIBAN(IBAN) then
+            exit('');
+
+        PureIBAN := DtaMgt.IBANDELCHR(IBAN);
+        if StrLen(PureIBAN) < 9 then
+            exit('');
+
+        exit(CopyStr(DelChr(CopyStr(PureIBAN, 5, 5), '<', '0'), 1, 5));
+    end;
+
     procedure IsDomesticCurrency(CurrencyCode: Code[10]): Boolean
     var
         DtaMgt: Codeunit DtaMgt;

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
@@ -239,7 +239,12 @@ codeunit 11503 CHMgt
         exit(CopyStr(DtaMgt.IBANDELCHR(IBAN), 1, 2) in ['CH', 'LI']);
     end;
 
-    procedure GetClearingNoFromIBAN(IBAN: Code[50]) ClearingNo: Code[5]
+    /// <summary>
+    /// Extracts the Swiss bank clearing number (IID) from a domestic (CH/LI) IBAN.
+    /// </summary>
+    /// <param name="IBAN">The IBAN to read the clearing number from.</param>
+    /// <returns>The clearing number from IBAN positions 5-9 with leading zeros stripped, or an empty code if the IBAN is not a domestic IBAN or is too short.</returns>
+    internal procedure GetClearingNoFromIBAN(IBAN: Code[50]) ClearingNo: Code[5]
     var
         DtaMgt: Codeunit DtaMgt;
         PureIBAN: Text;

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/CHMgt.Codeunit.al
@@ -258,7 +258,7 @@ codeunit 11503 CHMgt
         if StrLen(PureIBAN) < 9 then
             exit('');
 
-        exit(CopyStr(DelChr(CopyStr(PureIBAN, 5, 5), '<', '0'), 1, 5));
+        ClearingNo := CopyStr(DelChr(CopyStr(PureIBAN, 5, 5), '<', '0'), 1, 5);
     end;
 
     procedure IsDomesticCurrency(CurrencyCode: Code[10]): Boolean

--- a/src/Layers/CH/BaseApp/Purchases/Vendor/VendorBankAccount.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Vendor/VendorBankAccount.Table.al
@@ -536,9 +536,10 @@ table 288 "Vendor Bank Account"
         DomesticIBAN := CHMgt.IsDomesticIBAN(IBAN);
 
         // Payment Type 2.2
-        // The bank clearing number is derived from the domestic IBAN when the Clearing No. field is left blank.
+        // When the Clearing No. field is left blank, the bank clearing number is derived from the domestic IBAN,
+        // but only when no SWIFT Code is provided so SWIFT-routed accounts still classify as Payment Type 3/4.
         if ("Payment Form" = "Payment Form"::"Bank Payment Domestic") and
-           (("Clearing No." <> '') or (CHMgt.GetClearingNoFromIBAN(IBAN) <> '')) and
+           (("Clearing No." <> '') or (("SWIFT Code" = '') and (CHMgt.GetClearingNoFromIBAN(IBAN) <> ''))) and
            DomesticCurrency and DomesticIBAN and
            (IBAN <> '')
         then begin

--- a/src/Layers/CH/BaseApp/Purchases/Vendor/VendorBankAccount.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Vendor/VendorBankAccount.Table.al
@@ -536,8 +536,10 @@ table 288 "Vendor Bank Account"
         DomesticIBAN := CHMgt.IsDomesticIBAN(IBAN);
 
         // Payment Type 2.2
+        // The bank clearing number is derived from the domestic IBAN when the Clearing No. field is left blank.
         if ("Payment Form" = "Payment Form"::"Bank Payment Domestic") and
-           ("Clearing No." <> '') and DomesticCurrency and DomesticIBAN and
+           (("Clearing No." <> '') or (CHMgt.GetClearingNoFromIBAN(IBAN) <> '')) and
+           DomesticCurrency and DomesticIBAN and
            (IBAN <> '')
         then begin
             PaymentType := DummyPaymentExportData."Swiss Payment Type"::"2.2";

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -921,12 +921,12 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         // [WHEN] Export payments to file
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
-        // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
+        // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm/Prtry = "CH03")
         ExportFile.Open(FileName);
         ExportFile.CreateInStream(XMLInStream);
         LibraryXPathXMLReader.InitializeXml(XMLInStream, 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.09');
         ExportFile.Close();
-        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:PmtTpInf//ns:LclInstrm', 'CH03');
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:PmtTpInf//ns:LclInstrm/ns:Prtry', 'CH03');
         // [THEN] The creditor agent uses the CHBCC clearing system with MmbId = the IID derived from the IBAN, and no BICFI
         LibraryXPathXMLReader.VerifyXmlNodeAbsence('//ns:CdtrAgt//ns:BICFI');
         LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAgt//ns:Cd', 'CHBCC');

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -74,6 +74,27 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
     [Test]
     [Scope('OnPrem')]
+    procedure CHMgt_GetClearingNoFromIBAN()
+    var
+        CHMgt: Codeunit CHMgt;
+    begin
+        // [FEATURE] [AI test 0.3] [UT]
+        // [SCENARIO] COD 11503 "CHMgt".GetClearingNoFromIBAN() extracts the bank clearing number (IID) from positions 5-9 of a domestic IBAN, strips leading zeros, and returns blank when it cannot be derived
+        // [THEN] Domestic CH IBAN: clearing number from positions 5-9 with leading zeros stripped
+        Assert.AreEqual('8888', CHMgt.GetClearingNoFromIBAN('CH3808888123456789012'), 'CH IBAN with a leading zero in the clearing slice');
+        Assert.AreEqual('12345', CHMgt.GetClearingNoFromIBAN('CH9312345678901234567'), 'CH IBAN with a full 5-digit clearing number');
+        // [THEN] Domestic LI IBAN is also supported
+        Assert.AreEqual('8800', CHMgt.GetClearingNoFromIBAN('LI2108800123456789012'), 'LI IBAN clearing slice');
+        // [THEN] Non-domestic IBAN returns blank
+        Assert.AreEqual('', CHMgt.GetClearingNoFromIBAN('DE62007620110623852957'), 'Non-domestic IBAN');
+        // [THEN] Domestic IBAN too short to contain positions 5-9 returns blank
+        Assert.AreEqual('', CHMgt.GetClearingNoFromIBAN('CH1234'), 'Too-short domestic IBAN');
+        // [THEN] Domestic IBAN with all-zero clearing digits returns blank
+        Assert.AreEqual('', CHMgt.GetClearingNoFromIBAN('CH9300000123456789012'), 'All-zero clearing slice');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure CHMgt_IsSwissSEPACTExport_Negative()
     var
         GenJournalLine: Record "Gen. Journal Line";
@@ -2026,6 +2047,33 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
         // [GIVEN] Customer with a bank account whose domestic IBAN is too short to contain a bank clearing number
         CustomerNo := CreateCustomerWithBankAccount('', '', 'CH12345');
+
+        // [GIVEN] Customer refund journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
+          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
+
+        // [WHEN] Export payments to file
+        asserterror GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError(ExportHasErrorsErr);
+        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure Customer_XMLExport_PaymentType22_Negative_AllZeroClearingInIBAN()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CustomerNo: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
+        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export of a customer refund fails with a clear error when the domestic IBAN's clearing-number digits (positions 5-9) are all zero (payment type 2.2)
+        Initialize();
+
+        // [GIVEN] Customer with a bank account whose domestic IBAN has all-zero clearing digits in positions 5-9
+        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH9300000123456789012');
 
         // [GIVEN] Customer refund journal line with "Currency Code" = ""
         CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -28,6 +28,7 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         FieldBlankErr: Label 'The %1 field must be filled.', Comment = '%1= field name. Example: The Name field must be filled.';
         FieldKeyBlankErr: Label '%1 %2 must have a value in %3.', Comment = '%1=table name, %2=key field value, %3=field name. Example: Customer 10000 must have a value in Name.';
         FieldKeyBlank2Err: Label '%1 %2 must have a value in %3 or in %4', Comment = '%1=table name, %2=key field value, %3=field name,%4=field name 2. Example: Customer 10000 must have a value in Name.';
+        CustomerIBANNoClearingErr: Label 'The IBAN on customer bank account %1 does not contain a valid Swiss bank clearing number, which is required for a domestic (payment type 2.2) transfer.', Comment = '%1 - customer bank account code';
         UnknownSwissPaymentTypeErr: Label 'Unknown Swiss SEPA CT export payment type.';
         ReferenceNumberIsDefinedErr: Label 'For vendor %1 and document %2, a reference number is defined. \The document type must be "Invoice".';
         MessageToRecipientMsg: Label 'Payment of %1 %2 to vendor %3', Comment = '%1 document type, %2 Document No., %3 Vendor No.';
@@ -2010,6 +2011,33 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
         LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
         LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure Customer_XMLExport_PaymentType22_Negative_NoClearingInIBAN()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CustomerNo: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
+        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export of a customer refund fails with a clear error when the domestic IBAN does not contain a derivable bank clearing number (payment type 2.2)
+        Initialize();
+
+        // [GIVEN] Customer with a bank account whose domestic IBAN is too short to contain a bank clearing number
+        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH12345');
+
+        // [GIVEN] Customer refund journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
+          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
+
+        // [WHEN] Export payments to file
+        asserterror GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError(ExportHasErrorsErr);
+        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -883,7 +883,7 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         VendorNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
-        // [FEATURE] [XML] [Export]
+        // [FEATURE] [AI test 0.3] [XML] [Export]
         // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export for "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN when "Clearing No." is blank
         Initialize();
 
@@ -1987,7 +1987,7 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         CustomerNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
-        // [FEATURE] [XML] [Export] [Customer]
+        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
         // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export for a customer refund of "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN, not the IBAN itself
         Initialize();
 
@@ -2090,7 +2090,7 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
     var
         VendorBankAccount: Record "Vendor Bank Account";
     begin
-        // [FEATURE] [UT]
+        // [FEATURE] [AI test 0.3] [UT]
         // [SCENARIO] "Vendor Bank Account".GetPaymentType returns Swiss Payment Type 2.2 when "Clearing No." and "SWIFT Code" are blank but the clearing number can be derived from a domestic IBAN
         VendorBankAccount.Init();
         VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";
@@ -2106,7 +2106,7 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
     var
         VendorBankAccount: Record "Vendor Bank Account";
     begin
-        // [FEATURE] [UT]
+        // [FEATURE] [AI test 0.3] [UT]
         // [SCENARIO] "Vendor Bank Account".GetPaymentType keeps Swiss Payment Type 3 (not 2.2) when "Clearing No." is blank but a "SWIFT Code" is provided, so the IBAN-derived clearing does not reclassify SWIFT-routed accounts
         VendorBankAccount.Init();
         VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -898,7 +898,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
     procedure XMLExport_PaymentType22_CHF_BlankClearingNo()
     var
         GenJournalLine: Record "Gen. Journal Line";
-        CHMgt: Codeunit CHMgt;
         LibraryXPathXMLReader: Codeunit "Library - XPath XML Reader";
         ExportFile: File;
         XMLInStream: InStream;
@@ -912,9 +911,8 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
         // [GIVEN] Vendor with bank account having "Payment Form" = "Bank Payment Domestic", blank "Clearing No." and "SWIFT Code", and a domestic IBAN
         VendorNo := CreateVendorWithBankAccount(PaymentFormGbl::"Bank Payment Domestic", '', '', '', GetIBAN(true));
-        // [GIVEN] The clearing number can be derived from IBAN positions 5-9
-        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
-        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
+        // [GIVEN] Positions 5-9 of the domestic IBAN 'CH3808888123456789012' yield clearing member id '8888'
+        ExpectedMmbId := '8888';
 
         // [GIVEN] Vendor payment journal line with "Currency Code" = ""
         CreatePaymentJournalLine(GenJournalLine, VendorNo, '', '',

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -901,7 +901,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         GenJournalLine: Record "Gen. Journal Line";
         CHMgt: Codeunit CHMgt;
         FileName: Text;
-        MessageID: Text;
         VendorNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
@@ -920,7 +919,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
           GenJournalLine."Account Type"::Vendor, GenJournalLine."Document Type"::Payment);
 
         // [WHEN] Export payments to file
-        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
         // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
@@ -2005,7 +2003,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         GenJournalLine: Record "Gen. Journal Line";
         CHMgt: Codeunit CHMgt;
         FileName: Text;
-        MessageID: Text;
         CustomerNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
@@ -2023,7 +2020,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
           GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
 
         // [WHEN] Export payments to file
-        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
         // [THEN] <MmbId> holds the bank clearing number (IID) derived from the IBAN

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -28,7 +28,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         FieldBlankErr: Label 'The %1 field must be filled.', Comment = '%1= field name. Example: The Name field must be filled.';
         FieldKeyBlankErr: Label '%1 %2 must have a value in %3.', Comment = '%1=table name, %2=key field value, %3=field name. Example: Customer 10000 must have a value in Name.';
         FieldKeyBlank2Err: Label '%1 %2 must have a value in %3 or in %4', Comment = '%1=table name, %2=key field value, %3=field name,%4=field name 2. Example: Customer 10000 must have a value in Name.';
-        CustomerIBANNoClearingErr: Label 'The IBAN on customer bank account %1 does not contain a valid Swiss bank clearing number, which is required for a domestic (payment type 2.2) transfer.', Comment = '%1 - customer bank account code';
         UnknownSwissPaymentTypeErr: Label 'Unknown Swiss SEPA CT export payment type.';
         ReferenceNumberIsDefinedErr: Label 'For vendor %1 and document %2, a reference number is defined. \The document type must be "Invoice".';
         MessageToRecipientMsg: Label 'Payment of %1 %2 to vendor %3', Comment = '%1 document type, %2 Document No., %3 Vendor No.';
@@ -1994,94 +1993,6 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
         // [THEN] XML File has been exported with correct Swiss SEPA CT scheme for "Payment Type" = "2.2"
         VerifyXMLFile(GenJournalLine, FileName, MessageID, PaymentTypeGbl::"2.2");
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure Customer_XMLExport_PaymentType22_DerivedMmbId()
-    var
-        GenJournalLine: Record "Gen. Journal Line";
-        CHMgt: Codeunit CHMgt;
-        FileName: Text;
-        CustomerNo: Code[20];
-        ExpectedMmbId: Code[5];
-    begin
-        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
-        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export for a customer refund of "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN, not the IBAN itself
-        Initialize();
-
-        // [GIVEN] Customer with bank account with domestic IBAN (customer bank accounts have no "Clearing No." field)
-        CustomerNo := CreateCustomerWithBankAccount_DomesticIBAN();
-        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
-        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
-
-        // [GIVEN] Customer refund journal line with "Currency Code" = ""
-        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
-          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
-
-        // [WHEN] Export payments to file
-        FileName := GenJournalLine_XMLExport(GenJournalLine);
-
-        // [THEN] <MmbId> holds the bank clearing number (IID) derived from the IBAN
-        LibraryXMLRead.Initialize(FileName);
-        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure Customer_XMLExport_PaymentType22_Negative_NoClearingInIBAN()
-    var
-        GenJournalLine: Record "Gen. Journal Line";
-        CustomerNo: Code[20];
-    begin
-        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
-        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export of a customer refund fails with a clear error when the domestic IBAN does not contain a derivable bank clearing number (payment type 2.2)
-        Initialize();
-
-        // [GIVEN] Customer with a bank account whose domestic IBAN is too short to contain a bank clearing number
-        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH12345');
-
-        // [GIVEN] Customer refund journal line with "Currency Code" = ""
-        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
-          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
-
-        // [WHEN] Export payments to file
-        asserterror GenJournalLine_XMLExport(GenJournalLine);
-
-        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
-        Assert.ExpectedErrorCode('Dialog');
-        Assert.ExpectedError(ExportHasErrorsErr);
-        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure Customer_XMLExport_PaymentType22_Negative_AllZeroClearingInIBAN()
-    var
-        GenJournalLine: Record "Gen. Journal Line";
-        CustomerNo: Code[20];
-    begin
-        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
-        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export of a customer refund fails with a clear error when the domestic IBAN's clearing-number digits (positions 5-9) are all zero (payment type 2.2)
-        Initialize();
-
-        // [GIVEN] Customer with a bank account whose domestic IBAN has all-zero clearing digits in positions 5-9
-        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH9300000123456789012');
-
-        // [GIVEN] Customer refund journal line with "Currency Code" = ""
-        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
-          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
-
-        // [WHEN] Export payments to file
-        asserterror GenJournalLine_XMLExport(GenJournalLine);
-
-        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
-        Assert.ExpectedErrorCode('Dialog');
-        Assert.ExpectedError(ExportHasErrorsErr);
-        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -899,6 +899,9 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
     var
         GenJournalLine: Record "Gen. Journal Line";
         CHMgt: Codeunit CHMgt;
+        LibraryXPathXMLReader: Codeunit "Library - XPath XML Reader";
+        ExportFile: File;
+        XMLInStream: InStream;
         FileName: Text;
         VendorNo: Code[20];
         ExpectedMmbId: Code[5];
@@ -921,14 +924,17 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
         // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
-        LibraryXMLRead.Initialize(FileName);
-        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
+        ExportFile.Open(FileName);
+        ExportFile.CreateInStream(XMLInStream);
+        LibraryXPathXMLReader.InitializeXml(XMLInStream, 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.09');
+        ExportFile.Close();
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:PmtTpInf//ns:LclInstrm', 'CH03');
         // [THEN] The creditor agent uses the CHBCC clearing system with MmbId = the IID derived from the IBAN, and no BICFI
-        LibraryXMLRead.VerifyNodeAbsenceInSubtree('CdtrAgt', 'BICFI');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
+        LibraryXPathXMLReader.VerifyXmlNodeAbsence('//ns:CdtrAgt//ns:BICFI');
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAgt//ns:Cd', 'CHBCC');
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAgt//ns:MmbId', ExpectedMmbId);
         // [THEN] The creditor account holds the IBAN
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAcct//ns:IBAN', GetIBAN(true));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -874,6 +874,46 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
     [Test]
     [Scope('OnPrem')]
+    procedure XMLExport_PaymentType22_CHF_BlankClearingNo()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CHMgt: Codeunit CHMgt;
+        FileName: Text;
+        MessageID: Text;
+        VendorNo: Code[20];
+        ExpectedMmbId: Code[5];
+    begin
+        // [FEATURE] [XML] [Export]
+        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export for "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN when "Clearing No." is blank
+        Initialize();
+
+        // [GIVEN] Vendor with bank account having "Payment Form" = "Bank Payment Domestic", blank "Clearing No." and "SWIFT Code", and a domestic IBAN
+        VendorNo := CreateVendorWithBankAccount(PaymentFormGbl::"Bank Payment Domestic", '', '', '', GetIBAN(true));
+        // [GIVEN] The clearing number can be derived from IBAN positions 5-9
+        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
+        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
+
+        // [GIVEN] Vendor payment journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, VendorNo, '', '',
+          GenJournalLine."Account Type"::Vendor, GenJournalLine."Document Type"::Payment);
+
+        // [WHEN] Export payments to file
+        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
+        FileName := GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
+        LibraryXMLRead.Initialize(FileName);
+        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
+        // [THEN] The creditor agent uses the CHBCC clearing system with MmbId = the IID derived from the IBAN, and no BICFI
+        LibraryXMLRead.VerifyNodeAbsenceInSubtree('CdtrAgt', 'BICFI');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
+        // [THEN] The creditor account holds the IBAN
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure XMLExport_PaymentType3_Negative_BlankedSWIFT()
     var
         GenJournalLine: Record "Gen. Journal Line";
@@ -1934,6 +1974,42 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
         // [THEN] XML File has been exported with correct Swiss SEPA CT scheme for "Payment Type" = "2.2"
         VerifyXMLFile(GenJournalLine, FileName, MessageID, PaymentTypeGbl::"2.2");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure Customer_XMLExport_PaymentType22_DerivedMmbId()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CHMgt: Codeunit CHMgt;
+        FileName: Text;
+        MessageID: Text;
+        CustomerNo: Code[20];
+        ExpectedMmbId: Code[5];
+    begin
+        // [FEATURE] [XML] [Export] [Customer]
+        // [SCENARIO] Swiss SEPA CT (pain.001.001.09) export for a customer refund of "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN, not the IBAN itself
+        Initialize();
+
+        // [GIVEN] Customer with bank account with domestic IBAN (customer bank accounts have no "Clearing No." field)
+        CustomerNo := CreateCustomerWithBankAccount_DomesticIBAN();
+        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
+        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
+
+        // [GIVEN] Customer refund journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
+          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
+
+        // [WHEN] Export payments to file
+        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
+        FileName := GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] <MmbId> holds the bank clearing number (IID) derived from the IBAN
+        LibraryXMLRead.Initialize(FileName);
+        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -2086,6 +2086,38 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
     [Test]
     [Scope('OnPrem')]
+    procedure VendorBankAccountGetPaymentTypeType22WhenClearingNoDerivedFromIBAN()
+    var
+        VendorBankAccount: Record "Vendor Bank Account";
+    begin
+        // [FEATURE] [UT]
+        // [SCENARIO] "Vendor Bank Account".GetPaymentType returns Swiss Payment Type 2.2 when "Clearing No." and "SWIFT Code" are blank but the clearing number can be derived from a domestic IBAN
+        VendorBankAccount.Init();
+        VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";
+        VendorBankAccount."SWIFT Code" := '';
+        VendorBankAccount.IBAN := GetIBAN(true);
+        Assert.IsTrue(VendorBankAccount.GetPaymentType(PaymentTypeGbl, GetCurrencyCode('')), GetPaymentTypeErr);
+        Assert.AreEqual(PaymentTypeGbl::"2.2", PaymentTypeGbl, GetPaymentTypeErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure VendorBankAccountGetPaymentTypeType3WhenBlankClearingNoAndSWIFTSet()
+    var
+        VendorBankAccount: Record "Vendor Bank Account";
+    begin
+        // [FEATURE] [UT]
+        // [SCENARIO] "Vendor Bank Account".GetPaymentType keeps Swiss Payment Type 3 (not 2.2) when "Clearing No." is blank but a "SWIFT Code" is provided, so the IBAN-derived clearing does not reclassify SWIFT-routed accounts
+        VendorBankAccount.Init();
+        VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";
+        VendorBankAccount."SWIFT Code" := GetSWIFT(true);
+        VendorBankAccount.IBAN := GetIBAN(true);
+        Assert.IsTrue(VendorBankAccount.GetPaymentType(PaymentTypeGbl, GetCurrencyCode('')), GetPaymentTypeErr);
+        Assert.AreEqual(PaymentTypeGbl::"3", PaymentTypeGbl, GetPaymentTypeErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure XMLExport_PaymentType6_Negative_BlankedSWIFTCode()
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -28,7 +28,6 @@ codeunit 144352 "Swiss SEPA CT Export"
         FieldBlankErr: Label 'The %1 field must be filled.', Comment = '%1= field name. Example: The Name field must be filled.';
         FieldKeyBlankErr: Label '%1 %2 must have a value in %3.', Comment = '%1=table name, %2=key field value, %3=field name. Example: Customer 10000 must have a value in Name.';
         FieldKeyBlank2Err: Label '%1 %2 must have a value in %3 or in %4', Comment = '%1=table name, %2=key field value, %3=field name,%4=field name 2. Example: Customer 10000 must have a value in Name.';
-        CustomerIBANNoClearingErr: Label 'The IBAN on customer bank account %1 does not contain a valid Swiss bank clearing number, which is required for a domestic (payment type 2.2) transfer.', Comment = '%1 - customer bank account code';
         UnknownSwissPaymentTypeErr: Label 'Unknown Swiss SEPA CT export payment type.';
         ReferenceNumberIsDefinedErr: Label 'For vendor %1 and document %2, a reference number is defined. \The document type must be "Invoice".';
         MessageToRecipientMsg: Label 'Payment of %1 %2 to vendor %3', Comment = '%1 document type, %2 Document No., %3 Vendor No.';
@@ -1997,94 +1996,6 @@ codeunit 144352 "Swiss SEPA CT Export"
 
         // [THEN] XML File has been exported with correct Swiss SEPA CT scheme for "Payment Type" = "2.2"
         VerifyXMLFile(GenJournalLine, FileName, MessageID, PaymentTypeGbl::"2.2");
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure Customer_XMLExport_PaymentType22_DerivedMmbId()
-    var
-        GenJournalLine: Record "Gen. Journal Line";
-        CHMgt: Codeunit CHMgt;
-        FileName: Text;
-        CustomerNo: Code[20];
-        ExpectedMmbId: Code[5];
-    begin
-        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
-        // [SCENARIO] Swiss SEPA CT export for a customer refund of "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN, not the IBAN itself
-        Initialize();
-
-        // [GIVEN] Customer with bank account with domestic IBAN (customer bank accounts have no "Clearing No." field)
-        CustomerNo := CreateCustomerWithBankAccount_DomesticIBAN();
-        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
-        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
-
-        // [GIVEN] Customer refund journal line with "Currency Code" = ""
-        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
-          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
-
-        // [WHEN] Export payments to file
-        FileName := GenJournalLine_XMLExport(GenJournalLine);
-
-        // [THEN] <MmbId> holds the bank clearing number (IID) derived from the IBAN
-        LibraryXMLRead.Initialize(FileName);
-        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure Customer_XMLExport_PaymentType22_Negative_NoClearingInIBAN()
-    var
-        GenJournalLine: Record "Gen. Journal Line";
-        CustomerNo: Code[20];
-    begin
-        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
-        // [SCENARIO] Swiss SEPA CT export of a customer refund fails with a clear error when the domestic IBAN does not contain a derivable bank clearing number (payment type 2.2)
-        Initialize();
-
-        // [GIVEN] Customer with a bank account whose domestic IBAN is too short to contain a bank clearing number
-        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH12345');
-
-        // [GIVEN] Customer refund journal line with "Currency Code" = ""
-        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
-          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
-
-        // [WHEN] Export payments to file
-        asserterror GenJournalLine_XMLExport(GenJournalLine);
-
-        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
-        Assert.ExpectedErrorCode('Dialog');
-        Assert.ExpectedError(ExportHasErrorsErr);
-        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
-    procedure Customer_XMLExport_PaymentType22_Negative_AllZeroClearingInIBAN()
-    var
-        GenJournalLine: Record "Gen. Journal Line";
-        CustomerNo: Code[20];
-    begin
-        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
-        // [SCENARIO] Swiss SEPA CT export of a customer refund fails with a clear error when the domestic IBAN's clearing-number digits (positions 5-9) are all zero (payment type 2.2)
-        Initialize();
-
-        // [GIVEN] Customer with a bank account whose domestic IBAN has all-zero clearing digits in positions 5-9
-        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH9300000123456789012');
-
-        // [GIVEN] Customer refund journal line with "Currency Code" = ""
-        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
-          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
-
-        // [WHEN] Export payments to file
-        asserterror GenJournalLine_XMLExport(GenJournalLine);
-
-        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
-        Assert.ExpectedErrorCode('Dialog');
-        Assert.ExpectedError(ExportHasErrorsErr);
-        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -924,12 +924,12 @@ codeunit 144352 "Swiss SEPA CT Export"
         // [WHEN] Export payments to file
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
-        // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
+        // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm/Prtry = "CH03")
         ExportFile.Open(FileName);
         ExportFile.CreateInStream(XMLInStream);
         LibraryXPathXMLReader.InitializeXml(XMLInStream, 'http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd');
         ExportFile.Close();
-        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:PmtTpInf//ns:LclInstrm', 'CH03');
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:PmtTpInf//ns:LclInstrm/ns:Prtry', 'CH03');
         // [THEN] The creditor agent uses the CHBCC clearing system with MmbId = the IID derived from the IBAN, and no BIC
         LibraryXPathXMLReader.VerifyXmlNodeAbsence('//ns:CdtrAgt//ns:BIC');
         LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAgt//ns:Cd', 'CHBCC');

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -877,6 +877,46 @@ codeunit 144352 "Swiss SEPA CT Export"
 
     [Test]
     [Scope('OnPrem')]
+    procedure XMLExport_PaymentType22_CHF_BlankClearingNo()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CHMgt: Codeunit CHMgt;
+        FileName: Text;
+        MessageID: Text;
+        VendorNo: Code[20];
+        ExpectedMmbId: Code[5];
+    begin
+        // [FEATURE] [XML] [Export]
+        // [SCENARIO] Swiss SEPA CT export for "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN when "Clearing No." is blank
+        Initialize();
+
+        // [GIVEN] Vendor with bank account having "Payment Form" = "Bank Payment Domestic", blank "Clearing No." and "SWIFT Code", and a domestic IBAN
+        VendorNo := CreateVendorWithBankAccount(PaymentFormGbl::"Bank Payment Domestic", '', '', '', GetIBAN(true));
+        // [GIVEN] The clearing number can be derived from IBAN positions 5-9
+        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
+        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
+
+        // [GIVEN] Vendor payment journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, VendorNo, '', '',
+          GenJournalLine."Account Type"::Vendor, GenJournalLine."Document Type"::Payment);
+
+        // [WHEN] Export payments to file
+        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
+        FileName := GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
+        LibraryXMLRead.Initialize(FileName);
+        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
+        // [THEN] The creditor agent uses the CHBCC clearing system with MmbId = the IID derived from the IBAN, and no BIC
+        LibraryXMLRead.VerifyNodeAbsenceInSubtree('CdtrAgt', 'BIC');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
+        // [THEN] The creditor account holds the IBAN
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure XMLExport_PaymentType3_Negative_BlankedSWIFT()
     var
         GenJournalLine: Record "Gen. Journal Line";
@@ -1937,6 +1977,42 @@ codeunit 144352 "Swiss SEPA CT Export"
 
         // [THEN] XML File has been exported with correct Swiss SEPA CT scheme for "Payment Type" = "2.2"
         VerifyXMLFile(GenJournalLine, FileName, MessageID, PaymentTypeGbl::"2.2");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure Customer_XMLExport_PaymentType22_DerivedMmbId()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CHMgt: Codeunit CHMgt;
+        FileName: Text;
+        MessageID: Text;
+        CustomerNo: Code[20];
+        ExpectedMmbId: Code[5];
+    begin
+        // [FEATURE] [XML] [Export] [Customer]
+        // [SCENARIO] Swiss SEPA CT export for a customer refund of "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN, not the IBAN itself
+        Initialize();
+
+        // [GIVEN] Customer with bank account with domestic IBAN (customer bank accounts have no "Clearing No." field)
+        CustomerNo := CreateCustomerWithBankAccount_DomesticIBAN();
+        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
+        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
+
+        // [GIVEN] Customer refund journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
+          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
+
+        // [WHEN] Export payments to file
+        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
+        FileName := GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] <MmbId> holds the bank clearing number (IID) derived from the IBAN
+        LibraryXMLRead.Initialize(FileName);
+        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
+        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -28,6 +28,7 @@ codeunit 144352 "Swiss SEPA CT Export"
         FieldBlankErr: Label 'The %1 field must be filled.', Comment = '%1= field name. Example: The Name field must be filled.';
         FieldKeyBlankErr: Label '%1 %2 must have a value in %3.', Comment = '%1=table name, %2=key field value, %3=field name. Example: Customer 10000 must have a value in Name.';
         FieldKeyBlank2Err: Label '%1 %2 must have a value in %3 or in %4', Comment = '%1=table name, %2=key field value, %3=field name,%4=field name 2. Example: Customer 10000 must have a value in Name.';
+        CustomerIBANNoClearingErr: Label 'The IBAN on customer bank account %1 does not contain a valid Swiss bank clearing number, which is required for a domestic (payment type 2.2) transfer.', Comment = '%1 - customer bank account code';
         UnknownSwissPaymentTypeErr: Label 'Unknown Swiss SEPA CT export payment type.';
         ReferenceNumberIsDefinedErr: Label 'For vendor %1 and document %2, a reference number is defined. \The document type must be "Invoice".';
         MessageToRecipientMsg: Label 'Payment of %1 %2 to vendor %3', Comment = '%1 document type, %2 Document No., %3 Vendor No.';
@@ -2013,6 +2014,33 @@ codeunit 144352 "Swiss SEPA CT Export"
         LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
         LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
         LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure Customer_XMLExport_PaymentType22_Negative_NoClearingInIBAN()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CustomerNo: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
+        // [SCENARIO] Swiss SEPA CT export of a customer refund fails with a clear error when the domestic IBAN does not contain a derivable bank clearing number (payment type 2.2)
+        Initialize();
+
+        // [GIVEN] Customer with a bank account whose domestic IBAN is too short to contain a bank clearing number
+        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH12345');
+
+        // [GIVEN] Customer refund journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
+          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
+
+        // [WHEN] Export payments to file
+        asserterror GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError(ExportHasErrorsErr);
+        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -901,7 +901,6 @@ codeunit 144352 "Swiss SEPA CT Export"
     procedure XMLExport_PaymentType22_CHF_BlankClearingNo()
     var
         GenJournalLine: Record "Gen. Journal Line";
-        CHMgt: Codeunit CHMgt;
         LibraryXPathXMLReader: Codeunit "Library - XPath XML Reader";
         ExportFile: File;
         XMLInStream: InStream;
@@ -915,9 +914,8 @@ codeunit 144352 "Swiss SEPA CT Export"
 
         // [GIVEN] Vendor with bank account having "Payment Form" = "Bank Payment Domestic", blank "Clearing No." and "SWIFT Code", and a domestic IBAN
         VendorNo := CreateVendorWithBankAccount(PaymentFormGbl::"Bank Payment Domestic", '', '', '', GetIBAN(true));
-        // [GIVEN] The clearing number can be derived from IBAN positions 5-9
-        ExpectedMmbId := CHMgt.GetClearingNoFromIBAN(GetIBAN(true));
-        Assert.AreNotEqual('', ExpectedMmbId, 'Derived clearing number should not be blank');
+        // [GIVEN] Positions 5-9 of the domestic IBAN 'CH3808888123456789012' yield clearing member id '8888'
+        ExpectedMmbId := '8888';
 
         // [GIVEN] Vendor payment journal line with "Currency Code" = ""
         CreatePaymentJournalLine(GenJournalLine, VendorNo, '', '',

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -902,6 +902,9 @@ codeunit 144352 "Swiss SEPA CT Export"
     var
         GenJournalLine: Record "Gen. Journal Line";
         CHMgt: Codeunit CHMgt;
+        LibraryXPathXMLReader: Codeunit "Library - XPath XML Reader";
+        ExportFile: File;
+        XMLInStream: InStream;
         FileName: Text;
         VendorNo: Code[20];
         ExpectedMmbId: Code[5];
@@ -924,14 +927,17 @@ codeunit 144352 "Swiss SEPA CT Export"
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
         // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
-        LibraryXMLRead.Initialize(FileName);
-        LibraryXMLRead.VerifyNodeValueInSubtree('PmtTpInf', 'LclInstrm', 'CH03');
+        ExportFile.Open(FileName);
+        ExportFile.CreateInStream(XMLInStream);
+        LibraryXPathXMLReader.InitializeXml(XMLInStream, 'http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd');
+        ExportFile.Close();
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:PmtTpInf//ns:LclInstrm', 'CH03');
         // [THEN] The creditor agent uses the CHBCC clearing system with MmbId = the IID derived from the IBAN, and no BIC
-        LibraryXMLRead.VerifyNodeAbsenceInSubtree('CdtrAgt', 'BIC');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'Cd', 'CHBCC');
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAgt', 'MmbId', ExpectedMmbId);
+        LibraryXPathXMLReader.VerifyXmlNodeAbsence('//ns:CdtrAgt//ns:BIC');
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAgt//ns:Cd', 'CHBCC');
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAgt//ns:MmbId', ExpectedMmbId);
         // [THEN] The creditor account holds the IBAN
-        LibraryXMLRead.VerifyNodeValueInSubtree('CdtrAcct', 'IBAN', GetIBAN(true));
+        LibraryXPathXMLReader.VerifyXmlNodeValue('//ns:CdtrAcct//ns:IBAN', GetIBAN(true));
     end;
 
     [Test]

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -904,7 +904,6 @@ codeunit 144352 "Swiss SEPA CT Export"
         GenJournalLine: Record "Gen. Journal Line";
         CHMgt: Codeunit CHMgt;
         FileName: Text;
-        MessageID: Text;
         VendorNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
@@ -923,7 +922,6 @@ codeunit 144352 "Swiss SEPA CT Export"
           GenJournalLine."Account Type"::Vendor, GenJournalLine."Document Type"::Payment);
 
         // [WHEN] Export payments to file
-        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
         // [THEN] The payment is classified as Swiss Payment Type "2.2" (LclInstrm = "CH03")
@@ -2008,7 +2006,6 @@ codeunit 144352 "Swiss SEPA CT Export"
         GenJournalLine: Record "Gen. Journal Line";
         CHMgt: Codeunit CHMgt;
         FileName: Text;
-        MessageID: Text;
         CustomerNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
@@ -2026,7 +2023,6 @@ codeunit 144352 "Swiss SEPA CT Export"
           GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
 
         // [WHEN] Export payments to file
-        MessageID := GetMessageID(GenJournalLine."Bal. Account No.");
         FileName := GenJournalLine_XMLExport(GenJournalLine);
 
         // [THEN] <MmbId> holds the bank clearing number (IID) derived from the IBAN

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -2089,6 +2089,38 @@ codeunit 144352 "Swiss SEPA CT Export"
 
     [Test]
     [Scope('OnPrem')]
+    procedure VendorBankAccountGetPaymentTypeType22WhenClearingNoDerivedFromIBAN()
+    var
+        VendorBankAccount: Record "Vendor Bank Account";
+    begin
+        // [FEATURE] [UT]
+        // [SCENARIO] "Vendor Bank Account".GetPaymentType returns Swiss Payment Type 2.2 when "Clearing No." and "SWIFT Code" are blank but the clearing number can be derived from a domestic IBAN
+        VendorBankAccount.Init();
+        VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";
+        VendorBankAccount."SWIFT Code" := '';
+        VendorBankAccount.IBAN := GetIBAN(true);
+        Assert.IsTrue(VendorBankAccount.GetPaymentType(PaymentTypeGbl, GetCurrencyCode('')), GetPaymentTypeErr);
+        Assert.AreEqual(PaymentTypeGbl::"2.2", PaymentTypeGbl, GetPaymentTypeErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure VendorBankAccountGetPaymentTypeType3WhenBlankClearingNoAndSWIFTSet()
+    var
+        VendorBankAccount: Record "Vendor Bank Account";
+    begin
+        // [FEATURE] [UT]
+        // [SCENARIO] "Vendor Bank Account".GetPaymentType keeps Swiss Payment Type 3 (not 2.2) when "Clearing No." is blank but a "SWIFT Code" is provided, so the IBAN-derived clearing does not reclassify SWIFT-routed accounts
+        VendorBankAccount.Init();
+        VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";
+        VendorBankAccount."SWIFT Code" := GetSWIFT(true);
+        VendorBankAccount.IBAN := GetIBAN(true);
+        Assert.IsTrue(VendorBankAccount.GetPaymentType(PaymentTypeGbl, GetCurrencyCode('')), GetPaymentTypeErr);
+        Assert.AreEqual(PaymentTypeGbl::"3", PaymentTypeGbl, GetPaymentTypeErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure XMLExport_PaymentType6_Negative_BlankedSWIFTCode()
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -77,6 +77,27 @@ codeunit 144352 "Swiss SEPA CT Export"
 
     [Test]
     [Scope('OnPrem')]
+    procedure CHMgt_GetClearingNoFromIBAN()
+    var
+        CHMgt: Codeunit CHMgt;
+    begin
+        // [FEATURE] [AI test 0.3] [UT]
+        // [SCENARIO] COD 11503 "CHMgt".GetClearingNoFromIBAN() extracts the bank clearing number (IID) from positions 5-9 of a domestic IBAN, strips leading zeros, and returns blank when it cannot be derived
+        // [THEN] Domestic CH IBAN: clearing number from positions 5-9 with leading zeros stripped
+        Assert.AreEqual('8888', CHMgt.GetClearingNoFromIBAN('CH3808888123456789012'), 'CH IBAN with a leading zero in the clearing slice');
+        Assert.AreEqual('12345', CHMgt.GetClearingNoFromIBAN('CH9312345678901234567'), 'CH IBAN with a full 5-digit clearing number');
+        // [THEN] Domestic LI IBAN is also supported
+        Assert.AreEqual('8800', CHMgt.GetClearingNoFromIBAN('LI2108800123456789012'), 'LI IBAN clearing slice');
+        // [THEN] Non-domestic IBAN returns blank
+        Assert.AreEqual('', CHMgt.GetClearingNoFromIBAN('DE62007620110623852957'), 'Non-domestic IBAN');
+        // [THEN] Domestic IBAN too short to contain positions 5-9 returns blank
+        Assert.AreEqual('', CHMgt.GetClearingNoFromIBAN('CH1234'), 'Too-short domestic IBAN');
+        // [THEN] Domestic IBAN with all-zero clearing digits returns blank
+        Assert.AreEqual('', CHMgt.GetClearingNoFromIBAN('CH9300000123456789012'), 'All-zero clearing slice');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure CHMgt_IsSwissSEPACTExport_Negative()
     var
         GenJournalLine: Record "Gen. Journal Line";
@@ -2029,6 +2050,33 @@ codeunit 144352 "Swiss SEPA CT Export"
 
         // [GIVEN] Customer with a bank account whose domestic IBAN is too short to contain a bank clearing number
         CustomerNo := CreateCustomerWithBankAccount('', '', 'CH12345');
+
+        // [GIVEN] Customer refund journal line with "Currency Code" = ""
+        CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',
+          GenJournalLine."Account Type"::Customer, GenJournalLine."Document Type"::Refund);
+
+        // [WHEN] Export payments to file
+        asserterror GenJournalLine_XMLExport(GenJournalLine);
+
+        // [THEN] The export fails with a clear error that the IBAN contains no valid Swiss bank clearing number
+        Assert.ExpectedErrorCode('Dialog');
+        Assert.ExpectedError(ExportHasErrorsErr);
+        VerifyPaymentJnlExportErrorText(GenJournalLine, StrSubstNo(CustomerIBANNoClearingErr, GenJournalLine."Recipient Bank Account"));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure Customer_XMLExport_PaymentType22_Negative_AllZeroClearingInIBAN()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        CustomerNo: Code[20];
+    begin
+        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
+        // [SCENARIO] Swiss SEPA CT export of a customer refund fails with a clear error when the domestic IBAN's clearing-number digits (positions 5-9) are all zero (payment type 2.2)
+        Initialize();
+
+        // [GIVEN] Customer with a bank account whose domestic IBAN has all-zero clearing digits in positions 5-9
+        CustomerNo := CreateCustomerWithBankAccount('', '', 'CH9300000123456789012');
 
         // [GIVEN] Customer refund journal line with "Currency Code" = ""
         CreatePaymentJournalLine(GenJournalLine, CustomerNo, '', '',

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -886,7 +886,7 @@ codeunit 144352 "Swiss SEPA CT Export"
         VendorNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
-        // [FEATURE] [XML] [Export]
+        // [FEATURE] [AI test 0.3] [XML] [Export]
         // [SCENARIO] Swiss SEPA CT export for "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN when "Clearing No." is blank
         Initialize();
 
@@ -1990,7 +1990,7 @@ codeunit 144352 "Swiss SEPA CT Export"
         CustomerNo: Code[20];
         ExpectedMmbId: Code[5];
     begin
-        // [FEATURE] [XML] [Export] [Customer]
+        // [FEATURE] [AI test 0.3] [XML] [Export] [Customer]
         // [SCENARIO] Swiss SEPA CT export for a customer refund of "Payment Type" = "2.2" derives the clearing member id (MmbId) from the domestic IBAN, not the IBAN itself
         Initialize();
 
@@ -2093,7 +2093,7 @@ codeunit 144352 "Swiss SEPA CT Export"
     var
         VendorBankAccount: Record "Vendor Bank Account";
     begin
-        // [FEATURE] [UT]
+        // [FEATURE] [AI test 0.3] [UT]
         // [SCENARIO] "Vendor Bank Account".GetPaymentType returns Swiss Payment Type 2.2 when "Clearing No." and "SWIFT Code" are blank but the clearing number can be derived from a domestic IBAN
         VendorBankAccount.Init();
         VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";
@@ -2109,7 +2109,7 @@ codeunit 144352 "Swiss SEPA CT Export"
     var
         VendorBankAccount: Record "Vendor Bank Account";
     begin
-        // [FEATURE] [UT]
+        // [FEATURE] [AI test 0.3] [UT]
         // [SCENARIO] "Vendor Bank Account".GetPaymentType keeps Swiss Payment Type 3 (not 2.2) when "Clearing No." is blank but a "SWIFT Code" is provided, so the IBAN-derived clearing does not reclassify SWIFT-routed accounts
         VendorBankAccount.Init();
         VendorBankAccount."Payment Form" := VendorBankAccount."Payment Form"::"Bank Payment Domestic";


### PR DESCRIPTION
Swiss SEPA CT Export requires both IBAN and Clearing No. for domestic payments and refunds

Expected:
If Clearing No. is blank, it can be extracted from IBAN (IBAN contains it).

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
Added the logic that extracts Clearing No. from IBAN, and using it when determining the payment type, and when exporting to MmbId in the SEPA CT file.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#646497](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646497)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

- Vendor payment + clearing: identical output → zero risk.
- Customer refund / vendor-blank-clearing: old output was either invalid (MmbId = IBAN) or nonexistent (errored), so there's nothing valid to break; the fix only makes MmbId schema-correct.
Since CdtrAcct/IBAN is unchanged and is what routes, no in-flight payment behavior changes — only the redundant MmbId becomes correct.













