### PR TITLE
Add details to project sales tooltip

### DIFF
--- a/src/Apps/W1/PowerBIReports/App/Projects/APIs/Jobs.Query.al
+++ b/src/Apps/W1/PowerBIReports/App/Projects/APIs/Jobs.Query.al
@@ -32,6 +32,9 @@ query 36995 Jobs
             column(billToCustomerNo; "Bill-to Customer No.")
             {
             }
+            column(sellToCustomerNo; "Sell-to Customer No.")
+            {
+            }
             column(creationDate; "Creation Date")
             {
             }

--- a/src/Apps/W1/PowerBIReports/Power BI Files/Sales app/Sales app.Report/definition/pages/3f3a8251c4943f8c8fb2/visuals/840174a7f81ce1ba180e/visual.json
+++ b/src/Apps/W1/PowerBIReports/Power BI Files/Sales app/Sales app.Report/definition/pages/3f3a8251c4943f8c8fb2/visuals/840174a7f81ce1ba180e/visual.json
@@ -53,13 +53,13 @@
                 "Column": {
                   "Expression": {
                     "SourceRef": {
-                      "Entity": "Customer"
+                      "Entity": "Project"
                     }
                   },
-                  "Property": "Customer Name"
+                  "Property": "Sell-to Customer Name"
                 }
               },
-              "queryRef": "Customer.Customer Name",
+              "queryRef": "Project.Sell-to Customer Name",
               "nativeQueryRef": "Customer Name"
             },
             {

--- a/src/Apps/W1/PowerBIReports/Power BI Files/Sales app/Sales app.Report/definition/pages/3f3a8251c4943f8c8fb2/visuals/840174a7f81ce1ba180e/visual.json
+++ b/src/Apps/W1/PowerBIReports/Power BI Files/Sales app/Sales app.Report/definition/pages/3f3a8251c4943f8c8fb2/visuals/840174a7f81ce1ba180e/visual.json
@@ -36,6 +36,34 @@
           "projections": [
             {
               "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Project"
+                    }
+                  },
+                  "Property": "Project Description"
+                }
+              },
+              "queryRef": "Project.Project Description",
+              "nativeQueryRef": "Project Description"
+            },
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Customer"
+                    }
+                  },
+                  "Property": "Customer Name"
+                }
+              },
+              "queryRef": "Customer.Customer Name",
+              "nativeQueryRef": "Customer Name"
+            },
+            {
+              "field": {
                 "Measure": {
                   "Expression": {
                     "SourceRef": {

--- a/src/Apps/W1/PowerBIReports/Power BI Files/Sales app/Sales app.SemanticModel/definition/tables/Project.tmdl
+++ b/src/Apps/W1/PowerBIReports/Power BI Files/Sales app/Sales app.SemanticModel/definition/tables/Project.tmdl
@@ -25,6 +25,20 @@ table Project
 
 		annotation SummarizationSetBy = Automatic
 
+	column 'Project Sell to Customer No.'
+		dataType: string
+		lineageTag: 51838373-d0d1-43a7-bec8-da4955ea592b
+		summarizeBy: none
+		sourceColumn: Project Sell to Customer No.
+
+		annotation SummarizationSetBy = Automatic
+
+	column 'Sell-to Customer Name' = LOOKUPVALUE(Customer[Customer Name], Customer[Customer No.], Project[Project Sell to Customer No.])
+		lineageTag: 6fa0bf9d-3449-4a12-94b3-c6cb8885f797
+		summarizeBy: none
+
+		annotation SummarizationSetBy = Automatic
+
 	column 'Project Creation Date'
 		dataType: dateTime
 		formatString: Long Date
@@ -124,6 +138,7 @@ table Project
 				            {"projectManager", "Project Project Manager"},
 				            {"no", "Project No."},
 				            {"billToCustomerNo", "Project Bill to Customer No."},
+				            {"sellToCustomerNo", "Project Sell to Customer No."},
 				            {"status", "Project Status"},
 				            {"description", "Project Description"},
 				            {"complete", "Project Complete"},
@@ -140,4 +155,3 @@ table Project
 	annotation PBI_NavigationStepName = Navigation
 
 	annotation PBI_ResultType = Table
-

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIProjectTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIProjectTest.Codeunit.al
@@ -84,6 +84,7 @@ codeunit 139879 "E2E PowerBI Project Test"
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(Job."No.") + ''')]'), 'Job not found.');
         Assert.AreEqual(Job.Description, JsonMgt.GetValue('description'), 'Description did not match.');
         Assert.AreEqual(Job."Bill-to Customer No.", JsonMgt.GetValue('billToCustomerNo'), 'Bill-to customer no. did not match.');
+        Assert.AreEqual(Job."Sell-to Customer No.", JsonMgt.GetValue('sellToCustomerNo'), 'Sell-to customer no. did not match.');
         Assert.AreEqual(Format(Job."Creation Date", 0, 9), JsonMgt.GetValue('creationDate'), 'Creation date did not match.');
         Assert.AreEqual(Format(Job."Starting Date", 0, 9), JsonMgt.GetValue('startingDate'), 'Starting date did not match.');
         Assert.AreEqual(Format(Job."Ending Date", 0, 9), JsonMgt.GetValue('endingDate'), 'Ending date did not match.');


### PR DESCRIPTION
## What & why

The **Project Sales by Project** chart identifies projects only by number, which requires users to cross-reference project details. Replacing the axis with number and description would make labels too long for the visual.

Keep `Project No.` as the compact axis and add `Project Description` and `Customer Name` to the tooltip so users can identify the project and customer without reducing chart readability.

## Linked work

[AB#602212](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/602212)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Parsed the changed `visual.json` with PowerShell `ConvertFrom-Json`; the report definition remains valid JSON.
- Ran `git diff --check`; no whitespace errors were reported.
- Confirmed both tooltip fields already exist in the Sales semantic model and that project ledger entries are related to the Customer dimension.
- No automated test was added because this change only updates Power BI visual metadata. Power BI Desktop is not available on this machine for interactive report validation.

## Risk & compatibility

Low. The existing project axis, measures, sorting, and filters are unchanged; the visual only exposes two additional tooltip fields.


