### PR TITLE
[Bug][Subscription Billing] "Delete Invoiced Sales Orders" leaves orphaned Sales Subscription Lines behind

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Codeunits/SalesSubscriptionLineMgmt.Codeunit.al
@@ -303,14 +303,21 @@ codeunit 8069 "Sales Subscription Line Mgmt."
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnBeforeSalesLineDeleteAll, '', false, false)]
-    local procedure DeleteSalesServiceCommitmentOnBeforeSalesLineDeleteAll(var SalesLine: Record "Sales Line")
-    var
-        SalesServiceCommitment: Record "Sales Subscription Line";
+    local procedure DeleteSalesServiceCommitmentOnBeforeSalesLineDeleteAll(var SalesLine: Record "Sales Line"; CommitIsSuppressed: Boolean; var SalesHeader: Record "Sales Header")
     begin
-        if not SalesLine.FindFirst() then
-            exit;
-        SalesServiceCommitment.FilterOnDocument(SalesLine."Document Type", SalesLine."Document No.");
-        SalesServiceCommitment.DeleteAll(false);
+        SalesHeader.DeleteSalesServiceCommitments();
+    end;
+
+    [EventSubscriber(ObjectType::Report, Report::"Delete Invoiced Sales Orders", OnAfterDeleteSalesLinesLoop, '', false, false)]
+    local procedure DeleteSalesServiceCommitmentOnAfterDeleteSalesLinesLoop(var SalesHeader: Record "Sales Header")
+    begin
+        SalesHeader.DeleteSalesServiceCommitments();
+    end;
+
+    [EventSubscriber(ObjectType::Report, Report::"Delete Invd Blnkt Sales Orders", OnBeforeDeleteSalesHeader, '', false, false)]
+    local procedure DeleteSalesServiceCommitmentOnBeforeDeleteBlanketSalesHeader(var SalesHeader: Record "Sales Header")
+    begin
+        SalesHeader.DeleteSalesServiceCommitments();
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Quote to Order", OnAfterInsertSalesOrderLine, '', false, false)]
@@ -321,12 +328,8 @@ codeunit 8069 "Sales Subscription Line Mgmt."
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Quote to Order", OnRunOnAfterSalesQuoteLineDeleteAll, '', false, false)]
     local procedure DeleteSalesServiceCommitmentOnAfterSalesQuoteLineDeleteAll(var SalesHeaderRec: Record "Sales Header")
-    var
-        SalesServiceCommitment: Record "Sales Subscription Line";
     begin
-        SalesServiceCommitment.SetRange("Document Type", SalesHeaderRec."Document Type");
-        SalesServiceCommitment.SetRange("Document No.", SalesHeaderRec."No.");
-        SalesServiceCommitment.DeleteAll(false);
+        SalesHeaderRec.DeleteSalesServiceCommitments();
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Blanket Sales Order to Order", OnAfterInsertSalesOrderLine, '', false, false)]

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesHeader.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesHeader.TableExt.al
@@ -28,6 +28,31 @@ tableextension 8053 "Sales Header" extends "Sales Header"
         }
     }
 
+    /// <summary>
+    /// Deletes the Sales Subscription Lines of every line of this sales document in one batch.
+    /// Use this instead of the Sales Line procedure DeleteSalesServiceCommitment() when all lines of the
+    /// document are removed without running their triggers, for example when the document is posted, when
+    /// a quote is converted into an order, or by the "Delete Invoiced Sales Orders" and
+    /// "Delete Invoiced Blanket Sales Orders" batch jobs.
+    /// Unlike the Sales Line procedure this does not skip document types outside Quote, Order and Blanket
+    /// Order, because Copy Document carries Sales Subscription Lines over to an Invoice or Credit Memo as
+    /// well, and those have to be cleaned up when the document is posted.
+    /// Temporary records are skipped, so calling this on a temporary Sales Header never deletes the real
+    /// Sales Subscription Lines of a document that happens to share its number.
+    /// </summary>
+    procedure DeleteSalesServiceCommitments()
+    var
+        SalesServiceCommitment: Record "Sales Subscription Line";
+    begin
+        if Rec.IsTemporary() then
+            exit;
+        SalesServiceCommitment.FilterOnDocument(Rec."Document Type", Rec."No.");
+        if SalesServiceCommitment.IsEmpty() then
+            exit;
+
+        SalesServiceCommitment.DeleteAll(false);
+    end;
+
     local procedure GetLastLineNo(): Integer
     var
         SalesLine: Record "Sales Line";

--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Table Extensions/SalesLine.TableExt.al
@@ -189,7 +189,15 @@ tableextension 8054 "Sales Line" extends "Sales Line"
         Rec."Sell-to Customer No." := SourceSalesHeader."Sell-to Customer No.";
     end;
 
-    internal procedure DeleteSalesServiceCommitment()
+    /// <summary>
+    /// Deletes the Sales Subscription Lines that belong to this Sales Line.
+    /// Call this whenever a Sales Line is removed without running its triggers (Delete(false), DeleteAll(false)),
+    /// because the OnDelete() trigger of this table extension does not fire in that case and the
+    /// Sales Subscription Lines would be left behind as orphaned records.
+    /// Temporary records and document types that cannot carry Sales Subscription Lines are skipped,
+    /// so the call is safe for any Sales Line.
+    /// </summary>
+    procedure DeleteSalesServiceCommitment()
     var
         SalesServiceCommitment: Record "Sales Subscription Line";
     begin

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -67,6 +67,8 @@ codeunit 139915 "Sales Service Commitment Test"
         NotCreatedProperlyErr: Label 'Subscription Lines are not created properly.', Locked = true;
         SalesServiceCommitmentCannotBeDeletedErr: Label 'The Sales Subscription Line cannot be deleted, because it is the last line with Process Contract Renewal. Please delete the Sales line in order to delete the Sales Subscription Line.', Locked = true;
         NaturalNumberRatioErr: Label 'The ratio of ''%1'' and ''%2'' or vice versa must give a natural number.', Comment = '%1=Field Caption, %2=Field Caption', Locked = true;
+        SalesOrderNotDeletedErr: Label 'The Sales Order was not deleted by the Delete Invoiced Sales Orders batch job.', Locked = true;
+        BlanketSalesOrderNotDeletedErr: Label 'The Blanket Sales Order was not deleted by the Delete Invoiced Blanket Sales Orders batch job.', Locked = true;
 
     #region Tests
 
@@ -2109,9 +2111,179 @@ codeunit 139915 "Sales Service Commitment Test"
         ServiceCommitment.TestField("Subscription Line End Date", 0D);
     end;
 
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure CheckDeleteSalesServiceCommitmentOnDeleteInvoicedSalesOrders()
+    var
+        FetchSalesHeader: Record "Sales Header";
+        OtherSalesHeader: Record "Sales Header";
+        OtherSalesLine: Record "Sales Line";
+        SalesOrderNo: Code[20];
+    begin
+        // [SCENARIO] Report "Delete Invoiced Sales Orders" deletes the Sales Subscription Lines of the removed Sales Order
+        Initialize();
+
+        // [GIVEN] A Sales Order with a Subscription Item that has Sales Subscription Lines
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(Item, Enum::"Item Service Commitment Type"::"Service Commitment Item", ServiceCommitmentPackage.Code);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), LibraryRandom.RandIntInRange(2, 10));
+        SalesOrderNo := SalesHeader."No.";
+        SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [GIVEN] A second, untouched Sales Order with Sales Subscription Lines
+        LibrarySales.CreateSalesHeader(OtherSalesHeader, OtherSalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(OtherSalesLine, OtherSalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), LibraryRandom.RandIntInRange(2, 10));
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnSalesLine(OtherSalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [GIVEN] The Sales Order is fully shipped and invoiced, but not removed by posting
+        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        FetchSalesHeader.Get(SalesHeader."Document Type"::Order, SalesOrderNo);
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnDocument(SalesHeader."Document Type"::Order, SalesOrderNo);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [WHEN] Running report "Delete Invoiced Sales Orders" for the Sales Order
+        RunDeleteInvoicedSalesOrders(SalesOrderNo);
+
+        // [THEN] The Sales Order is deleted
+        Assert.IsFalse(FetchSalesHeader.Get(SalesHeader."Document Type"::Order, SalesOrderNo), SalesOrderNotDeletedErr);
+
+        // [THEN] No Sales Subscription Line of the deleted Sales Order is left behind
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnDocument(SalesHeader."Document Type"::Order, SalesOrderNo);
+        Assert.RecordIsEmpty(SalesServiceCommitment);
+
+        // [THEN] The Sales Subscription Lines of the second Sales Order are untouched
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnSalesLine(OtherSalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure CheckDeleteSalesServiceCommitmentOnDeleteInvdBlnktSalesOrders()
+    var
+        FetchSalesHeader: Record "Sales Header";
+        OtherSalesHeader: Record "Sales Header";
+        OtherSalesLine: Record "Sales Line";
+        SalesOrder: Record "Sales Header";
+        SecondSalesLine: Record "Sales Line";
+        BlanketSalesOrderToOrder: Codeunit "Blanket Sales Order to Order";
+        BlanketOrderNo: Code[20];
+    begin
+        // [SCENARIO] Report "Delete Invd Blnkt Sales Orders" deletes the Sales Subscription Lines of the removed Blanket Sales Order
+        Initialize();
+
+        // [GIVEN] A Blanket Sales Order with two lines that both have Sales Subscription Lines
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Blanket Order", '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), LibraryRandom.RandIntInRange(2, 10));
+        LibrarySales.CreateSalesLineWithShipmentDate(SecondSalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), LibraryRandom.RandIntInRange(2, 10));
+        BlanketOrderNo := SalesHeader."No.";
+        SalesServiceCommitment.FilterOnSalesLine(SalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnSalesLine(SecondSalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [GIVEN] A second, untouched Blanket Sales Order with Sales Subscription Lines
+        LibrarySales.CreateSalesHeader(OtherSalesHeader, OtherSalesHeader."Document Type"::"Blanket Order", '');
+        LibrarySales.CreateSalesLineWithShipmentDate(OtherSalesLine, OtherSalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), LibraryRandom.RandIntInRange(2, 10));
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnSalesLine(OtherSalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [GIVEN] The Blanket Sales Order is fully converted into a Sales Order, which is then fully shipped and invoiced
+        Clear(BlanketSalesOrderToOrder);
+        BlanketSalesOrderToOrder.SetHideValidationDialog(true);
+        BlanketSalesOrderToOrder.Run(SalesHeader);
+        BlanketSalesOrderToOrder.GetSalesOrderHeader(SalesOrder);
+        LibrarySales.PostSalesDocument(SalesOrder, true, true);
+
+        FetchSalesHeader.Get(SalesHeader."Document Type"::"Blanket Order", BlanketOrderNo);
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnDocument(SalesHeader."Document Type"::"Blanket Order", BlanketOrderNo);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [WHEN] Running report "Delete Invd Blnkt Sales Orders" for the Blanket Sales Order
+        RunDeleteInvdBlnktSalesOrders(BlanketOrderNo);
+
+        // [THEN] The Blanket Sales Order is deleted
+        Assert.IsFalse(FetchSalesHeader.Get(SalesHeader."Document Type"::"Blanket Order", BlanketOrderNo), BlanketSalesOrderNotDeletedErr);
+
+        // [THEN] No Sales Subscription Line of the deleted Blanket Sales Order is left behind
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnDocument(SalesHeader."Document Type"::"Blanket Order", BlanketOrderNo);
+        Assert.RecordIsEmpty(SalesServiceCommitment);
+
+        // [THEN] The Sales Subscription Lines of the second Blanket Sales Order are untouched
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnSalesLine(OtherSalesLine);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+    end;
+
+    [Test]
+    procedure CheckDeleteSalesServiceCommitmentOnPostSalesInvoiceCopiedFromSalesOrder()
+    var
+        SalesInvoiceHeader2: Record "Sales Header";
+        CopyDocMgt: Codeunit "Copy Document Mgt.";
+        SalesInvoiceNo: Code[20];
+    begin
+        // [SCENARIO] Posting a Sales Invoice that carries Sales Subscription Lines copied from a Sales Order deletes them
+        Initialize();
+
+        // [GIVEN] A Sales Order with an Item with Subscription Lines
+        ContractTestLibrary.SetupSalesServiceCommitmentItemAndAssignToServiceCommitmentPackage(Item, Enum::"Item Service Commitment Type"::"Sales with Service Commitment", ServiceCommitmentPackage.Code);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", WorkDate(), LibraryRandom.RandIntInRange(2, 10));
+
+        // [GIVEN] A Sales Invoice copied from that Sales Order, which carries over the Sales Subscription Lines
+        LibrarySales.CreateSalesHeader(SalesInvoiceHeader2, SalesInvoiceHeader2."Document Type"::Invoice, SalesHeader."Sell-to Customer No.");
+        SalesInvoiceNo := SalesInvoiceHeader2."No.";
+        CopyDocMgt.CopySalesDoc(Enum::"Sales Document Type From"::Order, SalesHeader."No.", SalesInvoiceHeader2);
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnDocument(SalesInvoiceHeader2."Document Type"::Invoice, SalesInvoiceNo);
+        Assert.RecordIsNotEmpty(SalesServiceCommitment);
+
+        // [WHEN] Posting the Sales Invoice
+        LibrarySales.PostSalesDocument(SalesInvoiceHeader2, true, true);
+
+        // [THEN] No Sales Subscription Line of the posted Sales Invoice is left behind
+        SalesServiceCommitment.Reset();
+        SalesServiceCommitment.FilterOnDocument(SalesInvoiceHeader2."Document Type"::Invoice, SalesInvoiceNo);
+        Assert.RecordIsEmpty(SalesServiceCommitment);
+    end;
+
     #endregion Tests
 
     #region Procedures
+
+    local procedure RunDeleteInvdBlnktSalesOrders(BlanketOrderNo: Code[20])
+    var
+        FilterSalesHeader: Record "Sales Header";
+        DeleteInvdBlnktSalesOrders: Report "Delete Invd Blnkt Sales Orders";
+    begin
+        FilterSalesHeader.SetRange("Document Type", FilterSalesHeader."Document Type"::"Blanket Order");
+        FilterSalesHeader.SetRange("No.", BlanketOrderNo);
+        DeleteInvdBlnktSalesOrders.SetTableView(FilterSalesHeader);
+        DeleteInvdBlnktSalesOrders.UseRequestPage(false);
+        DeleteInvdBlnktSalesOrders.Run();
+    end;
+
+    local procedure RunDeleteInvoicedSalesOrders(SalesOrderNo: Code[20])
+    var
+        FilterSalesHeader: Record "Sales Header";
+        DeleteInvoicedSalesOrders: Report "Delete Invoiced Sales Orders";
+    begin
+        FilterSalesHeader.SetRange("Document Type", FilterSalesHeader."Document Type"::Order);
+        FilterSalesHeader.SetRange("No.", SalesOrderNo);
+        DeleteInvoicedSalesOrders.SetTableView(FilterSalesHeader);
+        DeleteInvoicedSalesOrders.UseRequestPage(false);
+        DeleteInvoicedSalesOrders.Run();
+    end;
 
     local procedure Initialize()
     begin


### PR DESCRIPTION
## What & why

Reports 299 "Delete Invoiced Sales Orders" and 291 "Delete Invd Blnkt Sales Orders" remove sales
lines with `Delete()` and `DeleteAll()`, which default to `RunTrigger = false`. The `OnDelete()`
trigger of tableextension 8054 "Sales Line" therefore never fires, and the Sales Subscription Lines
of the deleted document survive as orphans pointing at a document number that no longer exists.
Users see the "Sales Subscription Lines" list keep growing with entries for orders nobody can open
any more, and nothing in the UI can clean them up — only a data fix can.

This hits Subscription Billing users especially often, because Subscription Items force
`Qty. to Invoice = 0`, so `EverythingInvoiced` is never true and `Sales-Post` does not auto-delete
the order. The order is left fully shipped and invoiced — exactly report 299's scope.

The issue reports report 299. Report 291 is included because it is the identical defect on the
blanket-order path: `SalesBlanketOrderLine.DeleteAll()` is equally trigger-less, and "Blanket Order"
is one of the document types in `IsSalesDocumentTypeWithServiceCommitments()`. It was confirmed by a
failing test before the fix, not assumed.

Changes:

- Two event subscribers in codeunit 8069 "Sales Subscription Line Mgmt.", following the per-path
  pattern the app already uses for `Sales-Post` and `Sales-Quote to Order`. No Base Application
  change is needed; both reports already publish suitable integration events.
- Report 299 hooks `OnAfterDeleteSalesLinesLoop`, not `OnBeforeDeleteSalesHeader`. The latter fires
  only when the header is deleted, which would leak the subscription lines on the branch where an
  unassigned `Charge (Item)` line keeps the order alive after its item lines were already removed.
- The four trigger-less deletion paths (both reports, `Sales-Post`, `Sales-Quote to Order`) now share
  a new `SalesHeader.DeleteSalesServiceCommitments()` on tableextension 8053, which batch-deletes a
  whole document's subscription lines. It lives on the header because `Document Type` + `No.` is the
  header's primary key and all four call sites already hold a `Sales Header`.
- That procedure deliberately does **not** filter on document type. Copy Document guards only the
  source line and stamps the target's document type unchecked, so subscription lines can legitimately
  exist on invoices and credit memos and must still be cleaned up on posting.
- `SalesLine.DeleteSalesServiceCommitment()` and `SalesHeader.DeleteSalesServiceCommitments()` are
  **public** rather than internal, and carry XML documentation. This is intentional: customers already
  need to call the deletion logic from outside the app, so both are exposed as a supported entry point.

## Linked work

Fixes #10175

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Built with `alc.exe` (CodeCop, UICop, PerTenantExtensionCop, `src/rulesets/base.ruleset.json`) and
published to a BC 29 container. The only warning is pre-existing `AA0139` in an untouched file.

Three new tests in codeunit 139915 "Sales Service Commitment Test":

- `CheckDeleteSalesServiceCommitmentOnDeleteInvoicedSalesOrders` — order with a Subscription Item,
  fully shipped and invoiced, still open; run report 299; order gone and no subscription line left.
- `CheckDeleteSalesServiceCommitmentOnDeleteInvdBlnktSalesOrders` — blanket order with two lines,
  converted to an order that is then fully posted; run report 291; same assertions.
- `CheckDeleteSalesServiceCommitmentOnPostSalesInvoiceCopiedFromSalesOrder` — invoice created from an
  order by Copy Document; posting it removes the copied subscription lines. This path had no coverage
  and is what proves the shared procedure must not filter on document type.

Both report tests carry `[TransactionModel(TransactionModel::AutoCommit)]` because reports 299 and 291
commit unconditionally.

Each test was confirmed red before the fix and green after. The fix was then mutation-tested by
rebuilding, republishing and re-running: removing either subscriber reddens only its own test;
weakening the shared filter to document-type-only reddens both new tests and the pre-existing
`SalesServiceCommitmentMakeOrderFromQuote`; dropping the second blanket-order line's cleanup reddens
the blanket test. Both new tests also assert that a second, untouched document keeps its subscription
lines, so an over-deleting filter cannot pass.

Suites run green on the container: codeunit 139915 (69/69), 139687 "Recurring Billing Docs Test"
(88/88, covering the invoice and credit-memo posting paths that share the refactored procedure), and
139916 "Service Comm. Archive Test" (5/5).

## Risk & compatibility

- **Public API surface.** Two procedures on tableextensions 8053/8054 become part of the app's public
  contract, by design (see above). `DeleteSalesServiceCommitment()` was previously `internal`.
- **Refactor of existing paths.** The `Sales-Post` and `Sales-Quote to Order` subscribers now route
  through the shared procedure. Behaviour is unchanged apart from the `Sales-Post` subscriber no longer
  needing `SalesLine.FindFirst()` to recover the document key, since the publisher passes the header.
- **No schema or upgrade impact**, no permission or telemetry changes.
- **Archiving is unaffected** — both reports archive the document before deleting it, so
  "Sales Subscription Line Archive" entries are written as before. Only the live table 8068 was leaking.
- No new translatable strings: the only new labels are `Locked = true` test assertion messages.

