### PR TITLE
[Subcontracting] Detect subcontracting purchase/transfer orders in legacy data check

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -59,7 +59,7 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         if not IsMigrationAllowedInCurrentEnvironment() then
             Error(MigrationNotAllowedInProductionErr);
 
-        if OpenSubcontractingTransfersExist() then
+        if OpenWIPTransfersExist() then
             Error(OpenSubcontractingTransfersExistErr);
 
         if OpenWIPPurchaseLinesExist() then
@@ -111,7 +111,7 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         if WIPItemCapacityLedgerEntriesExist() then
             exit(true);
 
-        if OpenSubcontractingTransfersExist() then
+        if OpenWIPTransfersExist() then
             exit(true);
 
         if OpenWIPPurchaseLinesExist() then
@@ -184,7 +184,7 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         exit(Result);
     end;
 
-    local procedure OpenSubcontractingTransfersExist(): Boolean
+    local procedure OpenWIPTransfersExist(): Boolean
     var
         TransferLine: Record "Transfer Line";
     begin

--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -98,10 +98,16 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
     end;
 
     /// <summary>
-    /// Returns whether the database contains Legacy Subcontracting data based on the presence of WIP Item related data in open transfer orders, open purchase orders, or capacity ledger entries.
+    /// Returns whether the database contains Legacy Subcontracting data based on the presence of subcontracting purchase orders, subcontracting transfer orders, WIP Item related data, capacity ledger entries, or subcontracting prices.
     /// </summary>
     internal procedure DatabaseHasLegacySubcontractingData(): Boolean
     begin
+        if SubcontractingPurchaseOrdersExist() then
+            exit(true);
+
+        if SubcontractingTransferOrdersExist() then
+            exit(true);
+
         if WIPItemCapacityLedgerEntriesExist() then
             exit(true);
 
@@ -184,6 +190,24 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
     begin
         TransferLine.SetRange("WIP Item", true);
         TransferLine.SetFilter("WIP Outstanding Qty.", '<>%1', 0);
+        exit(not TransferLine.IsEmpty());
+    end;
+
+    local procedure SubcontractingPurchaseOrdersExist(): Boolean
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetFilter("Prod. Order No.", '<>%1', '');
+        PurchaseLine.SetFilter("Prod. Order Line No.", '<>%1', 0);
+        exit(not PurchaseLine.IsEmpty());
+    end;
+
+    local procedure SubcontractingTransferOrdersExist(): Boolean
+    var
+        TransferLine: Record "Transfer Line";
+    begin
+        TransferLine.SetFilter("Prod. Order No.", '<>%1', '');
         exit(not TransferLine.IsEmpty());
     end;
 

--- a/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
@@ -249,6 +249,81 @@ codeunit 137500 "SCM Legacy Subcontracting"
 
     [Test]
     [Scope('OnPrem')]
+    procedure DatabaseHasDataWhenSubcontractingPurchaseOrderExists()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+        Item: Record Item;
+        LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
+    begin
+        // [SCENARIO] DatabaseHasLegacySubcontractingData returns true when a subcontracting purchase order (a purchase line linked to a production order) exists, even when "WIP Item" is not set
+        Initialize();
+
+        // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
+        SetLegacySubcontracting(true);
+
+        // [GIVEN] Purchase Line linked to a production order but with "WIP Item" = false
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        PurchaseLine."WIP Item" := false;
+        PurchaseLine."Prod. Order No." := 'TEST-LEGACYSUBC';
+        PurchaseLine."Prod. Order Line No." := 10000;
+        PurchaseLine.Modify();
+
+        // [WHEN] Check if data exists
+        // [THEN] DatabaseHasLegacySubcontractingData returns true (detects subcontracting POs without WIP)
+        Assert.IsTrue(LegacySubcFeatureHandler.DatabaseHasLegacySubcontractingData(),
+            'Should detect subcontracting purchase orders linked to a production order as legacy subcontracting data.');
+
+        // Cleanup
+        PurchaseLine.Delete();
+        PurchaseHeader.Delete();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DatabaseHasDataWhenSubcontractingTransferOrderExists()
+    var
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        LocationFrom: Record Location;
+        LocationTo: Record Location;
+        LocationInTransit: Record Location;
+        LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
+    begin
+        // [SCENARIO] DatabaseHasLegacySubcontractingData returns true when a subcontracting transfer order (a transfer line linked to a production order) exists, even when "WIP Item" is not set
+        Initialize();
+
+        // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
+        SetLegacySubcontracting(true);
+
+        // [GIVEN] Transfer Line linked to a production order but with "WIP Item" = false
+        LibraryWarehouse.CreateLocation(LocationFrom);
+        LibraryWarehouse.CreateLocation(LocationTo);
+        LibraryWarehouse.CreateInTransitLocation(LocationInTransit);
+        LibraryWarehouse.CreateTransferHeader(TransferHeader, LocationFrom.Code, LocationTo.Code, LocationInTransit.Code);
+        TransferLine.Init();
+        TransferLine."Document No." := TransferHeader."No.";
+        TransferLine."Line No." := 10000;
+        TransferLine."WIP Item" := false;
+        TransferLine."Prod. Order No." := 'TEST-LEGACYSUBC';
+        TransferLine.Insert();
+
+        // [WHEN] Check if data exists
+        // [THEN] DatabaseHasLegacySubcontractingData returns true (detects subcontracting transfers without WIP)
+        Assert.IsTrue(LegacySubcFeatureHandler.DatabaseHasLegacySubcontractingData(),
+            'Should detect subcontracting transfer orders linked to a production order as legacy subcontracting data.');
+
+        // Cleanup
+        TransferLine.Delete();
+        TransferHeader.Delete();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure DatabaseHasDataWhenSubcontractorPricesExist()
     var
         Item: Record Item;
@@ -414,7 +489,16 @@ codeunit 137500 "SCM Legacy Subcontracting"
         TransferLine.SetRange("WIP Item", true);
         if not TransferLine.IsEmpty() then
             TransferLine.DeleteAll();
+        TransferLine.Reset();
+        TransferLine.SetFilter("Prod. Order No.", '<>%1', '');
+        if not TransferLine.IsEmpty() then
+            TransferLine.DeleteAll();
         PurchaseLine.SetRange("WIP Item", true);
+        if not PurchaseLine.IsEmpty() then
+            PurchaseLine.DeleteAll();
+        PurchaseLine.Reset();
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetFilter("Prod. Order No.", '<>%1', '');
         if not PurchaseLine.IsEmpty() then
             PurchaseLine.DeleteAll();
 


### PR DESCRIPTION
## What & why

`DatabaseHasLegacySubcontractingData` previously only checked for WIP-related data and subcontracting prices. On an IT environment where a vendor is set up as a subcontractor and subcontracting purchase and/or transfer orders exist — but no new subcontracting prices or WIP setup was done — the migration check missed them. As a result, disabling Legacy Subcontracting skipped a needed data migration.

This change adds two new checks so migration runs when subcontracting purchase or transfer orders exist:
- `SubcontractingPurchaseOrdersExist()` — purchase order lines linked to a production order (`Prod. Order No.`/`Prod. Order Line No.` set), independent of the WIP Item flag (mirrors the "Subcontracting Order" FlowField on the Purchase Header).
- `SubcontractingTransferOrdersExist()` — transfer lines linked to a production order (mirrors the "Subcontracting Order" FlowField on the Transfer Header).

It also renames `OpenSubcontractingTransfersExist` -> `OpenWIPTransfersExist`, since that function filters only `"WIP Item" = true` transfers and the new name reflects its actual scope.

## Linked work

[AB#646168](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646168)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added two tests in `SCMLegacySubcontracting.Codeunit.al`: `DatabaseHasDataWhenSubcontractingPurchaseOrderExists` and `DatabaseHasDataWhenSubcontractingTransferOrderExists`. Both assert that `DatabaseHasLegacySubcontractingData` returns true for orders linked to a production order even when the WIP Item flag is not set.
- Extended test cleanup to also remove prod-order-linked purchase/transfer lines.

## Risk & compatibility

Low. The change only broadens detection of legacy subcontracting data (more scenarios now correctly trigger migration). The rename is internal (`local procedure`) with no external callers.




