### PR TITLE
Invoice with blank document currency still posts the Additional Currency Amount as a separate residual entry

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8435,6 +8435,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8435,13 +8435,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7870,6 +7870,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7870,13 +7870,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7895,6 +7895,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7895,13 +7895,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -9297,6 +9297,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -9297,13 +9297,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7904,6 +7904,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7904,13 +7904,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8147,13 +8147,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8147,6 +8147,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8724,13 +8724,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8724,6 +8724,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/IT/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -191,6 +191,64 @@
 
     [Test]
     [Scope('OnPrem')]
+    procedure GenJnlLineBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        GenJournalLine: Record "Gen. Journal Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a customer invoice through a General Journal Line in local currency (blank
+        // Currency Code) while an Additional Reporting Currency is set up must keep the reporting-currency amount
+        // on the receivables balancing G/L entry. This exercises the shared Gen. Journal posting path directly,
+        // not only the sales/purchase document posting entry points.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A customer invoice General Journal Line in local currency (blank Currency Code), balanced to a G/L account.
+        LibrarySales.CreateCustomer(Customer);
+        CreateJournalLineForInvoice(
+          GenJournalLine, GenJournalLine."Account Type"::Customer, Customer."No.", LibraryRandom.RandDec(100, 2) + 100);
+        ModifyGeneralJournalLine(GenJournalLine, GenJournalLine."Bal. Gen. Posting Type"::Sale, '');
+
+        // [WHEN] The General Journal Line is posted.
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/IT/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -66,6 +66,131 @@
 
     [Test]
     [Scope('OnPrem')]
+    procedure PurchaseInvoiceBlankCurrencyKeepsACYOnPayablesEntry()
+    var
+        Currency: Record Currency;
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        PayablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedPayablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a purchase invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the vendor
+        // payables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A purchase invoice for a vendor posted in local currency (blank Currency Code).
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        PurchaseHeader.Validate("Currency Code", '');
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The purchase invoice is posted.
+        PostedInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The payables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PayablesAccountNo := VendorPostingGroup."Payables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", PayablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedPayablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The payables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedPayablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The payables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SalesInvoiceBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a sales invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the customer
+        // receivables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A sales invoice for a customer posted in local currency (blank Currency Code).
+        LibrarySales.CreateCustomer(Customer);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Currency Code", '');
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(
+          SalesLine, SalesHeader, SalesLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The sales invoice is posted.
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8266,13 +8266,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8266,6 +8266,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/NA/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -191,6 +191,64 @@
 
     [Test]
     [Scope('OnPrem')]
+    procedure GenJnlLineBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        GenJournalLine: Record "Gen. Journal Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a customer invoice through a General Journal Line in local currency (blank
+        // Currency Code) while an Additional Reporting Currency is set up must keep the reporting-currency amount
+        // on the receivables balancing G/L entry. This exercises the shared Gen. Journal posting path directly,
+        // not only the sales/purchase document posting entry points.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A customer invoice General Journal Line in local currency (blank Currency Code), balanced to a G/L account.
+        LibrarySales.CreateCustomer(Customer);
+        CreateJournalLineForInvoice(
+          GenJournalLine, GenJournalLine."Account Type"::Customer, Customer."No.", LibraryRandom.RandDec(100, 2) + 100);
+        ModifyGeneralJournalLine(GenJournalLine, GenJournalLine."Bal. Gen. Posting Type"::Sale, '');
+
+        // [WHEN] The General Journal Line is posted.
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/NA/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -66,6 +66,131 @@
 
     [Test]
     [Scope('OnPrem')]
+    procedure PurchaseInvoiceBlankCurrencyKeepsACYOnPayablesEntry()
+    var
+        Currency: Record Currency;
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        PayablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedPayablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a purchase invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the vendor
+        // payables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A purchase invoice for a vendor posted in local currency (blank Currency Code).
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        PurchaseHeader.Validate("Currency Code", '');
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The purchase invoice is posted.
+        PostedInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The payables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PayablesAccountNo := VendorPostingGroup."Payables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", PayablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedPayablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The payables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedPayablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The payables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SalesInvoiceBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a sales invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the customer
+        // receivables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A sales invoice for a customer posted in local currency (blank Currency Code).
+        LibrarySales.CreateCustomer(Customer);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Currency Code", '');
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(
+          SalesLine, SalesHeader, SalesLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The sales invoice is posted.
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7872,13 +7872,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7872,6 +7872,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -9663,13 +9663,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -9663,6 +9663,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/RU/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -190,6 +190,64 @@ codeunit 134043 "ERM Additional Currency"
 
     [Test]
     [Scope('OnPrem')]
+    procedure GenJnlLineBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        GenJournalLine: Record "Gen. Journal Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a customer invoice through a General Journal Line in local currency (blank
+        // Currency Code) while an Additional Reporting Currency is set up must keep the reporting-currency amount
+        // on the receivables balancing G/L entry. This exercises the shared Gen. Journal posting path directly,
+        // not only the sales/purchase document posting entry points.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A customer invoice General Journal Line in local currency (blank Currency Code), balanced to a G/L account.
+        LibrarySales.CreateCustomer(Customer);
+        CreateJournalLineForInvoice(
+          GenJournalLine, GenJournalLine."Account Type"::Customer, Customer."No.", LibraryRandom.RandDec(100, 2) + 100);
+        ModifyGeneralJournalLine(GenJournalLine, GenJournalLine."Bal. Gen. Posting Type"::Sale, '');
+
+        // [WHEN] The General Journal Line is posted.
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/RU/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -65,6 +65,131 @@ codeunit 134043 "ERM Additional Currency"
 
     [Test]
     [Scope('OnPrem')]
+    procedure PurchaseInvoiceBlankCurrencyKeepsACYOnPayablesEntry()
+    var
+        Currency: Record Currency;
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        PayablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedPayablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a purchase invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the vendor
+        // payables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A purchase invoice for a vendor posted in local currency (blank Currency Code).
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        PurchaseHeader.Validate("Currency Code", '');
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The purchase invoice is posted.
+        PostedInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The payables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PayablesAccountNo := VendorPostingGroup."Payables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", PayablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedPayablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The payables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedPayablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The payables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SalesInvoiceBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a sales invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the customer
+        // receivables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A sales invoice for a customer posted in local currency (blank Currency Code).
+        LibrarySales.CreateCustomer(Customer);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Currency Code", '');
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(
+          SalesLine, SalesHeader, SalesLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The sales invoice is posted.
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7838,6 +7838,14 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
+        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
+        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
+        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
+        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
+        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
+        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
+        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+            GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";
         UpdateGLEntryNo(GLEntry."Entry No.", SavedEntryNo);

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -7838,13 +7838,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
     begin
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
-        // The aggregated customer/vendor balancing G/L entry must always carry its Additional-Currency Amount.
-        // When a document is posted in local currency (blank Currency Code) while an Additional Reporting Currency
-        // is set up, the balancing entry could be created with a zero Additional-Currency Amount (the reporting-currency
-        // amount ended up only on the Source Currency Amount). That left the additional reporting currency out of balance
-        // and pushed the full amount into a separate residual entry on the Realized Exchange Gain/Loss account.
-        // Recompute the reporting-currency amount from the local-currency amount so it stays on this balancing entry.
-        if (AddCurrencyCode <> '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
+        if (AddCurrencyCode <> '') and (GenJnlLine."Currency Code" = '') and (GLEntry."Additional-Currency Amount" = 0) and (GLEntry.Amount <> 0) then
             GLEntry."Additional-Currency Amount" := ExchangeAmtLCYToFCY2(GLEntry.Amount);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/W1/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -191,6 +191,64 @@ codeunit 134043 "ERM Additional Currency"
 
     [Test]
     [Scope('OnPrem')]
+    procedure GenJnlLineBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        GenJournalLine: Record "Gen. Journal Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a customer invoice through a General Journal Line in local currency (blank
+        // Currency Code) while an Additional Reporting Currency is set up must keep the reporting-currency amount
+        // on the receivables balancing G/L entry. This exercises the shared Gen. Journal posting path directly,
+        // not only the sales/purchase document posting entry points.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A customer invoice General Journal Line in local currency (blank Currency Code), balanced to a G/L account.
+        LibrarySales.CreateCustomer(Customer);
+        CreateJournalLineForInvoice(
+          GenJournalLine, GenJournalLine."Account Type"::Customer, Customer."No.", LibraryRandom.RandDec(100, 2) + 100);
+        ModifyGeneralJournalLine(GenJournalLine, GenJournalLine."Bal. Gen. Posting Type"::Sale, '');
+
+        // [WHEN] The General Journal Line is posted.
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";

--- a/src/Layers/W1/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMAdditionalCurrency.Codeunit.al
@@ -66,6 +66,131 @@ codeunit 134043 "ERM Additional Currency"
 
     [Test]
     [Scope('OnPrem')]
+    procedure PurchaseInvoiceBlankCurrencyKeepsACYOnPayablesEntry()
+    var
+        Currency: Record Currency;
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        PayablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedPayablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a purchase invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the vendor
+        // payables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A purchase invoice for a vendor posted in local currency (blank Currency Code).
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        PurchaseHeader.Validate("Currency Code", '');
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The purchase invoice is posted.
+        PostedInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The payables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PayablesAccountNo := VendorPostingGroup."Payables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", PayablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedPayablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The payables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedPayablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The payables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SalesInvoiceBlankCurrencyKeepsACYOnReceivablesEntry()
+    var
+        Currency: Record Currency;
+        Customer: Record Customer;
+        CustomerPostingGroup: Record "Customer Posting Group";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        GLEntry: Record "G/L Entry";
+        CurrencyCode: Code[10];
+        ReceivablesAccountNo: Code[20];
+        PostedInvoiceNo: Code[20];
+        ExpectedReceivablesACY: Decimal;
+    begin
+        // [SCENARIO 641829] Posting a sales invoice in local currency (blank Currency Code) while an
+        // Additional Reporting Currency is set up must keep the reporting-currency amount on the customer
+        // receivables G/L entry, instead of splitting the full amount into a separate residual entry on the
+        // realized exchange gain/loss account.
+        Initialize();
+
+        // [GIVEN] An Additional Reporting Currency is set up.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+        Currency.Get(CurrencyCode);
+
+        // [GIVEN] A sales invoice for a customer posted in local currency (blank Currency Code).
+        LibrarySales.CreateCustomer(Customer);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+        SalesHeader.Validate("Currency Code", '');
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(
+          SalesLine, SalesHeader, SalesLine.Type::Item, CreateItem(), LibraryRandom.RandInt(10));
+
+        // [WHEN] The sales invoice is posted.
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The receivables (balancing) G/L entry carries the reporting-currency amount converted from LCY.
+        CustomerPostingGroup.Get(Customer."Customer Posting Group");
+        ReceivablesAccountNo := CustomerPostingGroup."Receivables Account";
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetRange("G/L Account No.", ReceivablesAccountNo);
+        GLEntry.FindFirst();
+        ExpectedReceivablesACY :=
+          Round(LibraryERM.ConvertCurrency(GLEntry.Amount, '', CurrencyCode, WorkDate()), Currency."Amount Rounding Precision");
+        Assert.AreNotEqual(
+          0, GLEntry."Additional-Currency Amount",
+          'The receivables balancing entry must carry the additional reporting currency amount.');
+        Assert.AreNearlyEqual(
+          ExpectedReceivablesACY, GLEntry."Additional-Currency Amount", Currency."Amount Rounding Precision",
+          'The receivables Additional-Currency Amount must equal the reporting-currency conversion of the local amount.');
+
+        // [THEN] The reporting-currency amount is not split off into a separate residual entry.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedInvoiceNo);
+        GLEntry.SetFilter("G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        Assert.IsTrue(
+          Abs(GLEntry."Additional-Currency Amount") <= Currency."Amount Rounding Precision",
+          'The additional reporting currency amount must not be posted as a separate residual entry.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesAdditionalCurrencyAmt()
     var
         SalesHeader: Record "Sales Header";


### PR DESCRIPTION
Invoice with blank document currency still posts the Additional Currency Amount as a separate residual entry

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
Making sure that when GL Entry is created, if ACY is set up, Amount is not zero and "Additional-Currency Amount" is zero, we calculate and set "Additional-Currency Amount".

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#641827](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641827)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->






