### PR TITLE
Improve the Index Mgmt page discoverability

### DIFF
--- a/src/System Application/App/Table Information/app.json
+++ b/src/System Application/App/Table Information/app.json
@@ -22,6 +22,12 @@
       "name": "Permission Sets",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "2edca772-d3b5-4cfc-9ed6-b17ce4bd53c9",
+      "name": "Object Selection",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
     }
   ],
   "screenshots": [],

--- a/src/System Application/App/Table Information/src/IndexesListPart.Page.al
+++ b/src/System Application/App/Table Information/src/IndexesListPart.Page.al
@@ -94,27 +94,27 @@ page 8704 "Indexes List Part"
                     Caption = 'Updates';
                     ToolTip = 'Specifies the number of user updates on this index since the database was last started.';
                 }
-                field("Last seek"; Rec."Last seek")
+                field("Last seek"; FormatDateTime(Rec."Last seek"))
                 {
                     Caption = 'Last Seek';
                     ToolTip = 'Specifies the timestamp of the last user seek on this index since the database was last started.';
                 }
-                field("Last scan"; Rec."Last scan")
+                field("Last scan"; FormatDateTime(Rec."Last scan"))
                 {
                     Caption = 'Last Scan';
                     ToolTip = 'Specifies the timestamp of the last user scan on this index since the database was last started.';
                 }
-                field("Last lookup"; Rec."Last lookup")
+                field("Last lookup"; FormatDateTime(Rec."Last lookup"))
                 {
                     Caption = 'Last Lookup';
                     ToolTip = 'Specifies the timestamp of the last user lookup on this index since the database was last started.';
                 }
-                field("Last Update"; Rec."Last update")
+                field("Last Update"; FormatDateTime(Rec."Last update"))
                 {
                     Caption = 'Last Update';
                     ToolTip = 'Specifies the timestamp of the last user update on this index since the database was last started.';
                 }
-                field("Stat updated at"; Rec."Statistics rebuild at")
+                field("Stat updated at"; FormatDateTime(Rec."Statistics rebuild at"))
                 {
                     Caption = 'Statistics updated at';
                     ToolTip = 'Specifies the last time the index''s corresponding statistics was rebuild. Statistics are updated automatically by the database engine based on certain thresholds of data changes, or when an index is re-enabled.';
@@ -355,6 +355,14 @@ page 8704 "Indexes List Part"
         exit(IndexManagement.GetKeyIndexName(KeyRec, IsSift));
     end;
 
+    local procedure FormatDateTime(DateTimeValue: DateTime): Text
+    begin
+        if (DateTimeValue = 0DT) or (DateTimeValue = CreateDateTime(00000101D, 0T)) then
+            exit(NoDateTimeValueLbl);
+
+        exit(Format(DateTimeValue));
+    end;
+
     local procedure EnableIndex(KeyRec: Record "Key"; CompanyName: Text; IsSift: Boolean)
     var
         IndexManagement: Codeunit "Index Management";
@@ -367,6 +375,7 @@ page 8704 "Indexes List Part"
 
     var
         SetCompanyName: Text;
+        NoDateTimeValueLbl: Label '-', Locked = true;
         TurnOffIndexWarningQst: Label 'Turning a non-AL defined index off cannot be undone. Please confirm.';
         TurnOnIndexQueueInfoMsg: Label 'The index has been enqueued to be turned on. It will be attempted during the subsequent maintenance window (overnight local time).';
 }

--- a/src/System Application/App/Table Information/src/TableInformation.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformation.Page.al
@@ -58,11 +58,8 @@ page 8700 "Table Information"
                     ToolTip = 'Specifies the ID of the table.';
 
                     trigger OnDrillDown()
-                    var
-                        TableMetadata: Record "Table Metadata";
                     begin
-                        TableMetadata.SetRange(ID, Rec."Table No.");
-                        Page.Run(Page::"Table Information Card", TableMetadata);
+                        OpenTableDataManagement();
                     end;
                 }
 
@@ -116,6 +113,26 @@ page 8700 "Table Information"
 
     actions
     {
+        area(Processing)
+        {
+            action("Table Data Management")
+            {
+                ApplicationArea = All;
+                Caption = 'Table Data Management';
+                Image = "Table";
+                Promoted = true;
+                PromotedCategory = Process;
+                PromotedIsBig = true;
+                PromotedOnly = true;
+                Scope = Repeater;
+                ToolTip = 'Open data management information for the selected table.';
+
+                trigger OnAction()
+                begin
+                    OpenTableDataManagement();
+                end;
+            }
+        }
         area(Navigation)
         {
             action("View Table Permissions")
@@ -146,5 +163,13 @@ page 8700 "Table Information"
         else
             Rec.SetFilter("Company Name", '%1|%2', '', CompanyName);
         Rec.FilterGroup(0);
+    end;
+
+    local procedure OpenTableDataManagement()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        TableMetadata.SetRange(ID, Rec."Table No.");
+        Page.Run(Page::"Table Information Card", TableMetadata);
     end;
 }

--- a/src/System Application/App/Table Information/src/TableInformation.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformation.Page.al
@@ -120,10 +120,6 @@ page 8700 "Table Information"
                 ApplicationArea = All;
                 Caption = 'Manage Indexes';
                 Image = "Table";
-                Promoted = true;
-                PromotedCategory = Process;
-                PromotedIsBig = true;
-                PromotedOnly = true;
                 Scope = Repeater;
                 ToolTip = 'Manage indexes on the selected table. You can investigate index cost and usage, and turn indexes on/off.';
 
@@ -131,6 +127,15 @@ page 8700 "Table Information"
                 begin
                     OpenTableDataManagement();
                 end;
+            }
+        }
+        area(Promoted)
+        {
+            group(Category_Process)
+            {
+                actionref(ManageIndexesPromoted; "Manage Indexes")
+                {
+                }
             }
         }
         area(Navigation)

--- a/src/System Application/App/Table Information/src/TableInformation.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformation.Page.al
@@ -115,17 +115,17 @@ page 8700 "Table Information"
     {
         area(Processing)
         {
-            action("Table Data Management")
+            action("Manage Indexes")
             {
                 ApplicationArea = All;
-                Caption = 'Table Data Management';
+                Caption = 'Manage Indexes';
                 Image = "Table";
                 Promoted = true;
                 PromotedCategory = Process;
                 PromotedIsBig = true;
                 PromotedOnly = true;
                 Scope = Repeater;
-                ToolTip = 'Open data management information for the selected table.';
+                ToolTip = 'Manage indexes on the selected table. You can investigate index cost and usage, and turn indexes on/off.';
 
                 trigger OnAction()
                 begin

--- a/src/System Application/App/Table Information/src/TableInformationCard.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformationCard.Page.al
@@ -14,10 +14,11 @@ using System.Reflection;
 page 8705 "Table Information Card"
 {
     PageType = Card;
+    UsageCategory = Administration;
     ApplicationArea = All;
-    AdditionalSearchTerms = 'Database,Size,Storage';
+    AdditionalSearchTerms = 'Database,Size,Storage,Index';
     SourceTable = "Table Metadata";
-    Caption = 'Table Data Management - Card';
+    Caption = 'Table Data Management';
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = false;
@@ -99,8 +100,10 @@ page 8705 "Table Information Card"
 
     local procedure SetBasedOnCompanyName(NewCompanyName: Text)
     var
+        AllObjWithCaption: Record AllObjWithCaption;
         DatabaseIndex: Record "Database Index";
         TableMetadata: Record "Table Metadata";
+        Objects: Page System.Reflection.Objects;
         Recref: RecordRef;
         TableId: Integer;
     begin
@@ -109,11 +112,26 @@ page 8705 "Table Information Card"
         else
             if Evaluate(TableId, Rec.GetFilter("ID")) and (TableId <> 0) then
                 TableId := TableId
-            else
-                exit;
+            else begin
+                // Originally the page was opened via Table Information,
+                // but we want to allow opening the page directly, so we need to prompt the user to select a table.
+
+                AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
+                Objects.SetTableView(AllObjWithCaption);
+                Objects.Caption(SelectTableLbl);
+                Objects.LookupMode(true);
+
+                if Objects.RunModal() <> Action::LookupOK then
+                    Error(NoTableSelectedErr);
+
+                Objects.GetRecord(AllObjWithCaption);
+                TableId := AllObjWithCaption."Object ID";
+
+                Rec.SetRange(Id, TableId);
+            end;
 
         if not TableMetadata.Get(TableId) then
-            exit;
+            Error(TableNotFoundErr, TableId);
 
         // By-default show data for the current company.
         if TableMetadata.DataPerCompany and (NewCompanyName <> '') then begin
@@ -146,4 +164,7 @@ page 8705 "Table Information Card"
         SetCompanyName: Text;
         SqlServerRestartTime: DateTime;
         PerCompany: Boolean;
+        NoTableSelectedErr: Label 'No table selected. Please select a table to view its information.';
+        SelectTableLbl: Label 'Select Table';
+        TableNotFoundErr: Label 'Table %1 could not be found.', Comment = '%1 = table ID';
 }

--- a/src/System Application/App/Table Information/src/TableInformationCard.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformationCard.Page.al
@@ -117,6 +117,7 @@ page 8705 "Table Information Card"
                 // but we want to allow opening the page directly, so we need to prompt the user to select a table.
 
                 AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
+                Objects.SetRecord(AllObjWithCaption);
                 Objects.SetTableView(AllObjWithCaption);
                 Objects.Caption(SelectTableLbl);
                 Objects.LookupMode(true);

--- a/src/System Application/App/Table Information/src/TableInformationCard.Page.al
+++ b/src/System Application/App/Table Information/src/TableInformationCard.Page.al
@@ -16,9 +16,9 @@ page 8705 "Table Information Card"
     PageType = Card;
     UsageCategory = Administration;
     ApplicationArea = All;
-    AdditionalSearchTerms = 'Database,Size,Storage,Index';
+    AdditionalSearchTerms = 'Database,Size,Storage,Index,Key,Table';
     SourceTable = "Table Metadata";
-    Caption = 'Table Data Management';
+    Caption = 'Index Management';
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = false;


### PR DESCRIPTION
Improve the Index Mgmt page discoverability.

The index mgmt page could not be open directly from tell me or direct access to the page. Change the design to support opening the page directly by showing a table selection dialog.

This also adds the support for showing the page in tell me when searching for Index and giving a button to go from "Table Information" instead of just the hyperlink as it was before.

Also change the formatting of datetimes such that the datetime.MinValue is not shown, instead show a - value.
<img width="2266" height="1054" alt="image" src="https://github.com/user-attachments/assets/bb8836a1-07fb-4c2d-95b3-a1bc2cd8c622" />


[AB#632385](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/632385)





