### PR TITLE
[Quality Management] Make transaction blocked error more understandable and actionable

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
@@ -27,7 +27,7 @@ codeunit 20415 "Qlty. Tracking Integration"
         WarehouseEntryTypeBlockedErr: Label '"%1" warehouse transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
         NavigatePageSearchFiltersTok: Label 'NAVIGATEFILTERS', Locked = true;
         BlockedByQualityInspectionTitleLbl: Label 'Blocked by quality inspection', Comment = 'Title for the error message when a transaction is blocked by a quality inspection';
-        ShowInspectionActionLbl: Label 'Show Quality Inspection %1', Comment = '%1 = Quality Inspection identifier';
+        ShowInspectionActionLbl: Label 'Show Quality Inspection';
 
     [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Setup."Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Configuration.Result."Qlty. Inspection Result", 'R', InherentPermissionsScope::Permissions)]
@@ -445,7 +445,7 @@ codeunit 20415 "Qlty. Tracking Integration"
         BlockedErrorInfo.PageNo := Page::"Qlty. Inspection";
         BlockedErrorInfo.DataClassification := DataClassification::CustomerContent;
         BlockedErrorInfo.ErrorType := ErrorType::Client;
-        BlockedErrorInfo.AddNavigationAction(StrSubstNo(ShowInspectionActionLbl, QltyInspectionHeader.GetFriendlyIdentifier()));
+        BlockedErrorInfo.AddNavigationAction(ShowInspectionActionLbl);
         Error(BlockedErrorInfo);
     end;
 

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
@@ -16,14 +16,15 @@ using Microsoft.QualityManagement.Setup;
 using Microsoft.QualityManagement.Utilities;
 using Microsoft.Warehouse.Activity;
 using System.IO;
+using System.Utilities;
 
 codeunit 20415 "Qlty. Tracking Integration"
 {
     InherentPermissions = X;
 
     var
-        EntryTypeBlockedErr: Label 'This transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=combined package tracking details of Lot No., Serial No. and Package No.';
-        WarehouseEntryTypeBlockedErr: Label 'This warehouse transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5 %6 %7, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=Lot No., %6=Serial No., %7=Package No.';
+        EntryTypeBlockedErr: Label '"%1" transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
+        WarehouseEntryTypeBlockedErr: Label '"%1" warehouse transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
         NavigatePageSearchFiltersTok: Label 'NAVIGATEFILTERS', Locked = true;
 
     [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Setup."Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
@@ -38,7 +39,6 @@ codeunit 20415 "Qlty. Tracking Integration"
         Blocked: Boolean;
         IsFinished: Boolean;
         IsHandled: Boolean;
-        TrackingDetails: Text;
     begin
         if not QltyManagementSetup.GetSetupRecord() then
             exit;
@@ -101,6 +101,14 @@ codeunit 20415 "Qlty. Tracking Integration"
         repeat
             if QltyInspectionHeader."Result Code" <> '' then begin
                 IsFinished := QltyInspectionHeader.Status = QltyInspectionHeader.Status::Finished;
+                QltyInspectionResult.SetLoadFields(
+                    "Item Tracking Allow Asm. Cons.",
+                    "Item Tracking Allow Asm. Out.",
+                    "Item Tracking Allow Consump.",
+                    "Item Tracking Allow Output",
+                    "Item Tracking Allow Purchase",
+                    "Item Tracking Allow Sales",
+                    "Item Tracking Allow Transfer");
                 if QltyInspectionResult.Get(QltyInspectionHeader."Result Code") then begin
                     case ItemJnlLine2."Entry Type" of
                         ItemJnlLine2."Entry Type"::"Assembly Consumption":
@@ -133,25 +141,15 @@ codeunit 20415 "Qlty. Tracking Integration"
                     end;
                     OnHandleCheckItemTrackingBeforeBlockErrorCheck(ItemJnlLine2, TrackingSpecification, QltyInspectionHeader, QltyInspectionResult, Blocked);
 
-                    if Blocked then begin
-                        TrackingDetails := TrackingSpecification."Lot No.";
-                        if TrackingSpecification."Serial No." <> '' then begin
-                            if StrLen(TrackingDetails) > 0 then
-                                TrackingDetails += ' ';
-                            TrackingDetails += TrackingSpecification."Serial No.";
-                        end;
-                        if TrackingSpecification."Package No." <> '' then begin
-                            if StrLen(TrackingDetails) > 0 then
-                                TrackingDetails += ' ';
-                            TrackingDetails += TrackingSpecification."Package No.";
-                        end;
-                        Error(EntryTypeBlockedErr,
-                            QltyInspectionHeader.GetFriendlyIdentifier(),
-                            QltyInspectionResult.Code,
-                            ItemJnlLine2."Entry Type",
-                            ItemJnlLine2."Item No.",
-                            TrackingDetails);
-                    end;
+                    if Blocked then
+                        LogBlockedTransactionError(
+                            QltyInspectionHeader,
+                            StrSubstNo(EntryTypeBlockedErr,
+                                ItemJnlLine2."Entry Type",
+                                ItemJnlLine2."Item No.",
+                                GetItemTrackingDetails(TrackingSpecification."Lot No.", TrackingSpecification."Serial No.", TrackingSpecification."Package No."),
+                                QltyInspectionHeader.GetFriendlyIdentifier(),
+                                QltyInspectionResult.Code));
                 end;
             end;
         until QltyInspectionHeader.Next() = 0;
@@ -250,7 +248,13 @@ codeunit 20415 "Qlty. Tracking Integration"
         repeat
             if QltyInspectionHeader."Result Code" <> '' then begin
                 IsFinished := QltyInspectionHeader.Status = QltyInspectionHeader.Status::Finished;
-
+                QltyInspectionResult.SetLoadFields(
+                    "Item Tracking Allow Invt. Mov.",
+                    "Item Tracking Allow Invt. Pick",
+                    "Item Tracking Allow Invt. PA",
+                    "Item Tracking Allow Movement",
+                    "Item Tracking Allow Pick",
+                    "Item Tracking Allow Put-Away");
                 if QltyInspectionResult.Get(QltyInspectionHeader."Result Code") then begin
                     case WarehouseActivityLine."Activity Type" of
                         WarehouseActivityLine."Activity Type"::"Invt. Movement":
@@ -280,15 +284,14 @@ codeunit 20415 "Qlty. Tracking Integration"
                     OnHandleCheckWhseItemTrackingBeforeBlockErrorCheck(WarehouseActivityLine, QltyInspectionHeader, QltyInspectionResult, Blocked);
 
                     if Blocked then
-                        Error(
-                            WarehouseEntryTypeBlockedErr,
-                            QltyInspectionHeader.GetFriendlyIdentifier(),
-                            QltyInspectionResult.Code,
-                            WarehouseActivityLine."Activity Type",
-                            WarehouseActivityLine."Item No.",
-                            WarehouseActivityLine."Lot No.",
-                            WarehouseActivityLine."Serial No.",
-                            WarehouseActivityLine."Package No.");
+                        LogBlockedTransactionError(
+                                QltyInspectionHeader,
+                                StrSubstNo(WarehouseEntryTypeBlockedErr,
+                                    WarehouseActivityLine."Activity Type",
+                                    WarehouseActivityLine."Item No.",
+                                    GetItemTrackingDetails(WarehouseActivityLine."Lot No.", WarehouseActivityLine."Serial No.", WarehouseActivityLine."Package No."),
+                                    QltyInspectionHeader.GetFriendlyIdentifier(),
+                                    QltyInspectionResult.Code));
                 end;
             end;
         until QltyInspectionHeader.Next() = 0;
@@ -365,6 +368,50 @@ codeunit 20415 "Qlty. Tracking Integration"
 
             exit(PipeSeparatedOutputTextBuilder.ToText());
         end;
+    end;
+
+    local procedure GetItemTrackingDetails(LotNo: Code[50]; SerialNo: Code[50]; PackageNo: Code[50]): Text
+    var
+        TrackingDetails: Text;
+    begin
+        TrackingDetails := LotNo;
+        if SerialNo <> '' then begin
+            if TrackingDetails <> '' then
+                TrackingDetails += ' ';
+            TrackingDetails += SerialNo;
+        end;
+        if PackageNo <> '' then begin
+            if TrackingDetails <> '' then
+                TrackingDetails += ' ';
+            TrackingDetails += PackageNo;
+        end;
+        exit(TrackingDetails);
+    end;
+
+    local procedure LogBlockedTransactionError(QltyInspectionHeader: Record "Qlty. Inspection Header"; ErrorMessage: Text)
+    var
+        ErrorMessageManagement: Codeunit "Error Message Management";
+        BlockedErrorInfo: ErrorInfo;
+        BlockedByQualityInspectionTitleLbl: Label 'Blocked by quality inspection', Comment = 'Title for the error message when a transaction is blocked by a quality inspection';
+        ShowInspectionActionLbl: Label 'Show Quality Inspection %1', Comment = '%1 = Quality Inspection identifier';
+    begin
+        if ErrorMessageManagement.IsActive() then begin
+            ErrorMessageManagement.LogContextFieldError(
+            0,
+            ErrorMessage,
+            QltyInspectionHeader,
+            QltyInspectionHeader.FieldNo("Result Code"),
+            '');
+            Error(''); // Needed to stop the transaction from continuing in the preview mode, but the error message will be logged in the Error Message Management log.
+        end;
+
+        BlockedErrorInfo.Title := BlockedByQualityInspectionTitleLbl;
+        BlockedErrorInfo.Message := ErrorMessage;
+        BlockedErrorInfo.RecordId := QltyInspectionHeader.RecordId();
+        BlockedErrorInfo.FieldNo := QltyInspectionHeader.FieldNo("Result Code");
+        BlockedErrorInfo.PageNo := Page::"Qlty. Inspection";
+        BlockedErrorInfo.AddNavigationAction(StrSubstNo(ShowInspectionActionLbl, QltyInspectionHeader.GetFriendlyIdentifier()));
+        Error(BlockedErrorInfo);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Integration/Inventory/Tracking/QltyTrackingIntegration.Codeunit.al
@@ -26,6 +26,8 @@ codeunit 20415 "Qlty. Tracking Integration"
         EntryTypeBlockedErr: Label '"%1" transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
         WarehouseEntryTypeBlockedErr: Label '"%1" warehouse transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
         NavigatePageSearchFiltersTok: Label 'NAVIGATEFILTERS', Locked = true;
+        BlockedByQualityInspectionTitleLbl: Label 'Blocked by quality inspection', Comment = 'Title for the error message when a transaction is blocked by a quality inspection';
+        ShowInspectionActionLbl: Label 'Show Quality Inspection %1', Comment = '%1 = Quality Inspection identifier';
 
     [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Setup."Qlty. Management Setup", 'R', InherentPermissionsScope::Permissions)]
     [InherentPermissions(PermissionObjectType::TableData, Database::Microsoft.QualityManagement.Configuration.Result."Qlty. Inspection Result", 'R', InherentPermissionsScope::Permissions)]
@@ -98,17 +100,11 @@ codeunit 20415 "Qlty. Tracking Integration"
                 end;
         end;
 
+        SetLoadFieldsByEntryType(QltyInspectionResult, ItemJnlLine2."Entry Type");
+
         repeat
             if QltyInspectionHeader."Result Code" <> '' then begin
                 IsFinished := QltyInspectionHeader.Status = QltyInspectionHeader.Status::Finished;
-                QltyInspectionResult.SetLoadFields(
-                    "Item Tracking Allow Asm. Cons.",
-                    "Item Tracking Allow Asm. Out.",
-                    "Item Tracking Allow Consump.",
-                    "Item Tracking Allow Output",
-                    "Item Tracking Allow Purchase",
-                    "Item Tracking Allow Sales",
-                    "Item Tracking Allow Transfer");
                 if QltyInspectionResult.Get(QltyInspectionHeader."Result Code") then begin
                     case ItemJnlLine2."Entry Type" of
                         ItemJnlLine2."Entry Type"::"Assembly Consumption":
@@ -245,16 +241,11 @@ codeunit 20415 "Qlty. Tracking Integration"
                 end;
         end;
 
+        SetLoadFieldsByActivityType(QltyInspectionResult, WarehouseActivityLine."Activity Type");
+
         repeat
             if QltyInspectionHeader."Result Code" <> '' then begin
                 IsFinished := QltyInspectionHeader.Status = QltyInspectionHeader.Status::Finished;
-                QltyInspectionResult.SetLoadFields(
-                    "Item Tracking Allow Invt. Mov.",
-                    "Item Tracking Allow Invt. Pick",
-                    "Item Tracking Allow Invt. PA",
-                    "Item Tracking Allow Movement",
-                    "Item Tracking Allow Pick",
-                    "Item Tracking Allow Put-Away");
                 if QltyInspectionResult.Get(QltyInspectionHeader."Result Code") then begin
                     case WarehouseActivityLine."Activity Type" of
                         WarehouseActivityLine."Activity Type"::"Invt. Movement":
@@ -370,6 +361,50 @@ codeunit 20415 "Qlty. Tracking Integration"
         end;
     end;
 
+    /// <summary>
+    /// Loads only the result field that the given entry type is evaluated against.
+    /// </summary>
+    local procedure SetLoadFieldsByEntryType(var QltyInspectionResult: Record "Qlty. Inspection Result"; EntryType: Enum "Item Ledger Entry Type")
+    begin
+        case EntryType of
+            EntryType::"Assembly Consumption":
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Asm. Cons.");
+            EntryType::"Assembly Output":
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Asm. Out.");
+            EntryType::Consumption:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Consump.");
+            EntryType::Output:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Output");
+            EntryType::Purchase:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Purchase");
+            EntryType::Sale:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Sales");
+            EntryType::Transfer:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Transfer");
+        end;
+    end;
+
+    /// <summary>
+    /// Loads only the result field that the given warehouse activity type is evaluated against.
+    /// </summary>
+    local procedure SetLoadFieldsByActivityType(var QltyInspectionResult: Record "Qlty. Inspection Result"; ActivityType: Enum "Warehouse Activity Type")
+    begin
+        case ActivityType of
+            ActivityType::"Invt. Movement":
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Invt. Mov.");
+            ActivityType::"Invt. Pick":
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Invt. Pick");
+            ActivityType::"Invt. Put-away":
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Invt. PA");
+            ActivityType::Movement:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Movement");
+            ActivityType::Pick:
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Pick");
+            ActivityType::"Put-away":
+                QltyInspectionResult.SetLoadFields("Item Tracking Allow Put-Away");
+        end;
+    end;
+
     local procedure GetItemTrackingDetails(LotNo: Code[50]; SerialNo: Code[50]; PackageNo: Code[50]): Text
     var
         TrackingDetails: Text;
@@ -392,8 +427,6 @@ codeunit 20415 "Qlty. Tracking Integration"
     var
         ErrorMessageManagement: Codeunit "Error Message Management";
         BlockedErrorInfo: ErrorInfo;
-        BlockedByQualityInspectionTitleLbl: Label 'Blocked by quality inspection', Comment = 'Title for the error message when a transaction is blocked by a quality inspection';
-        ShowInspectionActionLbl: Label 'Show Quality Inspection %1', Comment = '%1 = Quality Inspection identifier';
     begin
         if ErrorMessageManagement.IsActive() then begin
             ErrorMessageManagement.LogContextFieldError(
@@ -410,6 +443,8 @@ codeunit 20415 "Qlty. Tracking Integration"
         BlockedErrorInfo.RecordId := QltyInspectionHeader.RecordId();
         BlockedErrorInfo.FieldNo := QltyInspectionHeader.FieldNo("Result Code");
         BlockedErrorInfo.PageNo := Page::"Qlty. Inspection";
+        BlockedErrorInfo.DataClassification := DataClassification::CustomerContent;
+        BlockedErrorInfo.ErrorType := ErrorType::Client;
         BlockedErrorInfo.AddNavigationAction(StrSubstNo(ShowInspectionActionLbl, QltyInspectionHeader.GetFriendlyIdentifier()));
         Error(BlockedErrorInfo);
     end;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -57,8 +57,8 @@ codeunit 139964 "Qlty. Tests - Misc."
         NotificationDataInspectionRecordIdTok: Label 'InspectionRecordId', Locked = true;
         Bin1Tok: Label 'Bin1';
         Bin2Tok: Label 'Bin2';
-        WarehouseEntryTypeBlockedErr: Label 'This warehouse transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5 %6 %7, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=Lot No., %6=Serial No., %7=Package No.';
-        EntryTypeBlockedErr: Label 'This transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=combined package tracking details of Lot No., Serial No. and Package No.';
+        WarehouseEntryTypeBlockedErr: Label '"%1" warehouse transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
+        EntryTypeBlockedErr: Label '"%1" transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
         UnableToSetTableValueFieldNotFoundErr: Label 'Unable to set a value because the field [%1] in table [%2] was not found.', Comment = '%1=the field name, %2=the table name';
         NotificationDataRelatedRecordIdTok: Label 'RelatedRecordId', Locked = true;
         LotSerialTrackingDetailsTok: Label '%1 %2', Comment = '%1=lot no,%2=serial no', Locked = true;
@@ -1887,11 +1887,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         // [THEN] An error is raised indicating assembly consumption is blocked by the result
         LibraryAssembly.PostAssemblyHeader(AssemblyHeader, StrSubstNo(
             EntryTypeBlockedErr,
-            QltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             ItemJournalLine."Entry Type"::"Assembly Consumption",
             ComponentItem."No.",
-            LotNo));
+            LotNo,
+            QltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -1961,11 +1961,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         // [THEN] An error is raised indicating purchase is blocked by the result on the highest re-inspection
         asserterror LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
         LibraryAssert.ExpectedError(StrSubstNo(EntryTypeBlockedErr,
-            ReQltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             ItemJournalLine."Entry Type"::Purchase,
             PurchaseLine."No.",
-            ReservationEntry."Package No."));
+            ReservationEntry."Package No.",
+            ReQltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -2126,11 +2126,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         asserterror LibraryAssembly.PostAssemblyHeader(AssemblyHeader, '');
         LibraryAssert.ExpectedError(StrSubstNo(
             EntryTypeBlockedErr,
-            QltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             ItemJournalLine."Entry Type"::"Assembly Output",
             AssemblyHeader."Item No.",
-            StrSubstNo(LotSerialTrackingDetailsTok, ReservationEntry."Lot No.", ReservationEntry."Serial No.")));
+            StrSubstNo(LotSerialTrackingDetailsTok, ReservationEntry."Lot No.", ReservationEntry."Serial No."),
+            QltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -2211,13 +2211,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         asserterror QltyPurOrderGenerator.ReceivePurchaseOrder(Location, PurchaseHeader, PurchaseLine);
         LibraryAssert.ExpectedError(StrSubstNo(
             WarehouseEntryTypeBlockedErr,
-            QltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             WarehouseActivityLine."Activity Type"::"Put-away",
             Item."No.",
             ReservationEntry."Lot No.",
-            '',
-            ''));
+            QltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -2290,13 +2288,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         asserterror QltyPurOrderGenerator.ReceivePurchaseOrder(Location, PurchaseHeader, PurchaseLine);
         LibraryAssert.ExpectedError(StrSubstNo(
             WarehouseEntryTypeBlockedErr,
-            QltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             WarehouseActivityLine."Activity Type"::"Put-away",
             Item."No.",
             ReservationEntry."Lot No.",
-            '',
-            ''));
+            QltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -2395,13 +2391,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         asserterror QltyPurOrderGenerator.ReceivePurchaseOrder(Location, PurchaseHeader, PurchaseLine);
         LibraryAssert.ExpectedError(StrSubstNo(
             WarehouseEntryTypeBlockedErr,
-            QltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             WarehouseActivityLine."Activity Type"::"Invt. Put-away",
             Item."No.",
             ReservationEntry."Lot No.",
-            '',
-            ''));
+            QltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -2538,13 +2532,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         asserterror LibraryWarehouse.RegisterWhseActivity(InventoryMovementWarehouseActivityHeader);
         LibraryAssert.ExpectedError(StrSubstNo(
             WarehouseEntryTypeBlockedErr,
-            ReQltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             WarehouseActivityLine."Activity Type"::"Invt. Movement",
             Item."No.",
             ReservationEntry."Lot No.",
-            '',
-            ''));
+            ReQltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]
@@ -2679,13 +2671,11 @@ codeunit 139964 "Qlty. Tests - Misc."
         asserterror LibraryWarehouse.RegisterWhseActivity(WhseMovementWarehouseActivityHeader);
         LibraryAssert.ExpectedError(StrSubstNo(
             WarehouseEntryTypeBlockedErr,
-            QltyInspectionHeader.GetFriendlyIdentifier(),
-            ToLoadQltyInspectionResult.Code,
             WarehouseActivityLine."Activity Type"::Movement,
             Item."No.",
             ReservationEntry."Lot No.",
-            '',
-            ''));
+            QltyInspectionHeader.GetFriendlyIdentifier(),
+            ToLoadQltyInspectionResult.Code));
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

**Changes when errors are collecting:**
1. Message is a bit simplified
2. When there are more item tracking lines, are all processed instead of first with error. That is a consequence of other changes actually, but probably makes sense.
3. Error message is clickable, user can copy call stack etc.
4. There is context of the source causing this issue in Fact box, and it navigates to exact quality inspection.

<img width="1932" height="807" alt="image" src="https://github.com/user-attachments/assets/55408476-6dea-4749-9e47-381d90621792" />


**Changes when error is non-collecting:**
Example scenario is when executing post (but not previewing post) in Item Journal.

<img width="1996" height="787" alt="image" src="https://github.com/user-attachments/assets/4eb48d61-9a70-40c0-a1ff-116e434e1a56" />

## Linked work

Fixes [AB#626132](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626132)




