### PR TITLE
[Main] -Drop shipment undo receipt fails for service and non-inventory items.

### DIFF
--- a/src/Layers/RU/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
@@ -248,13 +248,11 @@ codeunit 5815 "Undo Sales Shipment Line"
 
         ItemApplicationEntry.SetBaseLoadFields();
         ItemApplicationEntry.SetRange("Item Ledger Entry No.", ItemLedgerEntry."Entry No.");
-        ItemApplicationEntry.SetRange("Cost Application", true);
         ItemApplicationEntry.SetRange("Inbound Item Entry No.", ItemLedgerEntry."Applies-to Entry");
         ItemApplicationEntry.SetRange("Outbound Item Entry No.", ItemLedgerEntry."Entry No.");
         OnUnApplyDropShipmentOnBeforeFindItemApplicationEntry(ItemApplicationEntry, ItemLedgerEntry);
-        ItemApplicationEntry.FindFirst();
-
-        ItemJnlPostLine.UnApplyDropShipment(ItemApplicationEntry, RelevantUndoShipmentLedgerEntryNo);
+        if ItemApplicationEntry.FindFirst() then
+            ItemJnlPostLine.UnApplyDropShipment(ItemApplicationEntry, RelevantUndoShipmentLedgerEntryNo);
     end;
 
     local procedure FindRelevantNewSalesShptLedgerEntryNo(SalesShptLine: Record "Sales Shipment Line"; NewSalesShptLine: Record "Sales Shipment Line"; ItemLedgerEntry: Record "Item Ledger Entry"): Integer

--- a/src/Layers/W1/BaseApp/Purchases/History/UndoPurchaseReceiptLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/UndoPurchaseReceiptLine.Codeunit.al
@@ -71,6 +71,7 @@ codeunit 5813 "Undo Purchase Receipt Line"
 #pragma warning restore AA0074
         NoLinesToReverseErr: Label 'No lines with a quantity available for reversal were found among the selected lines. Select a line with a quantity that has not already been reversed, and try again.';
         AlreadyReversedErr: Label 'This receipt has already been reversed.';
+        AmbiguousDropShipmentLinkErr: Label 'The posted sales shipment line for drop shipment line %1 in posted purchase receipt %2 cannot be identified, because sales order %3 has more than one matching posted shipment line. Undo the shipment from the posted sales shipment instead.', Comment = '%1 - Purch. Rcpt. Line No., %2 - Purch. Rcpt. Header No., %3 - Sales Order No.';
 
     procedure SetHideDialog(NewHideDialog: Boolean)
     begin
@@ -626,12 +627,37 @@ codeunit 5813 "Undo Purchase Receipt Line"
                 SalesShipmentLine.SetRange("Document No.", OutboundItemLedgerEntry."Document No.");
                 SalesShipmentLine.SetRange("Line No.", OutboundItemLedgerEntry."Document Line No.");
 
-                if (OutboundItemLedgerEntry."Lot No." = '') and (OutboundItemLedgerEntry."Serial No." = '') then
+                if (OutboundItemLedgerEntry."Lot No." = '') and (OutboundItemLedgerEntry."Serial No." = '') then begin
                     SalesShipmentLine.SetRange("Item Shpt. Entry No.", OutboundItemLedgerEntry."Entry No.");
+                    if SalesShipmentLine.FindFirst() then
+                        exit;
 
-                SalesShipmentLine.FindFirst();
+                    SalesShipmentLine.SetRange("Item Shpt. Entry No.");
+                end;
+
+                if SalesShipmentLine.FindFirst() then
+                    exit;
             end;
         end;
+
+        FindSalesShipmentLineByDropShipmentLink(SalesShipmentLine, PurchRcptLine);
+    end;
+
+    local procedure FindSalesShipmentLineByDropShipmentLink(var SalesShipLine: Record "Sales Shipment Line"; PurchReceiptLine: Record "Purch. Rcpt. Line")
+    begin
+        SalesShipLine.Reset();
+        SalesShipLine.SetRange("Order No.", PurchReceiptLine."Sales Order No.");
+        SalesShipLine.SetRange("Order Line No.", PurchReceiptLine."Sales Order Line No.");
+        SalesShipLine.SetRange("Purchase Order No.", PurchReceiptLine."Order No.");
+        SalesShipLine.SetRange("Purch. Order Line No.", PurchReceiptLine."Order Line No.");
+        SalesShipLine.SetRange("Drop Shipment", true);
+        SalesShipLine.SetRange(Correction, false);
+        SalesShipLine.SetRange(Quantity, PurchReceiptLine.Quantity);
+
+        if SalesShipLine.Count() > 1 then
+            Error(AmbiguousDropShipmentLinkErr, PurchReceiptLine."Line No.", PurchReceiptLine."Document No.", PurchReceiptLine."Sales Order No.");
+
+        SalesShipLine.FindFirst();
     end;
 
     procedure IsUndoSalesShipmentLineForDropShipment(NewUndoSalesShptLineExists: Boolean)

--- a/src/Layers/W1/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/UndoSalesShipmentLine.Codeunit.al
@@ -248,13 +248,11 @@ codeunit 5815 "Undo Sales Shipment Line"
 
         ItemApplicationEntry.SetBaseLoadFields();
         ItemApplicationEntry.SetRange("Item Ledger Entry No.", ItemLedgerEntry."Entry No.");
-        ItemApplicationEntry.SetRange("Cost Application", true);
         ItemApplicationEntry.SetRange("Inbound Item Entry No.", ItemLedgerEntry."Applies-to Entry");
         ItemApplicationEntry.SetRange("Outbound Item Entry No.", ItemLedgerEntry."Entry No.");
         OnUnApplyDropShipmentOnBeforeFindItemApplicationEntry(ItemApplicationEntry, ItemLedgerEntry);
-        ItemApplicationEntry.FindFirst();
-
-        ItemJnlPostLine.UnApplyDropShipment(ItemApplicationEntry, RelevantUndoShipmentLedgerEntryNo);
+        if ItemApplicationEntry.FindFirst() then
+            ItemJnlPostLine.UnApplyDropShipment(ItemApplicationEntry, RelevantUndoShipmentLedgerEntryNo);
     end;
 
     local procedure FindRelevantNewSalesShptLedgerEntryNo(SalesShptLine: Record "Sales Shipment Line"; NewSalesShptLine: Record "Sales Shipment Line"; ItemLedgerEntry: Record "Item Ledger Entry"): Integer

--- a/src/Layers/W1/Tests/SCM-Reservation/SCMRTAMItemTrackingII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Reservation/SCMRTAMItemTrackingII.Codeunit.al
@@ -4375,6 +4375,102 @@ codeunit 137059 "SCM RTAM Item Tracking-II"
         PurchaseLine.TestField("Qty. to Receive", RegularQty);
     end;
 
+    [Test]
+    [HandlerFunctions('SalesListPageHandler,ConfirmHandler')]
+    procedure QuantityMustBeRestoredWhenUndoDropShipmentSalesShipmentIsExecutedForNonInventoryItem()
+    var
+        Item: Record Item;
+        SalesLine: Record "Sales Line";
+        SalesHeader: Record "Sales Header";
+        PurchaseHeader: Record "Purchase Header";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO 646367] Verify that quantity must be restored when Undo Drop Shipment Sales Shipment is executed for a Non-Inventory item.
+        Initialize();
+
+        // [GIVEN] Generate a random quantity.
+        Quantity := LibraryRandom.RandInt(50);
+
+        // [GIVEN] Create a Non-Inventory item.
+        CreateNonInventoriableItemWithVendorNo(Item, Item.Type::"Non-Inventory", Quantity);
+
+        // [GIVEN] Create a sales order with drop shipment.
+        CreateSalesOrderWithPurchasingCode(SalesHeader, SalesLine, Item."No.", '', Quantity, false);
+
+        // [GIVEN] Create a purchase order for drop shipment.
+        CreatePurchaseHeaderAndGetDropShipment(PurchaseHeader, SalesHeader."Sell-to Customer No.");
+
+        // [GIVEN] Post Sales Document with shipment only.
+        PostSalesDocument(SalesHeader."Document Type", SalesHeader."No.", true, false);
+
+        // [GIVEN] Verify that the shipment is posted and quantity shipped.
+        VerifyQuantityForDropShipmentInSalesLine(SalesHeader, Item."No.", Quantity, 0);
+
+        // [GIVEN] Verify that the Receipt is posted and quantity received.
+        VerifyQuantityForDropShipmentInPurchaseLine(PurchaseHeader, Item."No.", Quantity, 0);
+
+        // [WHEN] Undo Sales Shipment.
+        UndoSalesShipment(SalesHeader."No.");
+
+        // [THEN] Verify that Qty. to Ship is restored and Quantity Shipped is Zero.
+        VerifyQuantityForDropShipmentInSalesLine(SalesHeader, Item."No.", 0, Quantity);
+
+        // [THEN] Verify that Qty. to Receive is restored and Quantity Received is Zero.
+        VerifyQuantityForDropShipmentInPurchaseLine(PurchaseHeader, Item."No.", 0, Quantity);
+
+        // [THEN] Verify that the posted shipment and the linked posted receipt are both corrected.
+        VerifyUndoneSalesShipmentLine(SalesHeader."No.", Item."No.", Quantity);
+        VerifyUndonePurchRcptLine(PurchaseHeader."No.", Item."No.", Quantity);
+    end;
+
+    [Test]
+    [HandlerFunctions('SalesListPageHandler,ConfirmHandler')]
+    procedure QuantityMustBeRestoredWhenUndoDropShipmentPurchRcptIsExecutedForServiceItem()
+    var
+        Item: Record Item;
+        SalesLine: Record "Sales Line";
+        SalesHeader: Record "Sales Header";
+        PurchaseHeader: Record "Purchase Header";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO 646367] Verify that quantity must be restored when Undo Drop Shipment Purchase Receipt is executed for a Service item.
+        Initialize();
+
+        // [GIVEN] Generate a random quantity.
+        Quantity := LibraryRandom.RandInt(50);
+
+        // [GIVEN] Create a Service item.
+        CreateNonInventoriableItemWithVendorNo(Item, Item.Type::Service, Quantity);
+
+        // [GIVEN] Create a sales order with drop shipment.
+        CreateSalesOrderWithPurchasingCode(SalesHeader, SalesLine, Item."No.", '', Quantity, false);
+
+        // [GIVEN] Create a purchase order for drop shipment.
+        CreatePurchaseHeaderAndGetDropShipment(PurchaseHeader, SalesHeader."Sell-to Customer No.");
+
+        // [GIVEN] Post Sales Document with shipment only.
+        PostSalesDocument(SalesHeader."Document Type", SalesHeader."No.", true, false);
+
+        // [GIVEN] Verify that the shipment is posted and quantity shipped.
+        VerifyQuantityForDropShipmentInSalesLine(SalesHeader, Item."No.", Quantity, 0);
+
+        // [GIVEN] Verify that the Receipt is posted and quantity received.
+        VerifyQuantityForDropShipmentInPurchaseLine(PurchaseHeader, Item."No.", Quantity, 0);
+
+        // [WHEN] Undo Purchase Receipt.
+        UndoPurchaseReceipt(PurchaseHeader."No.");
+
+        // [THEN] Verify that Qty. to Ship is restored and Quantity Shipped is Zero.
+        VerifyQuantityForDropShipmentInSalesLine(SalesHeader, Item."No.", 0, Quantity);
+
+        // [THEN] Verify that Qty. to Receive is restored and Quantity Received is Zero.
+        VerifyQuantityForDropShipmentInPurchaseLine(PurchaseHeader, Item."No.", 0, Quantity);
+
+        // [THEN] Verify that the posted receipt and the linked posted shipment are both corrected.
+        VerifyUndonePurchRcptLine(PurchaseHeader."No.", Item."No.", Quantity);
+        VerifyUndoneSalesShipmentLine(SalesHeader."No.", Item."No.", Quantity);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -6211,6 +6307,46 @@ codeunit 137059 "SCM RTAM Item Tracking-II"
             CostActualAmount,
             ItemLedgEntry."Cost Amount (Actual)",
             StrSubstNo(ValueMustBeEqualErr, ItemLedgEntry.FieldCaption("Cost Amount (Actual)"), CostActualAmount, ItemLedgEntry.TableCaption()));
+    end;
+
+    local procedure CreateNonInventoriableItemWithVendorNo(var Item: Record Item; ItemType: Enum "Item Type"; UnitCost: Decimal)
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate(Type, ItemType);
+        Item.Validate("Vendor No.", LibraryPurchase.CreateVendorNo());
+        Item.Validate("Unit Price", LibraryRandom.RandDec(10, 2));
+        Item.Validate("Unit Cost", UnitCost);
+        Item.Validate("Last Direct Cost", Item."Unit Cost");
+        Item.Modify(true);
+    end;
+
+    local procedure VerifyUndoneSalesShipmentLine(SalesOrderNo: Code[20]; ItemNo: Code[20]; ExpectedQuantity: Decimal)
+    var
+        SalesShipmentHeader: Record "Sales Shipment Header";
+        SalesShipmentLine: Record "Sales Shipment Line";
+    begin
+        FindSalesShipmentHeader(SalesShipmentHeader, SalesOrderNo);
+        SalesShipmentLine.SetRange("Document No.", SalesShipmentHeader."No.");
+        SalesShipmentLine.SetRange(Type, SalesShipmentLine.Type::Item);
+        SalesShipmentLine.SetRange("No.", ItemNo);
+        SalesShipmentLine.SetRange(Correction, true);
+        SalesShipmentLine.SetRange(Quantity, -ExpectedQuantity);
+        Assert.RecordIsNotEmpty(SalesShipmentLine);
+    end;
+
+    local procedure VerifyUndonePurchRcptLine(PurchOrderNo: Code[20]; ItemNo: Code[20]; ExpectedQuantity: Decimal)
+    var
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+    begin
+        PurchRcptHeader.SetRange("Order No.", PurchOrderNo);
+        PurchRcptHeader.FindFirst();
+        PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
+        PurchRcptLine.SetRange(Type, PurchRcptLine.Type::Item);
+        PurchRcptLine.SetRange("No.", ItemNo);
+        PurchRcptLine.SetRange(Correction, true);
+        PurchRcptLine.SetRange(Quantity, -ExpectedQuantity);
+        Assert.RecordIsNotEmpty(PurchRcptLine);
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
[Bug 646535](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646535): [master] [ALL-E] Drop shipment undo receipt fails for service and non-inventory items.

[AB#646535](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646535)


Issue: When a Drop Shipment is posted for a Service or Non-Inventory item, both Undo Shipment on the Posted Sales Shipment and Undo Receipt on the Posted Purchase Receipt fail with There is no Item Application Entry within the filter. Filters: Item Ledger Entry No.: 888, Inbound Item Entry No.: 887, Outbound Item Entry No.: 888, Cost Application: Yes. Because Undo Receipt internally calls Undo Shipment for the linked drop shipment line, one defect blocks both actions and the linked document can never be reversed.

Cause: Two problems. (1) In UnApplyDropShipment in UndoSalesShipmentLine.Codeunit.al (CU 5815), the lookup filtered on ItemApplicationEntry.SetRange("Cost Application", true) and then called FindFirst() unguarded. Non-inventoriable items post a drop shipment application entry that carries no cost, so the "Cost Application" field is not set and the record is filtered out — even though the callee ItemJnlPostLine.UnApplyDropShipment never reads that field. (2) In FindSalesShipmentLine in UndoPurchaseReceiptLine.Codeunit.al (CU 5813), the linked Sales Shipment Line was resolved only through Item Ledger / Item Application Entries and ended with an unguarded FindFirst(), which errors for these items because that application link is not always present.

Solution: Removed the "Cost Application" filter in UnApplyDropShipment and guarded the lookup with if ItemApplicationEntry.FindFirst() then, so cost-less drop shipment application entries are unapplied and a missing entry is simply skipped instead of erroring. In FindSalesShipmentLine, the Item Ledger Entry path now exits only on a successful FindFirst(), otherwise it falls back to the new FindSalesShipmentLineByDropShipmentLink, which locates the Sales Shipment Line through the drop shipment document link (Order No./Order Line No./Purchase Order No./Purch. Order Line No. with Drop Shipment = true, Correction = false). The change was propagated to the RU layer copy of CU 5815 via Miapp; CU 5813 has no country overrides.


