### PR TITLE
Block unauthorized Sales Order Agent setup access

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
@@ -464,6 +464,7 @@ page 4400 "SOA Setup"
     var
         AgentRec: Record Agent;
         SOASetupRec: Record "SOA Setup";
+        AgentSystemPermissions: Codeunit "Agent System Permissions";
         FeatureTelemetry: Codeunit "Feature Telemetry";
         SOASetupCU: Codeunit "SOA Setup";
         UserSecurityIDFilter: Text;
@@ -479,6 +480,9 @@ page 4400 "SOA Setup"
         UserSecurityIDFilter := Rec.GetFilter("User Security ID");
         if not Evaluate(UserSecurityID, UserSecurityIDFilter) then
             Clear(UserSecurityID);
+
+        if not AgentSystemPermissions.CurrentUserCanManageAgent(UserSecurityID) then
+            Error(NotAuthorizedToConfigureAgentErr);
 
         if not IsNullGuid(UserSecurityID) then
             if SOASetupRec.GetBasedOnAgentUserSecurityID(UserSecurityID, false) then begin
@@ -798,6 +802,7 @@ page 4400 "SOA Setup"
         DailyEmailLimitErr: Label 'The daily email limit must be greater than zero.';
         EmailSignatureModifyLbl: Label 'Edit signature';
         SelectMailboxFirstMsg: Label 'Please select an email account first.';
+        NotAuthorizedToConfigureAgentErr: Label 'You do not have permission to configure the Sales Order Agent. Contact your system administrator to update your permissions or to mark you as one of the administrators for the agent.';
         ConfiguredBy: Text[80];
         SOACreateTaskLbl: Label 'Create task for the agent';
         EnableAgentForTaskQst: Label 'Trying out the agent will activate it and turn off incoming email monitoring immediately.\\Do you want to continue?';


### PR DESCRIPTION
## Problem
A user without Sales Order Agent configuration rights can navigate directly to page 4400 and activate or reconfigure the agent, bypassing the authorization applied by the normal Agents pages.

## Root cause
The SOA Setup page trusts its caller. Its `OnOpenPage` trigger resolves the target agent but does not verify that the current user can manage that agent.

## Fix
Validate the resolved agent user security ID with `Agent System Permissions`.`CurrentUserCanManageAgent`. This preserves per-agent **Can Configure** access and requires **Configure All Agents** for first-time setup or unfiltered direct navigation.

## Validation
- AL diagnostics for the changed file: clean
- `git diff --check`: clean
- Built a local-compatible Sales Order Agent package from the exact source exposed by the NAV_master environment, with this authorization change applied
- Published the package to NAV_master and downloaded its symbols back; verified that the deployed page contains both the `CurrentUserCanManageAgent` guard and authorization error
- The local environment's Base Application predates the current-main `Contact List`.`OnBeforeFindRecord` event, so GitHub validation remains authoritative for the complete current-main app build

## Risk
Low. The change is limited to the setup page entry boundary and uses the existing agent authorization API.

Fixes [AB#640825](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640825)

