### PR TITLE
[master] Financial Report Recalculate clears Global Dimension filters

### DIFF
--- a/src/Layers/APAC/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
+++ b/src/Layers/APAC/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
@@ -65,6 +65,7 @@ codeunit 134902 "ERM Account Schedule"
         IncorrectExpectedMessageErr: Label 'Incorrect Expected Message';
         IncorrectCalcCellValueErr: Label 'Incorrect CalcCell Value';
         Dim1FilterErr: Label 'Incorrect Dimension 1 Filter was created.';
+        RecalcFilterRetainErr: Label 'Recalculate must retain the entered %1 filter.', Comment = '%1 = filter name';
         PeriodTextCaptionLbl: Label 'Period: ';
         ClearDimTotalingConfirmTxt: Label 'Changing Analysis View will clear differing dimension totaling columns of Account Schedule Lines. \Do you want to continue?';
         AccSchedPrefixTxt: Label 'ROW.DEF.', MaxLength = 10, Comment = 'Part of the name for the configuration package, stands for Row Definition';
@@ -4138,6 +4139,49 @@ codeunit 134902 "ERM Account Schedule"
         // Tear down
         ResultDimValue.Reset();
         ResultDimValue.DeleteAll();
+    end;
+
+    [Test]
+    procedure RecalculateRetainsGlobalDimensionFilters()
+    var
+        AccScheduleLine: Record "Acc. Schedule Line";
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        GLSetup: Record "General Ledger Setup";
+        AccScheduleOverview: TestPage "Acc. Schedule Overview";
+    begin
+        // [FEATURE] [Dimension]
+        // [SCENARIO 646172] Recalculate on Acc. Schedule Overview retains the entered Global Dimension filters.
+        Initialize();
+
+        // [GIVEN] Create a dimension value exists for Global Dimension 1 and for Global Dimension 2.
+        GLSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue1, GLSetup."Global Dimension 1 Code");
+        LibraryDimension.CreateDimensionValue(DimensionValue2, GLSetup."Global Dimension 2 Code");
+
+        // [GIVEN] Acc. Schedule Overview is opened for a financial report.
+        CreateAccountScheduleWithGLAccount(AccScheduleLine);
+        AccScheduleOverview.Trap();
+        OpenAccountScheduleOverviewPage(AccScheduleLine."Schedule Name");
+
+        // [GIVEN] Global Dimension 1 and 2 filters are set on the page.
+        AccScheduleOverview.Dim1Filter.SetValue(DimensionValue1.Code);
+        AccScheduleOverview.Dim2Filter.SetValue(DimensionValue2.Code);
+
+        // [WHEN] Recalculate is invoked.
+        AccScheduleOverview.Recalculate.Invoke();
+
+        // [THEN] The dimension filter controls retain their values.
+        Assert.AreEqual(DimensionValue1.Code, AccScheduleOverview.Dim1Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(DimensionValue2.Code, AccScheduleOverview.Dim2Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        // [THEN] The underlying Acc. Schedule Line FlowFilters retain the same dimension filters.
+        Assert.AreEqual(
+            DimensionValue1.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 1 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(
+            DimensionValue2.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 2 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        AccScheduleOverview.OK().Invoke();
     end;
 
     [Test]

--- a/src/Layers/CZ/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
@@ -65,6 +65,7 @@ codeunit 134902 "ERM Account Schedule"
         IncorrectExpectedMessageErr: Label 'Incorrect Expected Message';
         IncorrectCalcCellValueErr: Label 'Incorrect CalcCell Value';
         Dim1FilterErr: Label 'Incorrect Dimension 1 Filter was created.';
+        RecalcFilterRetainErr: Label 'Recalculate must retain the entered %1 filter.', Comment = '%1 = filter name';
         PeriodTextCaptionLbl: Label 'Period: ';
         ClearDimTotalingConfirmTxt: Label 'Changing Analysis View will clear differing dimension totaling columns of Account Schedule Lines. \Do you want to continue?';
         AccSchedPrefixTxt: Label 'ROW.DEF.', MaxLength = 10, Comment = 'Part of the name for the configuration package, stands for Row Definition';
@@ -4183,6 +4184,49 @@ codeunit 134902 "ERM Account Schedule"
         // Tear down
         ResultDimValue.Reset();
         ResultDimValue.DeleteAll();
+    end;
+
+    [Test]
+    procedure RecalculateRetainsGlobalDimensionFilters()
+    var
+        AccScheduleLine: Record "Acc. Schedule Line";
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        GLSetup: Record "General Ledger Setup";
+        AccScheduleOverview: TestPage "Acc. Schedule Overview";
+    begin
+        // [FEATURE] [Dimension]
+        // [SCENARIO 646172] Recalculate on Acc. Schedule Overview retains the entered Global Dimension filters.
+        Initialize();
+
+        // [GIVEN] Create a dimension value exists for Global Dimension 1 and for Global Dimension 2.
+        GLSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue1, GLSetup."Global Dimension 1 Code");
+        LibraryDimension.CreateDimensionValue(DimensionValue2, GLSetup."Global Dimension 2 Code");
+
+        // [GIVEN] Acc. Schedule Overview is opened for a financial report.
+        CreateAccountScheduleWithGLAccount(AccScheduleLine);
+        AccScheduleOverview.Trap();
+        OpenAccountScheduleOverviewPage(AccScheduleLine."Schedule Name");
+
+        // [GIVEN] Global Dimension 1 and 2 filters are set on the page.
+        AccScheduleOverview.Dim1Filter.SetValue(DimensionValue1.Code);
+        AccScheduleOverview.Dim2Filter.SetValue(DimensionValue2.Code);
+
+        // [WHEN] Recalculate is invoked.
+        AccScheduleOverview.Recalculate.Invoke();
+
+        // [THEN] The dimension filter controls retain their values.
+        Assert.AreEqual(DimensionValue1.Code, AccScheduleOverview.Dim1Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(DimensionValue2.Code, AccScheduleOverview.Dim2Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        // [THEN] The underlying Acc. Schedule Line FlowFilters retain the same dimension filters.
+        Assert.AreEqual(
+            DimensionValue1.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 1 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(
+            DimensionValue2.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 2 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        AccScheduleOverview.OK().Invoke();
     end;
 
     [Test]

--- a/src/Layers/ES/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
@@ -65,6 +65,7 @@ codeunit 134902 "ERM Account Schedule"
         IncorrectExpectedMessageErr: Label 'Incorrect Expected Message';
         IncorrectCalcCellValueErr: Label 'Incorrect CalcCell Value';
         Dim1FilterErr: Label 'Incorrect Dimension 1 Filter was created.';
+        RecalcFilterRetainErr: Label 'Recalculate must retain the entered %1 filter.', Comment = '%1 = filter name';
         PeriodTextCaptionLbl: Label 'Period: ';
         ClearDimTotalingConfirmTxt: Label 'Changing Analysis View will clear differing dimension totaling columns of Account Schedule Lines. \Do you want to continue?';
         AccSchedPrefixTxt: Label 'ROW.DEF.', MaxLength = 10, Comment = 'Part of the name for the configuration package, stands for Row Definition';
@@ -4180,6 +4181,49 @@ codeunit 134902 "ERM Account Schedule"
         // Tear down
         ResultDimValue.Reset();
         ResultDimValue.DeleteAll();
+    end;
+
+    [Test]
+    procedure RecalculateRetainsGlobalDimensionFilters()
+    var
+        AccScheduleLine: Record "Acc. Schedule Line";
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        GLSetup: Record "General Ledger Setup";
+        AccScheduleOverview: TestPage "Acc. Schedule Overview";
+    begin
+        // [FEATURE] [Dimension]
+        // [SCENARIO 646172] Recalculate on Acc. Schedule Overview retains the entered Global Dimension filters.
+        Initialize();
+
+        // [GIVEN] Create a dimension value exists for Global Dimension 1 and for Global Dimension 2.
+        GLSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue1, GLSetup."Global Dimension 1 Code");
+        LibraryDimension.CreateDimensionValue(DimensionValue2, GLSetup."Global Dimension 2 Code");
+
+        // [GIVEN] Acc. Schedule Overview is opened for a financial report.
+        CreateAccountScheduleWithGLAccount(AccScheduleLine);
+        AccScheduleOverview.Trap();
+        OpenAccountScheduleOverviewPage(AccScheduleLine."Schedule Name");
+
+        // [GIVEN] Global Dimension 1 and 2 filters are set on the page.
+        AccScheduleOverview.Dim1Filter.SetValue(DimensionValue1.Code);
+        AccScheduleOverview.Dim2Filter.SetValue(DimensionValue2.Code);
+
+        // [WHEN] Recalculate is invoked.
+        AccScheduleOverview.Recalculate.Invoke();
+
+        // [THEN] The dimension filter controls retain their values.
+        Assert.AreEqual(DimensionValue1.Code, AccScheduleOverview.Dim1Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(DimensionValue2.Code, AccScheduleOverview.Dim2Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        // [THEN] The underlying Acc. Schedule Line FlowFilters retain the same dimension filters.
+        Assert.AreEqual(
+            DimensionValue1.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 1 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(
+            DimensionValue2.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 2 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        AccScheduleOverview.OK().Invoke();
     end;
 
     [Test]

--- a/src/Layers/RU/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
@@ -65,6 +65,7 @@ codeunit 134902 "ERM Account Schedule"
         IncorrectExpectedMessageErr: Label 'Incorrect Expected Message';
         IncorrectCalcCellValueErr: Label 'Incorrect CalcCell Value';
         Dim1FilterErr: Label 'Incorrect Dimension 1 Filter was created.';
+        RecalcFilterRetainErr: Label 'Recalculate must retain the entered %1 filter.', Comment = '%1 = filter name';
         PeriodTextCaptionLbl: Label 'Period: ';
         ClearDimTotalingConfirmTxt: Label 'Changing Analysis View will clear differing dimension totaling columns of Account Schedule Lines. \Do you want to continue?';
         AccSchedPrefixTxt: Label 'ROW.DEF.', MaxLength = 10, Comment = 'Part of the name for the configuration package, stands for Row Definition';
@@ -4180,6 +4181,49 @@ codeunit 134902 "ERM Account Schedule"
         // Tear down
         ResultDimValue.Reset();
         ResultDimValue.DeleteAll();
+    end;
+
+    [Test]
+    procedure RecalculateRetainsGlobalDimensionFilters()
+    var
+        AccScheduleLine: Record "Acc. Schedule Line";
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        GLSetup: Record "General Ledger Setup";
+        AccScheduleOverview: TestPage "Acc. Schedule Overview";
+    begin
+        // [FEATURE] [Dimension]
+        // [SCENARIO 646172] Recalculate on Acc. Schedule Overview retains the entered Global Dimension filters.
+        Initialize();
+
+        // [GIVEN] Create a dimension value exists for Global Dimension 1 and for Global Dimension 2.
+        GLSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue1, GLSetup."Global Dimension 1 Code");
+        LibraryDimension.CreateDimensionValue(DimensionValue2, GLSetup."Global Dimension 2 Code");
+
+        // [GIVEN] Acc. Schedule Overview is opened for a financial report.
+        CreateAccountScheduleWithGLAccount(AccScheduleLine);
+        AccScheduleOverview.Trap();
+        OpenAccountScheduleOverviewPage(AccScheduleLine."Schedule Name");
+
+        // [GIVEN] Global Dimension 1 and 2 filters are set on the page.
+        AccScheduleOverview.Dim1Filter.SetValue(DimensionValue1.Code);
+        AccScheduleOverview.Dim2Filter.SetValue(DimensionValue2.Code);
+
+        // [WHEN] Recalculate is invoked.
+        AccScheduleOverview.Recalculate.Invoke();
+
+        // [THEN] The dimension filter controls retain their values.
+        Assert.AreEqual(DimensionValue1.Code, AccScheduleOverview.Dim1Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(DimensionValue2.Code, AccScheduleOverview.Dim2Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        // [THEN] The underlying Acc. Schedule Line FlowFilters retain the same dimension filters.
+        Assert.AreEqual(
+            DimensionValue1.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 1 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(
+            DimensionValue2.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 2 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        AccScheduleOverview.OK().Invoke();
     end;
 
     [Test]

--- a/src/Layers/SE/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
+++ b/src/Layers/SE/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
@@ -65,6 +65,7 @@ codeunit 134902 "ERM Account Schedule"
         IncorrectExpectedMessageErr: Label 'Incorrect Expected Message';
         IncorrectCalcCellValueErr: Label 'Incorrect CalcCell Value';
         Dim1FilterErr: Label 'Incorrect Dimension 1 Filter was created.';
+        RecalcFilterRetainErr: Label 'Recalculate must retain the entered %1 filter.', Comment = '%1 = filter name';
         PeriodTextCaptionLbl: Label 'Period: ';
         ClearDimTotalingConfirmTxt: Label 'Changing Analysis View will clear differing dimension totaling columns of Account Schedule Lines. \Do you want to continue?';
         AccSchedPrefixTxt: Label 'ROW.DEF.', MaxLength = 10, Comment = 'Part of the name for the configuration package, stands for Row Definition';
@@ -4138,6 +4139,49 @@ codeunit 134902 "ERM Account Schedule"
         // Tear down
         ResultDimValue.Reset();
         ResultDimValue.DeleteAll();
+    end;
+
+    [Test]
+    procedure RecalculateRetainsGlobalDimensionFilters()
+    var
+        AccScheduleLine: Record "Acc. Schedule Line";
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        GLSetup: Record "General Ledger Setup";
+        AccScheduleOverview: TestPage "Acc. Schedule Overview";
+    begin
+        // [FEATURE] [Dimension]
+        // [SCENARIO 646172] Recalculate on Acc. Schedule Overview retains the entered Global Dimension filters.
+        Initialize();
+
+        // [GIVEN] Create a dimension value exists for Global Dimension 1 and for Global Dimension 2.
+        GLSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue1, GLSetup."Global Dimension 1 Code");
+        LibraryDimension.CreateDimensionValue(DimensionValue2, GLSetup."Global Dimension 2 Code");
+
+        // [GIVEN] Acc. Schedule Overview is opened for a financial report.
+        CreateAccountScheduleWithGLAccount(AccScheduleLine);
+        AccScheduleOverview.Trap();
+        OpenAccountScheduleOverviewPage(AccScheduleLine."Schedule Name");
+
+        // [GIVEN] Global Dimension 1 and 2 filters are set on the page.
+        AccScheduleOverview.Dim1Filter.SetValue(DimensionValue1.Code);
+        AccScheduleOverview.Dim2Filter.SetValue(DimensionValue2.Code);
+
+        // [WHEN] Recalculate is invoked.
+        AccScheduleOverview.Recalculate.Invoke();
+
+        // [THEN] The dimension filter controls retain their values.
+        Assert.AreEqual(DimensionValue1.Code, AccScheduleOverview.Dim1Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(DimensionValue2.Code, AccScheduleOverview.Dim2Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        // [THEN] The underlying Acc. Schedule Line FlowFilters retain the same dimension filters.
+        Assert.AreEqual(
+            DimensionValue1.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 1 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(
+            DimensionValue2.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 2 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        AccScheduleOverview.OK().Invoke();
     end;
 
     [Test]

--- a/src/Layers/W1/BaseApp/Finance/FinancialReports/AccScheduleOverview.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/FinancialReports/AccScheduleOverview.Page.al
@@ -1049,6 +1049,10 @@ page 490 "Acc. Schedule Overview"
                 trigger OnAction()
                 begin
                     AccSchedManagement.ForceRecalculate(true);
+                    // Recalculate must reuse the filters currently entered in the page (kept in TempFinancialReport)
+                    // instead of reloading the persisted/default report filters, which would silently discard the
+                    // user's in-page dimension and other filter values.
+                    PreserveCurrentPageFilters := true;
                     ReloadPage();
                 end;
             }
@@ -1462,6 +1466,9 @@ page 490 "Acc. Schedule Overview"
 #endif
         RowDefinitionBlocked: Boolean;
         ColDefinitionBlocked: Boolean;
+        // When set, LoadPageState keeps the filters currently entered in the page (TempFinancialReport)
+        // instead of reloading the persisted/default report filters. Used by the Recalculate action.
+        PreserveCurrentPageFilters: Boolean;
 
     protected var
         AnalysisView: Record "Analysis View";
@@ -1602,7 +1609,12 @@ page 490 "Acc. Schedule Overview"
 
         // `FinancialReportTemp` contains the state of the filters the user interacts with
         // `LoadFinancialReportFiltersOrDefault` loads this temporary record considering user overriden filters (if any).
-        LoadFinancialReportFiltersOrDefault(TempFinancialReport);
+        // When PreserveCurrentPageFilters is set (e.g. from Recalculate), the filters currently entered in the page
+        // must be kept instead of being replaced by the persisted/default report filters.
+        if PreserveCurrentPageFilters then
+            PreserveCurrentPageFilters := false
+        else
+            LoadFinancialReportFiltersOrDefault(TempFinancialReport);
 
         // Afterwards, we update all page state variables 
         SetFinancialReportTxt();

--- a/src/Layers/W1/BaseApp/Finance/FinancialReports/AccScheduleOverview.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/FinancialReports/AccScheduleOverview.Page.al
@@ -1049,9 +1049,6 @@ page 490 "Acc. Schedule Overview"
                 trigger OnAction()
                 begin
                     AccSchedManagement.ForceRecalculate(true);
-                    // Recalculate must reuse the filters currently entered in the page (kept in TempFinancialReport)
-                    // instead of reloading the persisted/default report filters, which would silently discard the
-                    // user's in-page dimension and other filter values.
                     PreserveCurrentPageFilters := true;
                     ReloadPage();
                 end;
@@ -1466,8 +1463,6 @@ page 490 "Acc. Schedule Overview"
 #endif
         RowDefinitionBlocked: Boolean;
         ColDefinitionBlocked: Boolean;
-        // When set, LoadPageState keeps the filters currently entered in the page (TempFinancialReport)
-        // instead of reloading the persisted/default report filters. Used by the Recalculate action.
         PreserveCurrentPageFilters: Boolean;
 
     protected var
@@ -1609,8 +1604,6 @@ page 490 "Acc. Schedule Overview"
 
         // `FinancialReportTemp` contains the state of the filters the user interacts with
         // `LoadFinancialReportFiltersOrDefault` loads this temporary record considering user overriden filters (if any).
-        // When PreserveCurrentPageFilters is set (e.g. from Recalculate), the filters currently entered in the page
-        // must be kept instead of being replaced by the persisted/default report filters.
         if PreserveCurrentPageFilters then
             PreserveCurrentPageFilters := false
         else

--- a/src/Layers/W1/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMAccountSchedule.Codeunit.al
@@ -65,6 +65,7 @@ codeunit 134902 "ERM Account Schedule"
         IncorrectExpectedMessageErr: Label 'Incorrect Expected Message';
         IncorrectCalcCellValueErr: Label 'Incorrect CalcCell Value';
         Dim1FilterErr: Label 'Incorrect Dimension 1 Filter was created.';
+        RecalcFilterRetainErr: Label 'Recalculate must retain the entered %1 filter.', Comment = '%1 = filter name';
         PeriodTextCaptionLbl: Label 'Period: ';
         ClearDimTotalingConfirmTxt: Label 'Changing Analysis View will clear differing dimension totaling columns of Account Schedule Lines. \Do you want to continue?';
         AccSchedPrefixTxt: Label 'ROW.DEF.', MaxLength = 10, Comment = 'Part of the name for the configuration package, stands for Row Definition';
@@ -4180,6 +4181,49 @@ codeunit 134902 "ERM Account Schedule"
         // Tear down
         ResultDimValue.Reset();
         ResultDimValue.DeleteAll();
+    end;
+
+    [Test]
+    procedure RecalculateRetainsGlobalDimensionFilters()
+    var
+        AccScheduleLine: Record "Acc. Schedule Line";
+        DimensionValue1: Record "Dimension Value";
+        DimensionValue2: Record "Dimension Value";
+        GLSetup: Record "General Ledger Setup";
+        AccScheduleOverview: TestPage "Acc. Schedule Overview";
+    begin
+        // [FEATURE] [Dimension]
+        // [SCENARIO 646172] Recalculate on Acc. Schedule Overview retains the entered Global Dimension filters.
+        Initialize();
+
+        // [GIVEN] Create a dimension value exists for Global Dimension 1 and for Global Dimension 2.
+        GLSetup.Get();
+        LibraryDimension.CreateDimensionValue(DimensionValue1, GLSetup."Global Dimension 1 Code");
+        LibraryDimension.CreateDimensionValue(DimensionValue2, GLSetup."Global Dimension 2 Code");
+
+        // [GIVEN] Acc. Schedule Overview is opened for a financial report.
+        CreateAccountScheduleWithGLAccount(AccScheduleLine);
+        AccScheduleOverview.Trap();
+        OpenAccountScheduleOverviewPage(AccScheduleLine."Schedule Name");
+
+        // [GIVEN] Global Dimension 1 and 2 filters are set on the page.
+        AccScheduleOverview.Dim1Filter.SetValue(DimensionValue1.Code);
+        AccScheduleOverview.Dim2Filter.SetValue(DimensionValue2.Code);
+
+        // [WHEN] Recalculate is invoked.
+        AccScheduleOverview.Recalculate.Invoke();
+
+        // [THEN] The dimension filter controls retain their values.
+        Assert.AreEqual(DimensionValue1.Code, AccScheduleOverview.Dim1Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(DimensionValue2.Code, AccScheduleOverview.Dim2Filter.Value, StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        // [THEN] The underlying Acc. Schedule Line FlowFilters retain the same dimension filters.
+        Assert.AreEqual(
+            DimensionValue1.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 1 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 1'));
+        Assert.AreEqual(
+            DimensionValue2.Code, AccScheduleOverview.FILTER.GetFilter("Dimension 2 Filter"), StrSubstNo(RecalcFilterRetainErr, 'Dimension 2'));
+
+        AccScheduleOverview.OK().Invoke();
     end;
 
     [Test]


### PR DESCRIPTION
Workitem : [Bug 646538](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646538): [Master][ALL-E] Financial Report Recalculate clears Global Dimension filters

Fixes [AB#646538](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646538)

**Issue:** Recalculating a financial report cleared the Global Dimension filters entered on the Acc. Schedule Overview page.
**Cause:** Recalculate reloaded persisted/default report filters, overwriting the current in-page filter values.
**Solution:** Preserve the current page filters during recalculation and add an automated regression test verifying the UI values and underlying FlowFilters remain unchanged.



