### PR TITLE
[Extensibility Request] issue 29643: enable split transfer demand profiles

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/InventoryProfileOffsetting.Codeunit.al
@@ -2609,28 +2609,32 @@ codeunit 99000854 "Inventory Profile Offsetting"
             then begin
                 AdjustTransferDates(ReqLine);
                 if ReqLine."Action Message" = ReqLine."Action Message"::New then begin
-                    CurrentSupplyInvtProfile.Copy(SupplyInvtProfile);
+                    IsHandled := false;
+                    OnMaintainPlanningLineOnBeforeCreateDemandInvtProfileForTransfer(ReqLine, SupplyInvtProfile, TempTrkgReservEntry, LineNo, IsHandled);
+                    if not IsHandled then begin
+                        CurrentSupplyInvtProfile.Copy(SupplyInvtProfile);
 
-                    SupplyInvtProfile.Reset();
-                    SupplyInvtProfile.SetSourceFilter(
-                      Database::"Requisition Line", 1, ReqLine."Worksheet Template Name", ReqLine."Line No.", ReqLine."Journal Batch Name", 0);
-                    SupplyInvtProfile.SetTrackingFilter(CurrentSupplyInvtProfile);
-                    if not SupplyInvtProfile.FindFirst() then begin
-                        SupplyInvtProfile.Init();
-                        SupplyInvtProfile."Line No." := GetNextLineNo();
-                        SupplyInvtProfile."Item No." := ReqLine."No.";
-                        SupplyInvtProfile.TransferFromOutboundTransfPlan(ReqLine, TempItemTrkgEntry);
-                        SupplyInvtProfile.CopyTrackingFromInvtProfile(CurrentSupplyInvtProfile);
-                        if SupplyInvtProfile.IsSupply then
-                            SupplyInvtProfile.ChangeSign();
-                        OnMaintainPlanningLineOnBeforeSupplyInvtProfileInsert(SupplyInvtProfile, CurrentSupplyInvtProfile);
-                        SupplyInvtProfile.Insert();
-                    end else begin
-                        SupplyInvtProfile.TransferFromOutboundTransfPlan(ReqLine, TempItemTrkgEntry);
-                        SupplyInvtProfile.Modify();
+                        SupplyInvtProfile.Reset();
+                        SupplyInvtProfile.SetSourceFilter(
+                          Database::"Requisition Line", 1, ReqLine."Worksheet Template Name", ReqLine."Line No.", ReqLine."Journal Batch Name", 0);
+                        SupplyInvtProfile.SetTrackingFilter(CurrentSupplyInvtProfile);
+                        if not SupplyInvtProfile.FindFirst() then begin
+                            SupplyInvtProfile.Init();
+                            SupplyInvtProfile."Line No." := GetNextLineNo();
+                            SupplyInvtProfile."Item No." := ReqLine."No.";
+                            SupplyInvtProfile.TransferFromOutboundTransfPlan(ReqLine, TempItemTrkgEntry);
+                            SupplyInvtProfile.CopyTrackingFromInvtProfile(CurrentSupplyInvtProfile);
+                            if SupplyInvtProfile.IsSupply then
+                                SupplyInvtProfile.ChangeSign();
+                            OnMaintainPlanningLineOnBeforeSupplyInvtProfileInsert(SupplyInvtProfile, CurrentSupplyInvtProfile);
+                            SupplyInvtProfile.Insert();
+                        end else begin
+                            SupplyInvtProfile.TransferFromOutboundTransfPlan(ReqLine, TempItemTrkgEntry);
+                            SupplyInvtProfile.Modify();
+                        end;
+
+                        SupplyInvtProfile.Copy(CurrentSupplyInvtProfile);
                     end;
-
-                    SupplyInvtProfile.Copy(CurrentSupplyInvtProfile);
                 end else
                     SynchronizeTransferProfiles(SupplyInvtProfile, ReqLine);
             end;
@@ -5437,6 +5441,11 @@ codeunit 99000854 "Inventory Profile Offsetting"
 
     [IntegrationEvent(false, false)]
     local procedure OnMaintainPlanningLineOnAfterLineCreated(var SupplyInvtProfile: Record "Inventory Profile"; var RequisitionLine: Record "Requisition Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnMaintainPlanningLineOnBeforeCreateDemandInvtProfileForTransfer(var RequisitionLine: Record "Requisition Line"; var SupplyInventoryProfile: Record "Inventory Profile"; var TempTrackingReservationEntry: Record "Reservation Entry" temporary; var InventoryProfileLineNo: Integer; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Cable and cut-length planning needs transfer demand to remain separated so downstream purchase suggestions preserve each required length instead of aggregating the total quantity. The standard transfer planning flow creates a single demand inventory profile and offers no supported way to replace it safely. This PR adds a take-over event with tracking context and shared line-number state so extensions can create multiple demand profiles while leaving standard behavior unchanged when there is no subscriber.

Source issue repository: microsoft/AlAppExtensions; issue number: 29643

## Changes Made
- `Inventory Profile Offsetting.MaintainPlanningLine` - adds a pre-creation event for transfer demand profiles with requisition, supply profile, temporary tracking reservation, line-number, and handled context

Fixes [AB#620193](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620193)



