### PR TITLE
Fix Reduce Contacts report silently ignores contacts whose company no…

### DIFF
--- a/src/Layers/W1/BaseApp/CRM/Segment/RemoveContacts.Report.al
+++ b/src/Layers/W1/BaseApp/CRM/Segment/RemoveContacts.Report.al
@@ -215,8 +215,9 @@ report 5186 "Remove Contacts"
                     trigger OnPreDataItem()
                     begin
                         FilterGroup(4);
-                        SetRange("Company No.", "Segment Line"."Contact Company No.");
-                        if not EntireCompanies then
+                        if EntireCompanies then
+                            SetRange("Company No.", "Segment Line"."Contact Company No.")
+                        else
                             SetRange("No.", "Segment Line"."Contact No.");
                         FilterGroup(0);
                     end;


### PR DESCRIPTION
Fixes [AB#640984](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640984)

Report 5186 filtered the Contact dataitem by both "No." and "Company No.". When a segment line's company no. didn't match the contact's actual company no., nothing matched and the contact was silently skipped. Now filters by unique "No." for single contacts, and by "Company No." only for Entire Companies.


