### PR TITLE
[Extensibility Request] issue 30111: add purchase prepayment update events

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1737,6 +1737,7 @@ codeunit 444 "Purchase-Post Prepayments"
         TotalPrepmtAmtInv: Decimal;
         LastLineNo: Integer;
         IsHandled: Boolean;
+        RaiseError: Boolean;
     begin
         IsHandled := false;
         OnBeforeUpdatePrepmtAmountOnPurchLines(PurchHeader, NewTotalPrepmtAmount, IsHandled);
@@ -1750,6 +1751,7 @@ codeunit 444 "Purchase-Post Prepayments"
         PurchLine.SetFilter(Type, '<>%1', PurchLine.Type::" ");
         PurchLine.SetFilter("Line Amount", '<>0');
         PurchLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(PurchLine, PurchHeader, NewTotalPrepmtAmount);
         PurchLine.LockTable();
         if PurchLine.Find('-') then
             repeat
@@ -1757,8 +1759,12 @@ codeunit 444 "Purchase-Post Prepayments"
                 TotalPrepmtAmtInv := TotalPrepmtAmtInv + PurchLine."Prepmt. Amt. Inv.";
                 LastLineNo := PurchLine."Line No.";
             until PurchLine.Next() = 0
-        else
-            Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        else begin
+            RaiseError := true;
+            OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(PurchLine, PurchHeader, RaiseError);
+            if RaiseError then
+                Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        end;
         if TotalLineAmount = 0 then
             Error(Text013, NewTotalPrepmtAmount);
         if not (NewTotalPrepmtAmount in [TotalPrepmtAmtInv .. TotalLineAmount]) then
@@ -1775,6 +1781,7 @@ codeunit 444 "Purchase-Post Prepayments"
                 else
                     PurchLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + PurchLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(PurchLine, PurchHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 PurchLine.Modify();
             until PurchLine.Next() = 0;
     end;
@@ -2517,6 +2524,21 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnPurchLines(PurchaseHeader: Record "Purchase Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var RaiseError: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal; var TotalPrepaymentAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1390,6 +1390,7 @@ codeunit 444 "Purchase-Post Prepayments"
         TotalPrepmtAmtInv: Decimal;
         LastLineNo: Integer;
         IsHandled: Boolean;
+        RaiseError: Boolean;
     begin
         IsHandled := false;
         OnBeforeUpdatePrepmtAmountOnPurchLines(PurchHeader, NewTotalPrepmtAmount, IsHandled);
@@ -1403,6 +1404,7 @@ codeunit 444 "Purchase-Post Prepayments"
         PurchLine.SetFilter(Type, '<>%1', PurchLine.Type::" ");
         PurchLine.SetFilter("Line Amount", '<>0');
         PurchLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(PurchLine, PurchHeader, NewTotalPrepmtAmount);
         PurchLine.LockTable();
         if PurchLine.Find('-') then
             repeat
@@ -1410,8 +1412,12 @@ codeunit 444 "Purchase-Post Prepayments"
                 TotalPrepmtAmtInv := TotalPrepmtAmtInv + PurchLine."Prepmt. Amt. Inv.";
                 LastLineNo := PurchLine."Line No.";
             until PurchLine.Next() = 0
-        else
-            Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        else begin
+            RaiseError := true;
+            OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(PurchLine, PurchHeader, RaiseError);
+            if RaiseError then
+                Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        end;
         if TotalLineAmount = 0 then
             Error(Text013, NewTotalPrepmtAmount);
         if not (NewTotalPrepmtAmount in [TotalPrepmtAmtInv .. TotalLineAmount]) then
@@ -1428,6 +1434,7 @@ codeunit 444 "Purchase-Post Prepayments"
                 else
                     PurchLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + PurchLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(PurchLine, PurchHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 PurchLine.Modify();
             until PurchLine.Next() = 0;
     end;
@@ -2014,6 +2021,21 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnPurchLines(PurchaseHeader: Record "Purchase Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var RaiseError: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal; var TotalPrepaymentAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1466,6 +1466,7 @@ codeunit 444 "Purchase-Post Prepayments"
         TotalPrepmtAmtInv: Decimal;
         LastLineNo: Integer;
         IsHandled: Boolean;
+        RaiseError: Boolean;
     begin
         IsHandled := false;
         OnBeforeUpdatePrepmtAmountOnPurchLines(PurchHeader, NewTotalPrepmtAmount, IsHandled);
@@ -1479,6 +1480,7 @@ codeunit 444 "Purchase-Post Prepayments"
         PurchLine.SetFilter(Type, '<>%1', PurchLine.Type::" ");
         PurchLine.SetFilter("Line Amount", '<>0');
         PurchLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(PurchLine, PurchHeader, NewTotalPrepmtAmount);
         PurchLine.LockTable();
         if PurchLine.Find('-') then
             repeat
@@ -1486,8 +1488,12 @@ codeunit 444 "Purchase-Post Prepayments"
                 TotalPrepmtAmtInv := TotalPrepmtAmtInv + PurchLine."Prepmt. Amt. Inv.";
                 LastLineNo := PurchLine."Line No.";
             until PurchLine.Next() = 0
-        else
-            Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        else begin
+            RaiseError := true;
+            OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(PurchLine, PurchHeader, RaiseError);
+            if RaiseError then
+                Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        end;
         if TotalLineAmount = 0 then
             Error(Text013, NewTotalPrepmtAmount);
         if not (NewTotalPrepmtAmount in [TotalPrepmtAmtInv .. TotalLineAmount]) then
@@ -1504,6 +1510,7 @@ codeunit 444 "Purchase-Post Prepayments"
                 else
                     PurchLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + PurchLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(PurchLine, PurchHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 PurchLine.Modify();
             until PurchLine.Next() = 0;
     end;
@@ -2125,6 +2132,21 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnPurchLines(PurchaseHeader: Record "Purchase Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var RaiseError: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal; var TotalPrepaymentAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1425,6 +1425,7 @@ codeunit 444 "Purchase-Post Prepayments"
         TotalPrepmtAmtInv: Decimal;
         LastLineNo: Integer;
         IsHandled: Boolean;
+        RaiseError: Boolean;
     begin
         IsHandled := false;
         OnBeforeUpdatePrepmtAmountOnPurchLines(PurchHeader, NewTotalPrepmtAmount, IsHandled);
@@ -1438,6 +1439,7 @@ codeunit 444 "Purchase-Post Prepayments"
         PurchLine.SetFilter(Type, '<>%1', PurchLine.Type::" ");
         PurchLine.SetFilter("Line Amount", '<>0');
         PurchLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(PurchLine, PurchHeader, NewTotalPrepmtAmount);
         PurchLine.LockTable();
         if PurchLine.Find('-') then
             repeat
@@ -1445,8 +1447,12 @@ codeunit 444 "Purchase-Post Prepayments"
                 TotalPrepmtAmtInv := TotalPrepmtAmtInv + PurchLine."Prepmt. Amt. Inv.";
                 LastLineNo := PurchLine."Line No.";
             until PurchLine.Next() = 0
-        else
-            Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        else begin
+            RaiseError := true;
+            OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(PurchLine, PurchHeader, RaiseError);
+            if RaiseError then
+                Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        end;
         if TotalLineAmount = 0 then
             Error(Text013, NewTotalPrepmtAmount);
         if not (NewTotalPrepmtAmount in [TotalPrepmtAmtInv .. TotalLineAmount]) then
@@ -1463,6 +1469,7 @@ codeunit 444 "Purchase-Post Prepayments"
                 else
                     PurchLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + PurchLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(PurchLine, PurchHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 PurchLine.Modify();
             until PurchLine.Next() = 0;
     end;
@@ -2040,6 +2047,21 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnPurchLines(PurchaseHeader: Record "Purchase Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var RaiseError: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal; var TotalPrepaymentAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1384,6 +1384,7 @@ codeunit 444 "Purchase-Post Prepayments"
         TotalPrepmtAmtInv: Decimal;
         LastLineNo: Integer;
         IsHandled: Boolean;
+        RaiseError: Boolean;
     begin
         IsHandled := false;
         OnBeforeUpdatePrepmtAmountOnPurchLines(PurchHeader, NewTotalPrepmtAmount, IsHandled);
@@ -1397,6 +1398,7 @@ codeunit 444 "Purchase-Post Prepayments"
         PurchLine.SetFilter(Type, '<>%1', PurchLine.Type::" ");
         PurchLine.SetFilter("Line Amount", '<>0');
         PurchLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(PurchLine, PurchHeader, NewTotalPrepmtAmount);
         PurchLine.LockTable();
         if PurchLine.Find('-') then
             repeat
@@ -1404,8 +1406,12 @@ codeunit 444 "Purchase-Post Prepayments"
                 TotalPrepmtAmtInv := TotalPrepmtAmtInv + PurchLine."Prepmt. Amt. Inv.";
                 LastLineNo := PurchLine."Line No.";
             until PurchLine.Next() = 0
-        else
-            Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        else begin
+            RaiseError := true;
+            OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(PurchLine, PurchHeader, RaiseError);
+            if RaiseError then
+                Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        end;
         if TotalLineAmount = 0 then
             Error(Text013, NewTotalPrepmtAmount);
         if not (NewTotalPrepmtAmount in [TotalPrepmtAmtInv .. TotalLineAmount]) then
@@ -1422,6 +1428,7 @@ codeunit 444 "Purchase-Post Prepayments"
                 else
                     PurchLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + PurchLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(PurchLine, PurchHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 PurchLine.Modify();
             until PurchLine.Next() = 0;
     end;
@@ -1976,6 +1983,21 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnPurchLines(PurchaseHeader: Record "Purchase Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var RaiseError: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal; var TotalPrepaymentAmount: Decimal)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1382,6 +1382,7 @@ codeunit 444 "Purchase-Post Prepayments"
         TotalPrepmtAmtInv: Decimal;
         LastLineNo: Integer;
         IsHandled: Boolean;
+        RaiseError: Boolean;
     begin
         IsHandled := false;
         OnBeforeUpdatePrepmtAmountOnPurchLines(PurchHeader, NewTotalPrepmtAmount, IsHandled);
@@ -1395,6 +1396,7 @@ codeunit 444 "Purchase-Post Prepayments"
         PurchLine.SetFilter(Type, '<>%1', PurchLine.Type::" ");
         PurchLine.SetFilter("Line Amount", '<>0');
         PurchLine.SetFilter("Prepayment %", '<>0');
+        OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(PurchLine, PurchHeader, NewTotalPrepmtAmount);
         PurchLine.LockTable();
         if PurchLine.Find('-') then
             repeat
@@ -1402,8 +1404,12 @@ codeunit 444 "Purchase-Post Prepayments"
                 TotalPrepmtAmtInv := TotalPrepmtAmtInv + PurchLine."Prepmt. Amt. Inv.";
                 LastLineNo := PurchLine."Line No.";
             until PurchLine.Next() = 0
-        else
-            Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        else begin
+            RaiseError := true;
+            OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(PurchLine, PurchHeader, RaiseError);
+            if RaiseError then
+                Error(Text017, PurchLine.FieldCaption("Prepayment %"));
+        end;
         if TotalLineAmount = 0 then
             Error(Text013, NewTotalPrepmtAmount);
         if not (NewTotalPrepmtAmount in [TotalPrepmtAmtInv .. TotalLineAmount]) then
@@ -1420,6 +1426,7 @@ codeunit 444 "Purchase-Post Prepayments"
                 else
                     PurchLine.Validate("Prepmt. Line Amount", NewTotalPrepmtAmount - TotalPrepmtAmount);
                 TotalPrepmtAmount := TotalPrepmtAmount + PurchLine."Prepmt. Line Amount";
+                OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(PurchLine, PurchHeader, NewTotalPrepmtAmount, TotalPrepmtAmount);
                 PurchLine.Modify();
             until PurchLine.Next() = 0;
     end;
@@ -1974,6 +1981,21 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdatePrepmtAmountOnPurchLines(PurchaseHeader: Record "Purchase Header"; NewTotalPrepmtAmount: Decimal; var IsHandled: Boolean);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnAfterSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeErrorIfLinesNotFound(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var RaiseError: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdatePrepmtAmountOnPurchLinesOnBeforeModify(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header"; var NewTotalPrepaymentAmount: Decimal; var TotalPrepaymentAmount: Decimal)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need finer control over purchase prepayment line updates so they can adjust line selection, handle the standard no-lines-found error, and update custom line data before each modification. This PR adds focused integration events at those three points while preserving the standard behavior when no subscriber intervenes.

Source issue repository: microsoft/AlAppExtensions; issue number: 30111

## Changes Made
- `Purchase-Post Prepayments.UpdatePrepmtAmountOnPurchLines` - added events after filters are set, before the no-lines-found error, and before each line modification, propagated to all existing layer counterparts

Fixes [AB#640956](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640956)



