### PR TITLE
[Extensibility Request] issue 30137: allow overriding cost share application

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Reports/CostSharesBreakdown.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Reports/CostSharesBreakdown.Report.al
@@ -799,6 +799,18 @@ report 5848 "Cost Shares Breakdown"
         CostShareBuffer."Material Overhead" += InvtAdjmtEntryOrder."Single-Level Mfg. Ovhd Cost";
         CostShareBuffer.Subcontracted += InvtAdjmtEntryOrder."Single-Level Subcontrd. Cost";
 
+        ApplyShareOfCostToCostShareBuffer(ItemLedgEntry, CostShareBuffer, InvtAdjmtEntryOrder, OutputQty, ShareOfCost);
+    end;
+
+    local procedure ApplyShareOfCostToCostShareBuffer(ItemLedgEntry: Record "Item Ledger Entry"; var CostShareBuffer: Record "Cost Share Buffer"; var InvtAdjmtEntryOrder: Record "Inventory Adjmt. Entry (Order)"; OutputQty: Decimal; var ShareOfCost: Decimal)
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnUpdateCostShareBufFromInvAdjmtEntryOrderOnBeforeApplyShareOfCost(ItemLedgEntry, CostShareBuffer, InvtAdjmtEntryOrder, OutputQty, ShareOfCost, IsHandled);
+        if IsHandled then
+            exit;
+
         if OutputQty <> 0 then begin
             ShareOfCost := ItemLedgEntry.Quantity / OutputQty;
             CostShareBuffer.Capacity *= ShareOfCost;
@@ -957,5 +969,9 @@ report 5848 "Cost Shares Breakdown"
     local procedure OnInsertItemLedgEntryCostShareOnAfterSetQuantity(ItemLedgerEntry: Record "Item Ledger Entry"; var TempCostShareBuffer: Record "Cost Share Buffer" temporary)
     begin
     end;
-}
 
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateCostShareBufFromInvAdjmtEntryOrderOnBeforeApplyShareOfCost(ItemLedgerEntry: Record "Item Ledger Entry"; var CostShareBuffer: Record "Cost Share Buffer"; var InventoryAdjmtEntryOrder: Record "Inventory Adjmt. Entry (Order)"; OutputQuantity: Decimal; var ShareOfCost: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+}


### PR DESCRIPTION
## Summary
Custom costing scenarios need to control how Report 5848 applies an output entry's share of cost to capacity and overhead amounts. This PR isolates the standard share application and adds an integration event so extensions can replace that cohesive calculation when required.

Source issue repository: microsoft/AlAppExtensions; issue number: 30137

## Changes Made
- `Cost Shares Breakdown` report / `ApplyShareOfCostToCostShareBuffer` - extracted the standard share calculation and buffer updates, then added an `IsHandled` integration event before the logic is applied

Fixes [AB#639379](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639379)



