### PR TITLE
Fix regression introduced by Apply-to-Oldest optimization

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4335,6 +4335,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4420,7 +4421,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4429,10 +4439,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -5325,6 +5335,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5394,7 +5405,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5403,10 +5423,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5424,6 +5444,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5479,7 +5500,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5487,10 +5517,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4054,6 +4054,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4128,7 +4129,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4137,10 +4147,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -4917,6 +4927,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -4986,7 +4997,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -4995,10 +5015,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5016,6 +5036,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5071,7 +5092,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5079,10 +5109,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4074,6 +4074,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4148,7 +4149,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4157,10 +4167,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -4942,6 +4952,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5011,7 +5022,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5020,10 +5040,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5041,6 +5061,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5096,7 +5117,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5104,10 +5134,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/CH/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
+++ b/src/Layers/CH/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
@@ -828,6 +828,95 @@ codeunit 134004 "ERM Partial Payment Vendor"
         end;
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentDoesNotApplyToOtherPayments()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        BalGLAccountNo: Code[20];
+        PaymentAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting a payment for a vendor with "Apply to Oldest" while an open invoice exceeds
+        // the new payment applies the payment to the invoice only; older payments are not consumed.
+        Initialize();
+
+        // [GIVEN] A vendor with Application Method = "Apply to Oldest"
+        VendorNo := CreateVendorWithApplyToOldest();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted payments of amount "A" on sequential dates
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, FindGeneralJournalTemplate());
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Payment,
+                GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] An invoice of 2.5 * "A", posted last but back-dated before all payments, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount * 5 / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Invoice);
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-PaymentAmount * 5 / 2, VendorLedgerEntry."Remaining Amount",
+            'Invoice should be open at its full amount before the new payment is posted.');
+
+        // [WHEN] A payment of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The invoice is fully applied and closed
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'Invoice should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'Invoice should be closed.');
+
+        // [THEN] The invoice excess reduces the oldest payment only; the other payments are not consumed
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Payment);
+        VendorLedgerEntry.SetCurrentKey("Posting Date");
+        VendorLedgerEntry.SetAscending("Posting Date", true);
+        VendorLedgerEntry.FindSet();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount / 2, VendorLedgerEntry."Remaining Amount",
+            'Oldest payment should absorb only the invoice excess.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, VendorLedgerEntry."Remaining Amount", 'Second payment should remain open.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, VendorLedgerEntry."Remaining Amount", 'Third payment should remain open.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
+    end;
+
     local procedure ApplytoOldestWithInvoice(DocumentType: Enum "Gen. Journal Document Type")
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/CH/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
+++ b/src/Layers/CH/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
@@ -917,6 +917,96 @@ codeunit 134004 "ERM Partial Payment Vendor"
         Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentExactOffsetSettlesNewDocument()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        BalGLAccountNo: Code[20];
+        PaymentAmount: Decimal;
+        InvoiceRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign payment plus
+        // the new payment net to exactly zero against the newer invoice, but the older invoice must still flip the
+        // sign decision. In this net-balance-opposes-the-new-document edge the new payment must be settled in full
+        // and the residual must land on the invoices - exactly as summing every open entry would. Exiting at the
+        // exact zero (the former "<= 0" behaviour) would leave the new payment open instead, so this locks in the
+        // "< 0" comparison.
+        Initialize();
+
+        // [GIVEN] A vendor with Application Method = "Apply to Oldest"
+        VendorNo := CreateVendorWithApplyToOldest();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, FindGeneralJournalTemplate());
+
+        // [GIVEN] An open payment of "A" (same sign as the new payment), dated after the invoices
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 3);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] An older invoice of "A" and a newer invoice of "3 * A", back-dated so they stay open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 2);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] A payment of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older invoice)
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 10);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The new payment is settled in full - not left open with a flipped remaining amount
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Payment);
+        VendorLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the invoices - not on the new payment
+        VendorLedgerEntry.Reset();
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Invoice);
+        VendorLedgerEntry.FindSet();
+        repeat
+            VendorLedgerEntry.CalcFields("Remaining Amount");
+            InvoiceRemaining += VendorLedgerEntry."Remaining Amount";
+        until VendorLedgerEntry.Next() = 0;
+        Assert.AreEqual(-PaymentAmount, InvoiceRemaining, 'Only the net balance should remain, on the invoices.');
+    end;
+
     local procedure ApplytoOldestWithInvoice(DocumentType: Enum "Gen. Journal Document Type")
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/CZ/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
+++ b/src/Layers/CZ/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
@@ -301,6 +301,72 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentDoesNotApplyToOtherPayments()
+    var
+        Employee: Record Employee;
+        GenJournalLine: Record "Gen. Journal Line";
+        EmployeeLedgerEntry: Record "Employee Ledger Entry";
+        PaymentAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting a payment for an employee with "Apply to Oldest" while an open expense exceeds
+        // the new payment applies the payment to the expense only; older payments are not consumed.
+        Initialize();
+        LibraryLowerPermissions.SetOutsideO365Scope();
+
+        // [GIVEN] An employee with Application Method = "Apply to Oldest"
+        CreateEmployee(Employee);
+        Employee.Validate("Application Method", Employee."Application Method"::"Apply to Oldest");
+        Employee.Modify(true);
+
+        // [GIVEN] 3 posted payments of amount "A" on sequential dates
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        for Counter := 1 to 3 do
+            CreateAndPostGenJournalLine(
+                GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount, WorkDate() + 1 + Counter);
+
+        // [GIVEN] An expense of 2.5 * "A", posted last but back-dated before all payments, so it stays open
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount * 5 / 2, WorkDate() + 1);
+        EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::" ");
+        EmployeeLedgerEntry.FindFirst();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-PaymentAmount * 5 / 2, EmployeeLedgerEntry."Remaining Amount",
+            'Expense should be open at its full amount before the new payment is posted.');
+
+        // [WHEN] A payment of 2 * "A" is posted
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount * 2, WorkDate() + 5);
+
+        // [THEN] The expense is fully applied and closed
+        EmployeeLedgerEntry.FindFirst();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, EmployeeLedgerEntry."Remaining Amount", 'Expense should be fully applied.');
+        Assert.IsFalse(EmployeeLedgerEntry.Open, 'Expense should be closed.');
+
+        // [THEN] The expense excess reduces the oldest payment only; the other payments are not consumed
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::Payment);
+        EmployeeLedgerEntry.SetCurrentKey("Posting Date");
+        EmployeeLedgerEntry.SetAscending("Posting Date", true);
+        EmployeeLedgerEntry.FindSet();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount / 2, EmployeeLedgerEntry."Remaining Amount",
+            'Oldest payment should absorb only the expense excess.');
+        EmployeeLedgerEntry.Next();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, EmployeeLedgerEntry."Remaining Amount", 'Second payment should remain open.');
+        EmployeeLedgerEntry.Next();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, EmployeeLedgerEntry."Remaining Amount", 'Third payment should remain open.');
+        EmployeeLedgerEntry.Next();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, EmployeeLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(EmployeeLedgerEntry.Open, 'New payment should be closed.');
+    end;
+
+    [Test]
     [HandlerFunctions('ApplyingEmployeeEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure CheckAmountOnApplyEmployeeEntriesPage()

--- a/src/Layers/CZ/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
+++ b/src/Layers/CZ/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
@@ -371,6 +371,70 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentExactOffsetSettlesNewDocument()
+    var
+        Employee: Record Employee;
+        GenJournalLine: Record "Gen. Journal Line";
+        EmployeeLedgerEntry: Record "Employee Ledger Entry";
+        PaymentAmount: Decimal;
+        ExpenseRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign payment plus
+        // the new payment net to exactly zero against the newer expense, but the older expense must still flip the
+        // sign decision. In this net-balance-opposes-the-new-document edge the new payment must be settled in full
+        // and the residual must land on the expenses - exactly as summing every open entry would. Exiting at the
+        // exact zero (the former "<= 0" behaviour) would leave the new payment open instead, so this locks in the
+        // "< 0" comparison.
+        Initialize();
+        LibraryLowerPermissions.SetOutsideO365Scope();
+
+        // [GIVEN] An employee with Application Method = "Apply to Oldest"
+        CreateEmployee(Employee);
+        Employee.Validate("Application Method", Employee."Application Method"::"Apply to Oldest");
+        Employee.Modify(true);
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+
+        // [GIVEN] An open payment of "A" (same sign as the new payment), dated after the expenses
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount, WorkDate() + 3);
+
+        // [GIVEN] An older expense of "A" and a newer expense of "3 * A", back-dated so they stay open
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount, WorkDate() + 1);
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount * 3, WorkDate() + 2);
+
+        // [WHEN] A payment of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older expense)
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount * 2, WorkDate() + 10);
+
+        // [THEN] The new payment is settled in full - not left open with a flipped remaining amount
+        EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+#pragma warning disable AA0210
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::Payment);
+        EmployeeLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+#pragma warning restore AA0210
+        EmployeeLedgerEntry.FindFirst();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, EmployeeLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(EmployeeLedgerEntry.Open, 'New payment should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the expenses - not on the new payment
+        EmployeeLedgerEntry.Reset();
+        EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+#pragma warning disable AA0210
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::" ");
+#pragma warning restore AA0210
+        EmployeeLedgerEntry.FindSet();
+        repeat
+            EmployeeLedgerEntry.CalcFields("Remaining Amount");
+            ExpenseRemaining += EmployeeLedgerEntry."Remaining Amount";
+        until EmployeeLedgerEntry.Next() = 0;
+        Assert.AreEqual(-PaymentAmount, ExpenseRemaining, 'Only the net balance should remain, on the expenses.');
+    end;
+
+    [Test]
     [HandlerFunctions('ApplyingEmployeeEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure CheckAmountOnApplyEmployeeEntriesPage()

--- a/src/Layers/CZ/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
+++ b/src/Layers/CZ/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
@@ -330,7 +330,9 @@
         CreateAndPostGenJournalLine(
             GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount * 5 / 2, WorkDate() + 1);
         EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+#pragma warning disable AA0210
         EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::" ");
+#pragma warning restore AA0210
         EmployeeLedgerEntry.FindFirst();
         EmployeeLedgerEntry.CalcFields("Remaining Amount");
         Assert.AreEqual(-PaymentAmount * 5 / 2, EmployeeLedgerEntry."Remaining Amount",
@@ -347,9 +349,11 @@
         Assert.IsFalse(EmployeeLedgerEntry.Open, 'Expense should be closed.');
 
         // [THEN] The expense excess reduces the oldest payment only; the other payments are not consumed
+#pragma warning disable AA0210
         EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::Payment);
         EmployeeLedgerEntry.SetCurrentKey("Posting Date");
         EmployeeLedgerEntry.SetAscending("Posting Date", true);
+#pragma warning restore AA0210
         EmployeeLedgerEntry.FindSet();
         EmployeeLedgerEntry.CalcFields("Remaining Amount");
         Assert.AreEqual(PaymentAmount / 2, EmployeeLedgerEntry."Remaining Amount",

--- a/src/Layers/DACH/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
+++ b/src/Layers/DACH/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
@@ -956,6 +956,283 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestInvoiceDoesNotApplyToOtherInvoices()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting an invoice for a customer with "Apply to Oldest" while an open credit memo
+        // exceeds the new invoice applies the invoice to the credit memo only; older invoices are not consumed.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted sales invoices of amount "A" on sequential dates
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Invoice,
+                GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] A credit memo of 2.5 * "A", posted last but back-dated before all invoices, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount * 5 / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::"Credit Memo");
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-InvoiceAmount * 5 / 2, CustLedgerEntry."Remaining Amount",
+            'Credit memo should be open at its full amount before the new invoice is posted.');
+
+        // [WHEN] An invoice of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The credit memo is fully applied and closed
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'Credit memo should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'Credit memo should be closed.');
+
+        // [THEN] The credit memo excess reduces the oldest invoice only; the other invoices are not consumed
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetCurrentKey("Posting Date");
+        CustLedgerEntry.SetAscending("Posting Date", true);
+        CustLedgerEntry.FindSet();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount / 2, CustLedgerEntry."Remaining Amount",
+            'Oldest invoice should absorb only the credit memo excess.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount", 'Second invoice should remain open.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount", 'Third invoice should remain open.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'New invoice should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'New invoice should be closed.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentNettingAgainstMixedEntries()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        Counter: Integer;
+        OpenPaymentEntryNo: Integer;
+    begin
+        // [SCENARIO 9529] A payment posted for a customer with "Apply to Oldest" holding open entries of both
+        // signs nets against the open payment first and then the oldest invoices. The outcome must not change
+        // when the application weighing is reworked.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 5 posted sales invoices of amount "A" on sequential dates
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+        for Counter := 1 to 5 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Invoice,
+                GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] A payment of 0.5 * "A", posted last but back-dated before all invoices, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Payment);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-InvoiceAmount / 2, CustLedgerEntry."Remaining Amount",
+            'Back-dated payment should be open at its full amount before the new payment is posted.');
+        OpenPaymentEntryNo := CustLedgerEntry."Entry No.";
+
+        // [WHEN] A payment of 3 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 7);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] Both payments are fully applied
+        CustLedgerEntry.Get(OpenPaymentEntryNo);
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'Back-dated payment should be fully applied.');
+        CustLedgerEntry.Reset();
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Payment);
+        CustLedgerEntry.SetFilter("Entry No.", '<>%1', OpenPaymentEntryNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+
+        // [THEN] The three oldest invoices are closed, the fourth is partially applied, the newest stays open
+        CustLedgerEntry.Reset();
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetCurrentKey("Posting Date");
+        CustLedgerEntry.SetAscending("Posting Date", true);
+        CustLedgerEntry.FindSet();
+        for Counter := 1 to 3 do begin
+            CustLedgerEntry.CalcFields("Remaining Amount");
+            Assert.AreEqual(0, CustLedgerEntry."Remaining Amount",
+                StrSubstNo('Invoice %1 should be fully applied.', Counter));
+            CustLedgerEntry.Next();
+        end;
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount / 2, CustLedgerEntry."Remaining Amount",
+            'Fourth invoice should be partially applied.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount", 'Newest invoice should remain open.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestInvoiceAppliesOnlyToSmallerCreditMemo()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting an invoice for a customer with "Apply to Oldest" while an open credit memo
+        // smaller than the new invoice closes the credit memo and leaves the new invoice open for the balance;
+        // the older invoices are not consumed. This mirrors the exceeding-credit-memo case and confirms the
+        // same-sign-first early exit lands on the same decision as summing every open entry.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted sales invoices of amount "A" on sequential dates
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Invoice,
+                GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] A credit memo of 0.5 * "A", posted last but back-dated before all invoices, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] An invoice of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The credit memo is fully applied and closed
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::"Credit Memo");
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'Credit memo should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'Credit memo should be closed.');
+
+        // [THEN] The new invoice stays open for the balance above the credit memo; the older invoices are untouched
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetCurrentKey("Posting Date");
+        CustLedgerEntry.SetAscending("Posting Date", true);
+        CustLedgerEntry.FindSet();
+        for Counter := 1 to 3 do begin
+            CustLedgerEntry.CalcFields("Remaining Amount");
+            Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount",
+                StrSubstNo('Invoice %1 should remain open.', Counter));
+            CustLedgerEntry.Next();
+        end;
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount * 3 / 2, CustLedgerEntry."Remaining Amount",
+            'New invoice should stay open for the amount above the credit memo.');
+    end;
+
+    [Test]
     [HandlerFunctions('CustomerLedgerEntriesPageHandler,ApplyCustomerEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure AmountToApplyAfterApplyToEntryForInvoice()

--- a/src/Layers/DACH/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
+++ b/src/Layers/DACH/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
@@ -1233,6 +1233,98 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestInvoiceExactOffsetSettlesNewDocument()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        CreditMemoRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign invoice plus
+        // the new invoice net to exactly zero against the newer credit memo, but the older credit memo must still
+        // flip the sign decision. In this net-balance-opposes-the-new-document edge the new invoice must be settled
+        // in full and the residual must land on the credit memos - exactly as summing every open entry would.
+        // Exiting at the exact zero (the former "<= 0" behaviour) would leave the new invoice open instead, so this
+        // locks in the "< 0" comparison.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+
+        // [GIVEN] An open invoice of "A" (same sign as the new invoice), dated after the credit memos
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 3);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] An older credit memo of "A" and a newer credit memo of "3 * A", back-dated so they stay open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 2);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] An invoice of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older memo)
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 10);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The new invoice is settled in full - not left open with a flipped remaining amount
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'New invoice should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'New invoice should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the credit memos - not on the new invoice
+        CustLedgerEntry.Reset();
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::"Credit Memo");
+        CustLedgerEntry.FindSet();
+        repeat
+            CustLedgerEntry.CalcFields("Remaining Amount");
+            CreditMemoRemaining += CustLedgerEntry."Remaining Amount";
+        until CustLedgerEntry.Next() = 0;
+        Assert.AreEqual(-InvoiceAmount, CreditMemoRemaining, 'Only the net balance should remain, on the credit memos.');
+    end;
+
+    [Test]
     [HandlerFunctions('CustomerLedgerEntriesPageHandler,ApplyCustomerEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure AmountToApplyAfterApplyToEntryForInvoice()

--- a/src/Layers/DACH/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
+++ b/src/Layers/DACH/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
@@ -1135,8 +1135,10 @@
         CustLedgerEntry.FindSet();
         for Counter := 1 to 3 do begin
             CustLedgerEntry.CalcFields("Remaining Amount");
+#pragma warning disable AA0217
             Assert.AreEqual(0, CustLedgerEntry."Remaining Amount",
                 StrSubstNo('Invoice %1 should be fully applied.', Counter));
+#pragma warning restore AA0217
             CustLedgerEntry.Next();
         end;
         CustLedgerEntry.CalcFields("Remaining Amount");
@@ -1223,8 +1225,10 @@
         CustLedgerEntry.FindSet();
         for Counter := 1 to 3 do begin
             CustLedgerEntry.CalcFields("Remaining Amount");
+#pragma warning disable AA0217
             Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount",
                 StrSubstNo('Invoice %1 should remain open.', Counter));
+#pragma warning restore AA0217
             CustLedgerEntry.Next();
         end;
         CustLedgerEntry.CalcFields("Remaining Amount");

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4234,6 +4234,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4313,7 +4314,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4322,10 +4332,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -5320,6 +5330,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5396,7 +5407,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5405,10 +5425,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5426,6 +5446,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5481,7 +5502,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5489,10 +5519,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4047,6 +4047,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4121,7 +4122,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4130,10 +4140,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -4910,6 +4920,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -4979,7 +4990,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -4988,10 +5008,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5009,6 +5029,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5064,7 +5085,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5072,10 +5102,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4056,6 +4056,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4130,7 +4131,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4139,10 +4149,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -4934,6 +4944,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5003,7 +5014,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5012,10 +5032,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5033,6 +5053,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5088,7 +5109,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5096,10 +5126,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4371,6 +4371,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4464,7 +4465,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4473,10 +4483,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -5264,6 +5274,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5351,7 +5362,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5360,10 +5380,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5381,6 +5401,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5436,7 +5457,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5444,10 +5474,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/IT/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
@@ -827,6 +827,95 @@ codeunit 134004 "ERM Partial Payment Vendor"
         end;
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentDoesNotApplyToOtherPayments()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        BalGLAccountNo: Code[20];
+        PaymentAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting a payment for a vendor with "Apply to Oldest" while an open invoice exceeds
+        // the new payment applies the payment to the invoice only; older payments are not consumed.
+        Initialize();
+
+        // [GIVEN] A vendor with Application Method = "Apply to Oldest"
+        VendorNo := CreateVendorWithApplyToOldest();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted payments of amount "A" on sequential dates
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, FindGeneralJournalTemplate());
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Payment,
+                GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] An invoice of 2.5 * "A", posted last but back-dated before all payments, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount * 5 / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Invoice);
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-PaymentAmount * 5 / 2, VendorLedgerEntry."Remaining Amount",
+            'Invoice should be open at its full amount before the new payment is posted.');
+
+        // [WHEN] A payment of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The invoice is fully applied and closed
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'Invoice should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'Invoice should be closed.');
+
+        // [THEN] The invoice excess reduces the oldest payment only; the other payments are not consumed
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Payment);
+        VendorLedgerEntry.SetCurrentKey("Posting Date");
+        VendorLedgerEntry.SetAscending("Posting Date", true);
+        VendorLedgerEntry.FindSet();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount / 2, VendorLedgerEntry."Remaining Amount",
+            'Oldest payment should absorb only the invoice excess.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, VendorLedgerEntry."Remaining Amount", 'Second payment should remain open.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, VendorLedgerEntry."Remaining Amount", 'Third payment should remain open.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
+    end;
+
     local procedure ApplytoOldestWithInvoice(DocumentType: Enum "Gen. Journal Document Type")
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/IT/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
@@ -916,6 +916,96 @@ codeunit 134004 "ERM Partial Payment Vendor"
         Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentExactOffsetSettlesNewDocument()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        BalGLAccountNo: Code[20];
+        PaymentAmount: Decimal;
+        InvoiceRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign payment plus
+        // the new payment net to exactly zero against the newer invoice, but the older invoice must still flip the
+        // sign decision. In this net-balance-opposes-the-new-document edge the new payment must be settled in full
+        // and the residual must land on the invoices - exactly as summing every open entry would. Exiting at the
+        // exact zero (the former "<= 0" behaviour) would leave the new payment open instead, so this locks in the
+        // "< 0" comparison.
+        Initialize();
+
+        // [GIVEN] A vendor with Application Method = "Apply to Oldest"
+        VendorNo := CreateVendorWithApplyToOldest();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, FindGeneralJournalTemplate());
+
+        // [GIVEN] An open payment of "A" (same sign as the new payment), dated after the invoices
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 3);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] An older invoice of "A" and a newer invoice of "3 * A", back-dated so they stay open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 2);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] A payment of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older invoice)
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 10);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The new payment is settled in full - not left open with a flipped remaining amount
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Payment);
+        VendorLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the invoices - not on the new payment
+        VendorLedgerEntry.Reset();
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Invoice);
+        VendorLedgerEntry.FindSet();
+        repeat
+            VendorLedgerEntry.CalcFields("Remaining Amount");
+            InvoiceRemaining += VendorLedgerEntry."Remaining Amount";
+        until VendorLedgerEntry.Next() = 0;
+        Assert.AreEqual(-PaymentAmount, InvoiceRemaining, 'Only the net balance should remain, on the invoices.');
+    end;
+
     local procedure ApplytoOldestWithInvoice(DocumentType: Enum "Gen. Journal Document Type")
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4151,6 +4151,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4225,7 +4226,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4234,10 +4244,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -5164,6 +5174,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5233,7 +5244,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5242,10 +5262,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5263,6 +5283,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5318,7 +5339,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5326,10 +5356,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4053,6 +4053,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4127,7 +4128,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4136,10 +4146,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -4919,6 +4929,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -4988,7 +4999,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -4997,10 +5017,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5018,6 +5038,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5073,7 +5094,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5081,10 +5111,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4695,6 +4695,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4786,7 +4787,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4795,10 +4805,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -5753,6 +5763,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -5832,7 +5843,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -5841,10 +5861,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -5862,6 +5882,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5917,7 +5938,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5925,10 +5955,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4022,6 +4022,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempCustledgEntry(GenJnlLine, NewCVLedgEntryBuf, Cust, ApplyingDate, Result, IsHandled, TempOldCustLedgEntry);
@@ -4096,7 +4097,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldCustLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldCustLedgEntry.SetRange(Positive);
-                TempOldCustLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldCustLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldCustLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldCustLedgEntry.CalcFields("Remaining Amount");
                     TempOldCustLedgEntry.RecalculateAmounts(
@@ -4105,10 +4115,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldCustLedgEntry."Remaining Amount" -= TempOldCustLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldCustLedgEntry."Remaining Amount";
                     if (Cust."Application Method" = Cust."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldCustLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldCustLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldCustLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldCustLedgEntry.SetRange(Positive);
@@ -4885,6 +4895,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempVendLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldVendLedgEntry, Vend, ApplyingDate, Result, IsHandled);
@@ -4954,7 +4965,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldVendLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldVendLedgEntry.SetRange(Positive);
-                TempOldVendLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldVendLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldVendLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldVendLedgEntry.CalcFields("Remaining Amount");
                     TempOldVendLedgEntry.RecalculateAmounts(
@@ -4963,10 +4983,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TempOldVendLedgEntry."Remaining Amount" -= TempOldVendLedgEntry.GetRemainingPmtDiscPossible(NewCVLedgEntryBuf."Posting Date");
                     RemainingAmount += TempOldVendLedgEntry."Remaining Amount";
                     if (Vend."Application Method" = Vend."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldVendLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldVendLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldVendLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldVendLedgEntry.SetRange(Positive);
@@ -4984,6 +5004,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         IsHandled: Boolean;
         Result: Boolean;
         SufficientEntriesFound: Boolean;
+        NextStep: Integer;
     begin
         IsHandled := false;
         OnBeforePrepareTempEmplLedgEntry(GenJnlLine, NewCVLedgEntryBuf, TempOldEmplLedgEntry, Employee, ApplyingDate, Result, IsHandled);
@@ -5039,7 +5060,16 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if TempOldEmplLedgEntry.Find('-') then begin
                 RemainingAmount := NewCVLedgEntryBuf."Remaining Amount";
                 TempOldEmplLedgEntry.SetRange(Positive);
-                TempOldEmplLedgEntry.Find('-');
+                // Weigh the entries of the same sign as the new document before the opposite-sign ones.
+                // The sign decision below is a property of the whole open-entry set, so the early exit
+                // must not stop before the opposite-sign entries have settled that sign.
+                if NewCVLedgEntryBuf."Remaining Amount" > 0 then begin
+                    TempOldEmplLedgEntry.Find('+');
+                    NextStep := -1;
+                end else begin
+                    TempOldEmplLedgEntry.Find('-');
+                    NextStep := 1;
+                end;
                 repeat
                     TempOldEmplLedgEntry.CalcFields("Remaining Amount");
                     TempOldEmplLedgEntry.RecalculateAmounts(
@@ -5047,10 +5077,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     OnPrepareTempEmplLedgEntryOnBeforeUpdateRemainingAmount(TempOldEmplLedgEntry, NewCVLedgEntryBuf);
                     RemainingAmount += TempOldEmplLedgEntry."Remaining Amount";
                     if (Employee."Application Method" = Employee."Application Method"::"Apply to Oldest") and
-                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" <= 0)
+                       (RemainingAmount * NewCVLedgEntryBuf."Remaining Amount" < 0)
                     then
                         SufficientEntriesFound := true;
-                until (TempOldEmplLedgEntry.Next() = 0) or SufficientEntriesFound;
+                until (TempOldEmplLedgEntry.Next(NextStep) = 0) or SufficientEntriesFound;
                 TempOldEmplLedgEntry.SetRange(Positive, RemainingAmount < 0);
             end else
                 TempOldEmplLedgEntry.SetRange(Positive);

--- a/src/Layers/W1/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
@@ -956,6 +956,283 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestInvoiceDoesNotApplyToOtherInvoices()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting an invoice for a customer with "Apply to Oldest" while an open credit memo
+        // exceeds the new invoice applies the invoice to the credit memo only; older invoices are not consumed.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted sales invoices of amount "A" on sequential dates
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Invoice,
+                GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] A credit memo of 2.5 * "A", posted last but back-dated before all invoices, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount * 5 / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::"Credit Memo");
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-InvoiceAmount * 5 / 2, CustLedgerEntry."Remaining Amount",
+            'Credit memo should be open at its full amount before the new invoice is posted.');
+
+        // [WHEN] An invoice of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The credit memo is fully applied and closed
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'Credit memo should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'Credit memo should be closed.');
+
+        // [THEN] The credit memo excess reduces the oldest invoice only; the other invoices are not consumed
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetCurrentKey("Posting Date");
+        CustLedgerEntry.SetAscending("Posting Date", true);
+        CustLedgerEntry.FindSet();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount / 2, CustLedgerEntry."Remaining Amount",
+            'Oldest invoice should absorb only the credit memo excess.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount", 'Second invoice should remain open.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount", 'Third invoice should remain open.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'New invoice should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'New invoice should be closed.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentNettingAgainstMixedEntries()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        Counter: Integer;
+        OpenPaymentEntryNo: Integer;
+    begin
+        // [SCENARIO 9529] A payment posted for a customer with "Apply to Oldest" holding open entries of both
+        // signs nets against the open payment first and then the oldest invoices. The outcome must not change
+        // when the application weighing is reworked.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 5 posted sales invoices of amount "A" on sequential dates
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+        for Counter := 1 to 5 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Invoice,
+                GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] A payment of 0.5 * "A", posted last but back-dated before all invoices, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Payment);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-InvoiceAmount / 2, CustLedgerEntry."Remaining Amount",
+            'Back-dated payment should be open at its full amount before the new payment is posted.');
+        OpenPaymentEntryNo := CustLedgerEntry."Entry No.";
+
+        // [WHEN] A payment of 3 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 7);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] Both payments are fully applied
+        CustLedgerEntry.Get(OpenPaymentEntryNo);
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'Back-dated payment should be fully applied.');
+        CustLedgerEntry.Reset();
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Payment);
+        CustLedgerEntry.SetFilter("Entry No.", '<>%1', OpenPaymentEntryNo);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+
+        // [THEN] The three oldest invoices are closed, the fourth is partially applied, the newest stays open
+        CustLedgerEntry.Reset();
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetCurrentKey("Posting Date");
+        CustLedgerEntry.SetAscending("Posting Date", true);
+        CustLedgerEntry.FindSet();
+        for Counter := 1 to 3 do begin
+            CustLedgerEntry.CalcFields("Remaining Amount");
+            Assert.AreEqual(0, CustLedgerEntry."Remaining Amount",
+                StrSubstNo('Invoice %1 should be fully applied.', Counter));
+            CustLedgerEntry.Next();
+        end;
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount / 2, CustLedgerEntry."Remaining Amount",
+            'Fourth invoice should be partially applied.');
+        CustLedgerEntry.Next();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount", 'Newest invoice should remain open.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestInvoiceAppliesOnlyToSmallerCreditMemo()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting an invoice for a customer with "Apply to Oldest" while an open credit memo
+        // smaller than the new invoice closes the credit memo and leaves the new invoice open for the balance;
+        // the older invoices are not consumed. This mirrors the exceeding-credit-memo case and confirms the
+        // same-sign-first early exit lands on the same decision as summing every open entry.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted sales invoices of amount "A" on sequential dates
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Invoice,
+                GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] A credit memo of 0.5 * "A", posted last but back-dated before all invoices, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] An invoice of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The credit memo is fully applied and closed
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::"Credit Memo");
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'Credit memo should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'Credit memo should be closed.');
+
+        // [THEN] The new invoice stays open for the balance above the credit memo; the older invoices are untouched
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetCurrentKey("Posting Date");
+        CustLedgerEntry.SetAscending("Posting Date", true);
+        CustLedgerEntry.FindSet();
+        for Counter := 1 to 3 do begin
+            CustLedgerEntry.CalcFields("Remaining Amount");
+            Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount",
+                StrSubstNo('Invoice %1 should remain open.', Counter));
+            CustLedgerEntry.Next();
+        end;
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(InvoiceAmount * 3 / 2, CustLedgerEntry."Remaining Amount",
+            'New invoice should stay open for the amount above the credit memo.');
+    end;
+
+    [Test]
     [HandlerFunctions('CustomerLedgerEntriesPageHandler,ApplyCustomerEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure AmountToApplyAfterApplyToEntryForInvoice()

--- a/src/Layers/W1/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
@@ -1233,6 +1233,98 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestInvoiceExactOffsetSettlesNewDocument()
+    var
+        Customer: Record Customer;
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        BalGLAccountNo: Code[20];
+        InvoiceAmount: Decimal;
+        CreditMemoRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign invoice plus
+        // the new invoice net to exactly zero against the newer credit memo, but the older credit memo must still
+        // flip the sign decision. In this net-balance-opposes-the-new-document edge the new invoice must be settled
+        // in full and the residual must land on the credit memos - exactly as summing every open entry would.
+        // Exiting at the exact zero (the former "<= 0" behaviour) would leave the new invoice open instead, so this
+        // locks in the "< 0" comparison.
+        Initialize();
+
+        // [GIVEN] A customer with Application Method = "Apply to Oldest"
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Application Method", Customer."Application Method"::"Apply to Oldest");
+        Customer.Modify(true);
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        InvoiceAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        SelectGenJournalBatch(GenJournalBatch, false);
+
+        // [GIVEN] An open invoice of "A" (same sign as the new invoice), dated after the credit memos
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 3);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] An older credit memo of "A" and a newer credit memo of "3 * A", back-dated so they stay open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::"Credit Memo",
+            GenJournalLine."Account Type"::Customer, Customer."No.", -InvoiceAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 2);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] An invoice of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older memo)
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Customer, Customer."No.", InvoiceAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 10);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The new invoice is settled in full - not left open with a flipped remaining amount
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+        CustLedgerEntry.FindFirst();
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, CustLedgerEntry."Remaining Amount", 'New invoice should be fully applied.');
+        Assert.IsFalse(CustLedgerEntry.Open, 'New invoice should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the credit memos - not on the new invoice
+        CustLedgerEntry.Reset();
+        CustLedgerEntry.SetRange("Customer No.", Customer."No.");
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::"Credit Memo");
+        CustLedgerEntry.FindSet();
+        repeat
+            CustLedgerEntry.CalcFields("Remaining Amount");
+            CreditMemoRemaining += CustLedgerEntry."Remaining Amount";
+        until CustLedgerEntry.Next() = 0;
+        Assert.AreEqual(-InvoiceAmount, CreditMemoRemaining, 'Only the net balance should remain, on the credit memos.');
+    end;
+
+    [Test]
     [HandlerFunctions('CustomerLedgerEntriesPageHandler,ApplyCustomerEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure AmountToApplyAfterApplyToEntryForInvoice()

--- a/src/Layers/W1/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Application/ERMApplyUnapplyCustomer.Codeunit.al
@@ -1135,8 +1135,10 @@
         CustLedgerEntry.FindSet();
         for Counter := 1 to 3 do begin
             CustLedgerEntry.CalcFields("Remaining Amount");
+#pragma warning disable AA0217
             Assert.AreEqual(0, CustLedgerEntry."Remaining Amount",
                 StrSubstNo('Invoice %1 should be fully applied.', Counter));
+#pragma warning restore AA0217
             CustLedgerEntry.Next();
         end;
         CustLedgerEntry.CalcFields("Remaining Amount");
@@ -1223,8 +1225,10 @@
         CustLedgerEntry.FindSet();
         for Counter := 1 to 3 do begin
             CustLedgerEntry.CalcFields("Remaining Amount");
+#pragma warning disable AA0217
             Assert.AreEqual(InvoiceAmount, CustLedgerEntry."Remaining Amount",
                 StrSubstNo('Invoice %1 should remain open.', Counter));
+#pragma warning restore AA0217
             CustLedgerEntry.Next();
         end;
         CustLedgerEntry.CalcFields("Remaining Amount");

--- a/src/Layers/W1/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
@@ -825,6 +825,95 @@ codeunit 134004 "ERM Partial Payment Vendor"
         end;
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentDoesNotApplyToOtherPayments()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        BalGLAccountNo: Code[20];
+        PaymentAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting a payment for a vendor with "Apply to Oldest" while an open invoice exceeds
+        // the new payment applies the payment to the invoice only; older payments are not consumed.
+        Initialize();
+
+        // [GIVEN] A vendor with Application Method = "Apply to Oldest"
+        VendorNo := CreateVendorWithApplyToOldest();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+
+        // [GIVEN] 3 posted payments of amount "A" on sequential dates
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, FindGeneralJournalTemplate());
+        for Counter := 1 to 3 do begin
+            LibraryERM.CreateGeneralJnlLine(
+                GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+                GenJournalLine."Document Type"::Payment,
+                GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount);
+            GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+            GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+            GenJournalLine.Validate("Posting Date", WorkDate() + 1 + Counter);
+            GenJournalLine.Modify(true);
+            LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        end;
+
+        // [GIVEN] An invoice of 2.5 * "A", posted last but back-dated before all payments, so it stays open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount * 5 / 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Invoice);
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-PaymentAmount * 5 / 2, VendorLedgerEntry."Remaining Amount",
+            'Invoice should be open at its full amount before the new payment is posted.');
+
+        // [WHEN] A payment of 2 * "A" is posted
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 5);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The invoice is fully applied and closed
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'Invoice should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'Invoice should be closed.');
+
+        // [THEN] The invoice excess reduces the oldest payment only; the other payments are not consumed
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Payment);
+        VendorLedgerEntry.SetCurrentKey("Posting Date");
+        VendorLedgerEntry.SetAscending("Posting Date", true);
+        VendorLedgerEntry.FindSet();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount / 2, VendorLedgerEntry."Remaining Amount",
+            'Oldest payment should absorb only the invoice excess.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, VendorLedgerEntry."Remaining Amount", 'Second payment should remain open.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, VendorLedgerEntry."Remaining Amount", 'Third payment should remain open.');
+        VendorLedgerEntry.Next();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
+    end;
+
     local procedure ApplytoOldestWithInvoice(DocumentType: Enum "Gen. Journal Document Type")
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/W1/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Application/ERMPartialPaymentVendor.Codeunit.al
@@ -914,6 +914,96 @@ codeunit 134004 "ERM Partial Payment Vendor"
         Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentExactOffsetSettlesNewDocument()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        BalGLAccountNo: Code[20];
+        PaymentAmount: Decimal;
+        InvoiceRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign payment plus
+        // the new payment net to exactly zero against the newer invoice, but the older invoice must still flip the
+        // sign decision. In this net-balance-opposes-the-new-document edge the new payment must be settled in full
+        // and the residual must land on the invoices - exactly as summing every open entry would. Exiting at the
+        // exact zero (the former "<= 0" behaviour) would leave the new payment open instead, so this locks in the
+        // "< 0" comparison.
+        Initialize();
+
+        // [GIVEN] A vendor with Application Method = "Apply to Oldest"
+        VendorNo := CreateVendorWithApplyToOldest();
+        BalGLAccountNo := LibraryERM.CreateGLAccountNo();
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, FindGeneralJournalTemplate());
+
+        // [GIVEN] An open payment of "A" (same sign as the new payment), dated after the invoices
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 3);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [GIVEN] An older invoice of "A" and a newer invoice of "3 * A", back-dated so they stay open
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 1);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice,
+            GenJournalLine."Account Type"::Vendor, VendorNo, -PaymentAmount * 3);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 2);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [WHEN] A payment of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older invoice)
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Payment,
+            GenJournalLine."Account Type"::Vendor, VendorNo, PaymentAmount * 2);
+        GenJournalLine.Validate("Bal. Account Type", GenJournalLine."Bal. Account Type"::"G/L Account");
+        GenJournalLine.Validate("Bal. Account No.", BalGLAccountNo);
+        GenJournalLine.Validate("Posting Date", WorkDate() + 10);
+        GenJournalLine.Modify(true);
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The new payment is settled in full - not left open with a flipped remaining amount
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Payment);
+        VendorLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+        VendorLedgerEntry.FindFirst();
+        VendorLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, VendorLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(VendorLedgerEntry.Open, 'New payment should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the invoices - not on the new payment
+        VendorLedgerEntry.Reset();
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document Type", VendorLedgerEntry."Document Type"::Invoice);
+        VendorLedgerEntry.FindSet();
+        repeat
+            VendorLedgerEntry.CalcFields("Remaining Amount");
+            InvoiceRemaining += VendorLedgerEntry."Remaining Amount";
+        until VendorLedgerEntry.Next() = 0;
+        Assert.AreEqual(-PaymentAmount, InvoiceRemaining, 'Only the net balance should remain, on the invoices.');
+    end;
+
     local procedure ApplytoOldestWithInvoice(DocumentType: Enum "Gen. Journal Document Type")
     var
         GenJournalLine: Record "Gen. Journal Line";

--- a/src/Layers/W1/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
+++ b/src/Layers/W1/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
@@ -301,6 +301,72 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentDoesNotApplyToOtherPayments()
+    var
+        Employee: Record Employee;
+        GenJournalLine: Record "Gen. Journal Line";
+        EmployeeLedgerEntry: Record "Employee Ledger Entry";
+        PaymentAmount: Decimal;
+        Counter: Integer;
+    begin
+        // [SCENARIO 9529] Posting a payment for an employee with "Apply to Oldest" while an open expense exceeds
+        // the new payment applies the payment to the expense only; older payments are not consumed.
+        Initialize();
+        LibraryLowerPermissions.SetOutsideO365Scope();
+
+        // [GIVEN] An employee with Application Method = "Apply to Oldest"
+        CreateEmployee(Employee);
+        Employee.Validate("Application Method", Employee."Application Method"::"Apply to Oldest");
+        Employee.Modify(true);
+
+        // [GIVEN] 3 posted payments of amount "A" on sequential dates
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+        for Counter := 1 to 3 do
+            CreateAndPostGenJournalLine(
+                GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount, WorkDate() + 1 + Counter);
+
+        // [GIVEN] An expense of 2.5 * "A", posted last but back-dated before all payments, so it stays open
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount * 5 / 2, WorkDate() + 1);
+        EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::" ");
+        EmployeeLedgerEntry.FindFirst();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(-PaymentAmount * 5 / 2, EmployeeLedgerEntry."Remaining Amount",
+            'Expense should be open at its full amount before the new payment is posted.');
+
+        // [WHEN] A payment of 2 * "A" is posted
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount * 2, WorkDate() + 5);
+
+        // [THEN] The expense is fully applied and closed
+        EmployeeLedgerEntry.FindFirst();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, EmployeeLedgerEntry."Remaining Amount", 'Expense should be fully applied.');
+        Assert.IsFalse(EmployeeLedgerEntry.Open, 'Expense should be closed.');
+
+        // [THEN] The expense excess reduces the oldest payment only; the other payments are not consumed
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::Payment);
+        EmployeeLedgerEntry.SetCurrentKey("Posting Date");
+        EmployeeLedgerEntry.SetAscending("Posting Date", true);
+        EmployeeLedgerEntry.FindSet();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount / 2, EmployeeLedgerEntry."Remaining Amount",
+            'Oldest payment should absorb only the expense excess.');
+        EmployeeLedgerEntry.Next();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, EmployeeLedgerEntry."Remaining Amount", 'Second payment should remain open.');
+        EmployeeLedgerEntry.Next();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(PaymentAmount, EmployeeLedgerEntry."Remaining Amount", 'Third payment should remain open.');
+        EmployeeLedgerEntry.Next();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, EmployeeLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(EmployeeLedgerEntry.Open, 'New payment should be closed.');
+    end;
+
+    [Test]
     [HandlerFunctions('ApplyingEmployeeEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure CheckAmountOnApplyEmployeeEntriesPage()

--- a/src/Layers/W1/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
+++ b/src/Layers/W1/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
@@ -371,6 +371,70 @@
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure ApplyToOldestPaymentExactOffsetSettlesNewDocument()
+    var
+        Employee: Record Employee;
+        GenJournalLine: Record "Gen. Journal Line";
+        EmployeeLedgerEntry: Record "Employee Ledger Entry";
+        PaymentAmount: Decimal;
+        ExpenseRemaining: Decimal;
+    begin
+        // [SCENARIO 9529] Exact-offset boundary for the tightened "< 0" early exit. The open same-sign payment plus
+        // the new payment net to exactly zero against the newer expense, but the older expense must still flip the
+        // sign decision. In this net-balance-opposes-the-new-document edge the new payment must be settled in full
+        // and the residual must land on the expenses - exactly as summing every open entry would. Exiting at the
+        // exact zero (the former "<= 0" behaviour) would leave the new payment open instead, so this locks in the
+        // "< 0" comparison.
+        Initialize();
+        LibraryLowerPermissions.SetOutsideO365Scope();
+
+        // [GIVEN] An employee with Application Method = "Apply to Oldest"
+        CreateEmployee(Employee);
+        Employee.Validate("Application Method", Employee."Application Method"::"Apply to Oldest");
+        Employee.Modify(true);
+        PaymentAmount := 2 * LibraryRandom.RandIntInRange(100, 200);
+
+        // [GIVEN] An open payment of "A" (same sign as the new payment), dated after the expenses
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount, WorkDate() + 3);
+
+        // [GIVEN] An older expense of "A" and a newer expense of "3 * A", back-dated so they stay open
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount, WorkDate() + 1);
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount * 3, WorkDate() + 2);
+
+        // [WHEN] A payment of "2 * A" is posted (weighing: +2A +A -3A = exactly 0, then -A after the older expense)
+        CreateAndPostGenJournalLine(
+            GenJournalLine, Employee."No.", GenJournalLine."Document Type"::Payment, PaymentAmount * 2, WorkDate() + 10);
+
+        // [THEN] The new payment is settled in full - not left open with a flipped remaining amount
+        EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+#pragma warning disable AA0210
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::Payment);
+        EmployeeLedgerEntry.SetRange("Posting Date", WorkDate() + 10);
+#pragma warning restore AA0210
+        EmployeeLedgerEntry.FindFirst();
+        EmployeeLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreEqual(0, EmployeeLedgerEntry."Remaining Amount", 'New payment should be fully applied.');
+        Assert.IsFalse(EmployeeLedgerEntry.Open, 'New payment should be closed.');
+
+        // [THEN] Only the net balance (-A) remains, and it stays on the expenses - not on the new payment
+        EmployeeLedgerEntry.Reset();
+        EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+#pragma warning disable AA0210
+        EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::" ");
+#pragma warning restore AA0210
+        EmployeeLedgerEntry.FindSet();
+        repeat
+            EmployeeLedgerEntry.CalcFields("Remaining Amount");
+            ExpenseRemaining += EmployeeLedgerEntry."Remaining Amount";
+        until EmployeeLedgerEntry.Next() = 0;
+        Assert.AreEqual(-PaymentAmount, ExpenseRemaining, 'Only the net balance should remain, on the expenses.');
+    end;
+
+    [Test]
     [HandlerFunctions('ApplyingEmployeeEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure CheckAmountOnApplyEmployeeEntriesPage()

--- a/src/Layers/W1/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
+++ b/src/Layers/W1/Tests/Resource/ERMApplyUnapplyEmployee.Codeunit.al
@@ -330,7 +330,9 @@
         CreateAndPostGenJournalLine(
             GenJournalLine, Employee."No.", GenJournalLine."Document Type"::" ", -PaymentAmount * 5 / 2, WorkDate() + 1);
         EmployeeLedgerEntry.SetRange("Employee No.", Employee."No.");
+#pragma warning disable AA0210
         EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::" ");
+#pragma warning restore AA0210
         EmployeeLedgerEntry.FindFirst();
         EmployeeLedgerEntry.CalcFields("Remaining Amount");
         Assert.AreEqual(-PaymentAmount * 5 / 2, EmployeeLedgerEntry."Remaining Amount",
@@ -347,9 +349,11 @@
         Assert.IsFalse(EmployeeLedgerEntry.Open, 'Expense should be closed.');
 
         // [THEN] The expense excess reduces the oldest payment only; the other payments are not consumed
+#pragma warning disable AA0210
         EmployeeLedgerEntry.SetRange("Document Type", EmployeeLedgerEntry."Document Type"::Payment);
         EmployeeLedgerEntry.SetCurrentKey("Posting Date");
         EmployeeLedgerEntry.SetAscending("Posting Date", true);
+#pragma warning restore AA0210
         EmployeeLedgerEntry.FindSet();
         EmployeeLedgerEntry.CalcFields("Remaining Amount");
         Assert.AreEqual(PaymentAmount / 2, EmployeeLedgerEntry."Remaining Amount",


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Fix regression introduced by Apply-to-Oldest optimization. Detailed explanation of the regression is in https://github.com/microsoft/BCApps/issues/9529

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#646691](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646691) and its GitHub counterpart #9529 

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
Added new automated tests:
- 4 tests that guard against the regression added by the partner, taken from this PR https://github.com/microsoft/BCApps/pull/9881
- - one extra tests that confirms the performance optimization works (that early exit is done when summing is sufficient)
- 
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility
There is test coverage for both the regression and the performance optimization, so the risk is low.
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->






