### PR TITLE
Add SetReferenceType method to SignedXml and SignedXmlImpl (#10139)

### DIFF
--- a/src/System Application/App/Cryptography Management/src/Xml/SignedXml.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/Xml/SignedXml.Codeunit.al
@@ -92,6 +92,15 @@ codeunit 1460 SignedXml
     end;
 
     /// <summary>
+    /// Sets the type Uniform Resource Identifier (URI) of the current Reference.
+    /// </summary>
+    /// <param name="Type">The type URI of the current Reference.</param>
+    procedure SetReferenceType(Type: Text)
+    begin
+        SignedXmlImpl.SetReferenceType(Type);
+    end;
+
+    /// <summary>
     /// Sets the digest method Uniform Resource Identifier (URI) of the current Reference.
     /// </summary>
     /// <param name="DigestMethod">The digest method URI of the current Reference. The default value is http://www.w3.org/2001/04/xmlenc#sha256.</param>

--- a/src/System Application/App/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
+++ b/src/System Application/App/Cryptography Management/src/Xml/SignedXmlImpl.Codeunit.al
@@ -47,6 +47,11 @@ codeunit 1461 "SignedXml Impl."
         DotNetReference := DotNetReference.Reference(Uri);
     end;
 
+    procedure SetReferenceType(Type: Text)
+    begin
+        DotNetReference.Type := Type;
+    end;
+
     procedure SetDigestMethod(DigestMethod: Text)
     begin
         DotNetReference.DigestMethod := DigestMethod;

--- a/src/System Application/Test/Cryptography Management/src/Xml/SignedXmlModuleTest.Codeunit.al
+++ b/src/System Application/Test/Cryptography Management/src/Xml/SignedXmlModuleTest.Codeunit.al
@@ -82,6 +82,43 @@ codeunit 132612 "Signed Xml Module Test"
     end;
 
     [Test]
+    procedure SetReferenceType()
+    var
+        SignatureKey: Codeunit "Signature Key";
+        XmlToSign: XmlDocument;
+        KeyText: SecretText;
+        Signature: XmlElement;
+        NamespaceMgr: XmlNamespaceManager;
+        Node: XmlNode;
+        SignatureNamespaceUriTok: Label 'http://www.w3.org/2000/09/xmldsig#', Locked = true;
+        ReferenceTypeTok: Label 'http://uri.etsi.org/01903#SignedProperties', Locked = true;
+    begin
+        XmlDocument.ReadFrom('<XmlData Id="ID01">This is a document</XmlData>', XmlToSign);
+        GetSignatureKeyXmlString(KeyText);
+        SignatureKey.FromXmlString(KeyText);
+
+        SignedXml.InitializeSignedXml(XmlToSign);
+        SignedXml.SetSigningKey(SignatureKey);
+        SignedXml.InitializeReference('#ID01');
+        SignedXml.SetReferenceType(ReferenceTypeTok);
+        SignedXml.AddReferenceToSignedXML();
+
+        SignedXml.ComputeSignature();
+        Signature := SignedXml.GetXml();
+
+        NamespaceMgr.AddNamespace('ns', SignatureNamespaceUriTok);
+        Signature.SelectSingleNode(
+            './ns:SignedInfo/ns:Reference/@Type',
+            NamespaceMgr,
+            Node);
+
+        LibraryAssert.AreEqual(
+            ReferenceTypeTok,
+            Node.AsXmlAttribute().Value,
+            'Incorrect reference type was applied.');
+    end;
+
+    [Test]
     procedure SetXmlDSigC14NTranform()
     var
         SignatureKey: Codeunit "Signature Key";


### PR DESCRIPTION
## What & why

Adds support for setting the `Type` property on an XMLDSIG `Reference` through the public `SignedXml` codeunit.

`SignedXml` already exposes the reference URI, digest method, and transforms, but not the underlying `Reference.Type` property. This prevents callers from creating XML signatures that require a typed reference, such as a reference to XAdES `SignedProperties`.

The change adds `SetReferenceType(Type: Text)` to `SignedXml` and its implementation, together with a unit test verifying that the configured value is emitted as the `Type` attribute of the generated `<Reference>` element.

## Linked work

Fixes #10139

## How I validated this

* [x] I read the full diff and it contains only changes I intended.
* [x] I built the affected app(s) locally with no new analyzer warnings.
* [x] I ran the change in Business Central and confirmed it behaves as expected.
* [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

* Added a unit test in `SignedXmlModuleTest.Codeunit.al` that initializes an XMLDSIG reference, sets its `Type`, computes the signature, and verifies that the generated `<Reference>` element contains the expected `Type` attribute.
* The affected Cryptography Management test module passes locally.
* No UI changes are involved.

## Risk & compatibility

Low risk. The change only adds a new public procedure and delegates it to the existing underlying .NET `Reference.Type` property.

There are no breaking changes, data or upgrade impacts, permission changes, telemetry changes, or feature flags.

