### PR TITLE
Fix Purchase Journal document amount decimal formatting

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -170,6 +170,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -176,6 +176,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -181,6 +181,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -170,6 +170,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -171,6 +171,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -170,6 +170,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -185,6 +185,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/PurchaseJournal.Page.al
@@ -170,6 +170,7 @@ page 254 "Purchase Journal"
                         GenJnlManagement.GetAccounts(Rec, AccName, BalAccName);
                         Rec.ShowShortcutDimCode(ShortcutDimCode);
                         CurrPage.SaveRecord();
+                        CurrPage.Update(false);
                     end;
                 }
                 field("<Vendor Name>"; GetVendorName())


### PR DESCRIPTION
## What & why

The Purchase Journal's `Document Amount` field uses `Currency Code` as its auto-format expression. Validating a vendor updates the journal line's currency, but the page did not refresh the field format, so three-decimal values were still parsed with the previous two-decimal format.

Refresh the page without saving after account validation so `Document Amount` immediately uses the vendor currency's decimal-place settings. The change is propagated to the W1 page and all localized copies.

## Test coverage

The existing `DocumentAmountInPurchJnlAcceptsMaxThreeDecimalPlacesValue` test covers this scenario by assigning a currency configured for three decimal places and verifying that `2.402` is preserved.

Fixes [AB#642737](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642737)
