### PR TITLE
[Extensibility Request] issue 30081: add VAT registration number override event

### DIFF
--- a/src/Apps/W1/Intrastat/app/src/Processing/IntrastatReportManagement.Codeunit.al
+++ b/src/Apps/W1/Intrastat/app/src/Processing/IntrastatReportManagement.Codeunit.al
@@ -397,11 +397,17 @@ codeunit 4810 IntrastatReportManagement
             IntrastatReportSetup."Company VAT No. on File"));
     end;
 
-    procedure GetVATRegNo(CountryCode: Code[10]; VATRegNo: Text[20]; VATRegNoType: Enum "Intrastat Report VAT File Fmt"): Text[50]
+    procedure GetVATRegNo(CountryCode: Code[10]; VATRegNo: Text[20]; VATRegNoType: Enum "Intrastat Report VAT File Fmt") Result: Text[50]
     var
         IntrastatReportSetup: Record "Intrastat Report Setup";
         CountryRegion: Record "Country/Region";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeGetVATRegNo(CountryCode, VATRegNo, VATRegNoType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case VATRegNoType of
             IntrastatReportSetup."Company VAT No. on File"::"VAT Reg. No.":
                 exit(VATRegNo);
@@ -1165,6 +1171,11 @@ codeunit 4810 IntrastatReportManagement
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeGetIntrastatBaseCountryCode(var ItemLedgerEntry: Record "Item Ledger Entry"; var IntrastatReportSetup: Record "Intrastat Report Setup"; var CountryCode: Code[10]; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeGetVATRegNo(CountryCode: Code[10]; VATRegNo: Text[20]; VATRegNoType: Enum "Intrastat Report VAT File Fmt"; var Result: Text[50]; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Intrastat report suggestions can produce an invalid partner VAT ID when the stored VAT registration number already includes the country prefix. This PR lets extensions override the formatted VAT registration number before the standard concatenation logic runs.

Source issue repository: microsoft/AlAppExtensions; issue number: 30081

## Changes Made
- `IntrastatReportManagement.GetVATRegNo` - added an `OnBeforeGetVATRegNo` integration event with the result and `IsHandled` parameters so subscribers can provide the correct VAT ID and bypass standard formatting.

Fixes [AB#635857](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/635857)




