### PR TITLE
Slice 550732: Keep routing descriptions when vendor changes

### DIFF
--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2512,7 +2512,6 @@ codeunit 139989 "Subc. Subcontracting Test"
         Vendor: Record Vendor;
         WorkCenter: array[2] of Record "Work Center";
         SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
-        LibraryUtility: Codeunit "Library - Utility";
         ExpectedDescription: Text[100];
         ExpectedDescription2: Text[50];
     begin
@@ -2540,16 +2539,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         ProdOrderRoutingLine.Modify();
 
         // [GIVEN] The production routing line is suggested on the subcontracting worksheet
-        ReqWkshTemplate.DeleteAll(true);
-        ReqWkshTemplate.Name := SelectRequisitionTemplateName();
-        RequisitionWkshName.Init();
-        RequisitionWkshName.Validate("Worksheet Template Name", ReqWkshTemplate.Name);
-        RequisitionWkshName.Validate(
-            Name,
-            CopyStr(
-                LibraryUtility.GenerateRandomCode(RequisitionWkshName.FieldNo(Name), Database::"Requisition Wksh. Name"),
-                1, LibraryUtility.GetFieldLength(Database::"Requisition Wksh. Name", RequisitionWkshName.FieldNo(Name))));
-        RequisitionWkshName.Insert(true);
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
         RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
         RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
         SubcCalculateSubContract.SetWkShLine(RequisitionLine);
@@ -2581,7 +2571,6 @@ codeunit 139989 "Subc. Subcontracting Test"
         Vendor: Record Vendor;
         WorkCenter: array[2] of Record "Work Center";
         SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
-        LibraryUtility: Codeunit "Library - Utility";
         ExpectedDescription: Text[100];
         ExpectedDescription2: Text[50];
     begin
@@ -2605,16 +2594,7 @@ codeunit 139989 "Subc. Subcontracting Test"
             ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
 
         // [GIVEN] A subcontracting requisition line whose routing operation does not exist
-        ReqWkshTemplate.DeleteAll(true);
-        ReqWkshTemplate.Name := SelectRequisitionTemplateName();
-        RequisitionWkshName.Init();
-        RequisitionWkshName.Validate("Worksheet Template Name", ReqWkshTemplate.Name);
-        RequisitionWkshName.Validate(
-            Name,
-            CopyStr(
-                LibraryUtility.GenerateRandomCode(RequisitionWkshName.FieldNo(Name), Database::"Requisition Wksh. Name"),
-                1, LibraryUtility.GetFieldLength(Database::"Requisition Wksh. Name", RequisitionWkshName.FieldNo(Name))));
-        RequisitionWkshName.Insert(true);
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
         RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
         RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
         SubcCalculateSubContract.SetWkShLine(RequisitionLine);

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2560,6 +2560,68 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    procedure ChangingVendorKeepsBlankRoutingDescriptionAndUsesWorkCenterDescription2()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+        ExpectedDescription2: Text[50];
+    begin
+        // [SCENARIO 550732] Changing the vendor keeps a blank routing description and uses work center description 2
+        Initialize();
+
+        // [GIVEN] A released production order with blank descriptions on its subcontracting routing line
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        ExpectedDescription2 := 'Work center details';
+        WorkCenter[2].Validate("Name 2", ExpectedDescription2);
+        WorkCenter[2].Modify(true);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        ProdOrderRoutingLine.FindFirst();
+        Clear(ProdOrderRoutingLine.Description);
+        Clear(ProdOrderRoutingLine."Description 2");
+        ProdOrderRoutingLine.Modify();
+
+        // [GIVEN] The production routing line is suggested on the subcontracting worksheet
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+        RequisitionLine.SetRange("Ref. Order No.", ProductionOrder."No.");
+        RequisitionLine.FindFirst();
+        RequisitionLine.Description := 'Description before vendor validation';
+        RequisitionLine."Description 2" := 'Description 2 before validation';
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [WHEN] The vendor is changed on the subcontracting requisition line
+        RequisitionLine.Validate("Vendor No.", Vendor."No.");
+
+        // [THEN] The description remains blank and description 2 comes from the subcontracting work center
+        Assert.AreEqual('', RequisitionLine.Description, 'The blank routing line description must be kept when the vendor changes.');
+        Assert.AreEqual(ExpectedDescription2, RequisitionLine."Description 2", 'The work center description 2 must be used when the routing line description 2 is blank.');
+    end;
+
+    [Test]
     procedure ChangingVendorUsesWorkCenterDescriptionsWhenRoutingLineNotFound()
     var
         Item: Record Item;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2557,7 +2557,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         SubcCalculateSubContract.RunModal();
         RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
         RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
-        RequisitionLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        RequisitionLine.SetRange("Ref. Order No.", ProductionOrder."No.");
         RequisitionLine.FindFirst();
         LibraryPurchase.CreateVendor(Vendor);
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2680,6 +2680,69 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    procedure ChangingVendorUsesWorkCenterDescriptionsWhenRoutingLineWorkCenterDiffers()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+        ExpectedDescription: Text[100];
+        ExpectedDescription2: Text[50];
+    begin
+        // [SCENARIO 550732] Changing the vendor uses the requisition work center descriptions when the routing line work center differs
+        Initialize();
+
+        // [GIVEN] A released production order with distinct descriptions on its subcontracting work center
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        ExpectedDescription := 'Current subcontracting work center';
+        ExpectedDescription2 := 'Current work center details';
+        WorkCenter[2].Validate(Name, ExpectedDescription);
+        WorkCenter[2].Validate("Name 2", ExpectedDescription2);
+        WorkCenter[2].Modify(true);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] A subcontracting requisition line and its matching-key routing line with different work centers
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+        RequisitionLine.SetRange("Ref. Order No.", ProductionOrder."No.");
+        RequisitionLine.FindFirst();
+        ProdOrderRoutingLine.Get(
+            RequisitionLine."Ref. Order Status", RequisitionLine."Ref. Order No.", RequisitionLine."Routing Reference No.",
+            RequisitionLine."Routing No.", RequisitionLine."Operation No.");
+        ProdOrderRoutingLine."Work Center No." := WorkCenter[1]."No.";
+        ProdOrderRoutingLine.Description := 'Mismatched routing description';
+        ProdOrderRoutingLine."Description 2" := 'Mismatched routing details';
+        ProdOrderRoutingLine.Modify();
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [WHEN] The vendor is changed on the subcontracting requisition line
+        RequisitionLine.Validate("Vendor No.", Vendor."No.");
+
+        // [THEN] Both descriptions fall back to the requisition line's subcontracting work center
+        Assert.AreEqual(ExpectedDescription, RequisitionLine.Description, 'The requisition work center description must be used when the routing line work center differs.');
+        Assert.AreEqual(ExpectedDescription2, RequisitionLine."Description 2", 'The requisition work center description 2 must be used when the routing line work center differs.');
+    end;
+
+    [Test]
     procedure CalculateSubcontractsErrorsWhenWorkCenterMissingGenProdPostingGroup()
     var
         Item: Record Item;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -2570,6 +2570,74 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    procedure ChangingVendorUsesWorkCenterDescriptionsWhenRoutingLineNotFound()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+        LibraryUtility: Codeunit "Library - Utility";
+        ExpectedDescription: Text[100];
+        ExpectedDescription2: Text[50];
+    begin
+        // [SCENARIO 550732] Changing the vendor uses the subcontracting work center descriptions when the routing line is not found
+        Initialize();
+
+        // [GIVEN] A released production order with distinct descriptions on its subcontracting work center
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        ExpectedDescription := 'Subcontracting work center';
+        ExpectedDescription2 := 'Work center details';
+        WorkCenter[2].Validate(Name, ExpectedDescription);
+        WorkCenter[2].Validate("Name 2", ExpectedDescription2);
+        WorkCenter[2].Modify(true);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+
+        // [GIVEN] A subcontracting requisition line whose routing operation does not exist
+        ReqWkshTemplate.DeleteAll(true);
+        ReqWkshTemplate.Name := SelectRequisitionTemplateName();
+        RequisitionWkshName.Init();
+        RequisitionWkshName.Validate("Worksheet Template Name", ReqWkshTemplate.Name);
+        RequisitionWkshName.Validate(
+            Name,
+            CopyStr(
+                LibraryUtility.GenerateRandomCode(RequisitionWkshName.FieldNo(Name), Database::"Requisition Wksh. Name"),
+                1, LibraryUtility.GetFieldLength(Database::"Requisition Wksh. Name", RequisitionWkshName.FieldNo(Name))));
+        RequisitionWkshName.Insert(true);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+        RequisitionLine.SetRange("Ref. Order No.", ProductionOrder."No.");
+        RequisitionLine.FindFirst();
+        RequisitionLine."Operation No." := 'NOTFOUND';
+        RequisitionLine.Description := 'Description before vendor validation';
+        RequisitionLine."Description 2" := 'Description 2 before validation';
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [WHEN] The vendor is changed on the subcontracting requisition line
+        RequisitionLine.Validate("Vendor No.", Vendor."No.");
+
+        // [THEN] Both descriptions fall back to the subcontracting work center
+        Assert.AreEqual(ExpectedDescription, RequisitionLine.Description, 'The work center description must be used when the routing line is not found.');
+        Assert.AreEqual(ExpectedDescription2, RequisitionLine."Description 2", 'The work center description 2 must be used when the routing line is not found.');
+    end;
+
+    [Test]
     procedure CalculateSubcontractsErrorsWhenWorkCenterMissingGenProdPostingGroup()
     var
         Item: Record Item;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -1130,8 +1130,8 @@ codeunit 139989 "Subc. Subcontracting Test"
         ManufacturingSetup: Record "Manufacturing Setup";
         Vendor: Record Vendor;
         WorkCenter: array[2] of Record "Work Center";
-        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
         CarryOutActionMsgReq: Report "Carry Out Action Msg. - Req.";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
         GenBusPostingGroup1, GenBusPostingGroup2 : Code[20];
         ProdPostingGroup1, ProdPostingGroup2 : Code[20];
         VATBusPostingGroup1, VATBusPostingGroup2 : Code[20];
@@ -2497,6 +2497,76 @@ codeunit 139989 "Subc. Subcontracting Test"
         Assert.AreEqual(
             ExpectedDescription2, RequisitionLine."Description 2",
             'Description 2 must be populated on the Requisition Line from the subcontracting Work Center');
+    end;
+
+    [Test]
+    procedure ChangingVendorKeepsProdOrderRoutingLineDescriptions()
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        ProductionOrder: Record "Production Order";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+        LibraryUtility: Codeunit "Library - Utility";
+        ExpectedDescription: Text[100];
+        ExpectedDescription2: Text[50];
+    begin
+        // [SCENARIO 550732] Changing the vendor on a subcontracting requisition line keeps the production routing descriptions
+        Initialize();
+
+        // [GIVEN] A released production order with custom descriptions on its subcontracting routing line
+        Subcontracting := true;
+        UnitCostCalculation := UnitCostCalculation::Units;
+        UpdateSubMgmtSetupWithReqWkshTemplate();
+        CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter);
+        CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        UpdateProdBomAndRoutingWithRoutingLink(Item, WorkCenter[2]."No.");
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        SubcontractingMgmtLibrary.CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        ProdOrderRoutingLine.SetRange(Status, ProdOrderRoutingLine.Status::Released);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter[2]."No.");
+        ProdOrderRoutingLine.FindFirst();
+        ExpectedDescription := 'Custom subcontracting operation';
+        ExpectedDescription2 := 'Custom operation details';
+        ProdOrderRoutingLine.Description := ExpectedDescription;
+        ProdOrderRoutingLine."Description 2" := ExpectedDescription2;
+        ProdOrderRoutingLine.Modify();
+
+        // [GIVEN] The production routing line is suggested on the subcontracting worksheet
+        ReqWkshTemplate.DeleteAll(true);
+        ReqWkshTemplate.Name := SelectRequisitionTemplateName();
+        RequisitionWkshName.Init();
+        RequisitionWkshName.Validate("Worksheet Template Name", ReqWkshTemplate.Name);
+        RequisitionWkshName.Validate(
+            Name,
+            CopyStr(
+                LibraryUtility.GenerateRandomCode(RequisitionWkshName.FieldNo(Name), Database::"Requisition Wksh. Name"),
+                1, LibraryUtility.GetFieldLength(Database::"Requisition Wksh. Name", RequisitionWkshName.FieldNo(Name))));
+        RequisitionWkshName.Insert(true);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+        RequisitionLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        RequisitionLine.FindFirst();
+        LibraryPurchase.CreateVendor(Vendor);
+
+        // [WHEN] The vendor is changed on the subcontracting requisition line
+        RequisitionLine.Validate("Vendor No.", Vendor."No.");
+
+        // [THEN] Both descriptions still come from the production order routing line
+        Assert.AreEqual(ExpectedDescription, RequisitionLine.Description, 'The routing line description must be kept when the vendor changes.');
+        Assert.AreEqual(ExpectedDescription2, RequisitionLine."Description 2", 'The routing line description 2 must be kept when the vendor changes.');
     end;
 
     [Test]

--- a/src/Layers/IT/BaseApp/Manufacturing/Inventory/Requisition/MfgRequisitionLine.TableExt.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Inventory/Requisition/MfgRequisitionLine.TableExt.al
@@ -634,7 +634,9 @@ tableextension 99000860 "Mfg. Requisition Line" extends "Requisition Line"
 
     procedure UpdateWorkCenterDescription(): Boolean
     var
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         WorkCenterForDescription: Record "Work Center";
+        RoutingLineFound: Boolean;
     begin
         if ("Ref. Order Type" <> "Ref. Order Type"::"Prod. Order") or ("Work Center No." = '') then
             exit(false);
@@ -645,8 +647,18 @@ tableextension 99000860 "Mfg. Requisition Line" extends "Requisition Line"
         if WorkCenterForDescription."Subcontractor No." = '' then
             exit(false);
 
-        Description := WorkCenterForDescription.Name;
-        "Description 2" := WorkCenterForDescription."Name 2";
+        ProdOrderRoutingLine.SetLoadFields(Description, "Description 2", "Work Center No.");
+        RoutingLineFound := ProdOrderRoutingLine.Get(
+            "Ref. Order Status", "Ref. Order No.", "Routing Reference No.", "Routing No.", "Operation No.");
+        if RoutingLineFound and (ProdOrderRoutingLine."Work Center No." = "Work Center No.") then begin
+            Description := ProdOrderRoutingLine.Description;
+            "Description 2" := ProdOrderRoutingLine."Description 2";
+            if "Description 2" = '' then
+                "Description 2" := WorkCenterForDescription."Name 2";
+        end else begin
+            Description := WorkCenterForDescription.Name;
+            "Description 2" := WorkCenterForDescription."Name 2";
+        end;
 
         exit(true);
     end;

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Requisition/MfgRequisitionLine.TableExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Requisition/MfgRequisitionLine.TableExt.al
@@ -459,7 +459,9 @@ tableextension 99000860 "Mfg. Requisition Line" extends "Requisition Line"
 
     procedure UpdateWorkCenterDescription(): Boolean
     var
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         WorkCenterForDescription: Record "Work Center";
+        RoutingLineFound: Boolean;
     begin
         if ("Ref. Order Type" <> "Ref. Order Type"::"Prod. Order") or ("Work Center No." = '') then
             exit(false);
@@ -470,8 +472,18 @@ tableextension 99000860 "Mfg. Requisition Line" extends "Requisition Line"
         if WorkCenterForDescription."Subcontractor No." = '' then
             exit(false);
 
-        Description := WorkCenterForDescription.Name;
-        "Description 2" := WorkCenterForDescription."Name 2";
+        ProdOrderRoutingLine.SetLoadFields(Description, "Description 2", "Work Center No.");
+        RoutingLineFound := ProdOrderRoutingLine.Get(
+            "Ref. Order Status", "Ref. Order No.", "Routing Reference No.", "Routing No.", "Operation No.");
+        if RoutingLineFound and (ProdOrderRoutingLine."Work Center No." = "Work Center No.") then begin
+            Description := ProdOrderRoutingLine.Description;
+            "Description 2" := ProdOrderRoutingLine."Description 2";
+            if "Description 2" = '' then
+                "Description 2" := WorkCenterForDescription."Name 2";
+        end else begin
+            Description := WorkCenterForDescription.Name;
+            "Description 2" := WorkCenterForDescription."Name 2";
+        end;
 
         exit(true);
     end;


### PR DESCRIPTION
## Summary
- preserve subcontracting requisition Description and Description 2 from the matching production order routing line when the vendor changes
- retain the existing work-center fallback when the routing line is missing, belongs to another work center, or has a blank Description 2
- apply the same fix to the IT BaseApp layer

## Root Cause
Vendor validation refreshed requisition descriptions from the subcontracting work center instead of the production order routing operation.

## Test
Added \ChangingVendorKeepsProdOrderRoutingLineDescriptions\ ([SCENARIO 550732]) in codeunit 139989.

Validation:
- Subcontracting app compile: passed, 0 warnings/errors
- Subcontracting test app compile: passed, 0 warnings/errors
- app/test publish: passed
- regression test against the currently published unmodified Base Application: failed as expected, proving the old behavior
- final execution with the updated Base Application is blocked locally by the existing Base Application compiler/platform AL0126 mismatch; CI should run the integrated validation

Fixes [AB#550732](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/550732)

🤖 Generated with GitHub Copilot








