### PR TITLE
Move SOA item search and attachment extraction to GPT-5.5 deployments

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAAttachmentMLLM.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAAttachmentMLLM.Codeunit.al
@@ -117,7 +117,7 @@ codeunit 4421 "SOA Attachment MLLM"
         end;
         Prompt := SecretText.SecretStrSubstNo(PromptTemplate, SecurityPrompt);
 
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41MiniPreview());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT55ChatPreview());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Sales Order Agent");
 
         AOAIChatCompletionParams.SetTemperature(0);

--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOABroaderItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOABroaderItemSearch.Codeunit.al
@@ -53,7 +53,7 @@ codeunit 4596 "SOA Broader Item Search"
         CompletionAnswer: Text;
     begin
         // Generate OpenAI Completion
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT55ChatLatest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Sales Order Agent");
 
         AOAIChatCompletionParams.SetMaxTokens(MaxTokens());

--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSelector.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSelector.Codeunit.al
@@ -83,7 +83,7 @@ codeunit 4417 "SOA Item Selector"
         end;
 
         // Configure Azure OpenAI
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT41Latest());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT55ChatLatest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Sales Order Agent");
 
         // Set parameters


### PR DESCRIPTION
#### Summary

Moves three Sales Order Agent AI calls to the GPT-5.5 chat deployments:

| Purpose | File | Before | After |
|---|---|---|---|
| Attachment content extraction (multimodal -> canonical text) | `SOAAttachmentMLLM.Codeunit.al` | `GetGPT41MiniPreview()` | `GetGPT55ChatPreview()` |
| Broader item search / keyword expansion (function-calling) | `SOABroaderItemSearch.Codeunit.al` | `GetGPT41Latest()` | `GetGPT55ChatLatest()` |
| Item selection / best-match ranking | `SOAItemSelector.Codeunit.al` | `GetGPT41Latest()` | `GetGPT55ChatLatest()` |

The remaining SOA AI calls (message and attachment relevance checks in `SOAAnnotation`, mail template validation and signature handling in `SOAOutputMessageSetup`) are unchanged and stay on `GetGPT41Latest()`.

#### Notes

- `gpt-55-chat-preview` is on the multimodal allow-list in `AOAIChatMessagesImpl` (`AddFilePart` validation), so the attachment extraction path continues to be able to send file parts.
- Prompts, schema resources, temperature, max tokens, and JSON mode settings are unchanged - this is a deployment swap only.

#### Work Item

Fixes [AB#641231](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641231)

