### PR TITLE
[Extensibility Request] issue 30240: add event before adding price list lines

### DIFF
--- a/src/Layers/W1/BaseApp/Pricing/PriceList/PriceListManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Pricing/PriceList/PriceListManagement.Codeunit.al
@@ -85,7 +85,13 @@ codeunit 7017 "Price List Management"
     var
         ExistingPriceListLine: Record "Price List Line";
         PriceListLine: Record "Price List Line";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeAddLine(ToPriceListHeader, PriceAsset, PriceLineFilters, IsHandled);
+        if IsHandled then
+            exit;
+
         PriceListLine."Price List Code" := ToPriceListHeader.Code;
         PriceListLine.SetNextLineNo();
         PriceListLine.CopyFrom(ToPriceListHeader, true);
@@ -1065,6 +1071,11 @@ codeunit 7017 "Price List Management"
 
     [IntegrationEvent(true, false)]
     local procedure OnAddLineOnAfterPopulatePriceListLineFields(var PriceListLine: Record "Price List Line"; ToPriceListHeader: Record "Price List Header"; PriceAsset: Record "Price Asset"; PriceLineFilters: Record "Price Line Filters")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeAddLine(PriceListHeader: Record "Price List Header"; PriceAsset: Record "Price Asset"; PriceLineFilters: Record "Price Line Filters"; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need to replace the standard logic that creates a price list line for an asset when suggested price lines are added. This PR adds a cancellable event at the start of the line creation procedure so subscribers can provide alternative handling before any standard fields are populated.

Source issue repository: microsoft/AlAppExtensions; issue number: 30240

## Changes Made
- `Price List Management.AddLine` - added `OnBeforeAddLine` with the relevant price records and an initialized `IsHandled` parameter so subscribers can bypass standard line creation; the W1 implementation is inherited by country layers.

Fixes [AB#638114](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638114)


