### PR TITLE
[Quality Management] Remove Description mandatory check when closing test card

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Template/Test/QltyTestCard.Page.al
@@ -631,14 +631,6 @@ page 20479 "Qlty. Test Card"
         UpdateRowData();
     end;
 
-    trigger OnQueryClosePage(CloseAction: Action): Boolean
-    begin
-        if CloseAction in [Action::OK, Action::LookupOK] then
-            if Rec.Code <> '' then
-                Rec.TestField(Description);
-        exit(true);
-    end;
-
     local procedure UpdateRowData()
     var
         DummyMatrixArrayCaptionSet: array[10] of Text;


### PR DESCRIPTION
## What & why

Product requirement:
1. Keep the existing field caption Description.
2. Keep the red mandatory indicator (asterisk) as visual guidance.
3. Do not enforce a value in Description. A blank Description must be accepted.
4. Deleting a new test with a blank Description must complete normally.

No test scenario added since this is standard behavior.

## Linked work

Fixes [AB#646627](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646627)
