### PR TITLE
[Main]Posting Error with 50% Non-Deductible VAT when "Check Source Currency Consistency" is enabled in "General Ledger Setup" page

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1100,7 +1100,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/APAC/Tests/VAT/NonDedVATCurrency.Codeunit.al
+++ b/src/Layers/APAC/Tests/VAT/NonDedVATCurrency.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 134286 "Non. Ded. VAT Currency"
         isInitialized: Boolean;
         GLEntriesSourceCurrNotBalancedErr: Label 'G/L Entries source currency amounts must be balanced';
         NoSourceCurrGLEntriesErr: Label 'No G/L Entries with the expected source currency were created';
+        GLEntrySourceCurrAmountErr: Label 'G/L Entry source currency amount for account %1 is not as expected', Comment = '%1 = G/L Account No.';
 
     [Test]
     procedure BasicPurchInvWithACY()
@@ -259,10 +260,11 @@ codeunit 134286 "Non. Ded. VAT Currency"
         // [GIVEN] "Check Source Curr. Consistency" is enabled in General Ledger Setup
         EnableCheckSourceCurrConsistency();
 
-        // [GIVEN] Normal VAT Posting Setup with "VAT %" = 20 and partial "Non-Deductible VAT %" = 50
+        // [GIVEN] Normal VAT Posting Setup with "VAT %" = 20 and partial "Non-Deductible VAT %" = 50, with a dedicated Non-Deductible Purchase VAT Account
         LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", 20);
         LibraryNonDeductibleVAT.SetAllowNonDeductibleVATForVATPostingSetup(VATPostingSetup);
         VATPostingSetup.Validate("Non-Deductible VAT %", 50);
+        VATPostingSetup.Validate("Non-Ded. Purchase VAT Account", LibraryERM.CreateGLAccountNo());
         VATPostingSetup.Modify(true);
 
         // [GIVEN] Currency "C" with exchange rate that differs from LCY
@@ -286,6 +288,11 @@ codeunit 134286 "Non. Ded. VAT Currency"
         // [THEN] G/L Entries are balanced in LCY and in source currency
         VerifyGLEntriesBalanced(DocNo, PurchHeader."Posting Date");
         VerifyGLEntriesSourceCurrencyBalanced(DocNo, PurchHeader."Posting Date", CurrencyCode);
+
+        // [THEN] The deductible VAT G/L entry carries the deductible half of the 20 source-currency VAT amount (100 base * 20% VAT * (100% - 50% Non-Deductible))
+        VerifyGLEntrySourceCurrencyAmountForAccount(DocNo, PurchHeader."Posting Date", CurrencyCode, VATPostingSetup."Purchase VAT Account", 10);
+        // [THEN] The non-deductible VAT G/L entry carries the non-deductible half of the 20 source-currency VAT amount (100 base * 20% VAT * 50% Non-Deductible)
+        VerifyGLEntrySourceCurrencyAmountForAccount(DocNo, PurchHeader."Posting Date", CurrencyCode, VATPostingSetup."Non-Ded. Purchase VAT Account", 10);
     end;
 
     local procedure Initialize()
@@ -439,6 +446,19 @@ codeunit 134286 "Non. Ded. VAT Currency"
         Assert.IsFalse(GLEntry.IsEmpty(), NoSourceCurrGLEntriesErr);
         GLEntry.CalcSums("Source Currency Amount");
         Assert.AreEqual(0, GLEntry."Source Currency Amount", GLEntriesSourceCurrNotBalancedErr);
+    end;
+
+    local procedure VerifyGLEntrySourceCurrencyAmountForAccount(DocumentNo: Code[20]; PostingDate: Date; CurrencyCode: Code[10]; GLAccountNo: Code[20]; ExpectedSourceCurrencyAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.SetRange("Source Currency Code", CurrencyCode);
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        Assert.IsFalse(GLEntry.IsEmpty(), NoSourceCurrGLEntriesErr);
+        GLEntry.CalcSums("Source Currency Amount");
+        Assert.AreEqual(ExpectedSourceCurrencyAmount, GLEntry."Source Currency Amount", StrSubstNo(GLEntrySourceCurrAmountErr, GLAccountNo));
     end;
 
     local procedure EnableCheckSourceCurrConsistency()

--- a/src/Layers/APAC/Tests/VAT/NonDedVATCurrency.Codeunit.al
+++ b/src/Layers/APAC/Tests/VAT/NonDedVATCurrency.Codeunit.al
@@ -20,6 +20,8 @@ codeunit 134286 "Non. Ded. VAT Currency"
         LibraryUtility: Codeunit "Library - Utility";
         Assert: Codeunit Assert;
         isInitialized: Boolean;
+        GLEntriesSourceCurrNotBalancedErr: Label 'G/L Entries source currency amounts must be balanced';
+        NoSourceCurrGLEntriesErr: Label 'No G/L Entries with the expected source currency were created';
 
     [Test]
     procedure BasicPurchInvWithACY()
@@ -242,6 +244,50 @@ codeunit 134286 "Non. Ded. VAT Currency"
         VerifyGLEntriesBalanced(DocumentNo, PostingDate);
     end;
 
+    [Test]
+    procedure PostFCYPurchInvWithPartialNonDedVATAndSourceCurrConsistency()
+    var
+        PurchHeader: Record "Purchase Header";
+        PurchLine: Record "Purchase Line";
+        VATPostingSetup: Record "VAT Posting Setup";
+        CurrencyCode: Code[10];
+        DocNo: Code[20];
+    begin
+        // [SCENARIO 640619] Posting a foreign currency Purchase Invoice with partial Non-Deductible VAT does not cause a G/L Entry consistency error when "Check Source Curr. Consistency" is enabled in General Ledger Setup.
+        Initialize();
+
+        // [GIVEN] "Check Source Curr. Consistency" is enabled in General Ledger Setup
+        EnableCheckSourceCurrConsistency();
+
+        // [GIVEN] Normal VAT Posting Setup with "VAT %" = 20 and partial "Non-Deductible VAT %" = 50
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", 20);
+        LibraryNonDeductibleVAT.SetAllowNonDeductibleVATForVATPostingSetup(VATPostingSetup);
+        VATPostingSetup.Validate("Non-Deductible VAT %", 50);
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Currency "C" with exchange rate that differs from LCY
+        CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 100, 130);
+
+        // [GIVEN] Purchase Invoice in currency "C" with Normal VAT and partial Non-Deductible VAT
+        LibraryPurchase.CreatePurchHeader(
+            PurchHeader, PurchHeader."Document Type"::Invoice,
+            LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
+        PurchHeader.Validate("Currency Code", CurrencyCode);
+        PurchHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+            PurchLine, PurchHeader, PurchLine.Type::Item,
+            LibraryInventory.CreateItemWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), 1);
+        PurchLine.Validate("Direct Unit Cost", 100);
+        PurchLine.Modify(true);
+
+        // [WHEN] Post the Purchase Invoice (must not raise a source currency consistency error)
+        DocNo := LibraryPurchase.PostPurchaseDocument(PurchHeader, true, true);
+
+        // [THEN] G/L Entries are balanced in LCY and in source currency
+        VerifyGLEntriesBalanced(DocNo, PurchHeader."Posting Date");
+        VerifyGLEntriesSourceCurrencyBalanced(DocNo, PurchHeader."Posting Date", CurrencyCode);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -381,5 +427,26 @@ codeunit 134286 "Non. Ded. VAT Currency"
         GLEntry.CalcSums("Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
         Assert.AreEqual(GLEntry."Debit Amount", GLEntry."Credit Amount", 'G/L Entries LCY must be balanced');
         Assert.AreEqual(GLEntry."Add.-Currency Debit Amount", GLEntry."Add.-Currency Credit Amount", 'G/L Entries ACY must be balanced');
+    end;
+
+    local procedure VerifyGLEntriesSourceCurrencyBalanced(DocumentNo: Code[20]; PostingDate: Date; CurrencyCode: Code[10])
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.SetRange("Source Currency Code", CurrencyCode);
+        Assert.IsFalse(GLEntry.IsEmpty(), NoSourceCurrGLEntriesErr);
+        GLEntry.CalcSums("Source Currency Amount");
+        Assert.AreEqual(0, GLEntry."Source Currency Amount", GLEntriesSourceCurrNotBalancedErr);
+    end;
+
+    local procedure EnableCheckSourceCurrConsistency()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+    begin
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("Check Source Curr. Consistency", true);
+        GeneralLedgerSetup.Modify(true);
     end;
 }

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1020,7 +1020,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1033,7 +1033,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1073,7 +1073,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1016,7 +1016,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1024,7 +1024,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1218,7 +1218,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1099,7 +1099,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1022,7 +1022,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1292,7 +1292,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1014,7 +1014,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),
                     VATPostingParameters."Deductible VAT Amount", VATPostingParameters."Deductible VAT Amount ACY", true,
-                    GenJnlLine."Source Curr. VAT Amount")
+                   GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount"))
             else
                 CreateGLEntry(
                     GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"),

--- a/src/Layers/W1/Tests/VAT/NonDedVATCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/VAT/NonDedVATCurrency.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 134286 "Non. Ded. VAT Currency"
         isInitialized: Boolean;
         GLEntriesSourceCurrNotBalancedErr: Label 'G/L Entries source currency amounts must be balanced';
         NoSourceCurrGLEntriesErr: Label 'No G/L Entries with the expected source currency were created';
+        GLEntrySourceCurrAmountErr: Label 'G/L Entry source currency amount for account %1 is not as expected', Comment = '%1 = G/L Account No.';
 
     [Test]
     procedure BasicPurchInvWithACY()
@@ -259,10 +260,11 @@ codeunit 134286 "Non. Ded. VAT Currency"
         // [GIVEN] "Check Source Curr. Consistency" is enabled in General Ledger Setup
         EnableCheckSourceCurrConsistency();
 
-        // [GIVEN] Normal VAT Posting Setup with "VAT %" = 20 and partial "Non-Deductible VAT %" = 50
+        // [GIVEN] Normal VAT Posting Setup with "VAT %" = 20 and partial "Non-Deductible VAT %" = 50, with a dedicated Non-Deductible Purchase VAT Account
         LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", 20);
         LibraryNonDeductibleVAT.SetAllowNonDeductibleVATForVATPostingSetup(VATPostingSetup);
         VATPostingSetup.Validate("Non-Deductible VAT %", 50);
+        VATPostingSetup.Validate("Non-Ded. Purchase VAT Account", LibraryERM.CreateGLAccountNo());
         VATPostingSetup.Modify(true);
 
         // [GIVEN] Currency "C" with exchange rate that differs from LCY
@@ -286,6 +288,11 @@ codeunit 134286 "Non. Ded. VAT Currency"
         // [THEN] G/L Entries are balanced in LCY and in source currency
         VerifyGLEntriesBalanced(DocNo, PurchHeader."Posting Date");
         VerifyGLEntriesSourceCurrencyBalanced(DocNo, PurchHeader."Posting Date", CurrencyCode);
+
+        // [THEN] The deductible VAT G/L entry carries the deductible half of the 20 source-currency VAT amount (100 base * 20% VAT * (100% - 50% Non-Deductible))
+        VerifyGLEntrySourceCurrencyAmountForAccount(DocNo, PurchHeader."Posting Date", CurrencyCode, VATPostingSetup."Purchase VAT Account", 10);
+        // [THEN] The non-deductible VAT G/L entry carries the non-deductible half of the 20 source-currency VAT amount (100 base * 20% VAT * 50% Non-Deductible)
+        VerifyGLEntrySourceCurrencyAmountForAccount(DocNo, PurchHeader."Posting Date", CurrencyCode, VATPostingSetup."Non-Ded. Purchase VAT Account", 10);
     end;
 
     local procedure Initialize()
@@ -424,6 +431,19 @@ codeunit 134286 "Non. Ded. VAT Currency"
         Assert.IsFalse(GLEntry.IsEmpty(), NoSourceCurrGLEntriesErr);
         GLEntry.CalcSums("Source Currency Amount");
         Assert.AreEqual(0, GLEntry."Source Currency Amount", GLEntriesSourceCurrNotBalancedErr);
+    end;
+
+    local procedure VerifyGLEntrySourceCurrencyAmountForAccount(DocumentNo: Code[20]; PostingDate: Date; CurrencyCode: Code[10]; GLAccountNo: Code[20]; ExpectedSourceCurrencyAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.SetRange("Source Currency Code", CurrencyCode);
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        Assert.IsFalse(GLEntry.IsEmpty(), NoSourceCurrGLEntriesErr);
+        GLEntry.CalcSums("Source Currency Amount");
+        Assert.AreEqual(ExpectedSourceCurrencyAmount, GLEntry."Source Currency Amount", StrSubstNo(GLEntrySourceCurrAmountErr, GLAccountNo));
     end;
 
     local procedure EnableCheckSourceCurrConsistency()

--- a/src/Layers/W1/Tests/VAT/NonDedVATCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/VAT/NonDedVATCurrency.Codeunit.al
@@ -20,6 +20,8 @@ codeunit 134286 "Non. Ded. VAT Currency"
         LibraryUtility: Codeunit "Library - Utility";
         Assert: Codeunit Assert;
         isInitialized: Boolean;
+        GLEntriesSourceCurrNotBalancedErr: Label 'G/L Entries source currency amounts must be balanced';
+        NoSourceCurrGLEntriesErr: Label 'No G/L Entries with the expected source currency were created';
 
     [Test]
     procedure BasicPurchInvWithACY()
@@ -242,6 +244,50 @@ codeunit 134286 "Non. Ded. VAT Currency"
         VerifyGLEntriesBalanced(DocumentNo, PostingDate);
     end;
 
+    [Test]
+    procedure PostFCYPurchInvWithPartialNonDedVATAndSourceCurrConsistency()
+    var
+        PurchHeader: Record "Purchase Header";
+        PurchLine: Record "Purchase Line";
+        VATPostingSetup: Record "VAT Posting Setup";
+        CurrencyCode: Code[10];
+        DocNo: Code[20];
+    begin
+        // [SCENARIO 640619] Posting a foreign currency Purchase Invoice with partial Non-Deductible VAT does not cause a G/L Entry consistency error when "Check Source Curr. Consistency" is enabled in General Ledger Setup.
+        Initialize();
+
+        // [GIVEN] "Check Source Curr. Consistency" is enabled in General Ledger Setup
+        EnableCheckSourceCurrConsistency();
+
+        // [GIVEN] Normal VAT Posting Setup with "VAT %" = 20 and partial "Non-Deductible VAT %" = 50
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", 20);
+        LibraryNonDeductibleVAT.SetAllowNonDeductibleVATForVATPostingSetup(VATPostingSetup);
+        VATPostingSetup.Validate("Non-Deductible VAT %", 50);
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Currency "C" with exchange rate that differs from LCY
+        CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 100, 130);
+
+        // [GIVEN] Purchase Invoice in currency "C" with Normal VAT and partial Non-Deductible VAT
+        LibraryPurchase.CreatePurchHeader(
+            PurchHeader, PurchHeader."Document Type"::Invoice,
+            LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
+        PurchHeader.Validate("Currency Code", CurrencyCode);
+        PurchHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+            PurchLine, PurchHeader, PurchLine.Type::Item,
+            LibraryInventory.CreateItemWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), 1);
+        PurchLine.Validate("Direct Unit Cost", 100);
+        PurchLine.Modify(true);
+
+        // [WHEN] Post the Purchase Invoice (must not raise a source currency consistency error)
+        DocNo := LibraryPurchase.PostPurchaseDocument(PurchHeader, true, true);
+
+        // [THEN] G/L Entries are balanced in LCY and in source currency
+        VerifyGLEntriesBalanced(DocNo, PurchHeader."Posting Date");
+        VerifyGLEntriesSourceCurrencyBalanced(DocNo, PurchHeader."Posting Date", CurrencyCode);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -366,5 +412,26 @@ codeunit 134286 "Non. Ded. VAT Currency"
         GLEntry.CalcSums("Debit Amount", "Credit Amount", "Add.-Currency Debit Amount", "Add.-Currency Credit Amount");
         Assert.AreEqual(GLEntry."Debit Amount", GLEntry."Credit Amount", 'G/L Entries LCY must be balanced');
         Assert.AreEqual(GLEntry."Add.-Currency Debit Amount", GLEntry."Add.-Currency Credit Amount", 'G/L Entries ACY must be balanced');
+    end;
+
+    local procedure VerifyGLEntriesSourceCurrencyBalanced(DocumentNo: Code[20]; PostingDate: Date; CurrencyCode: Code[10])
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("Posting Date", PostingDate);
+        GLEntry.SetRange("Source Currency Code", CurrencyCode);
+        Assert.IsFalse(GLEntry.IsEmpty(), NoSourceCurrGLEntriesErr);
+        GLEntry.CalcSums("Source Currency Amount");
+        Assert.AreEqual(0, GLEntry."Source Currency Amount", GLEntriesSourceCurrNotBalancedErr);
+    end;
+
+    local procedure EnableCheckSourceCurrConsistency()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+    begin
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup.Validate("Check Source Curr. Consistency", true);
+        GeneralLedgerSetup.Modify(true);
     end;
 }


### PR DESCRIPTION
[Bug 646637](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646637): [all-e][Master]Posting Error with 50% Non-Deductible VAT when "Check Source Currency Consistency" is enabled in "General Ledger Setup" page

Fixes [AB#646637](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646637)

**Issue :-**  Posting Error with 50% Non-Deductible VAT when "Check Source Currency Consistency" is enabled in "General Ledger Setup" page

**Cause :-**  When a purchase document is posted with partial non-deductible VAT in a foreign currency and “Check Source Curr. Consistency” is enabled in General Ledger Setup, the source-currency VAT amount on the deductible VAT G/L entry is created using the full source-currency VAT amount instead of subtracting the non-deductible VAT portion.

This causes the G/L source currency totals to become unbalanced, and the posting fails with the source currency consistency validation error.

**Solutions:-** Adjust the source-currency amount used for the deductible VAT G/L entry to exclude the non-deductible VAT portion:

Before:

GenJnlLine."Source Curr. VAT Amount"
After:

GenJnlLine."Source Curr. VAT Amount" - CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Non-Deductible VAT Amount")
This keeps the source-currency balance consistent for postings where only part of the VAT is deductible, while preserving the correct deductible VAT posting behavior.






