### PR TITLE
[Extensibility Request] issue 30419: add time sheet filtering events

### DIFF
--- a/src/Layers/W1/BaseApp/Projects/TimeSheet/SuggestJobJnlLines.Report.al
+++ b/src/Layers/W1/BaseApp/Projects/TimeSheet/SuggestJobJnlLines.Report.al
@@ -206,6 +206,7 @@ report 952 "Suggest Job Jnl. Lines"
             TimeSheetHeader.SetFilter("Ending Date", '%1..', TimeSheetHeader.GetRangeMin("Ending Date"));
         end;
 
+        OnFillTimeSheetLineBufferOnAfterFilterTimeSheetHeader(TimeSheetHeader);
         if TimeSheetHeader.FindSet() then
             repeat
                 TimeSheetLine.SetRange("Time Sheet No.", TimeSheetHeader."No.");
@@ -216,6 +217,7 @@ report 952 "Suggest Job Jnl. Lines"
                 if JobTaskNoFilter <> '' then
                     TimeSheetLine.SetFilter("Job Task No.", JobTaskNoFilter);
                 TimeSheetLine.SetRange(Posted, false);
+                OnFillTimeSheetLineBufferOnAfterFilterTimeSheetLine(TimeSheetHeader, TimeSheetLine);
                 if TimeSheetLine.FindSet() then
                     repeat
                         TempTimeSheetLine := TimeSheetLine;
@@ -247,6 +249,16 @@ report 952 "Suggest Job Jnl. Lines"
     end;
 
     [IntegrationEvent(false, false)]
+    local procedure OnFillTimeSheetLineBufferOnAfterFilterTimeSheetHeader(var TimeSheetHeader: Record "Time Sheet Header")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnFillTimeSheetLineBufferOnAfterFilterTimeSheetLine(TimeSheetHeader: Record "Time Sheet Header"; var TimeSheetLine: Record "Time Sheet Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
     local procedure OnBeforeInsertTempTimeSheetLine(JobJournalLine: Record "Job Journal Line"; TimeSheetHeader: Record "Time Sheet Header"; var TempTimeSheetLine: Record "Time Sheet Line" temporary; var SkipLine: Boolean)
     begin
     end;
@@ -266,4 +278,3 @@ report 952 "Suggest Job Jnl. Lines"
     begin
     end;
 }
-


### PR DESCRIPTION
## Summary
Extensions need to narrow the time sheet headers and lines processed by report 952 before records are read. This PR adds filter-stage integration events so subscribers can apply their own criteria while preserving the report's standard processing.

Source issue repository: microsoft/AlAppExtensions; issue number: 30419

## Changes Made
- `FillTimeSheetLineBuffer` - added events after standard header and line filters are applied, allowing extensions to refine each record set before `FindSet`.

Fixes [AB#646908](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646908)





