### PR TITLE
All emails in folder were processed at first activation

### DIFF
--- a/src/Apps/W1/EDocumentConnectors/Microsoft365/app/src/OutlookProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Microsoft365/app/src/OutlookProcessing.Codeunit.al
@@ -95,12 +95,15 @@ codeunit 6385 "Outlook Processing"
         TempFilters."Load Attachments" := true;
         TempFilters."Load Headers" := true;
         TempFilters."Max No. of Emails" := GetMaxNoOfEmails();
-        // In folder mode, dedup is enforced server-side by the category-exclude filter only.
-        // Applying "Earliest Email" would drop emails moved into the folder after that floor.
-        if not FolderConfigured then
+        if not FolderConfigured then begin
+            if OutlookSetup."Last Sync At" = 0DT then // Defensive, this should not happen due to the OnValidate then enabling.
+                OutlookSetup."Last Sync At" := CurrentDateTime();
             // An extra second is added at retrieval: Graph compares (either with `ge` or `gt`) with subsecond precision, but returns receivedDateTime truncated to whole seconds. 
             // A single refetch in the email module, even if the email is later not processed, creates a Tenant Media record for the email. The second bump avoids this.
             TempFilters."Earliest Email" := OutlookSetup."Last Sync At" + 1000;
+        end else
+            // In folder mode the sync floor cannot be used (it advances from receivedDateTime, but emails can be moved into the folder after their receivedDateTime). We use "Enabled At" to avoid fetching all emails in the folder. The category filter also gets rid of some.
+            TempFilters."Earliest Email" := OutlookSetup."Enabled At";
 
         // When the user has not configured a folder, default to Inbox so that Sent Items,
         // Junk, and other non-Inbox folders are excluded from monitoring.


### PR DESCRIPTION
In folder mode we were processing all old emails at activation, this fix sets a date filter (that doesn't move) by using the date at which the agent was enabled. Additionally a defensive validation to ensure no 0D goes in non-folder mode is also added (shouldn't happen, but still)

Fixes [AB#638782](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638782)

