### PR TITLE
[Bug 617189] Clarify strict expiration posting tooltip

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingCode.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/ItemTrackingCode.Table.al
@@ -56,7 +56,7 @@ table 6502 "Item Tracking Code"
         field(8; "Strict Expiration Posting"; Boolean)
         {
             Caption = 'Strict Expiration Posting';
-            ToolTip = 'Specifies if the expiration date is considered when you sell items. For example, you cannot post a sales order for an item that has passed its expiration date.';
+            ToolTip = 'Specifies if the expiration date is considered when you sell items. For example, you cannot post a sales order for an item that has passed its expiration date. For tracked items, this setting also uses the First-Expired-First-Out (FEFO) method to determine which items to pick, regardless of the Pick According to FEFO setting on the location.';
 
             trigger OnValidate()
             begin
@@ -770,4 +770,3 @@ table 6502 "Item Tracking Code"
     begin
     end;
 }
-


### PR DESCRIPTION
## Summary
- Clarify that Strict Expiration Posting uses First-Expired-First-Out (FEFO) picking for tracked items.
- Explain that this behavior applies regardless of the location's Pick According to FEFO setting.

## Validation
- `git diff --check`

Fixes [AB#617189](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/617189)

