### PR TITLE
[Bug][SubscriptionBilling] Assign Subscription Lines dialog does not identify the sales line it was opened for

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
@@ -106,6 +106,20 @@ codeunit 8069 "Sales Subscription Line Mgmt."
         end;
     end;
 
+    internal procedure GetAssignSubscriptionLinesCaption(SalesLine: Record "Sales Line"; SubscriptionHeader: Record "Subscription Header"; OpenedFromSalesLine: Boolean) Caption: Text
+    begin
+        if OpenedFromSalesLine then
+            case true of
+                SalesLine.Description = '':
+                    Caption := SalesLine."No.";
+                SalesLine."No." = '':
+                    Caption := SalesLine.Description;
+                else
+                    Caption := StrSubstNo(SalesLineCaptionLbl, SalesLine."No.", SalesLine.Description);
+            end;
+        OnAfterGetAssignSubscriptionLinesCaption(SalesLine, SubscriptionHeader, OpenedFromSalesLine, Caption);
+    end;
+
     procedure IsSalesLineWithSalesServiceCommitments(var SalesLine: Record "Sales Line"; SkipTemporaryCheck: Boolean; ServiceCommitmentItemOnly: Boolean): Boolean
     begin
         if not SkipTemporaryCheck then
@@ -381,11 +395,44 @@ codeunit 8069 "Sales Subscription Line Mgmt."
         AddSalesServiceCommitmentsForSalesLine(SalesLine, true);
     end;
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Explode BOM", OnBeforeOnRun, '', false, false)]
+    local procedure ClearExplodedSalesLineOnBeforeOnRun(var SalesLine: Record "Sales Line")
+    begin
+        ClearExplodedSalesLine();
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Explode BOM", OnExplodeBOMCompLinesOnAfterAssignType, '', false, false)]
+    local procedure SetExplodedSalesLineOnExplodeBOMCompLinesOnAfterAssignType(var ToSalesLine: Record "Sales Line")
+    begin
+        ExplodedDocumentType := ToSalesLine."Document Type";
+        ExplodedDocumentNo := ToSalesLine."Document No.";
+        ExplodedLineNo := ToSalesLine."Line No.";
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Explode BOM", OnExplodeBOMCompLinesOnAfterToSalesLineInsert, '', false, false)]
     local procedure AddSalesServiceCommitmentsForSalesLineOnAfterExplodeBOM(ToSalesLine: Record "Sales Line")
     begin
+        ClearExplodedSalesLine();
         ToSalesLine.Get(ToSalesLine."Document Type", ToSalesLine."Document No.", ToSalesLine."Line No.");
         AddSalesServiceCommitmentsForSalesLine(ToSalesLine, false);
+    end;
+
+    internal procedure IsSalesLineBeingExploded(SalesLine: Record "Sales Line"): Boolean
+    begin
+        // The exploded line is identified instead of a plain flag, so that an error between the two Sales-Explode BOM
+        // events cannot leave the state set for every other Sales Line of the session.
+        if ExplodedDocumentNo = '' then
+            exit(false);
+        exit((SalesLine."Document Type" = ExplodedDocumentType) and
+             (SalesLine."Document No." = ExplodedDocumentNo) and
+             (SalesLine."Line No." = ExplodedLineNo));
+    end;
+
+    local procedure ClearExplodedSalesLine()
+    begin
+        Clear(ExplodedDocumentType);
+        ExplodedDocumentNo := '';
+        ExplodedLineNo := 0;
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Sales Header", OnValidatePricesIncludingVATOnBeforeSalesLineModify, '', false, false)]
@@ -519,7 +566,16 @@ codeunit 8069 "Sales Subscription Line Mgmt."
     begin
     end;
 
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterGetAssignSubscriptionLinesCaption(SalesLine: Record "Sales Line"; SubscriptionHeader: Record "Subscription Header"; OpenedFromSalesLine: Boolean; var Caption: Text)
+    begin
+    end;
+
     var
         ItemManagement: Codeunit "Sub. Contracts Item Management";
+        ExplodedDocumentType: Enum "Sales Document Type";
+        SalesLineCaptionLbl: Label '%1 · %2', Comment = '%1 = Sales Line No., %2 = Sales Line Description';
+        ExplodedDocumentNo: Code[20];
+        ExplodedLineNo: Integer;
         SalesLineRestoreInProgress: Boolean;
 }

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
@@ -67,6 +67,10 @@ tableextension 8054 "Sales Line" extends "Sales Line"
                 if xRec."No." = Rec."No." then
                     exit;
                 CheckAndDeleteServiceCommitmentsForSalesLine(Rec, xRec);
+                // During Explode BOM the Subscription Lines are added from OnExplodeBOMCompLinesOnAfterToSalesLineInsert,
+                // where the line is inserted and the quantity is set. Adding them here as well offers the Subscription Packages twice per component.
+                if SalesServiceCommitmentMgmt.IsSalesLineBeingExploded(Rec) then
+                    exit;
                 SalesServiceCommitmentMgmt.AddSalesServiceCommitmentsForSalesLine(Rec, false);
             end;
         }

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Pages/AssignServiceCommitments.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Pages/AssignServiceCommitments.Page.al
@@ -6,6 +6,7 @@ using Microsoft.Sales.Document;
 page 8065 "Assign Service Commitments"
 {
     Caption = 'Assign Subscription Lines';
+    DataCaptionExpression = GetCaption();
     PageType = ListPlus;
     SourceTable = "Subscription Package";
     InsertAllowed = false;
@@ -105,6 +106,17 @@ page 8065 "Assign Service Commitments"
     internal procedure GetServiceAndCalculationStartDate(): Date
     begin
         exit(ServiceAndCalculationStartDate);
+    end;
+
+    local procedure GetCaption(): Text
+    var
+        SalesServiceCommitmentMgmt: Codeunit "Sales Subscription Line Mgmt.";
+        DataCaption: Text;
+    begin
+        DataCaption := SalesServiceCommitmentMgmt.GetAssignSubscriptionLinesCaption(SalesLine, ServiceObject, OpenedFromSalesLine);
+        if DataCaption = '' then
+            exit(Rec.Code);
+        exit(DataCaption);
     end;
 
     local procedure ErrorIfInvoicingItemNoIsMissingForSalesWithServiceCommitmentItem(): Boolean

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -63,12 +63,129 @@ codeunit 139915 "Sales Service Commitment Test"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         SerialNo: array[10] of Code[50];
+        AssignSubscriptionLinesOpenedCount: Integer;
         NoOfServiceObjects: Integer;
+        AssignSubscriptionLinesNotOfferedErr: Label 'The Assign Subscription Lines page must be opened for a Sales Line that is created after Explode BOM.', Locked = true;
+        AssignSubscriptionLinesOpenedPerComponentErr: Label 'The Assign Subscription Lines page must be opened exactly once per exploded BOM component.', Locked = true;
+        AssignSubscriptionLinesTok: Label 'Assign Subscription Lines', Locked = true;
+        CaptionDoesNotContainErr: Label 'The caption ''%1'' of the Assign Subscription Lines page does not contain ''%2''.', Locked = true;
+        CaptionNotCorrectErr: Label 'The caption of the Assign Subscription Lines page is not correct.', Locked = true;
         NotCreatedProperlyErr: Label 'Subscription Lines are not created properly.', Locked = true;
+        SalesLineCaptionTok: Label '%1 · %2', Locked = true;
         SalesServiceCommitmentCannotBeDeletedErr: Label 'The Sales Subscription Line cannot be deleted, because it is the last line with Process Contract Renewal. Please delete the Sales line in order to delete the Sales Subscription Line.', Locked = true;
         NaturalNumberRatioErr: Label 'The ratio of ''%1'' and ''%2'' or vice versa must give a natural number.', Comment = '%1=Field Caption, %2=Field Caption', Locked = true;
 
     #region Tests
+
+    [Test]
+    [HandlerFunctions('AssignServiceCommitmentsCaptureCaptionModalPageHandler')]
+    procedure AssignSubscriptionLinesCaptionIdentifiesSalesLine()
+    var
+        SalesItem: Record Item;
+        SalesServiceCommMgmt: Codeunit "Sales Subscription Line Mgmt.";
+        ActualCaption: Text;
+    begin
+        // [SCENARIO] The Assign Subscription Lines page identifies the Sales Line it has been opened for
+
+        // [GIVEN] Sales Line for an Item with a Subscription Package assigned to it
+        Initialize();
+        ContractTestLibrary.CreateItemWithServiceCommitmentOption(SalesItem, Enum::"Item Service Commitment Type"::"Sales with Service Commitment");
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, SalesItem."No.", LibraryRandom.RandIntInRange(1, 100));
+        SalesLine.Description := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(SalesLine.Description));
+        SalesLine.Modify(false);
+        ContractTestLibrary.AssignItemToServiceCommitmentPackage(SalesItem, ServiceCommitmentPackage.Code, false);
+
+        // [WHEN] Assign Subscription Lines page is opened for the Sales Line
+        SalesServiceCommMgmt.AddAdditionalSalesServiceCommitmentsForSalesLine(SalesLine);
+
+        // [THEN] The caption of the page contains the page name, the No. and the Description of the Sales Line
+        ActualCaption := LibraryVariableStorage.DequeueText();
+        Assert.IsTrue(StrPos(ActualCaption, AssignSubscriptionLinesTok) > 0, StrSubstNo(CaptionDoesNotContainErr, ActualCaption, AssignSubscriptionLinesTok));
+        Assert.IsTrue(StrPos(ActualCaption, SalesLine."No.") > 0, StrSubstNo(CaptionDoesNotContainErr, ActualCaption, SalesLine."No."));
+        Assert.IsTrue(StrPos(ActualCaption, SalesLine.Description) > 0, StrSubstNo(CaptionDoesNotContainErr, ActualCaption, SalesLine.Description));
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    procedure AssignSubscriptionLinesCaptionIsEmptyWhenNotOpenedFromSalesLine()
+    var
+        SalesServiceCommMgmt: Codeunit "Sales Subscription Line Mgmt.";
+    begin
+        // [SCENARIO] No Sales Line caption is provided if the Assign Subscription Lines page has not been opened from a Sales Line
+
+        // [GIVEN] Sales Line with No. and Description
+        Initialize();
+        SalesLine.Init();
+        SalesLine.Type := SalesLine.Type::Item;
+        SalesLine."No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(SalesLine."No."));
+        SalesLine.Description := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(SalesLine.Description));
+
+        // [WHEN] The caption is fetched for a page that has not been opened from a Sales Line
+        // [THEN] The caption is empty
+        Assert.AreEqual('', SalesServiceCommMgmt.GetAssignSubscriptionLinesCaption(SalesLine, ServiceObject, false), CaptionNotCorrectErr);
+    end;
+
+    [Test]
+    procedure AssignSubscriptionLinesCaptionShowsSubscriptionPackageWhenNotOpenedFromSalesLine()
+    var
+        AssignServiceCommitments: TestPage "Assign Service Commitments";
+        ActualCaption: Text;
+    begin
+        // [SCENARIO] The caption of the Assign Subscription Lines page keeps identifying the Subscription Package if the page has not been opened from a Sales Line
+
+        // [GIVEN] Subscription Package
+        Initialize();
+
+        // [WHEN] Assign Subscription Lines page is opened without a Sales Line
+        AssignServiceCommitments.OpenView();
+        AssignServiceCommitments.GoToRecord(ServiceCommitmentPackage);
+
+        // [THEN] The caption of the page contains the page name and the Code of the Subscription Package
+        ActualCaption := AssignServiceCommitments.Caption();
+        AssignServiceCommitments.Close();
+        Assert.IsTrue(StrPos(ActualCaption, AssignSubscriptionLinesTok) > 0, StrSubstNo(CaptionDoesNotContainErr, ActualCaption, AssignSubscriptionLinesTok));
+        Assert.IsTrue(StrPos(ActualCaption, ServiceCommitmentPackage.Code) > 0, StrSubstNo(CaptionDoesNotContainErr, ActualCaption, ServiceCommitmentPackage.Code));
+    end;
+
+    [Test]
+    procedure AssignSubscriptionLinesCaptionSkipsEmptySalesLineDescription()
+    var
+        SalesServiceCommMgmt: Codeunit "Sales Subscription Line Mgmt.";
+    begin
+        // [SCENARIO] The caption of the Assign Subscription Lines page contains no separator if the Sales Line has no Description
+
+        // [GIVEN] Sales Line with No. but without Description
+        Initialize();
+        SalesLine.Init();
+        SalesLine.Type := SalesLine.Type::Item;
+        SalesLine."No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(SalesLine."No."));
+
+        // [WHEN] The caption is fetched for a page that has been opened from the Sales Line
+        // [THEN] The caption consists of the No. of the Sales Line only
+        Assert.AreEqual(SalesLine."No.", SalesServiceCommMgmt.GetAssignSubscriptionLinesCaption(SalesLine, ServiceObject, true), CaptionNotCorrectErr);
+    end;
+
+    [Test]
+    procedure AssignSubscriptionLinesCaptionUsesSalesLineNoAndDescription()
+    var
+        SalesServiceCommMgmt: Codeunit "Sales Subscription Line Mgmt.";
+    begin
+        // [SCENARIO] The caption of the Assign Subscription Lines page consists of the No. and the Description of the Sales Line
+
+        // [GIVEN] Sales Line with No. and Description
+        Initialize();
+        SalesLine.Init();
+        SalesLine.Type := SalesLine.Type::Item;
+        SalesLine."No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(SalesLine."No."));
+        SalesLine.Description := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(SalesLine.Description));
+
+        // [WHEN] The caption is fetched for a page that has been opened from the Sales Line
+        // [THEN] The caption consists of the No. and the Description of the Sales Line
+        Assert.AreEqual(
+            StrSubstNo(SalesLineCaptionTok, SalesLine."No.", SalesLine.Description),
+            SalesServiceCommMgmt.GetAssignSubscriptionLinesCaption(SalesLine, ServiceObject, true), CaptionNotCorrectErr);
+    end;
 
     [Test]
     procedure CheckCopySalesServiceCommitmentFromSalesDocument()
@@ -1475,6 +1592,45 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
+    [HandlerFunctions('AssignServiceCommitmentsCountingModalPageHandler,StrMenuHandler')]
+    procedure ExplodeBOMOffersSubscriptionPackagesOncePerComponent()
+    var
+        BOMItem: Record Item;
+        ComponentItem1: Record Item;
+        ComponentItem2: Record Item;
+        ComponentSalesLine: Record "Sales Line";
+        StandardPackageCode1: Code[20];
+        StandardPackageCode2: Code[20];
+    begin
+        // [SCENARIO] Exploding the BOM of an Item offers the Subscription Packages exactly once per exploded component
+
+        // [GIVEN] Assembly Item with two components, each with a standard and an additional Subscription Package
+        Initialize();
+        LibraryAssembly.CreateItem(BOMItem, Item."Costing Method"::Standard, Item."Replenishment System"::Assembly, '', '');
+        CreateComponentItemWithAdditionalServiceCommPackage(BOMItem."No.", ComponentItem1, StandardPackageCode1);
+        CreateComponentItemWithAdditionalServiceCommPackage(BOMItem."No.", ComponentItem2, StandardPackageCode2);
+
+        // [GIVEN] Sales Order with a Sales Line for the Assembly Item
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, BOMItem."No.", WorkDate(), LibraryRandom.RandIntInRange(1, 10));
+
+        // [WHEN] The BOM is exploded
+        Codeunit.Run(Codeunit::"Sales-Explode BOM", SalesLine);
+
+        // [THEN] The Assign Subscription Lines page has been opened exactly once per component
+        Assert.AreEqual(2, AssignSubscriptionLinesOpenedCount, AssignSubscriptionLinesOpenedPerComponentErr);
+
+        // [THEN] Every component Sales Line holds the Subscription Lines of its standard Subscription Package only
+        VerifySalesSubscriptionLinesFromStandardPackageOnly(ComponentItem1."No.", StandardPackageCode1);
+        VerifySalesSubscriptionLinesFromStandardPackageOnly(ComponentItem2."No.", StandardPackageCode2);
+        ComponentSalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        ComponentSalesLine.SetRange("Document No.", SalesHeader."No.");
+        ComponentSalesLine.SetRange(Type, Enum::"Sales Line Type"::Item);
+        ComponentSalesLine.SetFilter("No.", '%1|%2', ComponentItem1."No.", ComponentItem2."No.");
+        Assert.RecordCount(ComponentSalesLine, 2);
+    end;
+
+    [Test]
     procedure InsertSalesServiceCommitmentWithInvoiceViaSalesWithoutInvoicingItemNo()
     begin
         Initialize();
@@ -1789,6 +1945,38 @@ codeunit 139915 "Sales Service Commitment Test"
         Assert.AreEqual(SubscriptionPackage[2].Code, LibraryVariableStorage.DequeueText(), 'Service Commitment Package without PriceGroup should be available for selection');
 
         LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('AssignServiceCommitmentsCountingModalPageHandler,StrMenuHandler')]
+    procedure SubscriptionPackagesAreOfferedForSalesLineCreatedAfterExplodeBOM()
+    var
+        BOMItem: Record Item;
+        ComponentItem: Record Item;
+        SalesItem: Record Item;
+        ComponentStandardPackageCode: Code[20];
+        SalesItemStandardPackageCode: Code[20];
+    begin
+        // [SCENARIO] The Subscription Packages are offered again for a Sales Line that is created after a BOM has been exploded
+
+        // [GIVEN] Sales Order in which the BOM of an Assembly Item with one component has been exploded
+        Initialize();
+        LibraryAssembly.CreateItem(BOMItem, Item."Costing Method"::Standard, Item."Replenishment System"::Assembly, '', '');
+        CreateComponentItemWithAdditionalServiceCommPackage(BOMItem."No.", ComponentItem, ComponentStandardPackageCode);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, BOMItem."No.", WorkDate(), LibraryRandom.RandIntInRange(1, 10));
+        Codeunit.Run(Codeunit::"Sales-Explode BOM", SalesLine);
+        Assert.AreEqual(1, AssignSubscriptionLinesOpenedCount, AssignSubscriptionLinesOpenedPerComponentErr);
+
+        // [WHEN] A Sales Line is created for another Item with Subscription Packages
+        CreateItemWithStandardAndAdditionalServiceCommPackage(SalesItem, SalesItemStandardPackageCode);
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, SalesItem."No.", WorkDate(), LibraryRandom.RandIntInRange(1, 10));
+
+        // [THEN] The Subscription Packages are offered for the new Sales Line
+        Assert.AreEqual(2, AssignSubscriptionLinesOpenedCount, AssignSubscriptionLinesNotOfferedErr);
+
+        // [THEN] The Subscription Lines of the standard Subscription Package are created for the new Sales Line
+        VerifySalesSubscriptionLinesFromStandardPackageOnly(SalesItem."No.", SalesItemStandardPackageCode);
     end;
 
     [Test]
@@ -2212,6 +2400,23 @@ codeunit 139915 "Sales Service Commitment Test"
         SalesHeader.Modify(false);
         LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), 1);
         LibrarySales.ReleaseSalesDocument(SalesHeader);
+    end;
+
+    local procedure CreateComponentItemWithAdditionalServiceCommPackage(BOMItemNo: Code[20]; var ComponentItem: Record Item; var StandardPackageCode: Code[20])
+    begin
+        CreateItemWithStandardAndAdditionalServiceCommPackage(ComponentItem, StandardPackageCode);
+        ContractTestLibrary.CreateBOMComponentForItem(BOMItemNo, ComponentItem."No.", 1, ComponentItem."Base Unit of Measure");
+    end;
+
+    local procedure CreateItemWithStandardAndAdditionalServiceCommPackage(var NewItem: Record Item; var StandardPackageCode: Code[20])
+    begin
+        ContractTestLibrary.CreateServiceCommitmentPackageWithLine(ServiceCommitmentTemplate.Code, ServiceCommitmentPackage, ServiceCommPackageLine);
+        ContractTestLibrary.InitServiceCommitmentPackageLineFields(ServiceCommPackageLine);
+        StandardPackageCode := ServiceCommitmentPackage.Code;
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(NewItem, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", StandardPackageCode);
+        ContractTestLibrary.CreateServiceCommitmentPackageWithLine(ServiceCommitmentTemplate.Code, ServiceCommitmentPackage, ServiceCommPackageLine);
+        ContractTestLibrary.InitServiceCommitmentPackageLineFields(ServiceCommPackageLine);
+        ContractTestLibrary.AssignItemToServiceCommitmentPackage(NewItem, ServiceCommitmentPackage.Code, false);
     end;
 
     local procedure CreateComponentItemWithSalesServiceCommitments(Item2No: Code[20])
@@ -2694,6 +2899,26 @@ codeunit 139915 "Sales Service Commitment Test"
         SalesReceivablesSetup.Modify(true);
     end;
 
+    local procedure VerifySalesSubscriptionLinesFromStandardPackageOnly(ItemNo: Code[20]; StandardPackageCode: Code[20])
+    var
+        ItemSalesLine: Record "Sales Line";
+        SalesSubscriptionLine: Record "Sales Subscription Line";
+        SubscriptionPackageLine: Record "Subscription Package Line";
+    begin
+        ItemSalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        ItemSalesLine.SetRange("Document No.", SalesHeader."No.");
+        ItemSalesLine.SetRange(Type, Enum::"Sales Line Type"::Item);
+        ItemSalesLine.SetRange("No.", ItemNo);
+        ItemSalesLine.FindFirst();
+
+        SubscriptionPackageLine.SetRange("Subscription Package Code", StandardPackageCode);
+        SalesSubscriptionLine.FilterOnSalesLine(ItemSalesLine);
+        Assert.RecordCount(SalesSubscriptionLine, SubscriptionPackageLine.Count());
+
+        SalesSubscriptionLine.SetFilter("Subscription Package Code", '<>%1', StandardPackageCode);
+        Assert.RecordIsEmpty(SalesSubscriptionLine);
+    end;
+
     local procedure VerifyServiceCommitmentUnitCostFromSalesServiceCommitment(ServiceCommitmentParam: Record "Subscription Line"; var TempSalesServiceCommitment: Record "Sales Subscription Line" temporary)
     var
         ValueNotCorrectTok: Label '%1 value is not correct.', Locked = true;
@@ -2706,6 +2931,20 @@ codeunit 139915 "Sales Service Commitment Test"
     #endregion Procedures
 
     #region Handlers
+
+    [ModalPageHandler]
+    procedure AssignServiceCommitmentsCaptureCaptionModalPageHandler(var AssignServiceCommitments: TestPage "Assign Service Commitments")
+    begin
+        LibraryVariableStorage.Enqueue(AssignServiceCommitments.Caption());
+        AssignServiceCommitments.Cancel().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure AssignServiceCommitmentsCountingModalPageHandler(var AssignServiceCommitments: TestPage "Assign Service Commitments")
+    begin
+        AssignSubscriptionLinesOpenedCount += 1;
+        AssignServiceCommitments.Cancel().Invoke();
+    end;
 
     [ModalPageHandler]
     procedure AssignServiceCommitmentsModalPageHandler(var AssignServiceCommitments: TestPage "Assign Service Commitments")


### PR DESCRIPTION

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
The Assign Subscription Lines page gave the user no way to tell which sales line it was opened for. With bundles the dialog appears several times in a row, so it is not clear which component the Subscription Packages are being offered for.

Two separate causes:

- Page 8065 declared no DataCaptionExpression, so the caption fell back to the Subscription Package code. It now shows the sales line "No." and Description, and raises OnAfterGetAssignSubscriptionLinesCaption so that extensions can supply their own context. When the page is opened from a Subscription Header the previous caption is kept unchanged.

- During Sales-Explode BOM, AddSalesServiceCommitmentsForSalesLine ran twice per component: once from the Sales Line "No." validation trigger and once from OnExplodeBOMCompLinesOnAfterToSalesLineInsert. Two components therefore opened the dialog four times. The validation path is now skipped for the line that is currently being exploded, which the codeunit tracks by document type, document number and line number rather than by a plain flag, so that an error between the two events cannot suppress package assignment for every other sales line of the session.

Consolidating onto the post-insert subscriber also removes a latent defect: the validation path inserted and committed Sales Subscription Lines against a Document Line No. whose sales line had not been inserted yet.


## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #9965
[AB#650454](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650454)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
Created two items and assigned a Subscription Package to each of them.
Created a BOM item and add both items to its BOM.
Created a sales order and add the bundle item on a sales line.
Run Functions > Explode BOM on that line, so the two component lines are inserted.
The Assign Subscription Lines dialog (page 8065 "Assign Service Commitments") opens twice, once per exploded component line.
Observed that both dialogs are distinguishable.

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->
## Risk & compatibility

**No schema, upgrade or permission impact.** No tables, fields or keys were added or changed; nothing to migrate.

**Behaviour changes reviewers should watch for:**

- The additional-packages dialog is now offered **once per exploded component instead of twice**, and at a later point — after `Insert()`, with the quantity set. Calculation base amounts are therefore derived from a complete sales line, where the first (pre-insert) offer saw a line without a quantity.
- The data caption of page 8065 changes. Any test or automation asserting the previous caption needs updating.

**Extensibility surface:**

- New integration event `OnAfterGetAssignSubscriptionLinesCaption`. Once shipped, its signature is a compatibility contract, so it is worth agreeing on the parameter set now. The `SubscriptionHeader` parameter is deliberate: it is the only context available on the path where the page is opened from a Subscription Header rather than a sales line.
- No existing public or internal signature was changed or removed. `IsSalesLineBeingExploded` is new and `internal`.

**Residual risk:**

- Tracking the exploded line by document type, document number and line number narrows the stuck-state window but does not close it entirely. If an error is thrown between `OnExplodeBOMCompLinesOnAfterAssignType` and `OnExplodeBOMCompLinesOnAfterToSalesLineInsert`, the stored identity survives until the next explosion resets it on `OnBeforeOnRun`. To be affected, a subsequently created line would have to match that exact document and line number — explosion uses line numbers between existing lines, while new lines are appended.




