### PR TITLE
Bug 646907: Disable App test for Composite Layouts due to platform changes.

### DIFF
--- a/src/DisabledTests/Tests-Report/Tests-Report.DisabledTest.json
+++ b/src/DisabledTests/Tests-Report/Tests-Report.DisabledTest.json
@@ -1555,5 +1555,36 @@
     "codeunitName": "Remittance REP Check UT",
     "method": "RemittanceAdviceEntrieShouldAllPayedDocumentsWithPartiallyPaid",
     "bug": "RU: shared W1 test fails under RU base-app behavior in the merged RU build; runs+passes for W1/other countries. Disabled globally (low value, RU pipeline enablement)."
+  },
+  {
+    "codeunitId": 134619,
+    "codeunitName": "Composite Layout Tests",
+    "method": "LayoutLevelAssignmentResolvesAsThisLayout",
+    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
+  }
+  ,
+  {
+    "codeunitId": 134619,
+    "codeunitName": "Composite Layout Tests",
+    "method": "HeaderAndThemeResolveIndependently",
+    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
+  },
+  {
+    "codeunitId": 134619,
+    "codeunitName": "Composite Layout Tests",
+    "method": "MoreSpecificLevelWinsOverGlobal",
+    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
+  },
+  {
+    "codeunitId": 134619,
+    "codeunitName": "Composite Layout Tests",
+    "method": "PageShowsDecodedPartNamesNotComposite",
+    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
+  },
+  {
+    "codeunitId": 134619,
+    "codeunitName": "Composite Layout Tests",
+    "method": "ShowInfoReportsPartDetailsAndUsage",
+    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
   }
 ]


### PR DESCRIPTION
## What & why

Disable selected tests for Composite Report Layouts as the platform changes behavior with respect to layout resolution. Test will be updated when platform have been uptaken.

## Linked work

Fixes [AB#646907](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646907)

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Required for platform uptake. Tests will be updated when the platform have stabilized.

## Risk & compatibility




