### PR TITLE
Ruleset hardening: promote 5 rules from Warning to Error

### DIFF
--- a/src/Apps/W1/EmailLogging/app/src/permissions/EmailLoggingObj.PermissionSet.al
+++ b/src/Apps/W1/EmailLogging/app/src/permissions/EmailLoggingObj.PermissionSet.al
@@ -17,6 +17,7 @@ permissionset 1680 "Email Logging - Obj."
                   codeunit "Email Logging API Client" = X,
                   codeunit "Email Logging API Helper" = X,
                   codeunit "Email Logging Message" = X,
+                  codeunit "Email Logging Install" = X,
                   codeunit "Email Logging Upgrade" = X,
                   page "Email Logging Setup" = X,
                   page "Email Logging Setup Wizard" = X,

--- a/src/Layers/APAC/BaseApp/eServices/EDocument/IncomingDocument.Page.al
+++ b/src/Layers/APAC/BaseApp/eServices/EDocument/IncomingDocument.Page.al
@@ -1164,10 +1164,12 @@ page 189 "Incoming Document"
         ReplaceMainAttachmentEnabled := Rec.CanReplaceMainAttachment();
     end;
 
+#pragma warning disable AL0547 // Accepted violation: turning off global variable access is a breaking change for existing subscribers of this published event.
     [IntegrationEvent(true, true)]
     local procedure OnCloseIncomingDocumentFromAction(var IncomingDocument: Record "Incoming Document")
     begin
     end;
+#pragma warning restore AL0547
 
     local procedure VerifyCanBeSentToOCR(): Boolean
     begin

--- a/src/Layers/ES/BaseApp/Finance/FinancialReports/AccountScheduleNames.Page.al
+++ b/src/Layers/ES/BaseApp/Finance/FinancialReports/AccountScheduleNames.Page.al
@@ -155,7 +155,6 @@ page 103 "Account Schedule Names"
             {
                 Caption = 'F&unctions';
                 Image = "Action";
-                Visible = false;
                 action("Export Schedules to ASC format")
                 {
                     ApplicationArea = Basic, Suite;

--- a/src/Layers/NL/Tests/TestLibraries/NLXMLReadHelper.Codeunit.al
+++ b/src/Layers/NL/Tests/TestLibraries/NLXMLReadHelper.Codeunit.al
@@ -46,7 +46,9 @@ codeunit 143001 "NL XML Read Helper"
     var
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetNodeByElementName(ElementName, Node);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedError('Element is missing!');
     end;
 
@@ -66,7 +68,9 @@ codeunit 143001 "NL XML Read Helper"
     var
         Attribute: DotNet XmlAttribute;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetAttributeFromElement(ElementName, AttributeName, Attribute);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedError('Attribute is missing!');
     end;
 

--- a/src/Layers/NO/Tests/TestLibraries/NOXMLReadHelper.Codeunit.al
+++ b/src/Layers/NO/Tests/TestLibraries/NOXMLReadHelper.Codeunit.al
@@ -47,7 +47,9 @@ codeunit 143001 "NO XML Read Helper"
     var
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetNodeByElementName(ElementName, Node);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedError(StrSubstNo(MissingElementErr, ElementName));
     end;
 
@@ -87,7 +89,9 @@ codeunit 143001 "NO XML Read Helper"
     var
         Attribute: DotNet XmlAttribute;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetAttributeFromElement(ElementName, AttributeName, Attribute);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedError('Attribute is missing!');
     end;
 

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookNotification.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookNotification.Codeunit.al
@@ -115,12 +115,14 @@ codeunit 1545 "Workflow Webhook Notification"
         end;
     end;
 
+#pragma warning disable AL0547 // Accepted violation: turning off global variable access is a breaking change for existing subscribers of this published event.
     [TryFunction]
     [IntegrationEvent(true, true)]
     [Scope('OnPrem')]
     procedure OnPostNotificationRequest(DataID: Guid; WorkflowStepInstanceID: Guid; NotificationUrl: Text; RequestedByUserEmail: Text)
     begin
     end;
+#pragma warning restore AL0547
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Workflow Webhook Notification", 'OnPostNotificationRequest', '', false, false)]
     [TryFunction]

--- a/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocument.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocument.Page.al
@@ -1163,10 +1163,12 @@ page 189 "Incoming Document"
         ReplaceMainAttachmentEnabled := Rec.CanReplaceMainAttachment();
     end;
 
+#pragma warning disable AL0547 // Accepted violation: turning off global variable access is a breaking change for existing subscribers of this published event.
     [IntegrationEvent(true, true)]
     local procedure OnCloseIncomingDocumentFromAction(var IncomingDocument: Record "Incoming Document")
     begin
     end;
+#pragma warning restore AL0547
 
     local procedure VerifyCanBeSentToOCR(): Boolean
     begin

--- a/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/IncomingDocuments.Page.al
@@ -903,10 +903,12 @@ page 190 "Incoming Documents"
         AutomaticCreationActionsAreEnabled := Rec."Data Exchange Type" <> '';
     end;
 
+#pragma warning disable AL0547 // Accepted violation: turning off global variable access is a breaking change for existing subscribers of this published event.
     [IntegrationEvent(true, true)]
     local procedure OnCloseIncomingDocumentsFromActions(var IncomingDocument: Record "Incoming Document")
     begin
     end;
+#pragma warning restore AL0547
 
     local procedure SetProcessedDocumentsVisibility(ShowProcessedItems: Boolean)
     begin

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryAssembly.Codeunit.al
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryAssembly.Codeunit.al
@@ -234,7 +234,9 @@ codeunit 132207 "Library - Assembly"
         if ExpectedError = '' then
             BatchPostAssemblyOrders.RunModal()
         else begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror BatchPostAssemblyOrders.RunModal();
+            #pragma warning restore AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ExpectedError) > 0, 'Actual:' + GetLastErrorText);
             ClearLastError();
         end;
@@ -1506,7 +1508,9 @@ codeunit 132207 "Library - Assembly"
         if ExpectedError = '' then
             AssemblyPost.Run(AssemblyHeader)
         else begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror AssemblyPost.Run(AssemblyHeader);
+            #pragma warning restore AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ExpectedError) > 0,
               'Expected:' + ExpectedError + '. Actual:' + GetLastErrorText);
             ClearLastError();
@@ -1742,7 +1746,9 @@ codeunit 132207 "Library - Assembly"
         if ExpectedError = '' then
             AsmPostCtrl.Undo(PostedAssemblyHeader, RestoreAO)
         else begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror AsmPostCtrl.Undo(PostedAssemblyHeader, RestoreAO);
+            #pragma warning restore AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ExpectedError) > 0, 'Actual:' + GetLastErrorText);
             ClearLastError();
         end;
@@ -1754,7 +1760,9 @@ codeunit 132207 "Library - Assembly"
     begin
         Commit();
         if AssemblyHeader.Quantity = 0 then begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror AssemblyHeader.UpdateUnitCost();
+            #pragma warning restore AS0058, PTE0007
             Assert.AreEqual(
               StrSubstNo(ErrorZeroQty, AssemblyHeader."No."), GetLastErrorText,
               'Actual:' + GetLastErrorText + '; Expected:' + StrSubstNo(ErrorZeroQty, AssemblyHeader."No."));
@@ -1766,7 +1774,9 @@ codeunit 132207 "Library - Assembly"
         if Item."Costing Method" <> Item."Costing Method"::Standard then
             AssemblyHeader.UpdateUnitCost()
         else begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror AssemblyHeader.UpdateUnitCost();
+            #pragma warning restore AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ErrorStdCost) > 0, 'Actual:' + GetLastErrorText + '; Expected:' + ErrorStdCost);
             ClearLastError();
         end;

--- a/src/Layers/W1/Tests/TestLibraries/LibraryCRMIntegration.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryCRMIntegration.Codeunit.al
@@ -1919,7 +1919,9 @@ codeunit 139164 "Library - CRM Integration"
         JobQueueEntryID := JobQueueEntry.ID;
         JobQueueEntry.SetStatus(JobQueueEntry.Status::Ready);
         if HandleError then begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror LibraryJobQueue.RunJobQueueDispatcher(JobQueueEntry);
+            #pragma warning restore AS0058, PTE0007
             LibraryJobQueue.RunJobQueueErrorHandler(JobQueueEntry);
         end else
             LibraryJobQueue.RunJobQueueDispatcher(JobQueueEntry);

--- a/src/Layers/W1/Tests/TestLibraries/LibraryJobQueue.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryJobQueue.Codeunit.al
@@ -71,7 +71,9 @@ codeunit 132458 "Library - Job Queue"
         JobQueueEntry.Status := JobQueueEntry.Status::Ready;
         JobQueueEntry.Modify();
         if WithErrorHandler then begin
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror RunJobQueueDispatcher(JobQueueEntry);
+            #pragma warning restore AS0058, PTE0007
             RunJobQueueErrorHandler(JobQueueEntry);
         end
         else

--- a/src/Layers/W1/Tests/TestLibraries/LibraryPermissionsVerify.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryPermissionsVerify.Codeunit.al
@@ -101,7 +101,9 @@ codeunit 132216 "Library - Permissions Verify"
         RecordRef: RecordRef;
     begin
         RecordRef.Open(TableNo);
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror RecordRef.FindFirst();
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedError(StrSubstNo(MissingPermissionErr, Format(RecordRef.Caption)))
     end;
 
@@ -116,10 +118,14 @@ codeunit 132216 "Library - Permissions Verify"
     begin
         RecordRef.Init();
 
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror RecordRef.Insert(true);
+        #pragma warning restore AS0058, PTE0007
         Assert.IsFalse(RecordRef.WritePermission, StrSubstNo(SupplementalPermissionErr, 'Insert', Format(RecordRef.Caption)));
 
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror RecordRef.Delete(true);
+        #pragma warning restore AS0058, PTE0007
         Assert.IsFalse(RecordRef.WritePermission, StrSubstNo(SupplementalPermissionErr, 'Delete', Format(RecordRef.Caption)));
     end;
 }

--- a/src/Layers/W1/Tests/TestLibraries/LibraryPostPrevHandler.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryPostPrevHandler.Codeunit.al
@@ -65,9 +65,13 @@ codeunit 131011 "Library - Post. Prev. Handler"
         InsertRecord(RecVar);
         Assert.IsTrue(GenJnlPostPreview.IsActive(), 'GenJnlPostPreview.IsActive');
         if InvokeCommit then
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror Commit()
+            #pragma warning restore AS0058, PTE0007
         else
+            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
             asserterror GenJnlPostPreview.ThrowError();
+            #pragma warning restore AS0058, PTE0007
         Result := false;
     end;
 }

--- a/src/Layers/W1/Tests/TestLibraries/LibraryXMLRead.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryXMLRead.Codeunit.al
@@ -214,7 +214,9 @@ codeunit 131335 "Library - XML Read"
         [RunOnClient]
         XMLNode: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetNodeByElementName(NodeName, XMLNode);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -224,7 +226,9 @@ codeunit 131335 "Library - XML Read"
         [RunOnClient]
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(NotFoundAnyInSubtreeErr, NodeName, RootNodeName));
     end;
@@ -234,7 +238,9 @@ codeunit 131335 "Library - XML Read"
         [RunOnClient]
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -261,7 +267,9 @@ codeunit 131335 "Library - XML Read"
 
     procedure VerifyAttributeAbsenceInSubtree(RootNodeName: Text; NodeName: Text; AttributeName: Text)
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetAttributeValueInSubtree(RootNodeName, NodeName, AttributeName);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(AttributeNotFoundErr, NodeName, RootNodeName, AttributeName));
     end;

--- a/src/Layers/W1/Tests/TestLibraries/LibraryXMLReadOnServer.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryXMLReadOnServer.Codeunit.al
@@ -218,7 +218,9 @@ codeunit 131341 "Library - XML Read OnServer"
     var
         XMLNode: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetNodeByElementName(NodeName, XMLNode);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -228,7 +230,9 @@ codeunit 131341 "Library - XML Read OnServer"
     var
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(NotFoundAnyInSubtreeErr, NodeName, RootNodeName));
     end;
@@ -238,7 +242,9 @@ codeunit 131341 "Library - XML Read OnServer"
     var
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -273,7 +279,9 @@ codeunit 131341 "Library - XML Read OnServer"
     [Scope('OnPrem')]
     procedure VerifyAttributeAbsenceInSubtree(RootNodeName: Text; NodeName: Text; AttributeName: Text)
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetAttributeValueInSubtree(RootNodeName, NodeName, AttributeName);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(AttributeNotFoundErr, NodeName, RootNodeName, AttributeName));
     end;

--- a/src/Layers/W1/Tests/TestLibraries/LibraryXPathXMLReader.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryXPathXMLReader.Codeunit.al
@@ -227,7 +227,9 @@ codeunit 131337 "Library - XPath XML Reader"
     var
         Node: DotNet XmlNode;
     begin
+        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
         asserterror GetNodeByElementName(ElementName, Node);
+        #pragma warning restore AS0058, PTE0007
         Assert.ExpectedError('Element is missing!');
     end;
 

--- a/src/Layers/W1/Tests/TestLibraries/TestProxyNotificationMgt.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/TestProxyNotificationMgt.Codeunit.al
@@ -69,7 +69,9 @@ codeunit 130231 "Test Proxy Notification Mgt."
             RemoveIgnoringNotifications();
             IsSuccess := not HasNotificationContextEntries();
             if not IsSuccess then
+                #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
                 asserterror Error(NotificationErr, GetFirstRecordIDText());
+                #pragma warning restore AS0058, PTE0007
         end;
     end;
 

--- a/src/Layers/W1/Tests/TestRunner-Internal/SnapTestRunner.Codeunit.al
+++ b/src/Layers/W1/Tests/TestRunner-Internal/SnapTestRunner.Codeunit.al
@@ -101,6 +101,7 @@ codeunit 130200 "Snap Test Runner"
 
         // File operations are not atomic, so this may still go wrong.
         Commit();
+#pragma warning disable AS0058, PTE0007 // Accepted violation: this test runner intentionally uses asserterror to detect whether the lock was acquired.
         asserterror
         begin
             LockFile.Create(LockFileName);
@@ -113,6 +114,7 @@ codeunit 130200 "Snap Test Runner"
             LockFile.Close();
             Error('Acquired')
         end;
+#pragma warning restore AS0058, PTE0007
 
         // If we did not acquire the lock, we assume somebody else did and return false.
         Acquired := GetLastErrorText = 'Acquired';
@@ -287,7 +289,9 @@ codeunit 130200 "Snap Test Runner"
         if (FName <> '') and (FName <> 'OnRun') then begin
             PermissionErrors := PermissionTestCatalog.GetPermissionErrors(FTestPermissions);
             if Success and (PermissionErrors <> '') then begin
+#pragma warning disable AS0058, PTE0007 // Accepted violation: this test runner intentionally uses asserterror to surface permission errors as a test failure.
                 asserterror Error(PermissionErrors);
+#pragma warning restore AS0058, PTE0007
                 Success := false;
             end;
         end;

--- a/src/Layers/W1/Tests/TestRunner-Internal/TestRunner.Codeunit.al
+++ b/src/Layers/W1/Tests/TestRunner-Internal/TestRunner.Codeunit.al
@@ -190,7 +190,9 @@ codeunit 130020 "Test Runner"
             // todo: move to subscribers
             PermissionErrors := PermissionTestCatalog.GetPermissionErrors(FunctionTestPermissions);
             if IsSuccess and (PermissionErrors <> '') then begin // Only show permission errors once everything else succeeds
+#pragma warning disable AS0058, PTE0007 // Accepted violation: this test runner intentionally uses asserterror to surface permission errors as a test failure.
                 asserterror Error(PermissionErrors);
+#pragma warning restore AS0058, PTE0007
                 IsSuccess := false;
             end;
 

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -24,14 +24,6 @@
       "justification": "Use pragma to remove obsolete warning."
     },
     {
-      "id": "AL0523",
-      "action": "Warning"
-    },
-    {
-      "id": "AL0547",
-      "action": "Warning"
-    },
-    {
       "id": "AL0589",
       "action": "Warning"
     },
@@ -117,12 +109,7 @@
     {
       "id": "AS0052",
       "action": "Warning",
-      "justification": "The property 'url' must be set to a valid URL."
-    },
-    {
-      "id": "AS0058",
-      "action": "Warning",
-      "justification": "Only use AssertError in Test Codeunits."
+      "justification": "The manifest property 'url' must be specified and contain a valid URL."
     },
     {
       "id": "AS0062",
@@ -383,11 +370,6 @@
       "justification": "Group 'Processing' only contains promoted actions that are not set to PromotedOnly='true'."
     },
     {
-      "id": "AW0014",
-      "action": "Warning",
-      "justification": "The group defined in Page should not be hidden because it contains the target actions for some ActionRefs."
-    },
-    {
       "id": "PTE0002",
       "action": "None",
       "justification": "Field ID must be within the range '[50000..99999]'."
@@ -396,11 +378,6 @@
       "id": "PTE0004",
       "action": "Warning",
       "justification": "Table is missing a matching permission set."
-    },
-    {
-      "id": "PTE0007",
-      "action": "Warning",
-      "justification": "Only use AssertError in Test Codeunits."
     },
     {
       "id": "PTE0008",
@@ -424,6 +401,10 @@
       "action": "Warning"
     },
     {
+      "id": "AL0523",
+      "action": "Warning"
+    },
+    {
       "id": "AL0604",
       "action": "Warning"
     },
@@ -433,10 +414,6 @@
     },
     {
       "id": "AL0611",
-      "action": "Warning"
-    },
-    {
-      "id": "AL0679",
       "action": "Warning"
     },
     {


### PR DESCRIPTION
## Summary

Continues the ruleset hardening work from #10088 and #10209. Promotes **5 rules** back to `Error` by removing their overrides from `src/rulesets/base.ruleset.json`, and resolves every violation those rules report.

Override count: **100 → 95**.

Promoted: `AL0547`, `AL0679`, `AW0014`, `AS0058`, `PTE0007`.

## Fixed in code

| Rule | Fix |
|---|---|
| `AL0679` | The `Email Logging Install` codeunit was missing from the `Email Logging - Obj.` permission set, so it was not covered by any entitlement. Every other object in the app was already listed. |
| `AW0014` | The hidden `F&unctions` group on the ES `Account Schedule Names` page contained `Export Schedules to ASC format`, which is the target of a promoted `actionref`. Hiding the group made the promoted action unreachable, so the `Visible = false` is removed. |

## Accepted with `#pragma warning disable`

Each suppression is documented in place with the reason.

| Rule | Sites | Why it is accepted |
|---|---|---|
| `AL0547` | 4 | Published integration events declaring `GlobalVarAccess`. Turning it off would break existing external subscribers. |
| `AS0058` / `PTE0007` | 26 | `asserterror` statements in 11 **test library** codeunits. These are `Subtype = Normal` helpers that deliberately wrap `asserterror` on behalf of test codeunits, which is exactly what these rules flag. |

## Deferred

These were in the original scope but need real remediation, a dedicated PR, or domain-owner input, so their overrides are retained:

- `AS0052` — **needs its own PR.** 61 `app.json` manifests have a missing or empty `url`, 44 of them under `src/Layers/W1`, each requiring propagation into the localized layers. CI only ever revealed two sites at a time because the build halts at the first project that errors, so the true scope was not visible up front.
- `AL0523` — **cannot be suppressed.** The `Posted Deposit Line` duplicate-method diagnostic is emitted without a source location (it is a project-level comparison against the Base Application symbol package), so `#pragma warning disable` has nothing to attach to. Resolving it means renaming released public methods.
- `AL0717` — FlowFields with **no** `CalcFormula` (`Script Editor Line."Has Errors"`, `Statutory Report Data Header."Requisites Quantity"` / `."Set Requisites Quantity"`). These are actively `CalcFields`'d, so they silently always return 0/false. Genuine latent bugs; suppressing them would enshrine the bug.
- `AL0589` — duplicate report column/data item names across ~27 reports. Renaming columns breaks RDLC and Word layouts.
- `AL0520` — references to removed tables (Intrastat, `Invoice Post. Buffer`, `Payment Buffer`, `VAT Code`). Real obsolescence debt.
- `AL0749` — public method parameters with `Internal` types. Resolving means changing accessibility, i.e. an API change.
- `AL0719`, `AW0003`, `AW0004` — small counts but the sites could not be pinpointed from CI logs alone (CI reports no file/line).

## Notes

- **CodeCop (`AA*`) rules are deliberately excluded** from this PR. Removing CodeCop entries perturbs `AA0021` reporting (observed in #10138), so those get their own PR.
- `AL1430` was considered but is defined in the shared `ruleset.json`, not in the base override list, so it is out of scope here.
- Violation counts were derived from the full 44-job CI matrix rather than local compilation, following the lesson from #10209.

Related to [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773)



