### PR TITLE
[Shopify] Fix customer matching when phone numbers contain spaces

### DIFF
--- a/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByEMail.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByEMail.graphql
@@ -1,2 +1,2 @@
 # cost: 3
-{"query":"{customers(first: 1, query:\"email:{{EMail}}\") {edges {node {id}}}}"}
+{"query":"{customers(first: 1, query:\"email:{{EMail}}\") {edges {node {id defaultEmailAddress { emailAddress }}}}}"}

--- a/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByEMail.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByEMail.graphql
@@ -1,2 +1,2 @@
-# cost: 3
+# cost: 4
 {"query":"{customers(first: 1, query:\"email:{{EMail}}\") {edges {node {id defaultEmailAddress { emailAddress }}}}}"}

--- a/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByPhone.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByPhone.graphql
@@ -1,2 +1,2 @@
-# cost: 3
+# cost: 4
 {"query":"{customers(first: 1, query:\"phone:{{Phone}}\") {edges {node {id defaultPhoneNumber { phoneNumber }}}}}"}

--- a/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByPhone.graphql
+++ b/src/Apps/W1/Shopify/App/.resources/graphql/Customers/FindCustomerIdByPhone.graphql
@@ -1,2 +1,2 @@
 # cost: 3
-{"query":"{customers(first: 1, query:\"phone:{{Phone}}\") {edges {node {id}}}}"}
+{"query":"{customers(first: 1, query:\"phone:{{Phone}}\") {edges {node {id defaultPhoneNumber { phoneNumber }}}}}"}

--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerAPI.Codeunit.al
@@ -132,14 +132,19 @@ codeunit 30114 "Shpfy Customer API"
         JResponse: JsonToken;
         GraphQLType: Enum "Shpfy GraphQL Type";
         Parameters: Dictionary of [Text, Text];
+        SearchEMail: Text;
     begin
         if EMail <> '' then begin
-            Parameters.Add('EMail', EMail.ToLower());
+            SearchEMail := EMail.ToLower();
+            Parameters.Add('EMail', SearchEMail);
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType::Customers_FindCustomerIdByEMail, Parameters);
             if JsonHelper.GetJsonArray(JResponse, JCustomers, 'data.customers.edges') then
                 foreach JItem in JCustomers do
                     if JsonHelper.GetJsonObject(JItem.AsObject(), JCustomer, 'node') then
-                        exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
+                        // Shopify's search syntax tokenizes the query, so it can return customers that do not match
+                        // the requested e-mail exactly. Only accept a result when the e-mail matches exactly.
+                        if JsonHelper.GetValueAsText(JCustomer, 'defaultEmailAddress.emailAddress').ToLower() = SearchEMail then
+                            exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
         end;
     end;
 
@@ -156,15 +161,34 @@ codeunit 30114 "Shpfy Customer API"
         JResponse: JsonToken;
         GraphQLType: Enum "Shpfy GraphQL Type";
         Parameters: Dictionary of [Text, Text];
+        SearchPhone: Text;
     begin
-        if Phone <> '' then begin
-            Parameters.Add('Phone', Phone);
+        // Reduce the phone number to '+' and digits. Shopify's search syntax treats whitespace as a term
+        // separator (implicit AND), so a formatted phone number such as '+45 4545 4545' would be parsed as
+        // 'phone:+45' plus two loose '4545' terms and match unrelated customers. Sending the normalized,
+        // whitespace-free value keeps the whole number scoped to the phone filter.
+        SearchPhone := FormatPhoneNo(Phone);
+        if SearchPhone <> '' then begin
+            Parameters.Add('Phone', SearchPhone);
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType::Customers_FindCustomerIdByPhone, Parameters);
             if JsonHelper.GetJsonArray(JResponse, JCustomers, 'data.customers.edges') then
                 foreach JItem in JCustomers do
                     if JsonHelper.GetJsonObject(JItem.AsObject(), JCustomer, 'node') then
-                        exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
+                        // Only accept a result when the returned phone number matches the requested one exactly,
+                        // so a tokenized or partial Shopify search result is not treated as an existing customer.
+                        if FormatPhoneNo(JsonHelper.GetValueAsText(JCustomer, 'defaultPhoneNumber.phoneNumber')) = SearchPhone then
+                            exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
         end;
+    end;
+
+    /// <summary>
+    /// Reduces a phone number to a comparable form containing only the leading '+' and digits.
+    /// </summary>
+    /// <param name="PhoneNo">Parameter of type Text.</param>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure FormatPhoneNo(PhoneNo: Text): Text
+    begin
+        exit(DelChr(PhoneNo, '=', DelChr(PhoneNo, '=', '+0123456789')));
     end;
 
     /// <summary> 

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -144,6 +144,7 @@ codeunit 139589 "Shpfy Customer API Test"
         CustomerId := CustomerApi.FindIdByPhone('+45 4545 4545');
 
         // [THEN] No customer id is returned because the phone numbers are not an exact match.
+        NoCustomerId := 0;
         LibraryAssert.AreEqual(NoCustomerId, CustomerId, 'A non-exact phone match must not be treated as an existing customer.');
     end;
 
@@ -187,6 +188,7 @@ codeunit 139589 "Shpfy Customer API Test"
         CustomerId := CustomerApi.FindIdByEmail('p1@contoso.com');
 
         // [THEN] No customer id is returned because the e-mail addresses are not an exact match.
+        NoCustomerId := 0;
         LibraryAssert.AreEqual(NoCustomerId, CustomerId, 'A non-exact e-mail match must not be treated as an existing customer.');
     end;
 

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -125,6 +125,7 @@ codeunit 139589 "Shpfy Customer API Test"
     end;
 
     [Test]
+    [HandlerFunctions('HttpClientHandler')]
     procedure UnitTestFindIdByPhoneIgnoresTokenizedPartialMatch()
     var
         CustomerApi: Codeunit "Shpfy Customer API";
@@ -146,6 +147,7 @@ codeunit 139589 "Shpfy Customer API Test"
     end;
 
     [Test]
+    [HandlerFunctions('HttpClientHandler')]
     procedure UnitTestFindIdByPhoneReturnsIdForExactMatch()
     var
         CustomerApi: Codeunit "Shpfy Customer API";
@@ -166,6 +168,7 @@ codeunit 139589 "Shpfy Customer API Test"
     end;
 
     [Test]
+    [HandlerFunctions('HttpClientHandler')]
     procedure UnitTestFindIdByEmailIgnoresNonExactMatch()
     var
         CustomerApi: Codeunit "Shpfy Customer API";
@@ -186,6 +189,7 @@ codeunit 139589 "Shpfy Customer API Test"
     end;
 
     [Test]
+    [HandlerFunctions('HttpClientHandler')]
     procedure UnitTestFindIdByEmailReturnsIdForExactMatch()
     var
         CustomerApi: Codeunit "Shpfy Customer API";

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -14,6 +14,7 @@ using System.TestLibraries.Utilities;
 codeunit 139589 "Shpfy Customer API Test"
 {
     Subtype = Test;
+    TestType = IntegrationTest;
     TestPermissions = Disabled;
     TestHttpRequestPolicy = BlockOutboundRequests;
 

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -130,6 +130,7 @@ codeunit 139589 "Shpfy Customer API Test"
     var
         CustomerApi: Codeunit "Shpfy Customer API";
         CustomerId: BigInteger;
+        NoCustomerId: BigInteger;
     begin
         // [SCENARIO] A spaced phone number must not match an unrelated Shopify customer that is only returned
         // because Shopify's search syntax tokenizes '+45 4545 4545' into 'phone:+45' plus loose '4545' terms.
@@ -143,7 +144,7 @@ codeunit 139589 "Shpfy Customer API Test"
         CustomerId := CustomerApi.FindIdByPhone('+45 4545 4545');
 
         // [THEN] No customer id is returned because the phone numbers are not an exact match.
-        LibraryAssert.AreEqual(0, CustomerId, 'A non-exact phone match must not be treated as an existing customer.');
+        LibraryAssert.AreEqual(NoCustomerId, CustomerId, 'A non-exact phone match must not be treated as an existing customer.');
     end;
 
     [Test]
@@ -173,6 +174,7 @@ codeunit 139589 "Shpfy Customer API Test"
     var
         CustomerApi: Codeunit "Shpfy Customer API";
         CustomerId: BigInteger;
+        NoCustomerId: BigInteger;
     begin
         // [SCENARIO] An e-mail search must not accept a Shopify customer whose e-mail differs from the requested one.
         Initialize();
@@ -185,7 +187,7 @@ codeunit 139589 "Shpfy Customer API Test"
         CustomerId := CustomerApi.FindIdByEmail('p1@contoso.com');
 
         // [THEN] No customer id is returned because the e-mail addresses are not an exact match.
-        LibraryAssert.AreEqual(0, CustomerId, 'A non-exact e-mail match must not be treated as an existing customer.');
+        LibraryAssert.AreEqual(NoCustomerId, CustomerId, 'A non-exact e-mail match must not be treated as an existing customer.');
     end;
 
     [Test]

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -15,9 +15,18 @@ codeunit 139589 "Shpfy Customer API Test"
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    TestHttpRequestPolicy = BlockOutboundRequests;
 
     var
+        Shop: Record "Shpfy Shop";
         LibraryAssert: Codeunit "Library Assert";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        Any: Codeunit Any;
+        ResponseContent: Text;
+        IsInitialized: Boolean;
+        CustomerSearchResponseTok: Label '{"data":{"customers":{"edges":[{"node":{"id":"gid://shopify/Customer/%1",%2}}]}},"extensions":{"cost":{"requestedQueryCost":3,"actualQueryCost":3,"throttleStatus":{"maximumAvailable":20000.0,"currentlyAvailable":19997,"restoreRate":1000.0}}}}', Locked = true;
+        DefaultPhoneNumberNodeTok: Label '"defaultPhoneNumber":{"phoneNumber":"%1"}', Locked = true;
+        DefaultEMailAddressNodeTok: Label '"defaultEmailAddress":{"emailAddress":"%1"}', Locked = true;
 
     [Test]
     procedure UnitTestCreateCustomerGraphQuery()
@@ -98,5 +107,142 @@ codeunit 139589 "Shpfy Customer API Test"
         CustomerInitTest.TextFieldsContainsFieldName(ShopifyCustomer);
         CustomerAddress.Get(CustomerAddress.Id);
         CustomerInitTest.TextFieldsContainsFieldName(CustomerAddress);
+    end;
+
+    [Test]
+    procedure UnitTestFormatPhoneNoStripsSpacesAndSeparators()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+    begin
+        // [SCENARIO] A formatted phone number is reduced to a comparable form of '+' and digits only,
+        // so it can be sent to Shopify as a single, whitespace-free search term.
+
+        // [THEN] Spaces are removed.
+        LibraryAssert.AreEqual('+4545454545', CustomerApi.FormatPhoneNo('+45 4545 4545'), 'Spaces should be removed.');
+        // [THEN] Other formatting characters are removed as well.
+        LibraryAssert.AreEqual('+4545454545', CustomerApi.FormatPhoneNo('+45 (45) 45.45/45'), 'Separators should be removed.');
+    end;
+
+    [Test]
+    procedure UnitTestFindIdByPhoneIgnoresTokenizedPartialMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+    begin
+        // [SCENARIO] A spaced phone number must not match an unrelated Shopify customer that is only returned
+        // because Shopify's search syntax tokenizes '+45 4545 4545' into 'phone:+45' plus loose '4545' terms.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer whose phone number differs from the requested one.
+        ResponseContent := CustomerPhoneSearchResponse(ShopifyCustomerId(), '+4545455555');
+
+        // [WHEN] Searching by the spaced phone number '+45 4545 4545'.
+        CustomerId := CustomerApi.FindIdByPhone('+45 4545 4545');
+
+        // [THEN] No customer id is returned because the phone numbers are not an exact match.
+        LibraryAssert.AreEqual(0, CustomerId, 'A non-exact phone match must not be treated as an existing customer.');
+    end;
+
+    [Test]
+    procedure UnitTestFindIdByPhoneReturnsIdForExactMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+    begin
+        // [SCENARIO] A spaced phone number matches a Shopify customer whose normalized phone number is identical.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer whose normalized phone equals the requested one.
+        ResponseContent := CustomerPhoneSearchResponse(ShopifyCustomerId(), '+4545454545');
+
+        // [WHEN] Searching by the spaced phone number '+45 4545 4545'.
+        CustomerId := CustomerApi.FindIdByPhone('+45 4545 4545');
+
+        // [THEN] The matching customer id is returned.
+        LibraryAssert.AreEqual(ShopifyCustomerId(), CustomerId, 'An exact phone match should return the customer id.');
+    end;
+
+    [Test]
+    procedure UnitTestFindIdByEmailIgnoresNonExactMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+    begin
+        // [SCENARIO] An e-mail search must not accept a Shopify customer whose e-mail differs from the requested one.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer with a different e-mail address.
+        ResponseContent := CustomerEMailSearchResponse(ShopifyCustomerId(), 'other@contoso.com');
+
+        // [WHEN] Searching by e-mail 'p1@contoso.com'.
+        CustomerId := CustomerApi.FindIdByEmail('p1@contoso.com');
+
+        // [THEN] No customer id is returned because the e-mail addresses are not an exact match.
+        LibraryAssert.AreEqual(0, CustomerId, 'A non-exact e-mail match must not be treated as an existing customer.');
+    end;
+
+    [Test]
+    procedure UnitTestFindIdByEmailReturnsIdForExactMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+    begin
+        // [SCENARIO] An e-mail search matches a Shopify customer with the same e-mail address, ignoring casing.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer with the same e-mail address in a different casing.
+        ResponseContent := CustomerEMailSearchResponse(ShopifyCustomerId(), 'P1@Contoso.com');
+
+        // [WHEN] Searching by e-mail 'p1@contoso.com'.
+        CustomerId := CustomerApi.FindIdByEmail('p1@contoso.com');
+
+        // [THEN] The matching customer id is returned.
+        LibraryAssert.AreEqual(ShopifyCustomerId(), CustomerId, 'An exact e-mail match should return the customer id.');
+    end;
+
+    local procedure CustomerPhoneSearchResponse(Id: BigInteger; PhoneNo: Text): Text
+    begin
+        exit(StrSubstNo(CustomerSearchResponseTok, Id, StrSubstNo(DefaultPhoneNumberNodeTok, PhoneNo)));
+    end;
+
+    local procedure ShopifyCustomerId(): BigInteger
+    var
+        Id: BigInteger;
+    begin
+        // A realistic Shopify customer id does not fit in an Integer, so it is parsed into a BigInteger.
+        Evaluate(Id, '9324520669439');
+        exit(Id);
+    end;
+
+    local procedure CustomerEMailSearchResponse(Id: BigInteger; EMail: Text): Text
+    begin
+        exit(StrSubstNo(CustomerSearchResponseTok, Id, StrSubstNo(DefaultEMailAddressNodeTok, EMail)));
+    end;
+
+    local procedure Initialize()
+    var
+        AccessToken: SecretText;
+    begin
+        if IsInitialized then
+            exit;
+        IsInitialized := true;
+        Shop := InitializeTest.CreateShop();
+        AccessToken := Any.AlphanumericText(20);
+        InitializeTest.RegisterAccessTokenForShop(Shop.GetStoreName(), AccessToken);
+        Commit();
+    end;
+
+    [HttpClientHandler]
+    internal procedure HttpClientHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        if not InitializeTest.VerifyRequestUrl(Request.Path, Shop."Shopify URL") then
+            exit(true);
+
+        Response.Content.WriteFrom(ResponseContent);
+        exit(false);
     end;
 }

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -25,7 +25,7 @@ codeunit 139589 "Shpfy Customer API Test"
         Any: Codeunit Any;
         ResponseContent: Text;
         IsInitialized: Boolean;
-        CustomerSearchResponseTok: Label '{"data":{"customers":{"edges":[{"node":{"id":"gid://shopify/Customer/%1",%2}}]}},"extensions":{"cost":{"requestedQueryCost":3,"actualQueryCost":3,"throttleStatus":{"maximumAvailable":20000.0,"currentlyAvailable":19997,"restoreRate":1000.0}}}}', Locked = true;
+        CustomerSearchResponseTok: Label '{"data":{"customers":{"edges":[{"node":{"id":"gid://shopify/Customer/%1",%2}}]}},"extensions":{"cost":{"requestedQueryCost":4,"actualQueryCost":4,"throttleStatus":{"maximumAvailable":20000.0,"currentlyAvailable":19996,"restoreRate":1000.0}}}}', Locked = true;
         DefaultPhoneNumberNodeTok: Label '"defaultPhoneNumber":{"phoneNumber":"%1"}', Locked = true;
         DefaultEMailAddressNodeTok: Label '"defaultEmailAddress":{"emailAddress":"%1"}', Locked = true;
 


### PR DESCRIPTION
Fixes [AB#646794](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646794)

## Problem
When exporting a Business Central customer to Shopify, the connector searches existing Shopify customers by email and then by phone. Shopify's search syntax treats whitespace as a term separator (implicit AND), so a formatted phone number such as `+45 4545 4545` is parsed as `phone:+45` plus two loose `4545` terms and can match an **unrelated** customer. The connector then accepts that customer id and skips the export with the misleading message *"Customer already exists with the same e-mail or phone."* — even though both the email and phone are unique. The outcome also depended on export order.

## Fix
- **Normalize the phone** to `+` and digits before sending it to Shopify, so the whole number is scoped to the `phone:` filter as a single, whitespace-free term (`Shpfy Customer API` — `FindIdByPhone` + new `FormatPhoneNo` helper).
- **Verify the match is exact** — only accept a search result when the returned customer's phone/email matches the requested value exactly, so a tokenized or partial Shopify search result is no longer treated as an existing customer (`FindIdByPhone` / `FindIdByEmail`).
- **Return the compared fields** — `FindCustomerIdByPhone.graphql` and `FindCustomerIdByEMail.graphql` now return `defaultPhoneNumber` / `defaultEmailAddress` so the match can be verified.

## Tests
Added `Shpfy Customer API` tests (HTTP-mocked) covering:
- spaced international phone numbers normalized to a single search term,
- a tokenized/partial Shopify result → no match (customer is not skipped),
- an exact phone match → the customer id is returned,
- exact and case-insensitive email matching.








