### PR TITLE
[28.x] [Quality Management] Quality Inspection User assignment fixes

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/AccessControl/QltyPermissionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/AccessControl/QltyPermissionMgmt.Codeunit.al
@@ -194,16 +194,16 @@ codeunit 20406 "Qlty. Permission Mgmt."
     end;
 
     /// <summary>
-    /// Determines whether auto-assignment should occur based on user permissions.
+    /// Determines whether the current user can assign an inspection to themselves and whether to prompt before assignment.
     /// </summary>
-    /// <param name="ShouldPrompt">Set to true when GUI is available and prompting is enabled.</param>
-    /// <returns>True if auto-assignment should occur; otherwise, false.</returns>
-    internal procedure GetShouldAutoAssign(var ShouldPrompt: Boolean) ShouldAssign: Boolean
+    /// <param name="ShouldPrompt">Set to true when a GUI is available and the user should be prompted; otherwise, false.</param>
+    /// <returns>True if the current user has write permission for inspection headers; otherwise, false.</returns>
+    internal procedure GetShouldAutoAssign(var ShouldPrompt: Boolean): Boolean
     var
         QltyInspectionHeader: Record "Qlty. Inspection Header";
     begin
-        ShouldAssign := QltyInspectionHeader.WritePermission();
         ShouldPrompt := GuiAllowed();
+        exit(QltyInspectionHeader.WritePermission());
     end;
 
     #region Verify Permissions

--- a/src/Apps/W1/Quality Management/app/src/AccessControl/QltyPermissionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/AccessControl/QltyPermissionMgmt.Codeunit.al
@@ -203,7 +203,7 @@ codeunit 20406 "Qlty. Permission Mgmt."
         QltyInspectionHeader: Record "Qlty. Inspection Header";
     begin
         ShouldAssign := QltyInspectionHeader.WritePermission();
-        ShouldPrompt := false;
+        ShouldPrompt := GuiAllowed();
     end;
 
     #region Verify Permissions

--- a/src/Apps/W1/Quality Management/app/src/AccessControl/QltyPermissionMgmt.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/AccessControl/QltyPermissionMgmt.Codeunit.al
@@ -198,12 +198,12 @@ codeunit 20406 "Qlty. Permission Mgmt."
     /// </summary>
     /// <param name="ShouldPrompt">Set to true when a GUI is available and the user should be prompted; otherwise, false.</param>
     /// <returns>True if the current user has write permission for inspection headers; otherwise, false.</returns>
-    internal procedure GetShouldAutoAssign(var ShouldPrompt: Boolean): Boolean
+    internal procedure GetShouldAutoAssign(var ShouldPrompt: Boolean) ShouldAssign: Boolean
     var
         QltyInspectionHeader: Record "Qlty. Inspection Header";
     begin
         ShouldPrompt := GuiAllowed();
-        exit(QltyInspectionHeader.WritePermission());
+        ShouldAssign := QltyInspectionHeader.WritePermission();
     end;
 
     #region Verify Permissions

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -173,6 +173,7 @@ table 20405 "Qlty. Inspection Header"
             DataClassification = EndUserIdentifiableInformation;
             Editable = false;
             TableRelation = User."User Name";
+            ValidateTableRelation = false;
             Caption = 'Assigned User ID';
             ToolTip = 'Specifies the user this inspection is assigned to. Changing another user''s assignment requires the Quality Admin & Supervisor role.';
 
@@ -607,7 +608,7 @@ table 20405 "Qlty. Inspection Header"
             end;
             if ShouldTryAndChangePrompt then
                 if QltyPermissionMgmt.GetShouldAutoAssign(PromptToAssignIfPossible) then
-                    if PromptToAssignIfPossible and GuiAllowed() then
+                    if PromptToAssignIfPossible then
                         QltyNotificationMgmt.NotifyDoYouWantToAssignToYourself(Rec)
                     else
                         Rec.AssignToSelf();

--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -27,6 +27,7 @@ using System.Device;
 using System.IO;
 using System.Reflection;
 using System.Security.AccessControl;
+using System.Security.User;
 using System.Utilities;
 
 table 20405 "Qlty. Inspection Header"
@@ -179,8 +180,11 @@ table 20405 "Qlty. Inspection Header"
 
             trigger OnValidate()
             var
+                UserSelection: Codeunit "User Selection";
                 CanChangeAssignmentWithoutPermission: Boolean;
             begin
+                UserSelection.ValidateUserName("Assigned User ID");
+
                 CanChangeAssignmentWithoutPermission := false;
 
                 if ((xRec."Assigned User ID" = UserId()) and (Rec."Assigned User ID" = '')) or (((xRec."Assigned User ID" = '') and (Rec."Assigned User ID" = UserId()))) then

--- a/src/Apps/W1/Quality Management/test/app.json
+++ b/src/Apps/W1/Quality Management/test/app.json
@@ -43,6 +43,12 @@
       "version": "28.5.0.0"
     },
     {
+      "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
+      "publisher": "Microsoft",
+      "name": "Library Variable Storage",
+      "version": "29.0.0.0"
+    },
+    {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
       "publisher": "Microsoft",
       "name": "Any",

--- a/src/Apps/W1/Quality Management/test/app.json
+++ b/src/Apps/W1/Quality Management/test/app.json
@@ -46,7 +46,7 @@
       "id": "5095f467-0a01-4b99-99d1-9ff1237d286f",
       "publisher": "Microsoft",
       "name": "Library Variable Storage",
-      "version": "29.0.0.0"
+      "version": "28.5.0.0"
     },
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -60,6 +60,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         Bin2Tok: Label 'Bin2';
         WarehouseEntryTypeBlockedErr: Label 'This warehouse transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5 %6 %7, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=Lot No., %6=Serial No., %7=Package No.';
         EntryTypeBlockedErr: Label 'This transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=combined package tracking details of Lot No., Serial No. and Package No.';
+        YouHaveAlteredDoYouWantToAutoAssignQst: Label 'You have altered inspection %1, would you like to assign it to yourself?', Comment = '%1=the inspection number';
         UnableToSetTableValueFieldNotFoundErr: Label 'Unable to set a value because the field [%1] in table [%2] was not found.', Comment = '%1=the field name, %2=the table name';
         NotificationDataRelatedRecordIdTok: Label 'RelatedRecordId', Locked = true;
         LotSerialTrackingDetailsTok: Label '%1 %2', Comment = '%1=lot no,%2=serial no', Locked = true;
@@ -2877,8 +2878,8 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Validate(Description, 'x');
         QltyInspectionHeader.Modify(true);
 
-        // [THEN] Exactly one "assign to yourself" notification was sent instead of the current user being silently assigned
-        LibraryAssert.IsTrue(StrPos(LibraryVariableStorage.DequeueText(), QltyInspectionHeader."No.") > 0, 'The notification message should reference the inspection number');
+        // [THEN] Exactly one "assign to yourself" notification was sent with the correct message
+        LibraryAssert.AreEqual(StrSubstNo(YouHaveAlteredDoYouWantToAutoAssignQst, QltyInspectionHeader."No."), LibraryVariableStorage.DequeueText(), 'The correct assign-to-yourself notification should have been sent');
         LibraryVariableStorage.AssertEmpty();
 
         // [THEN] The Assigned User ID remained blank because the user was prompted (not silently auto-assigned)

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -2867,6 +2867,7 @@ codeunit 139964 "Qlty. Tests - Misc."
         // [GIVEN] A quality inspection is created from a purchase line for an untracked item
         QltyPurOrderGenerator.CreateInspectionFromPurchaseWithUntrackedItem(Location, 100, PurchaseHeader, PurchaseLine, QltyInspectionHeader);
         QltyInspectionGenRule.Delete();
+        LibraryVariableStorage.Clear();
 
         // [GIVEN] The inspection has no Assigned User ID (bypass OnModify to reset the state, then re-fetch so xRec matches)
         QltyInspectionHeader."Assigned User ID" := '';

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -50,12 +50,11 @@ codeunit 139964 "Qlty. Tests - Misc."
     var
         LibraryAssert: Codeunit "Library Assert";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
         QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
         Any: Codeunit Any;
         DocumentNo: Text;
         FlagTestNavigateToSourceDocument: Text;
-        CapturedAssignToSelfNotificationMessage: Text;
-        AssignToSelfNotificationReceived: Boolean;
         NotificationDataInspectionRecordIdTok: Label 'InspectionRecordId', Locked = true;
         Bin1Tok: Label 'Bin1';
         Bin2Tok: Label 'Bin2';
@@ -2875,14 +2874,12 @@ codeunit 139964 "Qlty. Tests - Misc."
         LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Precondition: the inspection must start unassigned');
 
         // [WHEN] A user-modifiable field is changed and the inspection is modified (which runs OnModify)
-        AssignToSelfNotificationReceived := false;
-        CapturedAssignToSelfNotificationMessage := '';
         QltyInspectionHeader.Validate(Description, 'x');
         QltyInspectionHeader.Modify(true);
 
-        // [THEN] The "assign to yourself" notification was sent instead of the current user being silently assigned
-        LibraryAssert.IsTrue(AssignToSelfNotificationReceived, 'The AssignToSelf notification should have been sent when modifying an unassigned inspection');
-        LibraryAssert.IsTrue(StrPos(CapturedAssignToSelfNotificationMessage, QltyInspectionHeader."No.") > 0, 'The notification message should reference the inspection number');
+        // [THEN] Exactly one "assign to yourself" notification was sent instead of the current user being silently assigned
+        LibraryAssert.IsTrue(StrPos(LibraryVariableStorage.DequeueText(), QltyInspectionHeader."No.") > 0, 'The notification message should reference the inspection number');
+        LibraryVariableStorage.AssertEmpty();
 
         // [THEN] The Assigned User ID remained blank because the user was prompted (not silently auto-assigned)
         QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
@@ -2891,6 +2888,8 @@ codeunit 139964 "Qlty. Tests - Misc."
 
     local procedure Initialize()
     begin
+        LibraryVariableStorage.Clear();
+
         if IsInitialized then
             exit;
         LibraryERMCountryData.CreateVATData();
@@ -2925,8 +2924,7 @@ codeunit 139964 "Qlty. Tests - Misc."
     [SendNotificationHandler]
     procedure AssignToSelfNotificationHandler(var NotificationToShow: Notification): Boolean
     begin
-        AssignToSelfNotificationReceived := true;
-        CapturedAssignToSelfNotificationMessage := NotificationToShow.Message();
+        LibraryVariableStorage.Enqueue(NotificationToShow.Message());
     end;
 
     [ModalPageHandler]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -2874,6 +2874,9 @@ codeunit 139964 "Qlty. Tests - Misc."
         QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
         LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Precondition: the inspection must start unassigned');
 
+        // [GIVEN] The notifications raised while setting up the inspection are discarded
+        LibraryVariableStorage.Clear();
+
         // [WHEN] A user-modifiable field is changed and the inspection is modified (which runs OnModify)
         QltyInspectionHeader.Validate(Description, 'x');
         QltyInspectionHeader.Modify(true);

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -53,13 +53,14 @@ codeunit 139964 "Qlty. Tests - Misc."
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
         Any: Codeunit Any;
+        AssignToSelfNotification: Notification;
         DocumentNo: Text;
         FlagTestNavigateToSourceDocument: Text;
         NotificationDataInspectionRecordIdTok: Label 'InspectionRecordId', Locked = true;
         Bin1Tok: Label 'Bin1';
         Bin2Tok: Label 'Bin2';
-        WarehouseEntryTypeBlockedErr: Label 'This warehouse transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5 %6 %7, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=Lot No., %6=Serial No., %7=Package No.';
-        EntryTypeBlockedErr: Label 'This transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=combined package tracking details of Lot No., Serial No. and Package No.';
+        WarehouseEntryTypeBlockedErr: Label '"%1" warehouse transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
+        EntryTypeBlockedErr: Label '"%1" transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
         YouHaveAlteredDoYouWantToAutoAssignQst: Label 'You have altered inspection %1, would you like to assign it to yourself?', Comment = '%1=the inspection number';
         UnableToSetTableValueFieldNotFoundErr: Label 'Unable to set a value because the field [%1] in table [%2] was not found.', Comment = '%1=the field name, %2=the table name';
         NotificationDataRelatedRecordIdTok: Label 'RelatedRecordId', Locked = true;
@@ -2839,56 +2840,82 @@ codeunit 139964 "Qlty. Tests - Misc."
     [HandlerFunctions('AssignToSelfNotificationHandler')]
     procedure ModifyUnassignedInspection_SendsAssignToSelfNotification()
     var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+    begin
+        // [SCENARIO] Modifying an unassigned Quality Inspection sends the "assign to yourself" notification
+        // instead of silently auto-assigning the current user.
+
+        // [GIVEN] An unassigned quality inspection
+        CreateUnassignedInspection(QltyInspectionHeader);
+
+        // [GIVEN] The expected assign-to-self notification is queued
+        Clear(AssignToSelfNotification);
+        LibraryVariableStorage.Enqueue(StrSubstNo(YouHaveAlteredDoYouWantToAutoAssignQst, QltyInspectionHeader."No."));
+
+        // [WHEN] A user-modifiable field is changed and the inspection is modified (which runs OnModify)
+        QltyInspectionHeader.Validate(Description, 'x');
+        QltyInspectionHeader.Modify(true);
+
+        // [THEN] The inspection remains unassigned because the user was prompted
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'The inspection should not be silently assigned when the user is prompted');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('AssignToSelfNotificationHandler')]
+    procedure ModifyUnassignedInspection_AcceptAssignToSelfNotificationAssignsCurrentUser()
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+    begin
+        // [SCENARIO] Accepting the assign-to-self notification assigns the inspection to the current user
+
+        // [GIVEN] An unassigned quality inspection
+        CreateUnassignedInspection(QltyInspectionHeader);
+
+        // [GIVEN] The expected assign-to-self notification is queued
+        Clear(AssignToSelfNotification);
+        LibraryVariableStorage.Enqueue(StrSubstNo(YouHaveAlteredDoYouWantToAutoAssignQst, QltyInspectionHeader."No."));
+
+        // [WHEN] The inspection is modified and the user accepts the assign-to-self notification
+        QltyInspectionHeader.Validate(Description, 'x');
+        QltyInspectionHeader.Modify(true);
+        QltyInspectionUtility.HandleNotificationActionAssignToSelf(AssignToSelfNotification);
+
+        // [THEN] The inspection is assigned to the current user
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual(UserId(), QltyInspectionHeader."Assigned User ID", 'The inspection should be assigned to the current user after accepting the notification');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    local procedure CreateUnassignedInspection(var QltyInspectionHeader: Record "Qlty. Inspection Header")
+    var
         QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
         QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
         Location: Record Location;
         Item: Record Item;
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
-        QltyInspectionHeader: Record "Qlty. Inspection Header";
         QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryInventory: Codeunit "Library - Inventory";
     begin
-        // [SCENARIO] Modifying an unassigned Quality Inspection sends the "assign to yourself" notification
-        // instead of silently auto-assigning the current user. Regression coverage for
-        // Qlty. Permission Mgmt. GetShouldAutoAssign hardcoding ShouldPrompt := false, which made
-        // the OnModify trigger always call AssignToSelf and never reach the notification path.
-
-        // [GIVEN] Quality management setup with location, item, and inspection template are configured
         Initialize();
-
         QltyInspectionUtility.EnsureSetupExists();
         LibraryWarehouse.CreateLocation(Location);
         LibraryInventory.CreateItem(Item);
         QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 1);
         QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Purchase Line", QltyInspectionGenRule);
 
-        // [GIVEN] A quality inspection is created from a purchase line for an untracked item
+        LibraryVariableStorage.Enqueue(InspectionCreatedMsgFragmentTok);
         QltyPurOrderGenerator.CreateInspectionFromPurchaseWithUntrackedItem(Location, 100, PurchaseHeader, PurchaseLine, QltyInspectionHeader);
         QltyInspectionGenRule.Delete();
-        LibraryVariableStorage.Clear();
+        LibraryVariableStorage.AssertEmpty();
 
-        // [GIVEN] The inspection has no Assigned User ID (bypass OnModify to reset the state, then re-fetch so xRec matches)
         QltyInspectionHeader."Assigned User ID" := '';
         QltyInspectionHeader.Modify(false);
         QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
         LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Precondition: the inspection must start unassigned');
-
-        // [GIVEN] The notifications raised while setting up the inspection are discarded
-        LibraryVariableStorage.Clear();
-
-        // [WHEN] A user-modifiable field is changed and the inspection is modified (which runs OnModify)
-        QltyInspectionHeader.Validate(Description, 'x');
-        QltyInspectionHeader.Modify(true);
-
-        // [THEN] Exactly one "assign to yourself" notification was sent with the correct message
-        LibraryAssert.AreEqual(StrSubstNo(YouHaveAlteredDoYouWantToAutoAssignQst, QltyInspectionHeader."No."), LibraryVariableStorage.DequeueText(), 'The correct assign-to-yourself notification should have been sent');
-        LibraryVariableStorage.AssertEmpty();
-
-        // [THEN] The Assigned User ID remained blank because the user was prompted (not silently auto-assigned)
-        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
-        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'The inspection should not be silently auto-assigned when the notification prompt is available');
     end;
 
     local procedure Initialize()
@@ -2928,8 +2955,13 @@ codeunit 139964 "Qlty. Tests - Misc."
 
     [SendNotificationHandler]
     procedure AssignToSelfNotificationHandler(var NotificationToShow: Notification): Boolean
+    var
+        ExpectedMessage: Text;
     begin
-        LibraryVariableStorage.Enqueue(NotificationToShow.Message());
+        ExpectedMessage := LibraryVariableStorage.DequeueText();
+        LibraryAssert.ExpectedMessage(ExpectedMessage, NotificationToShow.Message());
+        if ExpectedMessage <> InspectionCreatedMsgFragmentTok then
+            AssignToSelfNotification := NotificationToShow;
     end;
 
     [ModalPageHandler]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -54,6 +54,8 @@ codeunit 139964 "Qlty. Tests - Misc."
         Any: Codeunit Any;
         DocumentNo: Text;
         FlagTestNavigateToSourceDocument: Text;
+        CapturedAssignToSelfNotificationMessage: Text;
+        AssignToSelfNotificationReceived: Boolean;
         NotificationDataInspectionRecordIdTok: Label 'InspectionRecordId', Locked = true;
         Bin1Tok: Label 'Bin1';
         Bin2Tok: Label 'Bin2';
@@ -2833,6 +2835,60 @@ codeunit 139964 "Qlty. Tests - Misc."
         LibraryAssert.IsTrue(QltyInspectionHeader.GetPreventAutoAssignment(), 'Inspection should be ignored');
     end;
 
+    [Test]
+    [HandlerFunctions('AssignToSelfNotificationHandler')]
+    procedure ModifyUnassignedInspection_SendsAssignToSelfNotification()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        Location: Record Location;
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
+        LibraryInventory: Codeunit "Library - Inventory";
+    begin
+        // [SCENARIO] Modifying an unassigned Quality Inspection sends the "assign to yourself" notification
+        // instead of silently auto-assigning the current user. Regression coverage for
+        // Qlty. Permission Mgmt. GetShouldAutoAssign hardcoding ShouldPrompt := false, which made
+        // the OnModify trigger always call AssignToSelf and never reach the notification path.
+
+        // [GIVEN] Quality management setup with location, item, and inspection template are configured
+        Initialize();
+
+        QltyInspectionUtility.EnsureSetupExists();
+        LibraryWarehouse.CreateLocation(Location);
+        LibraryInventory.CreateItem(Item);
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 1);
+        QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Purchase Line", QltyInspectionGenRule);
+
+        // [GIVEN] A quality inspection is created from a purchase line for an untracked item
+        QltyPurOrderGenerator.CreateInspectionFromPurchaseWithUntrackedItem(Location, 100, PurchaseHeader, PurchaseLine, QltyInspectionHeader);
+        QltyInspectionGenRule.Delete();
+
+        // [GIVEN] The inspection has no Assigned User ID (bypass OnModify to reset the state, then re-fetch so xRec matches)
+        QltyInspectionHeader."Assigned User ID" := '';
+        QltyInspectionHeader.Modify(false);
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Precondition: the inspection must start unassigned');
+
+        // [WHEN] A user-modifiable field is changed and the inspection is modified (which runs OnModify)
+        AssignToSelfNotificationReceived := false;
+        CapturedAssignToSelfNotificationMessage := '';
+        QltyInspectionHeader.Validate(Description, 'x');
+        QltyInspectionHeader.Modify(true);
+
+        // [THEN] The "assign to yourself" notification was sent instead of the current user being silently assigned
+        LibraryAssert.IsTrue(AssignToSelfNotificationReceived, 'The AssignToSelf notification should have been sent when modifying an unassigned inspection');
+        LibraryAssert.IsTrue(StrPos(CapturedAssignToSelfNotificationMessage, QltyInspectionHeader."No.") > 0, 'The notification message should reference the inspection number');
+
+        // [THEN] The Assigned User ID remained blank because the user was prompted (not silently auto-assigned)
+        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
+        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'The inspection should not be silently auto-assigned when the notification prompt is available');
+    end;
+
     local procedure Initialize()
     begin
         if IsInitialized then
@@ -2864,6 +2920,13 @@ codeunit 139964 "Qlty. Tests - Misc."
     [MessageHandler]
     procedure MessageHandler(MessageText: Text)
     begin
+    end;
+
+    [SendNotificationHandler]
+    procedure AssignToSelfNotificationHandler(var NotificationToShow: Notification): Boolean
+    begin
+        AssignToSelfNotificationReceived := true;
+        CapturedAssignToSelfNotificationMessage := NotificationToShow.Message();
     end;
 
     [ModalPageHandler]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsMisc.Codeunit.al
@@ -59,8 +59,9 @@ codeunit 139964 "Qlty. Tests - Misc."
         NotificationDataInspectionRecordIdTok: Label 'InspectionRecordId', Locked = true;
         Bin1Tok: Label 'Bin1';
         Bin2Tok: Label 'Bin2';
-        WarehouseEntryTypeBlockedErr: Label '"%1" warehouse transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
-        EntryTypeBlockedErr: Label '"%1" transaction is not allowed for item %2 with tracking %3 because quality inspection %4 has result %5, which is configured to block this transaction.', Comment = '%1=entry type being blocked, %2=item, %3=combined package tracking details of Lot No., Serial No. and Package No., %4=quality inspection, %5=result';
+        WarehouseEntryTypeBlockedErr: Label 'This warehouse transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5 %6 %7, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=Lot No., %6=Serial No., %7=Package No.';
+        EntryTypeBlockedErr: Label 'This transaction was blocked because the quality inspection %1 has the result of %2 for item %4 with tracking %5, which is configured to disallow the transaction "%3". You can change whether this transaction is allowed by navigating to Quality Inspection Results.', Comment = '%1=quality inspection, %2=result, %3=entry type being blocked, %4=item, %5=combined package tracking details of Lot No., Serial No. and Package No.';
+        InspectionCreatedMsgFragmentTok: Label 'has been created', Locked = true;
         YouHaveAlteredDoYouWantToAutoAssignQst: Label 'You have altered inspection %1, would you like to assign it to yourself?', Comment = '%1=the inspection number';
         UnableToSetTableValueFieldNotFoundErr: Label 'Unable to set a value because the field [%1] in table [%2] was not found.', Comment = '%1=the field name, %2=the table name';
         NotificationDataRelatedRecordIdTok: Label 'RelatedRecordId', Locked = true;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
@@ -93,6 +93,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         CannotBeRemovedExistingInspectionErr: Label 'This result cannot be removed because it is being used actively on at least one existing Quality Inspection. If you no longer want to use this result consider changing the description, or consider changing the visibility not to be promoted. You can also change the "Copy" setting on the result.';
         TestAddedExactlyOnceErr: Label 'Test %1 should be added exactly once.', Comment = '%1 = quality test code';
         AssignToSelfQstFragmentTok: Label 'would you like to assign it to yourself', Locked = true;
+        AssignToSelfNotification: Notification;
         AssignToSelfNotificationSeen: Boolean;
         IsInitialized: Boolean;
 
@@ -1639,6 +1640,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
     end;
 
     [Test]
+    [HandlerFunctions('AssignToSelfNotificationHandler')]
     procedure Table_InspectionAssignSelfOnModify()
     var
         Location: Record Location;
@@ -1650,7 +1652,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
         LibraryWarehouse: Codeunit "Library - Warehouse";
     begin
-        // [SCENARIO] Inspection is automatically assigned to current user on modification
+        // [SCENARIO] Modifying an unassigned inspection prompts the current user, who accepts the assignment
 
         Initialize();
 
@@ -1668,12 +1670,18 @@ codeunit 139967 "Qlty. Tests - Test Table"
 
         // [GIVEN] Inspection has no assigned user initially
         LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Should not have assigned user.');
+        Clear(AssignToSelfNotification);
+        AssignToSelfNotificationSeen := false;
 
         // [WHEN] Inspection is modified by changing source quantity
         QltyInspectionHeader."Source Quantity (Base)" := 99;
         QltyInspectionHeader.Modify(true);
 
-        // [THEN] Inspection is automatically assigned to current user
+        // [WHEN] The user accepts the assign-to-self notification
+        LibraryAssert.IsTrue(AssignToSelfNotificationSeen, 'The assign-to-self notification should have been sent.');
+        QltyInspectionUtility.HandleNotificationActionAssignToSelf(AssignToSelfNotification);
+
+        // [THEN] Inspection is assigned to current user
         QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
         LibraryAssert.AreEqual(UserId(), QltyInspectionHeader."Assigned User ID", 'Should be assigned to current user.');
     end;
@@ -4686,8 +4694,10 @@ codeunit 139967 "Qlty. Tests - Test Table"
     [SendNotificationHandler]
     procedure AssignToSelfNotificationHandler(var NotificationToShow: Notification): Boolean
     begin
-        if StrPos(NotificationToShow.Message(), AssignToSelfQstFragmentTok) > 0 then
+        if StrPos(NotificationToShow.Message(), AssignToSelfQstFragmentTok) > 0 then begin
+            AssignToSelfNotification := NotificationToShow;
             AssignToSelfNotificationSeen := true;
+        end;
     end;
 
     [ModalPageHandler]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
@@ -92,6 +92,8 @@ codeunit 139967 "Qlty. Tests - Test Table"
         ResultCode2Tok: Label '"|\/?&*()';
         CannotBeRemovedExistingInspectionErr: Label 'This result cannot be removed because it is being used actively on at least one existing Quality Inspection. If you no longer want to use this result consider changing the description, or consider changing the visibility not to be promoted. You can also change the "Copy" setting on the result.';
         TestAddedExactlyOnceErr: Label 'Test %1 should be added exactly once.', Comment = '%1 = quality test code';
+        AssignToSelfQstFragmentTok: Label 'would you like to assign it to yourself', Locked = true;
+        AssignToSelfNotificationSeen: Boolean;
         IsInitialized: Boolean;
 
     [Test]
@@ -1637,6 +1639,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
     end;
 
     [Test]
+    [HandlerFunctions('AssignToSelfNotificationHandler')]
     procedure Table_InspectionAssignSelfOnModify()
     var
         Location: Record Location;
@@ -1648,7 +1651,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
         LibraryWarehouse: Codeunit "Library - Warehouse";
     begin
-        // [SCENARIO] Inspection is automatically assigned to current user on modification
+        // [SCENARIO] Modifying an unassigned inspection prompts the current user to assign it to themselves instead of assigning it silently
 
         Initialize();
 
@@ -1666,14 +1669,18 @@ codeunit 139967 "Qlty. Tests - Test Table"
 
         // [GIVEN] Inspection has no assigned user initially
         LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Should not have assigned user.');
+        AssignToSelfNotificationSeen := false;
 
         // [WHEN] Inspection is modified by changing source quantity
         QltyInspectionHeader."Source Quantity (Base)" := 99;
         QltyInspectionHeader.Modify(true);
 
-        // [THEN] Inspection is automatically assigned to current user
+        // [THEN] The current user is notified and asked whether the inspection should be assigned to them
+        LibraryAssert.IsTrue(AssignToSelfNotificationSeen, 'Should be asked to assign the inspection to the current user.');
+
+        // [THEN] The inspection stays unassigned until the notification action is used
         QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
-        LibraryAssert.AreEqual(UserId(), QltyInspectionHeader."Assigned User ID", 'Should be assigned to current user.');
+        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Should not be assigned to current user without confirming the notification.');
     end;
 
     [Test]
@@ -4679,6 +4686,13 @@ codeunit 139967 "Qlty. Tests - Test Table"
     [MessageHandler]
     procedure MessageHandler(MessageText: Text)
     begin
+    end;
+
+    [SendNotificationHandler]
+    procedure AssignToSelfNotificationHandler(var NotificationToShow: Notification): Boolean
+    begin
+        if StrPos(NotificationToShow.Message(), AssignToSelfQstFragmentTok) > 0 then
+            AssignToSelfNotificationSeen := true;
     end;
 
     [ModalPageHandler]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
@@ -1639,7 +1639,6 @@ codeunit 139967 "Qlty. Tests - Test Table"
     end;
 
     [Test]
-    [HandlerFunctions('AssignToSelfNotificationHandler')]
     procedure Table_InspectionAssignSelfOnModify()
     var
         Location: Record Location;
@@ -1651,7 +1650,7 @@ codeunit 139967 "Qlty. Tests - Test Table"
         QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
         LibraryWarehouse: Codeunit "Library - Warehouse";
     begin
-        // [SCENARIO] Modifying an unassigned inspection prompts the current user to assign it to themselves instead of assigning it silently
+        // [SCENARIO] Inspection is automatically assigned to current user on modification
 
         Initialize();
 
@@ -1669,18 +1668,14 @@ codeunit 139967 "Qlty. Tests - Test Table"
 
         // [GIVEN] Inspection has no assigned user initially
         LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Should not have assigned user.');
-        AssignToSelfNotificationSeen := false;
 
         // [WHEN] Inspection is modified by changing source quantity
         QltyInspectionHeader."Source Quantity (Base)" := 99;
         QltyInspectionHeader.Modify(true);
 
-        // [THEN] The current user is notified and asked whether the inspection should be assigned to them
-        LibraryAssert.IsTrue(AssignToSelfNotificationSeen, 'Should be asked to assign the inspection to the current user.');
-
-        // [THEN] The inspection stays unassigned until the notification action is used
+        // [THEN] Inspection is automatically assigned to current user
         QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
-        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Should not be assigned to current user without confirming the notification.');
+        LibraryAssert.AreEqual(UserId(), QltyInspectionHeader."Assigned User ID", 'Should be assigned to current user.');
     end;
 
     [Test]

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsTestTable.Codeunit.al
@@ -92,9 +92,6 @@ codeunit 139967 "Qlty. Tests - Test Table"
         ResultCode2Tok: Label '"|\/?&*()';
         CannotBeRemovedExistingInspectionErr: Label 'This result cannot be removed because it is being used actively on at least one existing Quality Inspection. If you no longer want to use this result consider changing the description, or consider changing the visibility not to be promoted. You can also change the "Copy" setting on the result.';
         TestAddedExactlyOnceErr: Label 'Test %1 should be added exactly once.', Comment = '%1 = quality test code';
-        AssignToSelfQstFragmentTok: Label 'would you like to assign it to yourself', Locked = true;
-        AssignToSelfNotification: Notification;
-        AssignToSelfNotificationSeen: Boolean;
         IsInitialized: Boolean;
 
     [Test]
@@ -1637,53 +1634,6 @@ codeunit 139967 "Qlty. Tests - Test Table"
 
         // [THEN] Error is thrown indicating insufficient reserved or posted package quantity
         LibraryAssert.ExpectedError(StrSubstNo(ItemInsufficientPostedOrUnpostedErr, QltyInspectionHeader."Source Item No.", PackageTok, QltyInspectionHeader."Source Package No.", 0));
-    end;
-
-    [Test]
-    [HandlerFunctions('AssignToSelfNotificationHandler')]
-    procedure Table_InspectionAssignSelfOnModify()
-    var
-        Location: Record Location;
-        ConfigurationToLoadQltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
-        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
-        QltyInspectionHeader: Record "Qlty. Inspection Header";
-        PurchaseHeader: Record "Purchase Header";
-        PurchaseLine: Record "Purchase Line";
-        QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
-        LibraryWarehouse: Codeunit "Library - Warehouse";
-    begin
-        // [SCENARIO] Modifying an unassigned inspection prompts the current user, who accepts the assignment
-
-        Initialize();
-
-        // [GIVEN] Quality management setup is configured
-        QltyInspectionUtility.EnsureSetupExists();
-
-        // [GIVEN] A generation rule is created for purchase lines
-        QltyInspectionUtility.CreatePrioritizedRule(ConfigurationToLoadQltyInspectionTemplateHdr, Database::"Purchase Line", QltyInspectionGenRule);
-
-        // [GIVEN] A location is created
-        LibraryWarehouse.CreateLocation(Location);
-
-        // [GIVEN] An inspection is created from purchase with no assigned user
-        QltyPurOrderGenerator.CreateInspectionFromPurchaseWithUntrackedItem(Location, 100, PurchaseHeader, PurchaseLine, QltyInspectionHeader);
-
-        // [GIVEN] Inspection has no assigned user initially
-        LibraryAssert.AreEqual('', QltyInspectionHeader."Assigned User ID", 'Should not have assigned user.');
-        Clear(AssignToSelfNotification);
-        AssignToSelfNotificationSeen := false;
-
-        // [WHEN] Inspection is modified by changing source quantity
-        QltyInspectionHeader."Source Quantity (Base)" := 99;
-        QltyInspectionHeader.Modify(true);
-
-        // [WHEN] The user accepts the assign-to-self notification
-        LibraryAssert.IsTrue(AssignToSelfNotificationSeen, 'The assign-to-self notification should have been sent.');
-        QltyInspectionUtility.HandleNotificationActionAssignToSelf(AssignToSelfNotification);
-
-        // [THEN] Inspection is assigned to current user
-        QltyInspectionHeader.Get(QltyInspectionHeader."No.", QltyInspectionHeader."Re-inspection No.");
-        LibraryAssert.AreEqual(UserId(), QltyInspectionHeader."Assigned User ID", 'Should be assigned to current user.');
     end;
 
     [Test]
@@ -4689,15 +4639,6 @@ codeunit 139967 "Qlty. Tests - Test Table"
     [MessageHandler]
     procedure MessageHandler(MessageText: Text)
     begin
-    end;
-
-    [SendNotificationHandler]
-    procedure AssignToSelfNotificationHandler(var NotificationToShow: Notification): Boolean
-    begin
-        if StrPos(NotificationToShow.Message(), AssignToSelfQstFragmentTok) > 0 then begin
-            AssignToSelfNotification := NotificationToShow;
-            AssignToSelfNotificationSeen := true;
-        end;
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
## What & why

Fixes:
1. Resolved a table relation error that occurred when manually selecting an assigned user.
2. Enabled a self-assignment notification prompt when modifying a quality inspection that is not currently assigned to any user.

## Linked work

Fixes [AB#645120](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645120)

