### PR TITLE
[Extensibility Request] issue 30129: expose manufacturing cost calculation events

### DIFF
--- a/src/Layers/IT/BaseApp/Manufacturing/StandardCost/CalculateStandardCost.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/StandardCost/CalculateStandardCost.Codeunit.al
@@ -953,7 +953,7 @@ codeunit 5812 "Calculate Standard Cost"
 
             repeat
                 IsHandled := false;
-                OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(RtngLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, IsHandled);
+                OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(RtngLine, MainItem, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, IsHandled);
                 if not IsHandled then
                     CalcRtngLineCostSKU(RtngLine, MainItem, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd);
             until RtngLine.Next() = 0;
@@ -1409,7 +1409,7 @@ codeunit 5812 "Calculate Standard Cost"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(var RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var IsHandled: Boolean)
+    local procedure OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(var RoutingLine: Record "Routing Line"; MainItem: Record Item; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Manufacturing/StandardCost/CalculateStandardCost.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/StandardCost/CalculateStandardCost.Codeunit.al
@@ -943,6 +943,7 @@ codeunit 5812 "Calculate Standard Cost"
     var
         RtngLine: Record "Routing Line";
         RtngHeader: Record "Routing Header";
+        IsHandled: Boolean;
     begin
         if RtngLine.CertifiedRoutingVersionExists(RtngHeaderNo, CalculationDate) then begin
             if RtngLine."Version Code" = '' then begin
@@ -951,7 +952,10 @@ codeunit 5812 "Calculate Standard Cost"
             end;
 
             repeat
-                CalcRtngLineCostSKU(RtngLine, MainItem, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd);
+                IsHandled := false;
+                OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(RtngLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, IsHandled);
+                if not IsHandled then
+                    CalcRtngLineCostSKU(RtngLine, MainItem, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd);
             until RtngLine.Next() = 0;
         end;
     end;
@@ -1341,7 +1345,7 @@ codeunit 5812 "Calculate Standard Cost"
             IncrCost(SLCap, DirUnitCost, CostTime);
         IncrCost(SLCapOvhd, CostCalcMgt.CalcOvhdCost(DirUnitCost, IndirCostPct, OvhdRate, 1), CostTime);
 
-        OnAfterCalcRtngLineCost(RoutingLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, StdCostWkshName, ParentItem, CostTime);
+        OnAfterCalcRtngLineCost(RoutingLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, StdCostWkshName, ParentItem, CostTime, DirUnitCost);
     end;
 
     internal procedure CalcRtngLineCostSKU(RoutingLine: Record "Routing Line"; MainItem: Record Item; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal)
@@ -1400,7 +1404,12 @@ codeunit 5812 "Calculate Standard Cost"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterCalcRtngLineCost(RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var StdCostWkshName: Text[50]; var ParentItem: Record Item; CostTime: Decimal)
+    local procedure OnAfterCalcRtngLineCost(RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var StdCostWkshName: Text[50]; var ParentItem: Record Item; CostTime: Decimal; var DirUnitCost: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(var RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var IsHandled: Boolean)
     begin
     end;
 
@@ -1658,4 +1667,3 @@ codeunit 5812 "Calculate Standard Cost"
         end;
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Costing/MfgCostCalculationMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Costing/MfgCostCalculationMgt.Codeunit.al
@@ -240,7 +240,15 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
         ExpSubDirCostRtng: Decimal;
         ExpCapOvhdCostRtng: Decimal;
         ExpOvhdCost: Decimal;
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeCalcProdOrderLineExpCost(ProdOrderLine, ShareOfTotalCapCost, ExpMatCost, ExpCapDirCost, ExpSubDirCost, ExpCapOvhdCost, ExpMfgOvhdCost, IsHandled);
+        if IsHandled then begin
+            OnAfterCalcProdOrderLineExpCost(ProdOrderLine, ShareOfTotalCapCost, ExpMatCost, ExpCapDirCost, ExpSubDirCost, ExpCapOvhdCost, ExpMfgOvhdCost);
+            exit;
+        end;
+
         ProdOrderComp.SetCurrentKey(Status, "Prod. Order No.", "Prod. Order Line No.");
         ProdOrderComp.SetRange(Status, ProdOrderLine.Status);
         ProdOrderComp.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
@@ -746,7 +754,7 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
                 CostTime := CalcQtyAdjdForRoutingScrap(MfgItemQtyBase, ScrapFactorPctAccum, FixedScrapQtyAccum);
         end;
 
-        OnAfterCalculateCostTime(MfgItemQtyBase, ScrapFactorPctAccum, FixedScrapQtyAccum, UnitCostCalculation, CostTime);
+        OnAfterCalculateCostTime(MfgItemQtyBase, ScrapFactorPctAccum, FixedScrapQtyAccum, UnitCostCalculation, CostTime, SetupTime, RunTime, CostInclSetup, ConcurrentCapacities);
     end;
 
     procedure FindRoutingLine(var RoutingLine: Record "Routing Line"; ProdBOMLine: Record "Production BOM Line"; CalculationDate: Date; RoutingNo: Code[20]) RecFound: Boolean
@@ -852,6 +860,11 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
     end;
 
     [IntegrationEvent(false, false)]
+    local procedure OnBeforeCalcProdOrderLineExpCost(var ProdOrderLine: Record Microsoft.Manufacturing.Document."Prod. Order Line"; ShareOfTotalCapCost: Decimal; var ExpMatCost: Decimal; var ExpCapDirCost: Decimal; var ExpSubDirCost: Decimal; var ExpCapOvhdCost: Decimal; var ExpMfgOvhdCost: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
     local procedure OnCalcProdOrderLineActCostOnBeforeSetProdOrderLine(var ProdOrderLine: Record Microsoft.Manufacturing.Document."Prod. Order Line"; var ActMatCost: Decimal; var ActCapDirCost: Decimal; var ActSubDirCost: Decimal; var ActCapOvhdCost: Decimal; var ActMfgOvhdCost: Decimal; var ActMatCostCostACY: Decimal; var ActCapDirCostACY: Decimal; var ActSubDirCostACY: Decimal; var ActCapOvhdCostACY: Decimal; var ActMfgOvhdCostACY: Decimal)
     begin
     end;
@@ -937,7 +950,7 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterCalculateCostTime(MfgItemQtyBase: Decimal; ScrapFactorPctAccum: Decimal; FixedScrapQtyAccum: Decimal; UnitCostCalculationType: Enum "Unit Cost Calculation Type"; var CostTime: Decimal)
+    local procedure OnAfterCalculateCostTime(MfgItemQtyBase: Decimal; ScrapFactorPctAccum: Decimal; FixedScrapQtyAccum: Decimal; UnitCostCalculationType: Enum "Unit Cost Calculation Type"; var CostTime: Decimal; SetupTime: Decimal; RunTime: Decimal; CostInclSetup: Boolean; ConcurrentCapacities: Decimal)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Costing/MfgCostCalculationMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Costing/MfgCostCalculationMgt.Codeunit.al
@@ -306,7 +306,13 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
         ExpSubDirCostRtng: Decimal;
         ExpCapOvhdCostRtng: Decimal;
         ExpOvhdCost: Decimal;
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeCalcProdOrderLineExpCostWithNonInvMatCost(ProdOrderLine, ShareOfTotalCapCost, ExpMatCost, ExpNonInvMatCost, ExpCapDirCost, ExpSubDirCost, ExpCapOvhdCost, ExpMfgOvhdCost, IsHandled);
+        if IsHandled then
+            exit;
+
         ProdOrderComp.SetCurrentKey(Status, "Prod. Order No.", "Prod. Order Line No.");
         ProdOrderComp.SetRange(Status, ProdOrderLine.Status);
         ProdOrderComp.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
@@ -858,6 +864,11 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCalcProdOrderLineExpCost(var ProdOrderLine: Record Microsoft.Manufacturing.Document."Prod. Order Line"; ShareOfTotalCapCost: Decimal; var ExpMatCost: Decimal; var ExpCapDirCost: Decimal; var ExpSubDirCost: Decimal; var ExpCapOvhdCost: Decimal; var ExpMfgOvhdCost: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCalcProdOrderLineExpCostWithNonInvMatCost(var ProdOrderLine: Record Microsoft.Manufacturing.Document."Prod. Order Line"; ShareOfTotalCapCost: Decimal; var ExpMatCost: Decimal; var ExpNonInvMatCost: Decimal; var ExpCapDirCost: Decimal; var ExpSubDirCost: Decimal; var ExpCapOvhdCost: Decimal; var ExpMfgOvhdCost: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Costing/MfgCostCalculationMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Costing/MfgCostCalculationMgt.Codeunit.al
@@ -244,55 +244,52 @@ codeunit 99000758 "Mfg. Cost Calculation Mgt."
     begin
         IsHandled := false;
         OnBeforeCalcProdOrderLineExpCost(ProdOrderLine, ShareOfTotalCapCost, ExpMatCost, ExpCapDirCost, ExpSubDirCost, ExpCapOvhdCost, ExpMfgOvhdCost, IsHandled);
-        if IsHandled then begin
-            OnAfterCalcProdOrderLineExpCost(ProdOrderLine, ShareOfTotalCapCost, ExpMatCost, ExpCapDirCost, ExpSubDirCost, ExpCapOvhdCost, ExpMfgOvhdCost);
-            exit;
-        end;
+        if not IsHandled then begin
+            ProdOrderComp.SetCurrentKey(Status, "Prod. Order No.", "Prod. Order Line No.");
+            ProdOrderComp.SetRange(Status, ProdOrderLine.Status);
+            ProdOrderComp.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
+            ProdOrderComp.SetRange("Prod. Order Line No.", ProdOrderLine."Line No.");
+            OnCalcProdOrderLineExpCostOnAfterProdOrderCompSetFilters(ProdOrderComp, ProdOrderLine);
+            if ProdOrderComp.Find('-') then
+                repeat
+                    ExpMatCost := ExpMatCost + ProdOrderComp."Cost Amount";
+                until ProdOrderComp.Next() = 0;
 
-        ProdOrderComp.SetCurrentKey(Status, "Prod. Order No.", "Prod. Order Line No.");
-        ProdOrderComp.SetRange(Status, ProdOrderLine.Status);
-        ProdOrderComp.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
-        ProdOrderComp.SetRange("Prod. Order Line No.", ProdOrderLine."Line No.");
-        OnCalcProdOrderLineExpCostOnAfterProdOrderCompSetFilters(ProdOrderComp, ProdOrderLine);
-        if ProdOrderComp.Find('-') then
-            repeat
-                ExpMatCost := ExpMatCost + ProdOrderComp."Cost Amount";
-            until ProdOrderComp.Next() = 0;
-
-        ProdOrderRtngLine.SetRange(Status, ProdOrderLine.Status);
-        ProdOrderRtngLine.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
-        ProdOrderRtngLine.SetRange("Routing No.", ProdOrderLine."Routing No.");
-        ProdOrderRtngLine.SetRange("Routing Reference No.", ProdOrderLine."Routing Reference No.");
-        OnCalcProdOrderLineExpCostOnAfterProdOrderRtngLineSetFilters(ProdOrderRtngLine, ProdOrderLine);
-        if ProdOrderRtngLine.Find('-') then
-            repeat
-                ExpOperCost :=
-                  ProdOrderRtngLine."Expected Operation Cost Amt." -
-                  ProdOrderRtngLine."Expected Capacity Ovhd. Cost";
-                OnCalcProdOrderLineExpCostOnExpOperCostCalculated(ExpOperCost, ProdOrderRtngLine);
-                if ProdOrderRtngLine.Type = ProdOrderRtngLine.Type::"Work Center" then begin
-                    if not WorkCenter.Get(ProdOrderRtngLine."No.") then
+            ProdOrderRtngLine.SetRange(Status, ProdOrderLine.Status);
+            ProdOrderRtngLine.SetRange("Prod. Order No.", ProdOrderLine."Prod. Order No.");
+            ProdOrderRtngLine.SetRange("Routing No.", ProdOrderLine."Routing No.");
+            ProdOrderRtngLine.SetRange("Routing Reference No.", ProdOrderLine."Routing Reference No.");
+            OnCalcProdOrderLineExpCostOnAfterProdOrderRtngLineSetFilters(ProdOrderRtngLine, ProdOrderLine);
+            if ProdOrderRtngLine.Find('-') then
+                repeat
+                    ExpOperCost :=
+                      ProdOrderRtngLine."Expected Operation Cost Amt." -
+                      ProdOrderRtngLine."Expected Capacity Ovhd. Cost";
+                    OnCalcProdOrderLineExpCostOnExpOperCostCalculated(ExpOperCost, ProdOrderRtngLine);
+                    if ProdOrderRtngLine.Type = ProdOrderRtngLine.Type::"Work Center" then begin
+                        if not WorkCenter.Get(ProdOrderRtngLine."No.") then
+                            Clear(WorkCenter);
+                    end else
                         Clear(WorkCenter);
-                end else
-                    Clear(WorkCenter);
 
-                if WorkCenter."Subcontractor No." <> '' then
-                    ExpSubDirCostRtng := ExpSubDirCostRtng + ExpOperCost
-                else
-                    ExpCapDirCostRtng := ExpCapDirCostRtng + ExpOperCost;
-                ExpCapOvhdCostRtng := ExpCapOvhdCostRtng + ProdOrderRtngLine."Expected Capacity Ovhd. Cost";
-            until ProdOrderRtngLine.Next() = 0;
+                    if WorkCenter."Subcontractor No." <> '' then
+                        ExpSubDirCostRtng := ExpSubDirCostRtng + ExpOperCost
+                    else
+                        ExpCapDirCostRtng := ExpCapDirCostRtng + ExpOperCost;
+                    ExpCapOvhdCostRtng := ExpCapOvhdCostRtng + ProdOrderRtngLine."Expected Capacity Ovhd. Cost";
+                until ProdOrderRtngLine.Next() = 0;
 
-        ExpCapDirCost := ExpCapDirCost + Round(ExpCapDirCostRtng * ShareOfTotalCapCost);
-        ExpSubDirCost := ExpSubDirCost + Round(ExpSubDirCostRtng * ShareOfTotalCapCost);
-        ExpCapOvhdCost := ExpCapOvhdCost + Round(ExpCapOvhdCostRtng * ShareOfTotalCapCost);
-        ExpMfgDirCost := ExpMatCost + ExpCapDirCost + ExpSubDirCost + ExpCapOvhdCost;
-        ExpOvhdCost := ExpMfgOvhdCost;
-        if ExpMfgDirCost = 0 then
-            ExpMfgOvhdCost := ExpOvhdCost +
-              Round(CostCalculationMgt.CalcOvhdCost(ExpMfgDirCost, ProdOrderLine."Indirect Cost %", ProdOrderLine."Overhead Rate", ProdOrderLine."Quantity (Base)"))
-        else
-            ExpMfgOvhdCost := Round(CostCalculationMgt.CalcOvhdCost(ExpMfgDirCost, ProdOrderLine."Indirect Cost %", ProdOrderLine."Overhead Rate", ProdOrderLine."Quantity (Base)"));
+            ExpCapDirCost := ExpCapDirCost + Round(ExpCapDirCostRtng * ShareOfTotalCapCost);
+            ExpSubDirCost := ExpSubDirCost + Round(ExpSubDirCostRtng * ShareOfTotalCapCost);
+            ExpCapOvhdCost := ExpCapOvhdCost + Round(ExpCapOvhdCostRtng * ShareOfTotalCapCost);
+            ExpMfgDirCost := ExpMatCost + ExpCapDirCost + ExpSubDirCost + ExpCapOvhdCost;
+            ExpOvhdCost := ExpMfgOvhdCost;
+            if ExpMfgDirCost = 0 then
+                ExpMfgOvhdCost := ExpOvhdCost +
+                  Round(CostCalculationMgt.CalcOvhdCost(ExpMfgDirCost, ProdOrderLine."Indirect Cost %", ProdOrderLine."Overhead Rate", ProdOrderLine."Quantity (Base)"))
+            else
+                ExpMfgOvhdCost := Round(CostCalculationMgt.CalcOvhdCost(ExpMfgDirCost, ProdOrderLine."Indirect Cost %", ProdOrderLine."Overhead Rate", ProdOrderLine."Quantity (Base)"));
+        end;
 
         OnAfterCalcProdOrderLineExpCost(ProdOrderLine, ShareOfTotalCapCost, ExpMatCost, ExpCapDirCost, ExpSubDirCost, ExpCapOvhdCost, ExpMfgOvhdCost);
     end;

--- a/src/Layers/W1/BaseApp/Manufacturing/StandardCost/CalculateStandardCost.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/StandardCost/CalculateStandardCost.Codeunit.al
@@ -940,6 +940,7 @@ codeunit 5812 "Calculate Standard Cost"
     var
         RtngLine: Record "Routing Line";
         RtngHeader: Record "Routing Header";
+        IsHandled: Boolean;
     begin
         if RtngLine.CertifiedRoutingVersionExists(RtngHeaderNo, CalculationDate) then begin
             if RtngLine."Version Code" = '' then begin
@@ -948,7 +949,10 @@ codeunit 5812 "Calculate Standard Cost"
             end;
 
             repeat
-                CalcRtngLineCostSKU(RtngLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd);
+                IsHandled := false;
+                OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(RtngLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, IsHandled);
+                if not IsHandled then
+                    CalcRtngLineCostSKU(RtngLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd);
             until RtngLine.Next() = 0;
         end;
     end;
@@ -1312,7 +1316,7 @@ codeunit 5812 "Calculate Standard Cost"
             IncrCost(SLCap, DirUnitCost, CostTime);
         IncrCost(SLCapOvhd, CostCalcMgt.CalcOvhdCost(DirUnitCost, IndirCostPct, OvhdRate, 1), CostTime);
 
-        OnAfterCalcRtngLineCost(RoutingLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, StdCostWkshName, ParentItem, CostTime);
+        OnAfterCalcRtngLineCost(RoutingLine, MfgItemQtyBase, SLCap, SLSub, SLCapOvhd, StdCostWkshName, ParentItem, CostTime, DirUnitCost);
     end;
 
     internal procedure CalcRtngLineCostSKU(RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal)
@@ -1367,7 +1371,12 @@ codeunit 5812 "Calculate Standard Cost"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterCalcRtngLineCost(RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var StdCostWkshName: Text[50]; var ParentItem: Record Item; CostTime: Decimal)
+    local procedure OnAfterCalcRtngLineCost(RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var StdCostWkshName: Text[50]; var ParentItem: Record Item; CostTime: Decimal; var DirUnitCost: Decimal)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcRtngCostSKUOnBeforeCalcRtngLineCostSKU(var RoutingLine: Record "Routing Line"; MfgItemQtyBase: Decimal; var SLCap: Decimal; var SLSub: Decimal; var SLCapOvhd: Decimal; var IsHandled: Boolean)
     begin
     end;
 
@@ -1624,4 +1633,3 @@ codeunit 5812 "Calculate Standard Cost"
         end;
     end;
 }
-


### PR DESCRIPTION
## Summary
Manufacturing extensions need separate control over setup and runtime costs so fixed setup costs are not incorrectly spread across varying lot sizes. This change exposes the missing routing, cost-time, direct-unit-cost, and expected production-order cost extensibility points needed to implement that split without replacing base objects.

Source issue repository: microsoft/AlAppExtensions; issue number: 30129

## Changes Made
- `Calculate Standard Cost` - added an IsHandled routing-line event for SKU calculations and exposed direct unit cost on the existing post-calculation event, including the Italian layer counterpart
- `Mfg. Cost Calculation Mgt.` - exposed setup/runtime inputs after cost-time calculation and added an IsHandled entry point for expected production-order line costs

Fixes [AB#636806](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636806)





