### PR TITLE
[Extensibility Request] issue 30092: publish register restore event

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Inventory.Posting;
 
 using Microsoft.Assembly.Document;
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Ledger;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.AuditCodes;
@@ -24,6 +25,7 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 
 codeunit 22 "Item Jnl.-Post Line"
 {
@@ -8032,6 +8034,26 @@ codeunit 22 "Item Jnl.-Post Line"
     internal procedure GetItemLedgerEntryNo(): Integer
     begin
         exit(ItemLedgEntryNo);
+    end;
+
+    procedure SetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
+        if ItemRegister."No." <> 0 then begin
+            ItemReg := ItemRegister;
+            ItemLedgEntryNo := ItemRegister."To Entry No.";
+            PhysInvtEntryNo := ItemRegister."To Phys. Inventory Entry No.";
+            ValueEntryNo := ItemRegister."To Value Entry No.";
+            CapLedgEntryNo := ItemRegister."To Capacity Entry No.";
+            ItemApplnEntryNo := ItemApplicationEntryNo;
+        end;
+        if WarehouseRegister."No." <> 0 then
+            WhseJnlRegisterLine.SetWhseRegister(WarehouseRegister);
+        OnAfterSetRegisters(ItemRegister, ItemApplicationEntryNo, WarehouseRegister, GLRegister, NextVATEntryNo, NextTransactionNo);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterSetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
     end;
 
     internal procedure RegisterWhseJnlLine(var WhseJnlLine: Record "Warehouse Journal Line")

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Inventory.Posting;
 
 using Microsoft.Assembly.Document;
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Ledger;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.AuditCodes;
@@ -24,6 +25,7 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 
 codeunit 22 "Item Jnl.-Post Line"
 {
@@ -8003,6 +8005,26 @@ codeunit 22 "Item Jnl.-Post Line"
     internal procedure GetItemLedgerEntryNo(): Integer
     begin
         exit(ItemLedgEntryNo);
+    end;
+
+    procedure SetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
+        if ItemRegister."No." <> 0 then begin
+            ItemReg := ItemRegister;
+            ItemLedgEntryNo := ItemRegister."To Entry No.";
+            PhysInvtEntryNo := ItemRegister."To Phys. Inventory Entry No.";
+            ValueEntryNo := ItemRegister."To Value Entry No.";
+            CapLedgEntryNo := ItemRegister."To Capacity Entry No.";
+            ItemApplnEntryNo := ItemApplicationEntryNo;
+        end;
+        if WarehouseRegister."No." <> 0 then
+            WhseJnlRegisterLine.SetWhseRegister(WarehouseRegister);
+        OnAfterSetRegisters(ItemRegister, ItemApplicationEntryNo, WarehouseRegister, GLRegister, NextVATEntryNo, NextTransactionNo);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterSetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
     end;
 
     internal procedure RegisterWhseJnlLine(var WhseJnlLine: Record "Warehouse Journal Line")

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Inventory.Posting;
 
 using Microsoft.Assembly.Document;
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Ledger;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.AuditCodes;
@@ -24,6 +25,7 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 
 codeunit 22 "Item Jnl.-Post Line"
 {
@@ -8013,6 +8015,26 @@ codeunit 22 "Item Jnl.-Post Line"
     internal procedure GetItemLedgerEntryNo(): Integer
     begin
         exit(ItemLedgEntryNo);
+    end;
+
+    procedure SetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
+        if ItemRegister."No." <> 0 then begin
+            ItemReg := ItemRegister;
+            ItemLedgEntryNo := ItemRegister."To Entry No.";
+            PhysInvtEntryNo := ItemRegister."To Phys. Inventory Entry No.";
+            ValueEntryNo := ItemRegister."To Value Entry No.";
+            CapLedgEntryNo := ItemRegister."To Capacity Entry No.";
+            ItemApplnEntryNo := ItemApplicationEntryNo;
+        end;
+        if WarehouseRegister."No." <> 0 then
+            WhseJnlRegisterLine.SetWhseRegister(WarehouseRegister);
+        OnAfterSetRegisters(ItemRegister, ItemApplicationEntryNo, WarehouseRegister, GLRegister, NextVATEntryNo, NextTransactionNo);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterSetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
     end;
 
     internal procedure RegisterWhseJnlLine(var WhseJnlLine: Record "Warehouse Journal Line")

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Inventory.Posting;
 
 using Microsoft.Assembly.Document;
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Ledger;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.AuditCodes;
@@ -27,6 +28,7 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 
 codeunit 22 "Item Jnl.-Post Line"
 {
@@ -8030,6 +8032,26 @@ codeunit 22 "Item Jnl.-Post Line"
     internal procedure GetItemLedgerEntryNo(): Integer
     begin
         exit(ItemLedgEntryNo);
+    end;
+
+    procedure SetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
+        if ItemRegister."No." <> 0 then begin
+            ItemReg := ItemRegister;
+            ItemLedgEntryNo := ItemRegister."To Entry No.";
+            PhysInvtEntryNo := ItemRegister."To Phys. Inventory Entry No.";
+            ValueEntryNo := ItemRegister."To Value Entry No.";
+            CapLedgEntryNo := ItemRegister."To Capacity Entry No.";
+            ItemApplnEntryNo := ItemApplicationEntryNo;
+        end;
+        if WarehouseRegister."No." <> 0 then
+            WhseJnlRegisterLine.SetWhseRegister(WarehouseRegister);
+        OnAfterSetRegisters(ItemRegister, ItemApplicationEntryNo, WarehouseRegister, GLRegister, NextVATEntryNo, NextTransactionNo);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterSetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
     end;
 
     internal procedure RegisterWhseJnlLine(var WhseJnlLine: Record "Warehouse Journal Line")

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -29,6 +29,7 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 
 codeunit 22 "Item Jnl.-Post Line"
 {
@@ -8348,6 +8349,26 @@ codeunit 22 "Item Jnl.-Post Line"
     internal procedure GetItemLedgerEntryNo(): Integer
     begin
         exit(ItemLedgEntryNo);
+    end;
+
+    procedure SetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
+        if ItemRegister."No." <> 0 then begin
+            ItemReg := ItemRegister;
+            ItemLedgEntryNo := ItemRegister."To Entry No.";
+            PhysInvtEntryNo := ItemRegister."To Phys. Inventory Entry No.";
+            ValueEntryNo := ItemRegister."To Value Entry No.";
+            CapLedgEntryNo := ItemRegister."To Capacity Entry No.";
+            ItemApplnEntryNo := ItemApplicationEntryNo;
+        end;
+        if WarehouseRegister."No." <> 0 then
+            WhseJnlRegisterLine.SetWhseRegister(WarehouseRegister);
+        OnAfterSetRegisters(ItemRegister, ItemApplicationEntryNo, WarehouseRegister, GLRegister, NextVATEntryNo, NextTransactionNo);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterSetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
     end;
 
     internal procedure RegisterWhseJnlLine(var WhseJnlLine: Record "Warehouse Journal Line")

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Inventory.Posting;
 
 using Microsoft.Assembly.Document;
 using Microsoft.Finance.Currency;
+using Microsoft.Finance.GeneralLedger.Ledger;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.AuditCodes;
@@ -24,6 +25,7 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Warehouse.Journal;
+using Microsoft.Warehouse.Ledger;
 
 codeunit 22 "Item Jnl.-Post Line"
 {
@@ -7999,6 +8001,26 @@ codeunit 22 "Item Jnl.-Post Line"
     internal procedure GetItemLedgerEntryNo(): Integer
     begin
         exit(ItemLedgEntryNo);
+    end;
+
+    procedure SetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
+        if ItemRegister."No." <> 0 then begin
+            ItemReg := ItemRegister;
+            ItemLedgEntryNo := ItemRegister."To Entry No.";
+            PhysInvtEntryNo := ItemRegister."To Phys. Inventory Entry No.";
+            ValueEntryNo := ItemRegister."To Value Entry No.";
+            CapLedgEntryNo := ItemRegister."To Capacity Entry No.";
+            ItemApplnEntryNo := ItemApplicationEntryNo;
+        end;
+        if WarehouseRegister."No." <> 0 then
+            WhseJnlRegisterLine.SetWhseRegister(WarehouseRegister);
+        OnAfterSetRegisters(ItemRegister, ItemApplicationEntryNo, WarehouseRegister, GLRegister, NextVATEntryNo, NextTransactionNo);
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterSetRegisters(var ItemRegister: Record "Item Register"; ItemApplicationEntryNo: Integer; var WarehouseRegister: Record "Warehouse Register"; var GLRegister: Record "G/L Register"; NextVATEntryNo: Integer; NextTransactionNo: Integer)
+    begin
     end;
 
     internal procedure RegisterWhseJnlLine(var WhseJnlLine: Record "Warehouse Journal Line")


### PR DESCRIPTION
## Summary
Extensions need to restore additional G/L register state after the standard item and warehouse register state is restored. This change adds the register restoration entry point and publishes an event after the standard restore logic so subscribers can restore their extended state independently.

Source issue repository: microsoft/AlAppExtensions; issue number: 30092

## Changes Made
- `Item Jnl.-Post Line.SetRegisters` - restores item and warehouse register state and raises `OnAfterSetRegisters` with the full register context; propagated to existing localized counterparts.

Fixes [AB#646587](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646587)


