### PR TITLE
Fix stale start status in e-document import pipeline

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocImport.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocImport.Codeunit.al
@@ -87,7 +87,7 @@ codeunit 6140 "E-Doc. Import"
     var
         ImportEDocumentProcess: Codeunit "Import E-Document Process";
         EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
-        Status, CurrentStatus : Enum "Import E-Doc. Proc. Status";
+        Status, CurrentStatus, InitialStatus : Enum "Import E-Doc. Proc. Status";
         StepToDo, StepToUndo : Enum "Import E-Document Steps";
         StatusIndex: Integer;
     begin
@@ -97,6 +97,7 @@ codeunit 6140 "E-Doc. Import"
 
         EDocument.CalcFields("Import Processing Status");
         CurrentStatus := EDocument."Import Processing Status";
+        InitialStatus := CurrentStatus;
 
         EDocImpSessionTelemetry.SetSession(CurrentStatus, DesiredStatus);
         EDocImpSessionTelemetry.SetBool('Success', true);
@@ -126,9 +127,9 @@ codeunit 6140 "E-Doc. Import"
                     end;
                 end;
 
-        if CurrentStatus <> DesiredStatus then
+        if InitialStatus <> DesiredStatus then
             EDocImpSessionTelemetry.Emit(EDocument);
-        OnAfterProcessIncomingEDocument(EDocument, EDocImportParameters, CurrentStatus, DesiredStatus);
+        OnAfterProcessIncomingEDocument(EDocument, EDocImportParameters, InitialStatus, DesiredStatus);
         exit(true);
     end;
 


### PR DESCRIPTION
Use the initial (pre-undo) processing status instead of the post-undo CurrentStatus for both the telemetry emit guard and the OnAfterProcessIncomingEDocument event. More for code quality and it also gets rid of one edge case (when undoing went all the way to unprocessed, it didn't emit anything (telemetry or event), granted we don't have consumers like this)

Fixes [AB#646592](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646592)


