### PR TITLE
Bug 646799: Spend Request fields in Posted Gen. Journal Line have wrong/different field numbers in country versions (correct in w1)

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1115,7 +1115,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1125,7 +1125,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1113,7 +1113,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1123,7 +1123,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1114,7 +1114,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1124,7 +1124,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1113,7 +1113,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1123,7 +1123,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1114,7 +1114,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1124,7 +1124,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';
@@ -1814,7 +1814,7 @@ table 181 "Posted Gen. Journal Line"
             Caption = 'Auto. Acc. Group';
             TableRelation = "Automatic Acc. Header";
             ObsoleteReason = 'Moved to Automatic Account Codes app.';
-			ObsoleteState = Removed;
+            ObsoleteState = Removed;
             ObsoleteTag = '25.0';
         }
 #endif

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1113,7 +1113,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1123,7 +1123,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1113,7 +1113,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1123,7 +1123,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1117,7 +1117,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1127,7 +1127,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1113,7 +1113,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1123,7 +1123,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1114,7 +1114,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1124,7 +1124,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1115,7 +1115,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1125,7 +1125,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1116,7 +1116,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1126,7 +1126,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';

--- a/src/Layers/SE/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
+++ b/src/Layers/SE/BaseApp/Finance/GeneralLedger/Journal/PostedGenJournalLine.Table.al
@@ -1114,7 +1114,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies the spend request that this journal line relates to.
         /// </summary>
-        field(140; "Spend Request No."; Code[20])
+        field(146; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
             ToolTip = 'Specifies the spend request that this journal line relates to.';
@@ -1124,7 +1124,7 @@ table 181 "Posted Gen. Journal Line"
         /// <summary>
         /// Specifies that the spend request will be closed when the journal line is posted.
         /// </summary>
-        field(141; "Spend Request Close"; Boolean)
+        field(147; "Spend Request Close"; Boolean)
         {
             Caption = 'Spend Request Close';
             ToolTip = 'Specifies that the spend request will be closed when the journal line is posted.';
@@ -1813,7 +1813,7 @@ table 181 "Posted Gen. Journal Line"
         {
             Caption = 'Source Posting Date';
             ObsoleteReason = 'The field is not used and will be obsoleted';
-			ObsoleteState = Removed;
+            ObsoleteState = Removed;
             ObsoleteTag = '26.0';
         }
 #endif
@@ -1823,7 +1823,7 @@ table 181 "Posted Gen. Journal Line"
             Caption = 'Auto. Acc. Group';
             TableRelation = "Automatic Acc. Header";
             ObsoleteReason = 'Moved to Automatic Account Codes app.';
-			ObsoleteState = Removed;
+            ObsoleteState = Removed;
             ObsoleteTag = '25.0';
         }
 #endif


### PR DESCRIPTION
Posted Gen. Journal Line table is correct in w1 but has wrong IDs in country versions.

Fixes [AB#646799](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646799)


