### PR TITLE
[Extensibility Request] issue 30110: add prepayment update events

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1861,6 +1861,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1887,6 +1888,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -3244,6 +3246,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/BE/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1579,6 +1579,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1605,6 +1606,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2746,6 +2748,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1613,6 +1613,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1639,6 +1640,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2776,6 +2778,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1575,6 +1575,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1601,6 +1602,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2740,6 +2742,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/FI/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1571,6 +1571,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1597,6 +1598,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2737,6 +2739,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1625,6 +1625,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1651,6 +1652,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2840,6 +2842,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1600,6 +1600,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1626,6 +1627,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2816,6 +2818,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1570,6 +1570,7 @@ UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineB
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1596,6 +1597,7 @@ UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineB
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2733,6 +2735,29 @@ UpdateDifferenceAmount(SalesHeader, TotalPrepmtInvLineBuffer, TempPrepmtInvLineB
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Posting/SalesPostPrepayments.Codeunit.al
@@ -1568,6 +1568,7 @@ codeunit 442 "Sales-Post Prepayments"
         SalesLine.SetFilter(Type, '<>%1', SalesLine.Type::" ");
         SalesLine.SetFilter("Line Amount", '<>0');
         SalesLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(SalesLine, SalesHeader, NewTotalPrepmtAmount);
         SalesLine.LockTable();
         if SalesLine.Find('-') then
             repeat
@@ -1594,6 +1595,7 @@ codeunit 442 "Sales-Post Prepayments"
                 else
                     SalesLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + SalesLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(SalesLine, SalesHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 SalesLine.Modify();
             until SalesLine.Next() = 0;
     end;
@@ -2732,6 +2734,29 @@ codeunit 442 "Sales-Post Prepayments"
     /// <param name="IsHandled">Set to true to skip the default update logic.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnSaleslines(SalesHeader: Record "Sales Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after setting filters on sales lines when updating prepayment amounts.
+    /// </summary>
+    /// <param name="SalesLine">The filtered sales lines.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnAfterSetFilters(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before modifying a sales line with its updated prepayment amount.
+    /// </summary>
+    /// <param name="SalesLine">The sales line to modify.</param>
+    /// <param name="SalesHeader">The sales header being processed.</param>
+    /// <param name="NewTotalPrepmtAmount">The new total prepayment amount.</param>
+    /// <param name="TotalPrepmtAmount">The accumulated prepayment amount.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnSaleslinesOnBeforeModify(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; var NewTotalPrepmtAmount: Decimal; var TotalPrepmtAmount: Decimal)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need targeted hooks to adjust which sales lines participate in prepayment redistribution and to customize each updated line without duplicating the standard procedure. This PR publishes events after the standard filters are applied but before locking, and immediately before each modified sales line is persisted. The hooks preserve the existing standard behavior when no subscribers are present.

Source issue repository: microsoft/AlAppExtensions; issue number: 30110

## Changes Made
- `Sales-Post Prepayments.UpdatePrepmtAmountOnSaleslines` - added filter-adjustment and before-modify integration events in W1 and all existing layer counterparts.

Fixes [AB#640955](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640955)


