### PR TITLE
Bug 8845 Old Prices Calculated in Req. Worksheet

### DIFF
--- a/src/Layers/BE/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/BE/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -344,8 +344,8 @@ codeunit 137063 "SCM Manufacturing 7.0"
         // Exercise: Run Planning Worksheet.
         LibraryPlanning.CalcRegenPlanForPlanWksh(ParentItem, WorkDate(), WorkDate());
 
-        // Verify: Verify Quantity and Dates in Requisition line.
-        VerifyValueInRequisitionLine(ParentItem, SalesLine.Quantity, SalesHeader."Order Date");
+        // Verify: Verify Quantity in Requisition line.
+        VerifyQuantityInRequisitionLine(ParentItem, SalesLine.Quantity);
 
         // Exercise: Run Carry Out Action Messages to create a Production Order.
         CarryOutActionMsgForItem(ParentItem."No.");
@@ -3039,11 +3039,11 @@ codeunit 137063 "SCM Manufacturing 7.0"
         LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
 
         // [WHEN] Run Calculation Plan from Req Worksheet for created Item
-        CalculatePlanForReqWksh(Item, CalcDate('<-CY>', WorkDate()), CalcDate('<CY>', WorkDate()));
+        CalculatePlanForReqWksh(Item, WorkDate(), CalcDate('<CY>', WorkDate()));
 
         // [THEN] Verify Order Date in Requisition line is calculated correctly
         FindRequisitionLine(RequisitionLine, Item."No.");
-        RequisitionLine.TestField("Order Date", CalcDate('<-CY>', WorkDate()));
+        RequisitionLine.TestField("Order Date", WorkDate());
     end;
 
 #if not CLEAN29
@@ -5583,16 +5583,12 @@ codeunit 137063 "SCM Manufacturing 7.0"
           "Due Date", CalcDate(InventorySetup."Default Safety Lead Time", CalcDate(Item."Lead Time Calculation", WorkDate())));
     end;
 
-    local procedure VerifyValueInRequisitionLine(Item: Record Item; Quantity: Decimal; OrderDate: Date)
+    local procedure VerifyQuantityInRequisitionLine(Item: Record Item; Quantity: Decimal)
     var
         RequisitionLine: Record "Requisition Line";
     begin
         FindRequisitionLine(RequisitionLine, Item."No.");
         RequisitionLine.TestField(Quantity, Quantity);
-        RequisitionLine.TestField("Due Date", CalcDate(Item."Lead Time Calculation", WorkDate()));
-        InventorySetup.Get();
-        RequisitionLine.TestField(
-          "Order Date", CalcDate('<' + '-' + Format(InventorySetup."Default Safety Lead Time") + '>', OrderDate));
     end;
 
     local procedure VerifyPlanningRoutingLine(RoutingHeader: Record "Routing Header"; RequisitionWkshName: Record "Requisition Wksh. Name"; ItemNo: Code[20]; Quantity: Integer)

--- a/src/Layers/IT/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
@@ -2734,7 +2734,7 @@ table 246 "Requisition Line"
     /// </summary>
     /// <param name="LeadTime">Provided lead time formula.</param>
     /// <remarks>In case 'LeadTime' is empty, lead time code will be defined according to the reference order type. 
-    /// 'Order Date' of the current requisition line will be set to newly calculated 'Starting Date'. </remarks>
+    /// 'Order Date' of the current requisition line will be updated. </remarks>
     procedure CalcStartingDate(LeadTime: Code[20])
     var
         IsHandled: Boolean;

--- a/src/Layers/IT/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
@@ -442,12 +442,10 @@ table 246 "Requisition Line"
 
             trigger OnValidate()
             begin
-                "Starting Date" := "Order Date";
-
                 GetDirectCost(FieldNo("Order Date"));
 
                 if CurrFieldNo = FieldNo("Order Date") then
-                    Validate("Starting Date");
+                    Validate("Starting Date", "Order Date");
             end;
         }
         field(22; "Vendor Item No."; Text[50])
@@ -2779,7 +2777,11 @@ table 246 "Requisition Line"
         IsHandled := false;
         OnCalcStartingDateOnBeforeValidateOrderDate(Rec, LeadTime, IsHandled);
         if not IsHandled then
-            Validate("Order Date", "Starting Date");
+            // Don't use order date in the past for price calculation
+            if "Starting Date" >= WorkDate() then
+                Validate("Order Date", "Starting Date")
+            else
+                Validate("Order Date", WorkDate());
 
         if "Ref. Order Type" = "Ref. Order Type"::Transfer then
             CalcTransferShipmentDate();
@@ -2898,7 +2900,11 @@ table 246 "Requisition Line"
     begin
         "Demand Date" := DemandDate;
         "Starting Date" := "Demand Date";
-        "Order Date" := "Demand Date";
+        // Don't use order date in the past for price calculation
+        if DemandDate >= WorkDate() then
+            "Order Date" := "Demand Date"
+        else
+            "Order Date" := WorkDate();
         Validate("Due Date", "Demand Date");
 
         if "Planning Level" = 0 then begin

--- a/src/Layers/IT/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/IT/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -344,8 +344,8 @@ codeunit 137063 "SCM Manufacturing 7.0"
         // Exercise: Run Planning Worksheet.
         LibraryPlanning.CalcRegenPlanForPlanWksh(ParentItem, WorkDate(), WorkDate());
 
-        // Verify: Verify Quantity and Dates in Requisition line.
-        VerifyValueInRequisitionLine(ParentItem, SalesLine.Quantity, SalesHeader."Order Date");
+        // Verify: Verify Quantity in Requisition line.
+        VerifyQuantityInRequisitionLine(ParentItem, SalesLine.Quantity);
 
         // Exercise: Run Carry Out Action Messages to create a Production Order.
         CarryOutActionMsgForItem(ParentItem."No.");
@@ -3033,11 +3033,11 @@ codeunit 137063 "SCM Manufacturing 7.0"
         LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
 
         // [WHEN] Run Calculation Plan from Req Worksheet for created Item
-        CalculatePlanForReqWksh(Item, CalcDate('<-CY>', WorkDate()), CalcDate('<CY>', WorkDate()));
+        CalculatePlanForReqWksh(Item, WorkDate(), CalcDate('<CY>', WorkDate()));
 
         // [THEN] Verify Order Date in Requisition line is calculated correctly
         FindRequisitionLine(RequisitionLine, Item."No.");
-        RequisitionLine.TestField("Order Date", CalcDate('<-CY>', WorkDate()));
+        RequisitionLine.TestField("Order Date", WorkDate());
     end;
 
 #if not CLEAN28
@@ -5592,16 +5592,12 @@ codeunit 137063 "SCM Manufacturing 7.0"
           "Due Date", CalcDate(InventorySetup."Default Safety Lead Time", CalcDate(Item."Lead Time Calculation", WorkDate())));
     end;
 
-    local procedure VerifyValueInRequisitionLine(Item: Record Item; Quantity: Decimal; OrderDate: Date)
+    local procedure VerifyQuantityInRequisitionLine(Item: Record Item; Quantity: Decimal)
     var
         RequisitionLine: Record "Requisition Line";
     begin
         FindRequisitionLine(RequisitionLine, Item."No.");
         RequisitionLine.TestField(Quantity, Quantity);
-        RequisitionLine.TestField("Due Date", CalcDate(Item."Lead Time Calculation", WorkDate()));
-        InventorySetup.Get();
-        RequisitionLine.TestField(
-          "Order Date", CalcDate('<' + '-' + Format(InventorySetup."Default Safety Lead Time") + '>', OrderDate));
     end;
 
     local procedure VerifyPlanningRoutingLine(RoutingHeader: Record "Routing Header"; RequisitionWkshName: Record "Requisition Wksh. Name"; ItemNo: Code[20]; Quantity: Integer)

--- a/src/Layers/IT/Tests/SCM-Planning/SCMSupplyPlanningIV.Codeunit.al
+++ b/src/Layers/IT/Tests/SCM-Planning/SCMSupplyPlanningIV.Codeunit.al
@@ -1517,7 +1517,7 @@ codeunit 137077 "SCM Supply Planning -IV"
         if MakeToOrder then
             UpdateItemManufacturingPolicy(Item, Item."Manufacturing Policy"::"Make-to-Order");
         UpdateItemLeadTimeCalculation(Item, '<' + Format(LibraryRandom.RandInt(5) + 10) + 'D>');  // Random Lead Time Calculation.
-        CreateSalesOrder(Item."No.", '');
+        CreateSalesOrderWithShipmentDate(Item."No.", '', LibraryRandom.RandInt(10), CalcDate('<1M>', WorkDate()));
 
         // Exercise: Open Order Promising Lines Page and Invoke Capable to Promise Action.
         FindSalesLine(SalesLine, Item."No.");
@@ -5134,6 +5134,15 @@ codeunit 137077 "SCM Supply Planning -IV"
     begin
         LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, Quantity);
+    end;
+
+    local procedure CreateSalesOrderWithShipmentDate(ItemNo: Code[20]; CustomerNo: Code[20]; Quantity: Decimal; ShipmentDate: Date)
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+    begin
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, ShipmentDate, Quantity);
     end;
 
     local procedure CreateSalesOrderAtLocation(ItemNo: Code[20]; LocationCode: Code[10])

--- a/src/Layers/W1/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
@@ -2734,7 +2734,7 @@ table 246 "Requisition Line"
     /// </summary>
     /// <param name="LeadTime">Provided lead time formula.</param>
     /// <remarks>In case 'LeadTime' is empty, lead time code will be defined according to the reference order type. 
-    /// 'Order Date' of the current requisition line will be set to newly calculated 'Starting Date'. </remarks>
+    /// 'Order Date' of the current requisition line will be updated. </remarks>
     procedure CalcStartingDate(LeadTime: Code[20])
     var
         IsHandled: Boolean;

--- a/src/Layers/W1/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Requisition/RequisitionLine.Table.al
@@ -442,12 +442,10 @@ table 246 "Requisition Line"
 
             trigger OnValidate()
             begin
-                "Starting Date" := "Order Date";
-
                 GetDirectCost(FieldNo("Order Date"));
 
                 if CurrFieldNo = FieldNo("Order Date") then
-                    Validate("Starting Date");
+                    Validate("Starting Date", "Order Date");
             end;
         }
         field(22; "Vendor Item No."; Text[50])
@@ -2779,7 +2777,11 @@ table 246 "Requisition Line"
         IsHandled := false;
         OnCalcStartingDateOnBeforeValidateOrderDate(Rec, LeadTime, IsHandled);
         if not IsHandled then
-            Validate("Order Date", "Starting Date");
+            // Don't use order date in the past for price calculation
+            if "Starting Date" >= WorkDate() then
+                Validate("Order Date", "Starting Date")
+            else
+                Validate("Order Date", WorkDate());
 
         if "Ref. Order Type" = "Ref. Order Type"::Transfer then
             CalcTransferShipmentDate();
@@ -2898,7 +2900,11 @@ table 246 "Requisition Line"
     begin
         "Demand Date" := DemandDate;
         "Starting Date" := "Demand Date";
-        "Order Date" := "Demand Date";
+        // Don't use order date in the past for price calculation
+        if DemandDate >= WorkDate() then
+            "Order Date" := "Demand Date"
+        else
+            "Order Date" := WorkDate();
         Validate("Due Date", "Demand Date");
 
         if "Planning Level" = 0 then begin

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -344,8 +344,8 @@ codeunit 137063 "SCM Manufacturing 7.0"
         // Exercise: Run Planning Worksheet.
         LibraryPlanning.CalcRegenPlanForPlanWksh(ParentItem, WorkDate(), WorkDate());
 
-        // Verify: Verify Quantity and Dates in Requisition line.
-        VerifyValueInRequisitionLine(ParentItem, SalesLine.Quantity, SalesHeader."Order Date");
+        // Verify: Verify Quantity in Requisition line.
+        VerifyQuantityInRequisitionLine(ParentItem, SalesLine.Quantity);
 
         // Exercise: Run Carry Out Action Messages to create a Production Order.
         CarryOutActionMsgForItem(ParentItem."No.");
@@ -3033,11 +3033,11 @@ codeunit 137063 "SCM Manufacturing 7.0"
         LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
 
         // [WHEN] Run Calculation Plan from Req Worksheet for created Item
-        CalculatePlanForReqWksh(Item, CalcDate('<-CY>', WorkDate()), CalcDate('<CY>', WorkDate()));
+        CalculatePlanForReqWksh(Item, WorkDate(), CalcDate('<CY>', WorkDate()));
 
         // [THEN] Verify Order Date in Requisition line is calculated correctly
         FindRequisitionLine(RequisitionLine, Item."No.");
-        RequisitionLine.TestField("Order Date", CalcDate('<-CY>', WorkDate()));
+        RequisitionLine.TestField("Order Date", WorkDate());
     end;
 
 #if not CLEAN29
@@ -5473,16 +5473,12 @@ codeunit 137063 "SCM Manufacturing 7.0"
           "Due Date", CalcDate(InventorySetup."Default Safety Lead Time", CalcDate(Item."Lead Time Calculation", WorkDate())));
     end;
 
-    local procedure VerifyValueInRequisitionLine(Item: Record Item; Quantity: Decimal; OrderDate: Date)
+    local procedure VerifyQuantityInRequisitionLine(Item: Record Item; Quantity: Decimal)
     var
         RequisitionLine: Record "Requisition Line";
     begin
         FindRequisitionLine(RequisitionLine, Item."No.");
         RequisitionLine.TestField(Quantity, Quantity);
-        RequisitionLine.TestField("Due Date", CalcDate(Item."Lead Time Calculation", WorkDate()));
-        InventorySetup.Get();
-        RequisitionLine.TestField(
-          "Order Date", CalcDate('<' + '-' + Format(InventorySetup."Default Safety Lead Time") + '>', OrderDate));
     end;
 
     local procedure VerifyPlanningRoutingLine(RoutingHeader: Record "Routing Header"; RequisitionWkshName: Record "Requisition Wksh. Name"; ItemNo: Code[20]; Quantity: Integer)

--- a/src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningIII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningIII.Codeunit.al
@@ -2206,7 +2206,7 @@ codeunit 137088 "SCM Order Planning - III"
         ItemVendor.Validate("Lead Time Calculation", LeadTimeFormula);
         ItemVendor.Modify(true);
 
-        CreateSalesOrder(SalesHeader, Item."No.", '', Qty, Qty);
+        CreateSalesOrderWithShipmentDate(SalesHeader, Item."No.", '', Qty, Qty, CalcDate('<1M>', WorkDate()));
         FindSalesLine(SalesLine, SalesHeader, Item."No.");
 
         LibraryVariableStorage.Enqueue(Vendor."No.");
@@ -2249,7 +2249,7 @@ codeunit 137088 "SCM Order Planning - III"
         ItemVendor.Validate("Lead Time Calculation", LeadTimeFormula);
         ItemVendor.Modify(true);
 
-        CreateSalesOrder(SalesHeader, Item."No.", '', Qty, Qty);
+        CreateSalesOrderWithShipmentDate(SalesHeader, Item."No.", '', Qty, Qty, CalcDate('<1M>', WorkDate()));
         FindSalesLine(SalesLine, SalesHeader, Item."No.");
 
         LibraryVariableStorage.Enqueue(Vendor."No.");
@@ -4099,6 +4099,15 @@ codeunit 137088 "SCM Order Planning - III"
           SalesHeader, SalesLine, SalesHeader."Document Type"::Order, '', ItemNo, LibraryRandom.RandInt(100), '', WorkDate());
         SalesLine.Validate("Purchasing Code", PurchasingCode);
         SalesLine.Modify(true);
+    end;
+
+    local procedure CreateSalesOrderWithShipmentDate(var SalesHeader: Record "Sales Header"; ItemNo: Code[20]; LocationCode: Code[10]; Quantity: Decimal; QtyToShip: Decimal; ShipmentDate: Date)
+    begin
+        Clear(SalesHeader);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, '');
+        SalesHeader.Validate("Location Code", LocationCode);
+        SalesHeader.Modify(true);
+        CreateSalesLine(SalesHeader, ItemNo, LocationCode, ShipmentDate, Quantity, QtyToShip);
     end;
 
     local procedure CreateLocation(var Location: Record Location)

--- a/src/Layers/W1/Tests/SCM-Planning/SCMPlanReqWksht.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMPlanReqWksht.Codeunit.al
@@ -34,6 +34,7 @@
         LibraryERM: Codeunit "Library - ERM";
         AvailabilityMgt: Codeunit AvailabilityManagement;
         LibraryReportDataset: Codeunit "Library - Report Dataset";
+        LibraryPriceCalculation: Codeunit "Library - Price Calculation";
         isInitialized: Boolean;
         RequisitionLineMustNotExistTxt: Label 'Requisition Line must not exist for Item %1.', Comment = '%1 = Item No.';
         ShipmentDateMessageTxt: Label 'Shipment Date';
@@ -5663,6 +5664,74 @@
         PlanningComponent.SetRange("Item No.", ComponentItem."No.");
         PlanningComponent.FindFirst();
         Assert.AreEqual(ExpectedQty, PlanningComponent."Expected Quantity", 'Expected Quantity should be rounded up by Qty. Rounding Precision');
+    end;
+
+    [Test]
+    procedure CurrentPriceWhenUsingOldDate()
+    var
+        Item: Record Item;
+        ItemVendor: Record "Item Vendor";
+        PriceListLine: Record "Price List Line";
+        RequisitionLine: Record "Requisition Line";
+        Vendor: Record Vendor;
+    begin
+        // [SCENARIO] Rush orders should not get an old price
+        // [FEATURE] [Requisition Line] [Purchase Price Calculation]
+        Initialize();
+
+        // [GIVEN] New pricing enabled
+        LibraryPriceCalculation.EnableExtendedPriceCalculation();
+
+        // [GIVEN] Default price calculation is 'V16'
+        LibraryPriceCalculation.SetupDefaultHandler("Price Calculation Handler"::"Business Central (Version 16.0)");
+
+        // [GIVEN] Item with vendor.
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        UpdateItemVendorNo(Item, Vendor."No.");
+
+        // [GIVEN] Item Vendor with Lead Time Calculation
+        LibraryInventory.CreateItemVendor(ItemVendor, Vendor."No.", Item."No.");
+        Evaluate(ItemVendor."Lead Time Calculation", '<1W>');
+        ItemVendor.Modify();
+
+        // [GIVEN] Price List Line for the item and vendor using an old date range.
+        LibraryPriceCalculation.CreatePurchPriceLine(
+            PriceListLine, PriceListLine."Price List Code",
+            "Price Source Type"::Vendor, Vendor."No.", "Price Asset Type"::Item, Item."No.");
+        PriceListLine.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 20, 2));
+        PriceListLine.Status := PriceListLine.Status::Active;
+        PriceListLine.Validate("Ending Date", WorkDate() - 1);
+        PriceListLine.Modify(true);
+
+        // [GIVEN] Price List Line for the item and vendor using a new date range.
+        PriceListLine.Init();
+        LibraryPriceCalculation.CreatePurchPriceLine(
+            PriceListLine, PriceListLine."Price List Code",
+            "Price Source Type"::Vendor, Vendor."No.", "Price Asset Type"::Item, Item."No.");
+        PriceListLine.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(30, 60, 2));
+        PriceListLine.Status := PriceListLine.Status::Active;
+        PriceListLine.Validate("Starting Date", WorkDate());
+        PriceListLine.Modify(true);
+
+        // [GIVEN] A requisition line for the item and vendor
+        CreateRequisitionLine(RequisitionLine);
+        RequisitionLine.Validate(Type, RequisitionLine.Type::Item);
+        RequisitionLine.Validate("No.", Item."No.");
+        RequisitionLine.Validate("Vendor No.", Vendor."No.");
+        RequisitionLine.Validate(Quantity, LibraryRandom.RandIntInRange(1, 10));
+        RequisitionLine.Modify(true);
+
+        // [WHEN] Setting ending date to workdate, requiring the item to be ordered in the past according to the lead time
+        RequisitionLine.Validate("Ending Date", WorkDate());
+        RequisitionLine.Modify(true);
+
+        // [THEN] The price should still be current and not pick the price when the order should have been placed.
+        Assert.AreEqual(PriceListLine."Direct Unit Cost", RequisitionLine."Direct Unit Cost", 'Price Calculation did not pick new price');
+
+        // [THEN] Order date should be later than starting date.
+        Assert.AreEqual(RequisitionLine."Order Date", WorkDate(), 'Order Date is not set to current date');
+        Assert.IsTrue(RequisitionLine."Starting Date" < RequisitionLine."Order Date", 'Starting Date is not earlier than Order Date');
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/Tests/SCM-Planning/SCMSupplyPlanning.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMSupplyPlanning.Codeunit.al
@@ -47,7 +47,7 @@ codeunit 137054 "SCM Supply Planning"
         OrderDateErr: Label 'Order Date (%1) on Requisition Line is not equal to Order Date (%2) on Purchase Line.';
         ExceptionMsg: Label 'Exception: The projected available inventory is below Safety Stock Quantity %1 on %2.';
         RequisitionWorksheetErr: Label 'Requisition Worksheet cannot be used to create Prod. Order replenishment.';
-        ReqLineOrderDateErr: Label 'Order Date (%1) on Requisition Line is not equal to Starting Date on Planning Worksheet.';
+        ReqLineStartingDateErr: Label 'Starting Date (%1) on Requisition Line is not equal to Expected Receipt Date (%2).';
         ExpectedReceiptDateErr: Label 'Expected Receipt Date in Reservation Entry is not correct.';
         DemandTypeOption: Option "Sales Order","Transfer Order","Released Prod. Order",Assembly,"Purchase Return";
         SupplyTypeOption: array[5] of Option "None",Released,FirmPlanned,Purchase,"Sales Return",Transfer,Assembly,Planning;
@@ -4058,9 +4058,9 @@ codeunit 137054 "SCM Supply Planning"
         LibraryPlanning.CalcRegenPlanForPlanWksh(Item, WorkDate(), CalcDate('<CY>', WorkDate()));
         FindRequisitionLine(RequisitionLine, Item."No.");
 
-        // Verify: verify Order Date in created requisition line.
+        // Verify: verify Starting Date in created requisition line.
         ExpectedDate := FindClosestWorkingDay(ServiceMgtSetup, WorkDate());
-        Assert.AreEqual(ExpectedDate, RequisitionLine."Order Date", StrSubstNo(ReqLineOrderDateErr, ExpectedDate));
+        Assert.AreEqual(ExpectedDate, RequisitionLine."Starting Date", StrSubstNo(ReqLineStartingDateErr, RequisitionLine."Starting Date", ExpectedDate));
 
         // Tear Down.
         UpdateCompanyInformationBaseCalendarCode(OldBaseCalendarCode);
@@ -4081,8 +4081,8 @@ codeunit 137054 "SCM Supply Planning"
         LibraryPlanning.CalcRegenPlanForPlanWksh(Item, WorkDate(), CalcDate('<CY>', WorkDate()));
         FindRequisitionLine(RequisitionLine, Item."No.");
 
-        // Verify: verify Order Date in created requisition line.
-        Assert.AreEqual(WorkDate(), RequisitionLine."Order Date", StrSubstNo(ReqLineOrderDateErr, WorkDate()));
+        // Verify: verify Starting Date in created requisition line.
+        Assert.AreEqual(WorkDate(), RequisitionLine."Starting Date", StrSubstNo(ReqLineStartingDateErr, RequisitionLine."Starting Date", WorkDate()));
     end;
 
     [Test]
@@ -4110,9 +4110,9 @@ codeunit 137054 "SCM Supply Planning"
         LibraryPlanning.CalcRegenPlanForPlanWksh(Item, WorkDate(), CalcDate('<CY>', WorkDate()));
         FindRequisitionLine(RequisitionLine, Item."No.");
 
-        // Verify: verify Order Date in created requisition line.
+        // Verify: verify Starting Date in created requisition line.
         ExpectedDate := FindClosestWorkingDay(ServiceMgtSetup, WorkDate());
-        Assert.AreEqual(ExpectedDate, RequisitionLine."Order Date", StrSubstNo(ReqLineOrderDateErr, ExpectedDate));
+        Assert.AreEqual(ExpectedDate, RequisitionLine."Starting Date", StrSubstNo(ReqLineStartingDateErr, RequisitionLine."Starting Date", ExpectedDate));
 
         // Tear Down.
         UpdateCompanyInformationBaseCalendarCode(OldBaseCalendarCode);

--- a/src/Layers/W1/Tests/SCM-Planning/SCMSupplyPlanning.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMSupplyPlanning.Codeunit.al
@@ -38,16 +38,16 @@ codeunit 137054 "SCM Supply Planning"
         Assert: Codeunit Assert;
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         isInitialized: Boolean;
-        NumberOfLineEqualError: Label 'Number of Lines must be same.';
-        NumberOfLineNotEqualError: Label 'Number of Lines must not be same.';
+        NumberOfLineEqualErr: Label 'Number of Lines must be same.';
+        NumberOfLineNotEqualErr: Label 'Number of Lines must not be same.';
         GlobalItemNo: Code[20];
-        MaximumOrderQuantityErr: Label 'Quantity(%1) on RequisitionLine is more than Maximum Order Quantity(%2) of the Item.';
-        SafetyStockQuantityErr: Label 'After calculating supply and demand of the Item, its inventory(%1) does not meet Safety Stock Quantity(%2). Supply should meet both demand and Safety Stock Quantity.';
+        MaximumOrderQuantityErr: Label 'Quantity(%1) on RequisitionLine is more than Maximum Order Quantity(%2) of the Item.', Comment = '%1 = Quantity, %2 = Maximum Order Quantity';
+        SafetyStockQuantityErr: Label 'After calculating supply and demand of the Item, its inventory(%1) does not meet Safety Stock Quantity(%2). Supply should meet both demand and Safety Stock Quantity.', Comment = '%1 = Inventory, %2 = Safety Stock Quantity';
         RequisitionLineNotEmptyErr: Label 'There should be no Requisition Line.';
-        OrderDateErr: Label 'Order Date (%1) on Requisition Line is not equal to Order Date (%2) on Purchase Line.';
-        ExceptionMsg: Label 'Exception: The projected available inventory is below Safety Stock Quantity %1 on %2.';
+        OrderDateErr: Label 'Order Date (%1) on Requisition Line is not equal to Order Date (%2) on Purchase Line.', Comment = '%1 = Requisition Line Order Date, %2 = Purchase Line Order Date';
+        ExceptionMsg: Label 'Exception: The projected available inventory is below Safety Stock Quantity %1 on %2.', Comment = '%1 = Safety Stock Quantity, %2 = Date';
         RequisitionWorksheetErr: Label 'Requisition Worksheet cannot be used to create Prod. Order replenishment.';
-        ReqLineStartingDateErr: Label 'Starting Date (%1) on Requisition Line is not equal to Expected Receipt Date (%2).';
+        ReqLineStartingDateErr: Label 'Starting Date (%1) on Requisition Line is not equal to Expected Receipt Date (%2).', Comment = '%1 = Requisition Line Starting Date, %2 = Expected Receipt Date';
         ExpectedReceiptDateErr: Label 'Expected Receipt Date in Reservation Entry is not correct.';
         DemandTypeOption: Option "Sales Order","Transfer Order","Released Prod. Order",Assembly,"Purchase Return";
         SupplyTypeOption: array[5] of Option "None",Released,FirmPlanned,Purchase,"Sales Return",Transfer,Assembly,Planning;
@@ -1224,7 +1224,7 @@ codeunit 137054 "SCM Supply Planning"
             VerifyRequisitionLineCount(1);  // Expected no of lines in Planning Worksheet. Value important.
         end else begin
             RequisitionLine2.SetRange("No.", Item."No.");
-            Assert.AreEqual(0, RequisitionLine2.Count, NumberOfLineEqualError);
+            Assert.AreEqual(0, RequisitionLine2.Count, NumberOfLineEqualErr);
         end;
     end;
 
@@ -1768,7 +1768,7 @@ codeunit 137054 "SCM Supply Planning"
 
         // Verify: Verify planning worksheet.
         PlanningComponent.SetRange("Item No.", Item2."No.");
-        Assert.AreEqual(0, PlanningComponent.Count, NumberOfLineEqualError);  // Zero for empty line.
+        Assert.AreEqual(0, PlanningComponent.Count, NumberOfLineEqualErr);  // Zero for empty line.
     end;
 
     [Test]
@@ -2246,7 +2246,7 @@ codeunit 137054 "SCM Supply Planning"
 
         // Verify: Verify Empty planning worksheet.
         RequisitionLine2.SetRange("No.", Item."No.");
-        Assert.AreEqual(0, RequisitionLine2.Count, NumberOfLineEqualError);
+        Assert.AreEqual(0, RequisitionLine2.Count, NumberOfLineEqualErr);
     end;
 
     [Test]
@@ -7083,8 +7083,8 @@ codeunit 137054 "SCM Supply Planning"
         RequisitionLine2: Record "Requisition Line";
     begin
         RequisitionLine2.SetRange("No.", ItemNo);
-        Assert.AreNotEqual(PlanningLinesCountBeforeCarryOut, RequisitionLine2.Count, NumberOfLineNotEqualError);
-        Assert.AreEqual(0, RequisitionLine2.Count, NumberOfLineEqualError);
+        Assert.AreNotEqual(PlanningLinesCountBeforeCarryOut, RequisitionLine2.Count, NumberOfLineNotEqualErr);
+        Assert.AreEqual(0, RequisitionLine2.Count, NumberOfLineEqualErr);
     end;
 
     local procedure VerifyPlanningWorksheet(var PlanningWorksheet: TestPage "Planning Worksheet"; ActionMessage: Enum "Action Message Type"; No: Code[20]; DueDate: Date; OriginalQuantity: Decimal; Quantity: Decimal; OriginalDueDate: Date)
@@ -7140,7 +7140,7 @@ codeunit 137054 "SCM Supply Planning"
         RequisitionLine2: Record "Requisition Line";
     begin
         RequisitionLine2.SetFilter("No.", '<>''''');
-        Assert.AreEqual(ExpectedReqLinesCount, RequisitionLine2.Count, NumberOfLineEqualError);
+        Assert.AreEqual(ExpectedReqLinesCount, RequisitionLine2.Count, NumberOfLineEqualErr);
     end;
 
     local procedure VerifyPurchaseOrderQuantity(ItemNo: Code[20]; Quantity: Decimal)

--- a/src/Layers/W1/Tests/SCM-Planning/SCMSupplyPlanningIV.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMSupplyPlanningIV.Codeunit.al
@@ -1517,7 +1517,7 @@ codeunit 137077 "SCM Supply Planning -IV"
         if MakeToOrder then
             UpdateItemManufacturingPolicy(Item, Item."Manufacturing Policy"::"Make-to-Order");
         UpdateItemLeadTimeCalculation(Item, '<' + Format(LibraryRandom.RandInt(5) + 10) + 'D>');  // Random Lead Time Calculation.
-        CreateSalesOrder(Item."No.", '');
+        CreateSalesOrderWithShipmentDate(Item."No.", '', LibraryRandom.RandInt(10), CalcDate('<1M>', WorkDate()));
 
         // Exercise: Open Order Promising Lines Page and Invoke Capable to Promise Action.
         FindSalesLine(SalesLine, Item."No.");
@@ -5119,6 +5119,15 @@ codeunit 137077 "SCM Supply Planning -IV"
     begin
         LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, Quantity);
+    end;
+
+    local procedure CreateSalesOrderWithShipmentDate(ItemNo: Code[20]; CustomerNo: Code[20]; Quantity: Decimal; ShipmentDate: Date)
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+    begin
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, ShipmentDate, Quantity);
     end;
 
     local procedure CreateSalesOrderAtLocation(ItemNo: Code[20]; LocationCode: Code[10])


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Does not set Order Date in Requisition Line to an older date than workdate when validating other fields, to make the price calculations correct.
Only update Starting Date when it is also validated to not set a faulty starting date. Also doesn't make sense to set starting date without validation since the field Starting Date-Time will not be synchronised.

Same pull request as microsoft/BusinessCentralApps#1869 that was closed when base app moved.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #8845

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

- Ran Calculate Plan... in Requistion Worksheet to see the results
- Added unit test in SCMPlanReqWksht.Codeunit.al
- Fixed old tests that relied on order date in the past to pass

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Starting Date isn't set when validating Order Date on Requisition Line from code. Should be a small risk since Starting Date-Time wasn't synchronised without further field validations.




