### PR TITLE
Bug 636251: Disabled test in "ERM Gen. Jnl. Error Handling" codeunit

### DIFF
--- a/src/Layers/W1/Tests/General Journal/ERMGenJnlErrorHandling.Codeunit.al
+++ b/src/Layers/W1/Tests/General Journal/ERMGenJnlErrorHandling.Codeunit.al
@@ -431,6 +431,7 @@ codeunit 134932 "ERM Gen. Jnl. Error Handling"
         GenJournalLine.Modify();
 
         // [WHEN] Open general journal for batch "XXX"
+        Commit();
         GeneralJournal.Trap();
         Page.Run(Page::"General Journal", GenJournalLine);
 


### PR DESCRIPTION
**ISSUE:**
`JournalLineErrorsFactBoxFieldErrorNoErrorMessage` fails in MX because the background validation reports that the IC Partner does not exist instead of the expected Account Type error.

**CAUSE:**
The IC Partner and journal line are not committed before the General Journal starts background validation. The background session cannot see the uncommitted IC Partner.

**SOLUTION:**
Commit the test data before opening the General Journal page.

**TESTS:**
Compiled, built, and published `Tests-General Journal` in MX. The fixed test passed both individually and as part of codeunit 134932. The full codeunit run had 76 passing tests and 2 unrelated UI metadata failures.

Fixes [AB#636251](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636251)


