### PR TITLE
[Extensibility Request] issue 29901: expose item application entry before find

### DIFF
--- a/src/Layers/RU/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
@@ -251,6 +251,7 @@ codeunit 5815 "Undo Sales Shipment Line"
         ItemApplicationEntry.SetRange("Cost Application", true);
         ItemApplicationEntry.SetRange("Inbound Item Entry No.", ItemLedgerEntry."Applies-to Entry");
         ItemApplicationEntry.SetRange("Outbound Item Entry No.", ItemLedgerEntry."Entry No.");
+        OnUnApplyDropShipmentOnBeforeFindItemApplicationEntry(ItemApplicationEntry, ItemLedgerEntry);
         ItemApplicationEntry.FindFirst();
 
         ItemJnlPostLine.UnApplyDropShipment(ItemApplicationEntry, RelevantUndoShipmentLedgerEntryNo);
@@ -1123,6 +1124,16 @@ codeunit 5815 "Undo Sales Shipment Line"
     /// <param name="UndoSalesShptLineParams">The undo parameters being used.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeDeleteRelatedItems(var SalesShipmentLine: Record "Sales Shipment Line"; UndoSalesShptLineParams: Record "Undo Sales Shpt. Line Params")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the item application entry for a drop shipment being unapplied.
+    /// </summary>
+    /// <param name="ItemApplicationEntry">The item application entry with applied filters.</param>
+    /// <param name="ItemLedgerEntry">The item ledger entry for the drop shipment.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUnApplyDropShipmentOnBeforeFindItemApplicationEntry(var ItemApplicationEntry: Record "Item Application Entry"; ItemLedgerEntry: Record "Item Ledger Entry")
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
@@ -251,6 +251,7 @@ codeunit 5815 "Undo Sales Shipment Line"
         ItemApplicationEntry.SetRange("Cost Application", true);
         ItemApplicationEntry.SetRange("Inbound Item Entry No.", ItemLedgerEntry."Applies-to Entry");
         ItemApplicationEntry.SetRange("Outbound Item Entry No.", ItemLedgerEntry."Entry No.");
+        OnUnApplyDropShipmentOnBeforeFindItemApplicationEntry(ItemApplicationEntry, ItemLedgerEntry);
         ItemApplicationEntry.FindFirst();
 
         ItemJnlPostLine.UnApplyDropShipment(ItemApplicationEntry, RelevantUndoShipmentLedgerEntryNo);
@@ -1119,6 +1120,16 @@ codeunit 5815 "Undo Sales Shipment Line"
     /// <param name="UndoSalesShptLineParams">The undo parameters being used.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeDeleteRelatedItems(var SalesShipmentLine: Record "Sales Shipment Line"; UndoSalesShptLineParams: Record "Undo Sales Shpt. Line Params")
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before finding the item application entry for a drop shipment being unapplied.
+    /// </summary>
+    /// <param name="ItemApplicationEntry">The item application entry with applied filters.</param>
+    /// <param name="ItemLedgerEntry">The item ledger entry for the drop shipment.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUnApplyDropShipmentOnBeforeFindItemApplicationEntry(var ItemApplicationEntry: Record "Item Application Entry"; ItemLedgerEntry: Record "Item Ledger Entry")
     begin
     end;
 }


### PR DESCRIPTION
## Summary
Extensions that add fields to Item Application Entry can encounter a JIT load-field error when undoing a drop shipment because the standard record is restricted to base load fields before it is passed into item application logic. This PR adds an event before the filtered item application entry is retrieved so subscribers can adjust the record's loaded fields while preserving the standard optimization.

Source issue repository: microsoft/AlAppExtensions; issue number: 29901

## Changes Made
- `Undo Sales Shipment Line.UnApplyDropShipment` - added an event before finding the item application entry so subscribers can adjust loaded fields; propagated the event to the RU layer counterpart.

Fixes [AB#630549](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630549)


