### PR TITLE
[Master] - Bug 646815 [Expense Agent] Obsolete country-specific demo data, consolidating into single W1 app

### DIFF
--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountAT.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 11191 "Create Expense G/L Account AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -53,3 +57,4 @@ codeunit 11191 "Create Expense G/L Account AT"
         exit(CompanyCreditCardsClearingAccountTok);
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpAT.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 11192 "Create Expense Posting Grp AT"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -74,3 +78,4 @@ codeunit 11192 "Create Expense Posting Grp AT"
         exit(ExpensePERDIEMATok);
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 11193 "Update Exp. Emp Posting Grp AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -32,3 +37,4 @@ codeunit 11193 "Update Exp. Emp Posting Grp AT"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpRuleConditionAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpRuleConditionAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11196 "Create Exp. Rule Condition AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 11196 "Create Exp. Rule Condition AT"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesAT.PerDiemI(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11197 "Create Exp. SubCategories AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 11197 "Create Exp. SubCategories AT"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11194 "Create Expense Categories AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 11194 "Create Expense Categories AT"
         exit(PerDiemATok);
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 11195 "Create Expense Rule Header AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 11195 "Create Expense Rule Header AT"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesAT.PerDiemI(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', CreateCurrency.USD(), '');
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/3. Transactions/CreateExpenseAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/3. Transactions/CreateExpenseAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 11199 "Create Expense AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 11199 "Create Expense AT"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/4. Historical/CreatePostedExpReportAT.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/4. Historical/CreatePostedExpReportAT.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 11205 "Create Posted Exp. Report AT"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 11205 "Create Posted Exp. Report AT"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/ATExpContosoLocalization.Codeunit.al
+++ b/src/Apps/AT/ExpenseAgent_AT/demo data/Demo Data/ATExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 11198 "AT Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -81,3 +86,4 @@ codeunit 11198 "AT Exp. Contoso Localization"
             CurrencyCode := CreateCurrency.USD();
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountAU.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 17233 "Create Expense G/L Account AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -56,3 +60,4 @@ codeunit 17233 "Create Expense G/L Account AU"
         ContosoGLAccount: Codeunit "Contoso GL Account";
         ExpenseGLAccount: Codeunit "Create Expense G/L Account";
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpAU.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 17231 "Create Expense Posting Grp AU"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -63,3 +67,4 @@ codeunit 17231 "Create Expense Posting Grp AU"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpAU.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +12,9 @@ codeunit 17232 "Update Exp. Emp Posting Grp AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -29,3 +33,4 @@ codeunit 17232 "Update Exp. Emp Posting Grp AU"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpRuleConditionAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpRuleConditionAU.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 17237 "Create Exp. Rule Condition AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 17237 "Create Exp. Rule Condition AU"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesAU.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesAU.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 17238 "Create Exp. SubCategories AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 17238 "Create Exp. SubCategories AU"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesAU.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 17235 "Create Expense Categories AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 17235 "Create Expense Categories AU"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderAU.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 17236 "Create Expense Rule Header AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 17236 "Create Expense Rule Header AU"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesAU.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/3. Transactions/CreateExpenseAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/3. Transactions/CreateExpenseAU.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 17239 "Create Expense AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 17239 "Create Expense AU"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/4. Historical/CreatePostedExpReportAU.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/4. Historical/CreatePostedExpReportAU.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 17240 "Create Posted Exp. Report AU"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 17240 "Create Posted Exp. Report AU"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/AUExpContosoLocalization.Codeunit.al
+++ b/src/Apps/AU/ExpenseAgent_AU/demo data/Demo Data/AUExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 17234 "AU Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -72,3 +77,4 @@ codeunit 17234 "AU Exp. Contoso Localization"
         AccountNo := ExpenseGLAccount.FindGLAccountByName(CreateGLAccount.SalesResourcesExportName());
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountCA.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 27100 "Create Expense G/L Account CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -60,3 +64,4 @@ codeunit 27100 "Create Expense G/L Account CA"
         ContosoGLAccount: Codeunit "Contoso GL Account";
         ExpenseGLAccount: Codeunit "Create Expense G/L Account";
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpCA.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 27101 "Create Expense Posting Grp CA"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -63,3 +67,4 @@ codeunit 27101 "Create Expense Posting Grp CA"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpCA.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +12,9 @@ codeunit 27102 "Update Exp. Emp Posting Grp CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -30,3 +34,4 @@ codeunit 27102 "Update Exp. Emp Posting Grp CA"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpRuleConditionCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpRuleConditionCA.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 27106 "Create Exp. Rule Condition CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 27106 "Create Exp. Rule Condition CA"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesCA.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesCA.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 27107 "Create Exp. SubCategories CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 27107 "Create Exp. SubCategories CA"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesCA.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 27104 "Create Expense Categories CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 27104 "Create Expense Categories CA"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderCA.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 27105 "Create Expense Rule Header CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 27105 "Create Expense Rule Header CA"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesCA.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/3. Transactions/CreateExpenseCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/3. Transactions/CreateExpenseCA.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 27108 "Create Expense CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 27108 "Create Expense CA"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/4. Historical/CreatePostedExpReportCA.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/4. Historical/CreatePostedExpReportCA.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 27109 "Create Posted Exp. Report CA"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 27109 "Create Posted Exp. Report CA"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/CAExpContosoLocalization.Codeunit.al
+++ b/src/Apps/CA/ExpenseAgent_CA/demo data/Demo Data/CAExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 27103 "CA Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -72,3 +77,4 @@ codeunit 27103 "CA Exp. Contoso Localization"
         AccountNo := ExpenseGLAccount.FindGLAccountByName(CreateGLAccount.SalesResourcesExportName());
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountDE.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 11330 "Create Expense G/L Account DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -53,3 +57,4 @@ codeunit 11330 "Create Expense G/L Account DE"
         exit(CompanyCreditCardsClearingAccountTok);
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpDE.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 11331 "Create Expense Posting Grp DE"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -63,3 +67,4 @@ codeunit 11331 "Create Expense Posting Grp DE"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 11332 "Update Exp. Emp Posting Grp DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -31,3 +36,4 @@ codeunit 11332 "Update Exp. Emp Posting Grp DE"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpRuleConditionDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpRuleConditionDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11336 "Create Exp. Rule Condition DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 11336 "Create Exp. Rule Condition DE"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesDE.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11337 "Create Exp. SubCategories DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 11337 "Create Exp. SubCategories DE"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11333 "Create Expense Categories DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 11333 "Create Expense Categories DE"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 11334 "Create Expense Rule Header DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 11334 "Create Expense Rule Header DE"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesDE.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/3. Transactions/CreateExpenseDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/3. Transactions/CreateExpenseDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 11338 "Create Expense DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 11338 "Create Expense DE"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/4. Historical/CreatePostedExpReportDE.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/4. Historical/CreatePostedExpReportDE.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 11335 "Create Posted Exp. Report DE"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 11335 "Create Posted Exp. Report DE"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/DEExpContosoLocalization.Codeunit.al
+++ b/src/Apps/DE/ExpenseAgent_DE/demo data/Demo Data/DEExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 11339 "DE Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -81,3 +86,4 @@ codeunit 11339 "DE Exp. Contoso Localization"
             CurrencyCode := CreateCurrency.USD();
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountDK.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 13675 "Create Expense G/L Account DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -101,3 +105,4 @@ codeunit 13675 "Create Expense G/L Account DK"
         exit(OtherExpensesTok);
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 13676 "Create Expense Posting Grp DK"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -64,3 +69,4 @@ codeunit 13676 "Create Expense Posting Grp DK"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 13677 "Update Exp. Emp Posting Grp DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -30,3 +35,4 @@ codeunit 13677 "Update Exp. Emp Posting Grp DK"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpRuleConditionDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpRuleConditionDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 13680 "Create Exp. Rule Condition DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 13680 "Create Exp. Rule Condition DK"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesDK.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 13681 "Create Exp. SubCategories DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 13681 "Create Exp. SubCategories DK"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 13678 "Create Expense Categories DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 13678 "Create Expense Categories DK"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 13679 "Create Expense Rule Header DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 13679 "Create Expense Rule Header DK"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesDK.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/3. Transactions/CreateExpenseDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/3. Transactions/CreateExpenseDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 13682 "Create Expense DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 13682 "Create Expense DK"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/4. Historical/CreatePostedExpReportDK.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/4. Historical/CreatePostedExpReportDK.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 13683 "Create Posted Exp. Report DK"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 13683 "Create Posted Exp. Report DK"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/DKExpContosoLocalization.Codeunit.al
+++ b/src/Apps/DK/ExpenseAgent_DK/demo data/Demo Data/DKExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 13684 "DK Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -81,3 +86,4 @@ codeunit 13684 "DK Exp. Contoso Localization"
             CurrencyCode := '';
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountES.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -13,6 +14,9 @@ codeunit 10920 "Create Expense G/L Account ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -151,3 +155,4 @@ codeunit 10920 "Create Expense G/L Account ES"
         exit(RoundingExpensesOperatingTok);
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 10921 "Create Expense Posting Grp ES"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -64,3 +69,4 @@ codeunit 10921 "Create Expense Posting Grp ES"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 10922 "Update Exp. Emp Posting Grp ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -30,3 +35,4 @@ codeunit 10922 "Update Exp. Emp Posting Grp ES"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpRuleConditionES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpRuleConditionES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10927 "Create Exp. Rule Condition ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 10927 "Create Exp. Rule Condition ES"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesES.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10928 "Create Exp. SubCategories ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 10928 "Create Exp. SubCategories ES"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10925 "Create Expense Categories ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 10925 "Create Expense Categories ES"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpenseEmployeeES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpenseEmployeeES.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -13,6 +14,9 @@ codeunit 10924 "Create Expense Employee ES"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Table, Database::Employee, 'OnBeforeInsertEvent', '', false, false)]
     local procedure OnBeforeInsertResource(var Rec: Record Employee)
@@ -32,3 +36,4 @@ codeunit 10924 "Create Expense Employee ES"
         end;
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 10926 "Create Expense Rule Header ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 10926 "Create Expense Rule Header ES"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesES.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/3. Transactions/CreateExpenseES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/3. Transactions/CreateExpenseES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 10929 "Create Expense ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 10929 "Create Expense ES"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/4. Historical/CreatePostedExpReportES.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/4. Historical/CreatePostedExpReportES.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 10923 "Create Posted Exp. Report ES"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 10923 "Create Posted Exp. Report ES"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/ESExpContosoLocalization.Codeunit.al
+++ b/src/Apps/ES/ExpenseAgent_ES/demo data/Demo Data/ESExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 10919 "ES Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -87,3 +92,4 @@ codeunit 10919 "ES Exp. Contoso Localization"
             CurrencyCode := CreateCurrency.USD();
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountFR.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 10930 "Create Expense G/L Account FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -85,3 +89,4 @@ codeunit 10930 "Create Expense G/L Account FR"
         exit(RentalCarExpensesTok);
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 10931 "Create Expense Posting Grp FR"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -64,3 +69,4 @@ codeunit 10931 "Create Expense Posting Grp FR"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 10932 "Update Exp. Emp Posting Grp FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -30,3 +35,4 @@ codeunit 10932 "Update Exp. Emp Posting Grp FR"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpRuleConditionFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpRuleConditionFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10936 "Create Exp. Rule Condition FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 10936 "Create Exp. Rule Condition FR"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesFR.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10937 "Create Exp. SubCategories FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 10937 "Create Exp. SubCategories FR"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10934 "Create Expense Categories FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 10934 "Create Expense Categories FR"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 10935 "Create Expense Rule Header FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 10935 "Create Expense Rule Header FR"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesFR.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/3. Transactions/CreateExpenseFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/3. Transactions/CreateExpenseFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 10938 "Create Expense FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 10938 "Create Expense FR"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/4. Historical/CreatePostedExpReportFR.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/4. Historical/CreatePostedExpReportFR.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 10939 "Create Posted Exp. Report FR"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 10939 "Create Posted Exp. Report FR"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/FRExpContosoLocalization.Codeunit.al
+++ b/src/Apps/FR/ExpenseAgent_FR/demo data/Demo Data/FRExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 10933 "FR Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -81,3 +86,4 @@ codeunit 10933 "FR Exp. Contoso Localization"
             CurrencyCode := CreateCurrency.USD();
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountGB.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 10601 "Create Expense G/L Account GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -48,3 +52,4 @@ codeunit 10601 "Create Expense G/L Account GB"
         ContosoGLAccount: Codeunit "Contoso GL Account";
         ExpenseGLAccount: Codeunit "Create Expense G/L Account";
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpGB.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 10600 "Create Expense Posting Grp GB"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -63,3 +67,4 @@ codeunit 10600 "Create Expense Posting Grp GB"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpGB.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +12,9 @@ codeunit 10602 "Update Exp. Emp Posting Grp GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -30,3 +34,4 @@ codeunit 10602 "Update Exp. Emp Posting Grp GB"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpRuleConditionGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpRuleConditionGB.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10606 "Create Exp. Rule Condition GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 10606 "Create Exp. Rule Condition GB"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesGB.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesGB.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10607 "Create Exp. SubCategories GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 10607 "Create Exp. SubCategories GB"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesGB.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 10604 "Create Expense Categories GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 10604 "Create Expense Categories GB"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderGB.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 10605 "Create Expense Rule Header GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 10605 "Create Expense Rule Header GB"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesGB.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/3. Transactions/CreateExpenseGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/3. Transactions/CreateExpenseGB.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 10608 "Create Expense GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 10608 "Create Expense GB"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/4. Historical/CreatePostedExpReportGB.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/4. Historical/CreatePostedExpReportGB.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 10609 "Create Posted Exp. Report GB"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 10609 "Create Posted Exp. Report GB"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/GBExpContosoLocalization.Codeunit.al
+++ b/src/Apps/GB/ExpenseAgent_GB/demo data/Demo Data/GBExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 10603 "GB Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -72,3 +77,4 @@ codeunit 10603 "GB Exp. Contoso Localization"
         AccountNo := ExpenseGLAccount.FindGLAccountByName(CreateGBGLAccounts.SaleofResourcesName());
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/1.Setup Data/CreateExpenseGLAccountNZ.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 17220 "Create Expense G/L Account NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -56,3 +60,4 @@ codeunit 17220 "Create Expense G/L Account NZ"
         ContosoGLAccount: Codeunit "Contoso GL Account";
         ExpenseGLAccount: Codeunit "Create Expense G/L Account";
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpNZ.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 17221 "Create Expense Posting Grp NZ"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -63,3 +67,4 @@ codeunit 17221 "Create Expense Posting Grp NZ"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpNZ.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +12,9 @@ codeunit 17222 "Update Exp. Emp Posting Grp NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -29,3 +33,4 @@ codeunit 17222 "Update Exp. Emp Posting Grp NZ"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpRuleConditionNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpRuleConditionNZ.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 17226 "Create Exp. Rule Condition NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 17226 "Create Exp. Rule Condition NZ"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesNZ.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesNZ.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 17227 "Create Exp. SubCategories NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 17227 "Create Exp. SubCategories NZ"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesNZ.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 17224 "Create Expense Categories NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 17224 "Create Expense Categories NZ"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderNZ.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 17225 "Create Expense Rule Header NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 17225 "Create Expense Rule Header NZ"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesNZ.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/3. Transactions/CreateExpenseNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/3. Transactions/CreateExpenseNZ.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 17228 "Create Expense NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 17228 "Create Expense NZ"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/4. Historical/CreatePostedExpReportNZ.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/4. Historical/CreatePostedExpReportNZ.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 17229 "Create Posted Exp. Report NZ"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 17229 "Create Posted Exp. Report NZ"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/NZExpContosoLocalization.Codeunit.al
+++ b/src/Apps/NZ/ExpenseAgent_NZ/demo data/Demo Data/NZExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 17223 "NZ Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -72,3 +77,4 @@ codeunit 17223 "NZ Exp. Contoso Localization"
         AccountNo := ExpenseGLAccount.FindGLAccountByName(CreateGLAccount.SalesResourcesExportName());
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/1.Setup Data/CreateExpensePostingGrpUS.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 11602 "Create Expense Posting Grp US"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -63,3 +67,4 @@ codeunit 11602 "Create Expense Posting Grp US"
         exit(ExpensePERDIEMTok);
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/1.Setup Data/CreateExpenseUSGLAccount.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/1.Setup Data/CreateExpenseUSGLAccount.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ codeunit 11600 "Create Expense US G/L Account"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Create Expense G/L Account", 'OnAfterAddGLAccountsForLocalization', '', false, false)]
     local procedure ModifyGLAccount()
@@ -48,3 +52,4 @@ codeunit 11600 "Create Expense US G/L Account"
         ContosoGLAccount: Codeunit "Contoso GL Account";
         ExpenseGLAccount: Codeunit "Create Expense G/L Account";
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/1.Setup Data/UpdateExpEmpPostingGrpUS.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +12,9 @@ codeunit 11601 "Update Exp. Emp Posting Grp US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     begin
@@ -30,3 +34,4 @@ codeunit 11601 "Update Exp. Emp Posting Grp US"
         ContosoExpenseAgent.SetOverwriteData(false);
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpRuleConditionUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpRuleConditionUS.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11606 "Create Exp. Rule Condition US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -24,3 +29,4 @@ codeunit 11606 "Create Exp. Rule Condition US"
         ContosoExpenseAgent.InsertExpenseRuleCondition(CreateExpenseCategoriesUS.PerDiem(), CreateExpenseLocation.USAOther(), 0D, 10000, Enum::"Expense Rule Condition Type"::"Daily Rate", 120);
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpSubCategoriesUS.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11607 "Create Exp. SubCategories US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -37,3 +42,4 @@ codeunit 11607 "Create Exp. SubCategories US"
         exit(IntlTok);
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpenseCategoriesUS.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -8,6 +10,9 @@ codeunit 11604 "Create Expense Categories US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -29,3 +34,4 @@ codeunit 11604 "Create Expense Categories US"
         exit(PerDiemTok);
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/2.Master Data/CreateExpenseRuleHeaderUS.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 11605 "Create Expense Rule Header US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     trigger OnRun()
     var
@@ -27,3 +32,4 @@ codeunit 11605 "Create Expense Rule Header US"
         ContosoExpenseAgent.InsertExpenseRuleHeader(CreateExpenseCategoriesUS.PerDiem(), CreateExpenseLocation.USAOther(), 0D, Enum::"Expense Justification"::" ", false, '', '', '');
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/3. Transactions/CreateExpenseUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/3. Transactions/CreateExpenseUS.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -10,6 +12,9 @@ codeunit 11608 "Create Expense US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions = tabledata "Expense Per Diem" = rim;
 
     trigger OnRun()
@@ -49,3 +54,4 @@ codeunit 11608 "Create Expense US"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/4. Historical/CreatePostedExpReportUS.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/4. Historical/CreatePostedExpReportUS.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +14,9 @@ codeunit 11609 "Create Posted Exp. Report US"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
     Permissions =
         tabledata "Expense Per Diem" = rim,
         tabledata "Expense Report Line" = rim;
@@ -155,3 +160,4 @@ codeunit 11609 "Create Posted Exp. Report US"
         ExpensePerDiem.Modify();
     end;
 }
+#endif

--- a/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/USExpContosoLocalization.Codeunit.al
+++ b/src/Apps/US/ExpenseAgent_US/demo data/Demo Data/USExpContosoLocalization.Codeunit.al
@@ -1,3 +1,5 @@
+#if not CLEAN29
+#pragma warning disable AL0432
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +13,9 @@ codeunit 11603 "US Exp. Contoso Localization"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.';
+    ObsoleteTag = '29.0';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Contoso Demo Tool", 'OnAfterGeneratingDemoData', '', false, false)]
     local procedure LocalizationContosoDemoData(Module: Enum "Contoso Demo Data Module"; ContosoDemoDataLevel: Enum "Contoso Demo Data Level")
@@ -72,3 +77,4 @@ codeunit 11603 "US Exp. Contoso Localization"
         AccountNo := ExpenseGLAccount.FindGLAccountByName(CreateUSGLAccounts.SaleofResourcesName());
     end;
 }
+#endif


### PR DESCRIPTION
Workitem Bug 646815: [master] [Expense Agent] [Demo Data] Obsolete country-specific demo data, consolidating into single W1 app

Fixes [AB#646815](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646815)

Issue: After the Expense Agent demo data was consolidated into a single W1 app, the old country-specific demo data codeunits (AT, AU, CA, DE, DK, ES, FR, GB, NZ, US) were still present and active. Keeping them alongside the consolidated W1 demo data caused duplicated demo data generation and left dead, redundant objects in the country apps that needed a clean deprecation path before removal.

Cause: Each country still shipped its own set of Expense demo data codeunits — G/L accounts, posting groups, employee posting-group updates, expense categories/subcategories, rule headers/conditions, expenses, posted expense reports, and the <CC> Exp. Contoso Localization subscribers. These are now superseded by the single W1 app, but they cannot simply be deleted because external consumers may still reference them; they require a proper obsoletion window first.

Solution: Marked all country-specific Expense Agent demo data as obsolete (~101 files). Each codeunit is wrapped in #if not CLEAN29 / #endif so it compiles out under the CLEAN29 flag, and annotated with ObsoleteState = Pending, ObsoleteTag = '29.0', and ObsoleteReason = 'The country-specific Expense Agent demo data is being consolidated into a single app in W1 and will be removed in a future release.', with #pragma warning disable AL0432 where they reference other now-obsolete objects. Behavior is unchanged for non-CLEAN29 builds — the objects stay functional through the deprecation window and are excluded under CLEAN29, ready for full removal in a future release.




