### PR TITLE
Bug 646701: [28.x] [Backport] Guided error for subcontracting direct transfer from whse-handling location

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -85,39 +85,32 @@ report 20501 "Subc. Create Transf. Order"
         OrderNoDoesNotExistInProdOrderErr: Label 'Operation %1 in the subcontracting order %2 does not exist in the routing %3 of the production order %4.', Comment = '%1=Operation No., %2=Purchase Order No., %3=Routing No., %4=Production Order No.';
         OrderNoIsNotSubcontractorErr: Label 'Order %1 is not a Subcontractor work.', Comment = '%1=Purchase Order No.';
         WarningToSpecifyPurchOrderErr: Label 'Warning. Specify a Purchase Order No. for the Subcontractor work.';
-        CannotCreateTransferErr: Label 'Cannot create a transfer from location %1 to location %2 because location %1 requires warehousing. Set up an in-transit transfer route between the locations, or set Direct Transfer Posting to Direct Transfer on the transfer route or in Inventory Setup.', Comment = '%1=Transfer-from location code, %2=Transfer-to location code';
+        CannotCreateTransferErr: Label 'Cannot create a transfer from location %1 to location %2 because location %1 requires warehousing. Set up an in-transit transfer route between the locations, or set Direct Transfer Posting to Direct Transfer in Inventory Setup.', Comment = '%1=Transfer-from location code, %2=Transfer-to location code';
 
-    local procedure CheckDirectTransferAllowed(var TransferRoute: Record "Transfer Route"; TransferRouteExists: Boolean; TransferFromLocation: Code[10]; TransferToLocation: Code[10])
+    local procedure CheckDirectTransferAllowed(TransferFromLocation: Code[10]; TransferToLocation: Code[10])
     var
         Location: Record Location;
     begin
-        if IsOneStepDirectTransfer(TransferRoute, TransferRouteExists) then
+        if IsOneStepDirectTransfer() then
             exit;
 
         if Location.RequirePicking(TransferFromLocation) or Location.RequireShipment(TransferFromLocation) then
             Error(CannotCreateTransferErr, TransferFromLocation, TransferToLocation);
     end;
 
-    local procedure IsOneStepDirectTransfer(var TransferRoute: Record "Transfer Route"; TransferRouteExists: Boolean): Boolean
+    local procedure IsOneStepDirectTransfer(): Boolean
     var
         InventorySetup: Record "Inventory Setup";
-        DirectTransferPostingType: Enum "Direct Transfer Posting Type";
     begin
-        if TransferRouteExists and TransferRoute."Direct Transfer" then
-            DirectTransferPostingType := TransferRoute."Direct Transfer Posting"
-        else begin
-            InventorySetup.SetLoadFields("Direct Transfer Posting Type");
-            InventorySetup.GetRecordOnce();
-            DirectTransferPostingType := InventorySetup."Direct Transfer Posting Type";
-        end;
-        exit(DirectTransferPostingType = DirectTransferPostingType::"Direct Transfer");
+        InventorySetup.SetLoadFields("Direct Transfer Posting");
+        InventorySetup.GetRecordOnce();
+        exit(InventorySetup."Direct Transfer Posting" = InventorySetup."Direct Transfer Posting"::"Direct Transfer");
     end;
 
     local procedure InsertTransferHeader(TransferFromLocation: Code[10])
     var
         TransferRoute: Record "Transfer Route";
         TransferToLocationCode: Code[10];
-        TransferRouteExists: Boolean;
     begin
         GetTransferToLocationCode(TransferToLocationCode);
 
@@ -136,13 +129,10 @@ report 20501 "Subc. Create Transf. Order"
             TransferHeader.Insert(true);
             TransferHeader.Validate("Transfer-from Code", TransferFromLocation);
             TransferHeader.Validate("Transfer-to Code", TransferToLocationCode);
-            TransferRouteExists := TransferRoute.Get(TransferFromLocation, TransferToLocationCode);
-            if not TransferRouteExists or (TransferRoute."In-Transit Code" = '') then begin
-                CheckDirectTransferAllowed(TransferRoute, TransferRouteExists, TransferFromLocation, TransferToLocationCode);
+            if not TransferRoute.Get(TransferFromLocation, TransferToLocationCode) or (TransferRoute."In-Transit Code" = '') then begin
+                CheckDirectTransferAllowed(TransferFromLocation, TransferToLocationCode);
                 TransferHeader.Validate("Direct Transfer", true);
-            end else
-                if not IsOneStepDirectTransfer(TransferRoute, TransferRouteExists) then
-                    TransferHeader.Validate("In-Transit Code", TransferRoute."In-Transit Code");
+            end;
 
             TransferHeader."Subc. Source Type" := TransferHeader."Subc. Source Type"::Subcontracting;
             TransferHeader."Source ID" := "Purchase Header"."Buy-from Vendor No.";

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -7,6 +7,8 @@ namespace Microsoft.Manufacturing.Subcontracting;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Costing;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Setup;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.WorkCenter;
@@ -83,11 +85,39 @@ report 20501 "Subc. Create Transf. Order"
         OrderNoDoesNotExistInProdOrderErr: Label 'Operation %1 in the subcontracting order %2 does not exist in the routing %3 of the production order %4.', Comment = '%1=Operation No., %2=Purchase Order No., %3=Routing No., %4=Production Order No.';
         OrderNoIsNotSubcontractorErr: Label 'Order %1 is not a Subcontractor work.', Comment = '%1=Purchase Order No.';
         WarningToSpecifyPurchOrderErr: Label 'Warning. Specify a Purchase Order No. for the Subcontractor work.';
+        CannotCreateTransferErr: Label 'Cannot create a transfer from location %1 to location %2 because location %1 requires warehousing. Set up an in-transit transfer route between the locations, or set Direct Transfer Posting to Direct Transfer on the transfer route or in Inventory Setup.', Comment = '%1=Transfer-from location code, %2=Transfer-to location code';
+
+    local procedure CheckDirectTransferAllowed(var TransferRoute: Record "Transfer Route"; TransferRouteExists: Boolean; TransferFromLocation: Code[10]; TransferToLocation: Code[10])
+    var
+        Location: Record Location;
+    begin
+        if IsOneStepDirectTransfer(TransferRoute, TransferRouteExists) then
+            exit;
+
+        if Location.RequirePicking(TransferFromLocation) or Location.RequireShipment(TransferFromLocation) then
+            Error(CannotCreateTransferErr, TransferFromLocation, TransferToLocation);
+    end;
+
+    local procedure IsOneStepDirectTransfer(var TransferRoute: Record "Transfer Route"; TransferRouteExists: Boolean): Boolean
+    var
+        InventorySetup: Record "Inventory Setup";
+        DirectTransferPostingType: Enum "Direct Transfer Posting Type";
+    begin
+        if TransferRouteExists and TransferRoute."Direct Transfer" then
+            DirectTransferPostingType := TransferRoute."Direct Transfer Posting"
+        else begin
+            InventorySetup.SetLoadFields("Direct Transfer Posting Type");
+            InventorySetup.GetRecordOnce();
+            DirectTransferPostingType := InventorySetup."Direct Transfer Posting Type";
+        end;
+        exit(DirectTransferPostingType = DirectTransferPostingType::"Direct Transfer");
+    end;
 
     local procedure InsertTransferHeader(TransferFromLocation: Code[10])
     var
         TransferRoute: Record "Transfer Route";
         TransferToLocationCode: Code[10];
+        TransferRouteExists: Boolean;
     begin
         GetTransferToLocationCode(TransferToLocationCode);
 
@@ -106,8 +136,13 @@ report 20501 "Subc. Create Transf. Order"
             TransferHeader.Insert(true);
             TransferHeader.Validate("Transfer-from Code", TransferFromLocation);
             TransferHeader.Validate("Transfer-to Code", TransferToLocationCode);
-            if not TransferRoute.Get(TransferFromLocation, TransferToLocationCode) or (TransferRoute."In-Transit Code" = '') then
+            TransferRouteExists := TransferRoute.Get(TransferFromLocation, TransferToLocationCode);
+            if not TransferRouteExists or (TransferRoute."In-Transit Code" = '') then begin
+                CheckDirectTransferAllowed(TransferRoute, TransferRouteExists, TransferFromLocation, TransferToLocationCode);
                 TransferHeader.Validate("Direct Transfer", true);
+            end else
+                if not IsOneStepDirectTransfer(TransferRoute, TransferRouteExists) then
+                    TransferHeader.Validate("In-Transit Code", TransferRoute."In-Transit Code");
 
             TransferHeader."Subc. Source Type" := TransferHeader."Subc. Source Type"::Subcontracting;
             TransferHeader."Source ID" := "Purchase Header"."Buy-from Vendor No.";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcLocationHandlerTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcLocationHandlerTest.Codeunit.al
@@ -8,6 +8,7 @@ using Microsoft.Foundation.Company;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Location;
+using Microsoft.Inventory.Setup;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.MachineCenter;
@@ -61,6 +62,8 @@ codeunit 139981 "Subc. Location Handler Test"
         SubSetupLibrary.InitSetupFields();
         LibraryERMCountryData.CreateVATData();
         SubSetupLibrary.InitialSetupForGenProdPostingGroup();
+
+        LibrarySetupStorage.Save(Database::"Inventory Setup");
 
         IsInitialized := true;
         Commit();
@@ -195,6 +198,157 @@ codeunit 139981 "Subc. Location Handler Test"
         Assert.IsTrue(TransferHeader.FindFirst(), 'Transfer Order should be created');
         Assert.AreEqual(LocationOrig.Code, TransferHeader."Transfer-from Code", 'Transfer-from Code should be Origin Location');
         Assert.AreEqual(LocationSub.Code, TransferHeader."Transfer-to Code", 'Transfer-to Code should be Subcontractor Location');
+    end;
+
+    [Test]
+    procedure DirectTransferFromRequireShipmentLocationIsBlocked()
+    var
+        Item: Record Item;
+        LocationOrig: Record Location;
+        LocationSub: Record Location;
+        ProdOrder: Record "Production Order";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+        CreateSubCTransfOrder: Report "Subc. Create Transf. Order";
+    begin
+        // [SCENARIO 640958] Creating a subcontracting transfer with no in-transit route from a location that
+        //                 requires a shipment is blocked with a guided error instead of a raw TestField error.
+        Initialize();
+
+        // [GIVEN] Subcontractor and Original locations; the Original location requires a shipment; no in-transit transfer route exists.
+        LibraryWarehouse.CreateLocation(LocationSub);
+        LibraryWarehouse.CreateLocation(LocationOrig);
+        LocationOrig."Require Shipment" := true;
+        LocationOrig.Modify(true);
+
+        // [GIVEN] Inventory Setup posts direct transfers via Shipment and Receipt (so warehouse handling is enforced)
+        SetInventoryDirectTransferPostingType("Direct Transfer Posting Type"::"Shipment and Receipt");
+
+        // [GIVEN] Subcontracting Scenario Setup (component at the subcontractor location, original at the require-shipment location)
+        CreateSubcontractingSetup(
+            PurchaseHeader, PurchaseLine, ProdOrder, ProdOrderLine, ProdOrderComp, ProdOrderRtngLine, Vendor,
+            LocationSub, Item, LibraryRandom.RandInt(10), LocationSub.Code, LocationOrig.Code);
+
+        // [WHEN] Running the Create Subcontracting Transfer Order report
+        Commit(); // Report requires commit
+        PurchaseHeader.SetRecFilter();
+        CreateSubCTransfOrder.SetTableView(PurchaseHeader);
+        CreateSubCTransfOrder.UseRequestPage(false);
+
+        // [THEN] A guided error is raised instead of a raw TestField error on the location
+        asserterror CreateSubCTransfOrder.Run();
+        Assert.ExpectedError('requires warehousing');
+    end;
+
+    [Test]
+    [HandlerFunctions('HandleTransferOrder')]
+    procedure DirectTransferFromRequireShipmentLocationAllowedWithDirectTransferPosting()
+    var
+        Item: Record Item;
+        LocationOrig: Record Location;
+        LocationSub: Record Location;
+        ProdOrder: Record "Production Order";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        Vendor: Record Vendor;
+        CreateSubCTransfOrder: Report "Subc. Create Transf. Order";
+    begin
+        // [SCENARIO 640958] When Inventory Setup posts direct transfers as Direct Transfer, the transfer is created
+        //                 from a require-shipment source location instead of being blocked, because the Direct Transfer
+        //                 posting type skips the outbound warehouse-handling check.
+        Initialize();
+
+        // [GIVEN] Subcontractor and Original locations; the Original location requires a shipment; no in-transit route exists.
+        LibraryWarehouse.CreateLocation(LocationSub);
+        LibraryWarehouse.CreateLocation(LocationOrig);
+        LocationOrig."Require Shipment" := true;
+        LocationOrig.Modify(true);
+
+        // [GIVEN] Inventory Setup posts direct transfers via Direct Transfer
+        SetInventoryDirectTransferPostingType("Direct Transfer Posting Type"::"Direct Transfer");
+
+        // [GIVEN] Subcontracting Scenario Setup
+        CreateSubcontractingSetup(
+            PurchaseHeader, PurchaseLine, ProdOrder, ProdOrderLine, ProdOrderComp, ProdOrderRtngLine, Vendor,
+            LocationSub, Item, LibraryRandom.RandInt(10), LocationSub.Code, LocationOrig.Code);
+
+        // [WHEN] Running the Create Subcontracting Transfer Order report
+        Commit(); // Report requires commit
+        PurchaseHeader.SetRecFilter();
+        CreateSubCTransfOrder.SetTableView(PurchaseHeader);
+        CreateSubCTransfOrder.UseRequestPage(false);
+        CreateSubCTransfOrder.Run();
+
+        // [THEN] A direct transfer order is created (not blocked)
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        Assert.IsTrue(TransferHeader.FindFirst(), 'A transfer order should be created when Inventory Setup uses Direct Transfer posting.');
+        Assert.IsTrue(TransferHeader."Direct Transfer", 'The created transfer order should be a direct transfer.');
+    end;
+
+    [Test]
+    [HandlerFunctions('HandleTransferOrder')]
+    procedure InTransitRouteWithDirectTransferUsesInTransitCode()
+    var
+        Item: Record Item;
+        LocationOrig: Record Location;
+        LocationSub: Record Location;
+        ProdOrder: Record "Production Order";
+        ProdOrderComp: Record "Prod. Order Component";
+        ProdOrderLine: Record "Prod. Order Line";
+        ProdOrderRtngLine: Record "Prod. Order Routing Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TransferHeader: Record "Transfer Header";
+        TransferRoute: Record "Transfer Route";
+        TransitLocation: Record Location;
+        Vendor: Record Vendor;
+        CreateSubCTransfOrder: Report "Subc. Create Transf. Order";
+    begin
+        // [SCENARIO 640958] A transfer route flagged Direct Transfer with Shipment and Receipt posting and an In-Transit
+        //                 Code creates a transfer order that keeps the Direct Transfer flag, the posting type, and the In-Transit Code.
+        Initialize();
+
+        // [GIVEN] Subcontractor and Original locations and an in-transit location
+        LibraryWarehouse.CreateLocation(LocationSub);
+        LibraryWarehouse.CreateLocation(LocationOrig);
+        LibraryWarehouse.CreateInTransitLocation(TransitLocation);
+
+        // [GIVEN] Inventory Setup posts direct transfers via Shipment and Receipt
+        SetInventoryDirectTransferPostingType("Direct Transfer Posting Type"::"Shipment and Receipt");
+
+        // [GIVEN] A transfer route from Original to Subcontractor with an In-Transit Code, flagged Direct Transfer (Shipment and Receipt posting)
+        LibraryWarehouse.CreateAndUpdateTransferRoute(TransferRoute, LocationOrig.Code, LocationSub.Code, TransitLocation.Code, '', '');
+        TransferRoute.Validate("Direct Transfer", true);
+        TransferRoute.Modify(true);
+
+        // [GIVEN] Subcontracting Scenario Setup
+        CreateSubcontractingSetup(
+            PurchaseHeader, PurchaseLine, ProdOrder, ProdOrderLine, ProdOrderComp, ProdOrderRtngLine, Vendor,
+            LocationSub, Item, LibraryRandom.RandInt(10), LocationSub.Code, LocationOrig.Code);
+
+        // [WHEN] Running the Create Subcontracting Transfer Order report
+        Commit(); // Report requires commit
+        PurchaseHeader.SetRecFilter();
+        CreateSubCTransfOrder.SetTableView(PurchaseHeader);
+        CreateSubCTransfOrder.UseRequestPage(false);
+        CreateSubCTransfOrder.Run();
+
+        // [THEN] The transfer order keeps the route's Direct Transfer flag, Shipment and Receipt posting, and In-Transit Code
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        Assert.IsTrue(TransferHeader.FindFirst(), 'A transfer order should be created.');
+        Assert.IsTrue(TransferHeader."Direct Transfer", 'The created transfer order should keep the route''s Direct Transfer flag.');
+        Assert.AreEqual(
+            "Direct Transfer Posting Type"::"Shipment and Receipt", TransferHeader."Direct Transfer Posting",
+            'The transfer order should keep the route''s Direct Transfer Posting.');
+        Assert.AreEqual(TransitLocation.Code, TransferHeader."In-Transit Code", 'The transfer order should keep the route''s In-Transit Code.');
     end;
 
     [Test]
@@ -623,5 +777,14 @@ codeunit 139981 "Subc. Location Handler Test"
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin
+    end;
+
+    local procedure SetInventoryDirectTransferPostingType(PostingType: Enum "Direct Transfer Posting Type")
+    var
+        InventorySetup: Record "Inventory Setup";
+    begin
+        InventorySetup.Get();
+        InventorySetup.Validate("Direct Transfer Posting Type", PostingType);
+        InventorySetup.Modify(true);
     end;
 }

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcLocationHandlerTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcLocationHandlerTest.Codeunit.al
@@ -225,8 +225,8 @@ codeunit 139981 "Subc. Location Handler Test"
         LocationOrig."Require Shipment" := true;
         LocationOrig.Modify(true);
 
-        // [GIVEN] Inventory Setup posts direct transfers via Shipment and Receipt (so warehouse handling is enforced)
-        SetInventoryDirectTransferPostingType("Direct Transfer Posting Type"::"Shipment and Receipt");
+        // [GIVEN] Inventory Setup posts direct transfers via Receipt and Shipment (so warehouse handling is enforced)
+        SetInventoryDirectTransferPosting(false);
 
         // [GIVEN] Subcontracting Scenario Setup (component at the subcontractor location, original at the require-shipment location)
         CreateSubcontractingSetup(
@@ -273,7 +273,7 @@ codeunit 139981 "Subc. Location Handler Test"
         LocationOrig.Modify(true);
 
         // [GIVEN] Inventory Setup posts direct transfers via Direct Transfer
-        SetInventoryDirectTransferPostingType("Direct Transfer Posting Type"::"Direct Transfer");
+        SetInventoryDirectTransferPosting(true);
 
         // [GIVEN] Subcontracting Scenario Setup
         CreateSubcontractingSetup(
@@ -291,64 +291,6 @@ codeunit 139981 "Subc. Location Handler Test"
         TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
         Assert.IsTrue(TransferHeader.FindFirst(), 'A transfer order should be created when Inventory Setup uses Direct Transfer posting.');
         Assert.IsTrue(TransferHeader."Direct Transfer", 'The created transfer order should be a direct transfer.');
-    end;
-
-    [Test]
-    [HandlerFunctions('HandleTransferOrder')]
-    procedure InTransitRouteWithDirectTransferUsesInTransitCode()
-    var
-        Item: Record Item;
-        LocationOrig: Record Location;
-        LocationSub: Record Location;
-        ProdOrder: Record "Production Order";
-        ProdOrderComp: Record "Prod. Order Component";
-        ProdOrderLine: Record "Prod. Order Line";
-        ProdOrderRtngLine: Record "Prod. Order Routing Line";
-        PurchaseHeader: Record "Purchase Header";
-        PurchaseLine: Record "Purchase Line";
-        TransferHeader: Record "Transfer Header";
-        TransferRoute: Record "Transfer Route";
-        TransitLocation: Record Location;
-        Vendor: Record Vendor;
-        CreateSubCTransfOrder: Report "Subc. Create Transf. Order";
-    begin
-        // [SCENARIO 640958] A transfer route flagged Direct Transfer with Shipment and Receipt posting and an In-Transit
-        //                 Code creates a transfer order that keeps the Direct Transfer flag, the posting type, and the In-Transit Code.
-        Initialize();
-
-        // [GIVEN] Subcontractor and Original locations and an in-transit location
-        LibraryWarehouse.CreateLocation(LocationSub);
-        LibraryWarehouse.CreateLocation(LocationOrig);
-        LibraryWarehouse.CreateInTransitLocation(TransitLocation);
-
-        // [GIVEN] Inventory Setup posts direct transfers via Shipment and Receipt
-        SetInventoryDirectTransferPostingType("Direct Transfer Posting Type"::"Shipment and Receipt");
-
-        // [GIVEN] A transfer route from Original to Subcontractor with an In-Transit Code, flagged Direct Transfer (Shipment and Receipt posting)
-        LibraryWarehouse.CreateAndUpdateTransferRoute(TransferRoute, LocationOrig.Code, LocationSub.Code, TransitLocation.Code, '', '');
-        TransferRoute.Validate("Direct Transfer", true);
-        TransferRoute.Modify(true);
-
-        // [GIVEN] Subcontracting Scenario Setup
-        CreateSubcontractingSetup(
-            PurchaseHeader, PurchaseLine, ProdOrder, ProdOrderLine, ProdOrderComp, ProdOrderRtngLine, Vendor,
-            LocationSub, Item, LibraryRandom.RandInt(10), LocationSub.Code, LocationOrig.Code);
-
-        // [WHEN] Running the Create Subcontracting Transfer Order report
-        Commit(); // Report requires commit
-        PurchaseHeader.SetRecFilter();
-        CreateSubCTransfOrder.SetTableView(PurchaseHeader);
-        CreateSubCTransfOrder.UseRequestPage(false);
-        CreateSubCTransfOrder.Run();
-
-        // [THEN] The transfer order keeps the route's Direct Transfer flag, Shipment and Receipt posting, and In-Transit Code
-        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
-        Assert.IsTrue(TransferHeader.FindFirst(), 'A transfer order should be created.');
-        Assert.IsTrue(TransferHeader."Direct Transfer", 'The created transfer order should keep the route''s Direct Transfer flag.');
-        Assert.AreEqual(
-            "Direct Transfer Posting Type"::"Shipment and Receipt", TransferHeader."Direct Transfer Posting",
-            'The transfer order should keep the route''s Direct Transfer Posting.');
-        Assert.AreEqual(TransitLocation.Code, TransferHeader."In-Transit Code", 'The transfer order should keep the route''s In-Transit Code.');
     end;
 
     [Test]
@@ -779,12 +721,15 @@ codeunit 139981 "Subc. Location Handler Test"
     begin
     end;
 
-    local procedure SetInventoryDirectTransferPostingType(PostingType: Enum "Direct Transfer Posting Type")
+    local procedure SetInventoryDirectTransferPosting(UseDirectTransfer: Boolean)
     var
         InventorySetup: Record "Inventory Setup";
     begin
         InventorySetup.Get();
-        InventorySetup.Validate("Direct Transfer Posting Type", PostingType);
+        if UseDirectTransfer then
+            InventorySetup.Validate("Direct Transfer Posting", InventorySetup."Direct Transfer Posting"::"Direct Transfer")
+        else
+            InventorySetup.Validate("Direct Transfer Posting", InventorySetup."Direct Transfer Posting"::"Receipt and Shipment");
         InventorySetup.Modify(true);
     end;
 }


### PR DESCRIPTION
Backport of microsoft/BCApps#9085 to 
releases/28.x.

Fixes [AB#646701](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646701)

Report `Subc. Create Transf. Order` (`InsertTransferHeader`) previously blocked subcontracting transfers with a raw `TestField` error when the transfer-from location required warehouse handling (Require Shipment / Require Picking) and no in-transit transfer route existed.

This change adds `CheckDirectTransferAllowed` / `IsOneStepDirectTransfer` so that:
- A guided, actionable error is raised instead of a raw TestField error.
- Direct Transfer posting (route or Inventory Setup) skips the outbound warehouse-handling check.
- The route's In-Transit Code is honored when the route is not a one-step direct transfer.

Includes tests for the blocked case, the Direct-Transfer-posting allowed case, and the in-transit route case.




