### PR TITLE
[APAC] Keep vendor ACY on purchase invoice payables entry

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -188,6 +188,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
         HadWHTEntryNo: Boolean;
         NextNo: Integer;
         UseVendExchRate: Boolean;
+        VendGSTAmountACYEnabled: Boolean;
+        VendGSTAmountACYRead: Boolean;
         Text28000: Label 'No Matching Document';
         CheckRem: Boolean;
         IsReversal: Boolean;
@@ -8174,15 +8176,24 @@ codeunit 12 "Gen. Jnl.-Post Line"
     end;
 
     local procedure VendorACYExchangeRateApplies(): Boolean
-    var
-        PurchSetup: Record "Purchases & Payables Setup";
     begin
         // Mirrors GLCalcAddCurrency's vendor-ACY branch so the balancing entry's Source Currency Amount matches its ACY.
         if (AddCurrencyCode = '') or (not UseVendExchRate) then
             exit(false);
-        PurchSetup.SetLoadFields("Enable Vendor GST Amount (ACY)");
-        PurchSetup.Get();
-        exit(PurchSetup."Enable Vendor GST Amount (ACY)");
+        exit(GetVendGSTAmountACYEnabled());
+    end;
+
+    local procedure GetVendGSTAmountACYEnabled(): Boolean
+    var
+        PurchSetup: Record "Purchases & Payables Setup";
+    begin
+        if not VendGSTAmountACYRead then begin
+            PurchSetup.SetLoadFields("Enable Vendor GST Amount (ACY)");
+            PurchSetup.Get();
+            VendGSTAmountACYEnabled := PurchSetup."Enable Vendor GST Amount (ACY)";
+            VendGSTAmountACYRead := true;
+        end;
+        exit(VendGSTAmountACYEnabled);
     end;
 
     local procedure PostDtldAdjustment(GenJnlLine: Record "Gen. Journal Line"; var GLEntry: Record "G/L Entry"; AdjAmount: array[4] of Decimal; TotalAmountLCY: Decimal; TotalAmountAddCurr: Decimal; GLAcc: Code[20]; ArrayIndex: Integer): Boolean

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8163,9 +8163,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true, TotalAmountAddCurr)
                 else
                     if VendorACYExchangeRateApplies() then
-                        // [641827] With "Enable Vendor GST Amount (ACY)" the aggregated amount is the vendor-calculated
-                        // ACY, which GLCalcAddCurrency keeps on the balancing entry. Derive the source-currency amount
-                        // from LCY so the reporting currency stays balanced instead of posting a separate residual entry.
+                        // [641827] GLCalcAddCurrency keeps the vendor ACY here, so derive Source Currency Amount from LCY.
                         InitGLEntry(
                             GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true,
                             CalcAmountSrcCurr(GenJnlLine, TotalAmountLCY))
@@ -8179,12 +8177,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
     var
         PurchSetup: Record "Purchases & Payables Setup";
     begin
-        // Mirrors the vendor-ACY branch in GLCalcAddCurrency: only then does the balancing entry keep the
-        // aggregated amount as its Additional-Currency Amount, so only then must the Source Currency Amount be
-        // derived from LCY. In every other case the original behavior (Source Currency Amount = aggregated amount)
-        // must be preserved to keep Source Currency Consistency balanced.
+        // Mirrors GLCalcAddCurrency's vendor-ACY branch so the balancing entry's Source Currency Amount matches its ACY.
         if (AddCurrencyCode = '') or (not UseVendExchRate) then
             exit(false);
+        PurchSetup.SetLoadFields("Enable Vendor GST Amount (ACY)");
         PurchSetup.Get();
         exit(PurchSetup."Enable Vendor GST Amount (ACY)");
     end;
@@ -8456,6 +8452,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
         GLEntry: Record "G/L Entry";
         IsHandled: Boolean;
     begin
+        // General balancing entries are never the vendor-ACY case; clear the transient flag so leftover state cannot select it.
+        UseVendExchRate := false;
         HandleDtldAdjustment(GenJnlLine, GLEntry, AdjAmountBuf, Amount, AmountACY, GLAccNo);
         GLEntry."Bal. Account Type" := GenJnlLine."Bal. Account Type";
         GLEntry."Bal. Account No." := GenJnlLine."Bal. Account No.";

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8163,7 +8163,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true, TotalAmountAddCurr)
                 else
                     InitGLEntry(
-                        GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, 0, false, true, TotalAmountAddCurr);
+                        GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true,
+                        CalcAmountSrcCurr(GenJnlLine, TotalAmountLCY));
         end;
     end;
 

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -8162,10 +8162,31 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     InitGLEntry(
                         GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true, TotalAmountAddCurr)
                 else
-                    InitGLEntry(
-                        GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true,
-                        CalcAmountSrcCurr(GenJnlLine, TotalAmountLCY));
+                    if VendorACYExchangeRateApplies() then
+                        // [641827] With "Enable Vendor GST Amount (ACY)" the aggregated amount is the vendor-calculated
+                        // ACY, which GLCalcAddCurrency keeps on the balancing entry. Derive the source-currency amount
+                        // from LCY so the reporting currency stays balanced instead of posting a separate residual entry.
+                        InitGLEntry(
+                            GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true,
+                            CalcAmountSrcCurr(GenJnlLine, TotalAmountLCY))
+                    else
+                        InitGLEntry(
+                            GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, 0, false, true, TotalAmountAddCurr);
         end;
+    end;
+
+    local procedure VendorACYExchangeRateApplies(): Boolean
+    var
+        PurchSetup: Record "Purchases & Payables Setup";
+    begin
+        // Mirrors the vendor-ACY branch in GLCalcAddCurrency: only then does the balancing entry keep the
+        // aggregated amount as its Additional-Currency Amount, so only then must the Source Currency Amount be
+        // derived from LCY. In every other case the original behavior (Source Currency Amount = aggregated amount)
+        // must be preserved to keep Source Currency Consistency balanced.
+        if (AddCurrencyCode = '') or (not UseVendExchRate) then
+            exit(false);
+        PurchSetup.Get();
+        exit(PurchSetup."Enable Vendor GST Amount (ACY)");
     end;
 
     local procedure PostDtldAdjustment(GenJnlLine: Record "Gen. Journal Line"; var GLEntry: Record "G/L Entry"; AdjAmount: array[4] of Decimal; TotalAmountLCY: Decimal; TotalAmountAddCurr: Decimal; GLAcc: Code[20]; ArrayIndex: Integer): Boolean

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -188,8 +188,6 @@ codeunit 12 "Gen. Jnl.-Post Line"
         HadWHTEntryNo: Boolean;
         NextNo: Integer;
         UseVendExchRate: Boolean;
-        VendGSTAmountACYEnabled: Boolean;
-        VendGSTAmountACYRead: Boolean;
         Text28000: Label 'No Matching Document';
         CheckRem: Boolean;
         IsReversal: Boolean;
@@ -8164,7 +8162,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     InitGLEntry(
                         GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true, TotalAmountAddCurr)
                 else
-                    if VendorACYExchangeRateApplies() then
+                    if VendorACYExchangeRateApplies(GenJnlLine) then
                         // [641827] GLCalcAddCurrency keeps the vendor ACY here, so derive Source Currency Amount from LCY.
                         InitGLEntry(
                             GenJnlLine, GLEntry, GLAccNo, TotalAmountLCY, TotalAmountAddCurr, true, true,
@@ -8175,25 +8173,19 @@ codeunit 12 "Gen. Jnl.-Post Line"
         end;
     end;
 
-    local procedure VendorACYExchangeRateApplies(): Boolean
+    local procedure VendorACYExchangeRateApplies(GenJnlLine: Record "Gen. Journal Line"): Boolean
+    var
+        PurchSetup: Record "Purchases & Payables Setup";
     begin
         // Mirrors GLCalcAddCurrency's vendor-ACY branch so the balancing entry's Source Currency Amount matches its ACY.
         if (AddCurrencyCode = '') or (not UseVendExchRate) then
             exit(false);
-        exit(GetVendGSTAmountACYEnabled());
-    end;
-
-    local procedure GetVendGSTAmountACYEnabled(): Boolean
-    var
-        PurchSetup: Record "Purchases & Payables Setup";
-    begin
-        if not VendGSTAmountACYRead then begin
-            PurchSetup.SetLoadFields("Enable Vendor GST Amount (ACY)");
-            PurchSetup.Get();
-            VendGSTAmountACYEnabled := PurchSetup."Enable Vendor GST Amount (ACY)";
-            VendGSTAmountACYRead := true;
-        end;
-        exit(VendGSTAmountACYEnabled);
+        if GenJnlLine."Additional-Currency Posting" <> GenJnlLine."Additional-Currency Posting"::None then
+            exit(false);
+        // Read fresh, like GLCalcAddCurrency, so a mid-batch setup change is not masked by a cached value.
+        PurchSetup.SetLoadFields("Enable Vendor GST Amount (ACY)");
+        PurchSetup.Get();
+        exit(PurchSetup."Enable Vendor GST Amount (ACY)");
     end;
 
     local procedure PostDtldAdjustment(GenJnlLine: Record "Gen. Journal Line"; var GLEntry: Record "G/L Entry"; AdjAmount: array[4] of Decimal; TotalAmountLCY: Decimal; TotalAmountAddCurr: Decimal; GLAcc: Code[20]; ArrayIndex: Integer): Boolean

--- a/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
+++ b/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
@@ -828,6 +828,7 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         PostedDocumentNo: Code[20];
         ExpectedACYAmount: Decimal;
         NonPayablesACY: Decimal;
+        OriginalVendorGSTAmountACY: Boolean;
     begin
         // [FEATURE] [Purchase] [ACY]
         // [SCENARIO 641827] Vendor ACY is posted on the payables entry for a purchase invoice in LCY.
@@ -838,6 +839,7 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
         Currency.Get(CurrencyCode);
         PurchasesPayablesSetup.Get();
+        OriginalVendorGSTAmountACY := PurchasesPayablesSetup."Enable Vendor GST Amount (ACY)";
         PurchasesPayablesSetup."Enable Vendor GST Amount (ACY)" := true;
         PurchasesPayablesSetup.Modify();
         LibraryERM.SetAddReportingCurrency(CurrencyCode);
@@ -892,6 +894,11 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         GLEntry.SetFilter(
           "G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
         Assert.RecordCount(GLEntry, 0);
+
+        // The flag is not registered in setup storage, so restore its original value to avoid leaking into later tests.
+        PurchasesPayablesSetup.Get();
+        PurchasesPayablesSetup."Enable Vendor GST Amount (ACY)" := OriginalVendorGSTAmountACY;
+        PurchasesPayablesSetup.Modify();
     end;
 
     [Test]

--- a/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
+++ b/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
@@ -832,7 +832,6 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         // [FEATURE] [Purchase] [ACY]
         // [SCENARIO 641827] Vendor ACY is posted on the payables entry for a purchase invoice in LCY.
         Initialize();
-        LibrarySetupStorage.Save(DATABASE::"Purchases & Payables Setup");
         UpdateGeneralLedgerSetupGSTReport();
 
         // [GIVEN] Vendor GST amounts in ACY are enabled and an Additional Reporting Currency is configured.

--- a/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
+++ b/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
@@ -827,6 +827,7 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         PayablesAccountNo: Code[20];
         PostedDocumentNo: Code[20];
         ExpectedACYAmount: Decimal;
+        NonPayablesACY: Decimal;
     begin
         // [FEATURE] [Purchase] [ACY]
         // [SCENARIO 641827] Vendor ACY is posted on the payables entry for a purchase invoice in LCY.
@@ -855,12 +856,14 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         // [WHEN] The purchase invoice is posted.
         PostedDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
 
-        // [THEN] The purchase and payables entries carry balancing ACY amounts.
+        // [THEN] The purchase (expense) G/L entry carries the vendor-rate ACY: Quantity * Direct Unit Cost * Vendor Exchange Rate (ACY).
         GLEntry.SetRange("Document No.", PostedDocumentNo);
         GLEntry.SetRange("G/L Account No.", PurchaseLine."No.");
         Assert.RecordCount(GLEntry, 1);
         GLEntry.FindFirst();
+        GLEntry.TestField("Additional-Currency Amount", ExpectedACYAmount);
 
+        // [THEN] The payables (balancing) entry carries the offsetting ACY of all non-residual entries, in blank source currency.
         PayablesAccountNo := GetPayablesAccountFromVendorPostingGroup(PurchaseHeader."Pay-to Vendor No.");
         GLEntry.Reset();
         GLEntry.SetRange("Document No.", PostedDocumentNo);
@@ -868,15 +871,15 @@ codeunit 141008 "ERM - Miscellaneous APAC"
           "G/L Account No.", '<>%1&<>%2&<>%3',
           PayablesAccountNo, Currency."Residual Gains Account", Currency."Residual Losses Account");
         GLEntry.CalcSums("Additional-Currency Amount");
-        ExpectedACYAmount := GLEntry."Additional-Currency Amount";
-        Assert.IsTrue(ExpectedACYAmount <> 0, AmountMustBeEqualMsg);
+        NonPayablesACY := GLEntry."Additional-Currency Amount";
+        Assert.IsTrue(NonPayablesACY <> 0, AmountMustBeEqualMsg);
 
         GLEntry.SetRange("G/L Account No.", PayablesAccountNo);
         Assert.RecordCount(GLEntry, 1);
         GLEntry.FindFirst();
         GLEntry.TestField("Source Currency Code", '');
         GLEntry.TestField("Source Currency Amount", GLEntry.Amount);
-        GLEntry.TestField("Additional-Currency Amount", -ExpectedACYAmount);
+        GLEntry.TestField("Additional-Currency Amount", -NonPayablesACY);
 
         // [THEN] LCY, source currency, and ACY are balanced.
         GLEntry.Reset();

--- a/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
+++ b/src/Layers/APAC/Tests/Local/ERMMiscellaneousAPAC.Codeunit.al
@@ -816,6 +816,84 @@ codeunit 141008 "ERM - Miscellaneous APAC"
 
     [Test]
     [Scope('OnPrem')]
+    procedure PurchaseInvoiceWithVendorACYPostsACYOnPayablesEntry()
+    var
+        Currency: Record Currency;
+        GLEntry: Record "G/L Entry";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        CurrencyCode: Code[10];
+        PayablesAccountNo: Code[20];
+        PostedDocumentNo: Code[20];
+        ExpectedACYAmount: Decimal;
+    begin
+        // [FEATURE] [Purchase] [ACY]
+        // [SCENARIO 641827] Vendor ACY is posted on the payables entry for a purchase invoice in LCY.
+        Initialize();
+        LibrarySetupStorage.Save(DATABASE::"Purchases & Payables Setup");
+        UpdateGeneralLedgerSetupGSTReport();
+
+        // [GIVEN] Vendor GST amounts in ACY are enabled and an Additional Reporting Currency is configured.
+        CurrencyCode := LibraryERM.CreateCurrencyWithRandomExchRates();
+        Currency.Get(CurrencyCode);
+        PurchasesPayablesSetup.Get();
+        PurchasesPayablesSetup."Enable Vendor GST Amount (ACY)" := true;
+        PurchasesPayablesSetup.Modify();
+        LibraryERM.SetAddReportingCurrency(CurrencyCode);
+
+        // [GIVEN] A purchase invoice in LCY with a vendor exchange rate for ACY.
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), WorkDate());
+        PurchaseHeader.TestField("Currency Code", '');
+        PurchaseHeader."Vendor Exchange Rate (ACY)" := LibraryRandom.RandInt(10);
+        PurchaseHeader.Modify();
+        ExpectedACYAmount :=
+          PurchaseLine.Quantity * PurchaseLine."Direct Unit Cost" * PurchaseHeader."Vendor Exchange Rate (ACY)";
+
+        // [WHEN] The purchase invoice is posted.
+        PostedDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
+
+        // [THEN] The purchase and payables entries carry balancing ACY amounts.
+        GLEntry.SetRange("Document No.", PostedDocumentNo);
+        GLEntry.SetRange("G/L Account No.", PurchaseLine."No.");
+        Assert.RecordCount(GLEntry, 1);
+        GLEntry.FindFirst();
+
+        PayablesAccountNo := GetPayablesAccountFromVendorPostingGroup(PurchaseHeader."Pay-to Vendor No.");
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedDocumentNo);
+        GLEntry.SetFilter(
+          "G/L Account No.", '<>%1&<>%2&<>%3',
+          PayablesAccountNo, Currency."Residual Gains Account", Currency."Residual Losses Account");
+        GLEntry.CalcSums("Additional-Currency Amount");
+        ExpectedACYAmount := GLEntry."Additional-Currency Amount";
+        Assert.IsTrue(ExpectedACYAmount <> 0, AmountMustBeEqualMsg);
+
+        GLEntry.SetRange("G/L Account No.", PayablesAccountNo);
+        Assert.RecordCount(GLEntry, 1);
+        GLEntry.FindFirst();
+        GLEntry.TestField("Source Currency Code", '');
+        GLEntry.TestField("Source Currency Amount", GLEntry.Amount);
+        GLEntry.TestField("Additional-Currency Amount", -ExpectedACYAmount);
+
+        // [THEN] LCY, source currency, and ACY are balanced.
+        GLEntry.Reset();
+        GLEntry.SetRange("Document No.", PostedDocumentNo);
+        GLEntry.CalcSums(Amount, "Source Currency Amount", "Additional-Currency Amount");
+        Assert.AreEqual(0, GLEntry.Amount, AmountMustBeEqualMsg);
+        Assert.AreEqual(0, GLEntry."Source Currency Amount", AmountMustBeEqualMsg);
+        Assert.AreEqual(0, GLEntry."Additional-Currency Amount", AmountMustBeEqualMsg);
+
+        // [THEN] No residual gains or losses entry is created.
+        GLEntry.SetFilter(
+          "G/L Account No.", '%1|%2', Currency."Residual Gains Account", Currency."Residual Losses Account");
+        Assert.RecordCount(GLEntry, 0);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure SalesOrderWithTwoLinesAndDeferralCreatesSingleGSTSalesEntry()
     var
         Item: Record Item;
@@ -2944,4 +3022,3 @@ codeunit 141008 "ERM - Miscellaneous APAC"
         SalesStatistics.OK().Invoke();
     end;
 }
-


### PR DESCRIPTION
## What & why

I reproduced this issue in AU with an Additional Reporting Currency enabled, `Enable Vendor GST Amount (ACY)` turned on, a blank purchase invoice currency, and a nonzero `Vendor Exchange Rate (ACY)`.

The same scenario does not reproduce in W1 because W1 keeps the detailed CV buffer amount as the document/source amount and calculates ACY independently from LCY. APAC uses that buffer differently: it stores the vendor-calculated ACY so the vendor exchange rate is preserved.

The source-currency change from PR 241506 applied the W1 initialization pattern to APAC as well. In this APAC path, that passed zero as the balancing entry's ACY and reused the actual ACY as Source Currency Amount. The posting therefore left the full ACY amount unbalanced and created a separate residual entry.

This change keeps the already-calculated vendor ACY in `Additional-Currency Amount` and calculates Source Currency Amount independently from LCY. It does not restore the global `TotalSrcCurrAmount` state removed by PR 241506.

## Linked work

Fixes [AB#641827](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641827)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior.

**What I tested and the outcome**

- Built the AU Base Application and Tests-Local with static analysis.
- Added and ran `PurchaseInvoiceWithVendorACYPostsACYOnPayablesEntry`; the test passes.
- Ran the existing `PurchaseVendorExchangeRateIsUsedForAdditionalCurrencyAmountCalculation`; the test passes.
- Repeated the original AU preview-posting scenario with LCY `1,477.00` and vendor ACY rate `1.2726`.
  - Purchase entry: LCY/source `1,477.00`, ACY `1,879.63`.
  - Payables entry: LCY/source `-1,477.00`, ACY `-1,879.63`.
  - No `Residual caused by rounding` entry was created.

## Risk & compatibility

The change is limited to the APAC layer and does not change W1 behavior, table schemas, or stored data.

The existing branch where Source Currency Code equals ACY remains unchanged. For other APAC entries, source currency and ACY are now calculated independently rather than using the same amount for both fields.






