### PR TITLE
Pin all actions that are not currently pinned- #2346

### DIFF
--- a/.github/actions/GetGitBranches/action.yaml
+++ b/.github/actions/GetGitBranches/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: run
       shell: pwsh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     - dependency-name: "microsoft/AL-Go/*"
   labels:
     - "Automation"
+  cooldown:
+    default-days: 7

--- a/.github/workflows/ai-triage-dispatch.yml
+++ b/.github/workflows/ai-triage-dispatch.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Mint token for the agent repo
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.TRIAGE_APP_ID }}
           private-key: ${{ secrets.TRIAGE_APP_PRIVATE_KEY }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Apply triage result
         if: steps.download.outputs.have_result == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -172,7 +172,7 @@ jobs:
 
       - name: Report triage failure
         if: always() && (steps.await.outputs.run_id == '' || steps.download.outputs.have_result == 'false')
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check labels and manual override
         id: preflight
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           SUBJECT_KIND: ${{ env.SUBJECT_KIND }}
           SUBJECT_NUMBER: ${{ env.SUBJECT_NUMBER }}
@@ -162,7 +162,7 @@ jobs:
       - name: Create correlation token
         if: steps.preflight.outputs.dispatch == 'true'
         id: correlation
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: core.setOutput('token', require('crypto').randomUUID())
 
@@ -232,7 +232,7 @@ jobs:
 
       - name: Validate and apply ownership result
         if: steps.preflight.outputs.dispatch == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RESULT_PATH: result/ownership-result.json
           CORRELATION_TOKEN: ${{ steps.correlation.outputs.token }}


### PR DESCRIPTION
## What & why

Supply-chain hardening: pin all GitHub Actions that were not already pinned to full-length commit SHAs (with version comments) across BCApps workflows and composite actions. Also adds a 7-day dependabot cooldown so pinned-action bumps are batched.

## Linked work

[AB#646795](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646795)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Workflow/action edits only — replaced floating action version tags with pinned commit SHAs. Verified each pinned SHA resolves to the intended version tag.

## Risk & compatibility

None — no product code changes; CI workflows continue to reference the same action versions, now pinned to immutable SHAs.

