### PR TITLE
[Master] - Bug 641309: [Sustainability][Value Chain] Item Reclassification (location move) uses average emissions instead of Specific carbon tracking (lot/serial)

### DIFF
--- a/src/Apps/W1/Sustainability/app/src/Certificate/SustItem.TableExt.al
+++ b/src/Apps/W1/Sustainability/app/src/Certificate/SustItem.TableExt.al
@@ -274,7 +274,7 @@ tableextension 6220 "Sust. Item" extends Item
             trigger OnValidate()
             begin
                 if Rec."Carbon Tracking Method" = Rec."Carbon Tracking Method"::Specific then
-                    WarnIfSpecificCarbonTrackingLacksItemTracking();
+                    ErrorIfSpecificCarbonTrackingLacksItemTracking();
             end;
         }
         modify("Item Tracking Code")
@@ -282,7 +282,7 @@ tableextension 6220 "Sust. Item" extends Item
             trigger OnAfterValidate()
             begin
                 if Rec."Carbon Tracking Method" = Rec."Carbon Tracking Method"::Specific then
-                    WarnIfSpecificCarbonTrackingLacksItemTracking();
+                    ErrorIfSpecificCarbonTrackingLacksItemTracking();
             end;
         }
     }
@@ -290,7 +290,7 @@ tableextension 6220 "Sust. Item" extends Item
     var
         SustainabilitySetup: Record "Sustainability Setup";
         AtLeastOneNonZeroEmissionValueErr: Label '%1, %2, %3 cannot all be zero. Please provide at least one non-zero value.', Comment = '%1, %2 , %3 = Field Caption';
-        SpecificCarbonTrackingRequiresTrackingMsg: Label 'The %1 is set to %2, which requires serial or lot-specific tracking to calculate per-unit emissions. Set up an %3 with serial or lot-specific tracking for this item.', Comment = '%1 = Carbon Tracking Method field caption, %2 = Carbon Tracking Method value (Specific), %3 = Item Tracking Code field caption';
+        SpecificCarbonTrackingRequiresTrackingErr: Label 'The %1 is set to %2, which requires serial or lot-specific tracking to calculate per-unit emissions. Set up an %3 with serial or lot-specific tracking for this item.', Comment = '%1 = Carbon Tracking Method field caption, %2 = Carbon Tracking Method value (Specific), %3 = Item Tracking Code field caption';
 
     local procedure UpdateCertificateInformation()
     var
@@ -313,17 +313,14 @@ tableextension 6220 "Sust. Item" extends Item
                 Rec.FieldCaption("Default N2O Emission"));
     end;
 
-    local procedure WarnIfSpecificCarbonTrackingLacksItemTracking()
+    local procedure ErrorIfSpecificCarbonTrackingLacksItemTracking()
     var
         ItemTrackingCode: Record "Item Tracking Code";
     begin
-        if not GuiAllowed() then
-            exit;
-
         if ItemTrackingCode.Get(Rec."Item Tracking Code") and ItemTrackingCode.IsSpecific() then
             exit;
 
-        Message(SpecificCarbonTrackingRequiresTrackingMsg, Rec.FieldCaption("Carbon Tracking Method"), Rec."Carbon Tracking Method", Rec.FieldCaption("Item Tracking Code"));
+        Error(SpecificCarbonTrackingRequiresTrackingErr, Rec.FieldCaption("Carbon Tracking Method"), Rec."Carbon Tracking Method", Rec.FieldCaption("Item Tracking Code"));
     end;
 
     local procedure UpdateEPRFeeRateInItem()

--- a/src/Apps/W1/Sustainability/app/src/Posting/SustainabilityPostMgt.Codeunit.al
+++ b/src/Apps/W1/Sustainability/app/src/Posting/SustainabilityPostMgt.Codeunit.al
@@ -330,9 +330,44 @@ codeunit 6212 "Sustainability Post Mgt"
     begin
         SustainabilityValueEntry.SetLoadFields("Item Ledger Entry No.", "CO2e Amount (Actual)", "Item Ledger Entry Quantity");
         SustainabilityValueEntry.SetRange("Item Ledger Entry No.", ItemLedgerEntryNo);
+        if SustainabilityValueEntry.IsEmpty() then begin
+            ResolveTransferInCO2e(ItemLedgerEntryNo, CO2eAmount, CO2eQuantity);
+            exit;
+        end;
+
         SustainabilityValueEntry.CalcSums("CO2e Amount (Actual)", "Item Ledger Entry Quantity");
         CO2eAmount += SustainabilityValueEntry."CO2e Amount (Actual)";
         CO2eQuantity += SustainabilityValueEntry."Item Ledger Entry Quantity";
+    end;
+
+    local procedure ResolveTransferInCO2e(ItemLedgerEntryNo: Integer; var CO2eAmount: Decimal; var CO2eQuantity: Decimal)
+    var
+        TransferInILE: Record "Item Ledger Entry";
+        TransferOutILE: Record "Item Ledger Entry";
+        SustainabilityValueEntry: Record "Sustainability Value Entry";
+    begin
+        TransferInILE.SetLoadFields("Entry Type", Quantity, "Item Register No.", "Item No.", "Lot No.", "Serial No.");
+        if not TransferInILE.Get(ItemLedgerEntryNo) then
+            exit;
+
+        if (TransferInILE."Entry Type" <> TransferInILE."Entry Type"::Transfer) or (TransferInILE.Quantity <= 0) then
+            exit;
+
+        // Reclassification transfer-in ILEs lack SVEs; resolve from the transfer-out counterpart.
+        TransferOutILE.SetRange("Item Register No.", TransferInILE."Item Register No.");
+        TransferOutILE.SetRange("Item No.", TransferInILE."Item No.");
+        TransferOutILE.SetRange("Entry Type", TransferOutILE."Entry Type"::Transfer);
+        TransferOutILE.SetFilter(Quantity, '<%1', 0);
+        TransferOutILE.SetRange("Lot No.", TransferInILE."Lot No.");
+        TransferOutILE.SetRange("Serial No.", TransferInILE."Serial No.");
+        if not TransferOutILE.FindFirst() then
+            exit;
+
+        SustainabilityValueEntry.SetLoadFields("Item Ledger Entry No.", "CO2e Amount (Actual)", "Item Ledger Entry Quantity");
+        SustainabilityValueEntry.SetRange("Item Ledger Entry No.", TransferOutILE."Entry No.");
+        SustainabilityValueEntry.CalcSums("CO2e Amount (Actual)", "Item Ledger Entry Quantity");
+        CO2eAmount += SustainabilityValueEntry."CO2e Amount (Actual)";
+        CO2eQuantity += Abs(SustainabilityValueEntry."Item Ledger Entry Quantity");
     end;
 
     procedure GetTotalCO2eAmountFromValueEntry(

--- a/src/Apps/W1/Sustainability/test/src/LibrarySustainability.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/LibrarySustainability.Codeunit.al
@@ -502,13 +502,6 @@ codeunit 148182 "Library - Sustainability"
         SustainabilityDisclaimer.DeleteAll();
     end;
 
-    procedure CreateItemWithSpecificCarbonTrackingMethod(var Item: Record Item)
-    begin
-        LibraryInventory.CreateItem(Item);
-        Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
-        Item.Modify();
-    end;
-
     procedure UpdateCarbonTrackingMethod(var Item: Record Item; CarbonTrackingMethod: Enum "Sust. Carbon Tracking Method")
     begin
         if Item."No." = '' then

--- a/src/Apps/W1/Sustainability/test/src/SustValueEntryTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/SustValueEntryTest.Codeunit.al
@@ -3789,7 +3789,6 @@ codeunit 148190 "Sust. Value Entry Test"
     end;
 
     [Test]
-    [HandlerFunctions('MessageHandler')]
     procedure VerifySpecificCarbonTrackingCalculatesCO2eFromPurchaseLine()
     var
         CountryRegion: Record "Country/Region";
@@ -3830,8 +3829,9 @@ codeunit 148190 "Sust. Value Entry Test"
         PurchaseHeader.Modify();
 
         // [GIVEN] Create a Purchase Line of Item with Specific Carbon Tracking Method
-        LibrarySustainability.CreateItemWithSpecificCarbonTrackingMethod(Item);
-        CreatePurchaseLineWithEmissionValue(PurchaseLine, PurchaseHeader, Item."No.", '', '', LibraryRandom.RandIntInRange(10, 10), EmissionCO2[1], EmissionCH4[1], EmissionN2O[1], AccountCode);
+        LibraryItemTracking.CreateLotItem(Item);
+        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
+        CreatePurchaseLineWithEmissionValue(PurchaseLine, PurchaseHeader, Item."No.", Item."Item Tracking Code", LibraryUtility.GenerateGUID(), LibraryRandom.RandIntInRange(10, 10), EmissionCO2[1], EmissionCH4[1], EmissionN2O[1], AccountCode);
 
         // [GIVEN] Save Expected CO2e
         for Index := 1 to ArrayLen(ExpectedCO2eEmission) do
@@ -4046,7 +4046,8 @@ codeunit 148190 "Sust. Value Entry Test"
         CreateSustainabilityAccount(AccountCode[3], CategoryCode, SubcategoryCode, LibraryRandom.RandIntInRange(3, 3));
 
         // [GIVEN] Update "Default Sust. Account","CO2e per Unit" in Production Item.
-        LibraryInventory.CreateItem(ProdItem);
+        LibraryItemTracking.CreateLotItem(ProdItem);
+        ProdItem.Validate("Replenishment System", ProdItem."Replenishment System"::"Prod. Order");
         LibrarySustainability.UpdateCarbonTrackingMethod(ProdItem, ProdItem."Carbon Tracking Method"::Specific);
         ProdItem.Validate("Default Sust. Account", AccountCode[3]);
         ProdItem.Validate("CO2e per Unit", LibraryRandom.RandInt(100));
@@ -4072,8 +4073,11 @@ codeunit 148190 "Sust. Value Entry Test"
         ProductionOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
         ProductionOrderRoutingLine.FindFirst();
 
-        // [WHEN] Post Production Journal.
+        // [GIVEN] Assign lot tracking to the output prod order line so the production journal can post.
         FindProdOrderLine(ProdOrderLine, ProductionOrder, ProdItem."No.");
+        SetTrackingForProdOrderLine(ProdOrderLine, LibraryUtility.GenerateGUID());
+
+        // [WHEN] Post Production Journal.
         LibraryManufacturing.OpenProductionJournal(ProductionOrder, ProdOrderLine."Line No.");
 
         // [THEN] Verify Sustainability Ledger Entry should not be created When Production Journal is posted.
@@ -4462,56 +4466,6 @@ codeunit 148190 "Sust. Value Entry Test"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandler,MessageHandler')]
-    procedure VerifyUndoSalesShipmentCreatesReversingCO2eForSpecificNonTrackedItem()
-    var
-        CountryRegion: Record "Country/Region";
-        Item: Record Item;
-        SalesHeader: Record "Sales Header";
-        SalesShipmentHeader: Record "Sales Shipment Header";
-        SalesShipmentLine: Record "Sales Shipment Line";
-        ExpectedShipmentCO2e: Decimal;
-        ShipmentNo: Code[20];
-        CategoryCode: Code[20];
-        SubcategoryCode: Code[20];
-        AccountCode: Code[20];
-    begin
-        // [SCENARIO 641487] Undo of a Sales Shipment for a Specific carbon item without item tracking creates a reversing
-        // (positive) Sustainability Value Entry so the item's emissions return to the pre-shipment value.
-        LibrarySustainability.CleanUpBeforeTesting();
-        LibrarySustainability.UpdateValueChainTrackingInSustainabilitySetup(true);
-        CreateSustainabilityAccount(AccountCode, CategoryCode, SubcategoryCode, LibraryRandom.RandInt(10));
-        LibraryERM.CreateCountryRegion(CountryRegion);
-
-        // [GIVEN] A Specific carbon item (no item tracking) with 10 pcs carrying a known CO2e per unit.
-        LibraryInventory.CreateItem(Item);
-        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
-        ExpectedShipmentCO2e := LibraryRandom.RandDecInRange(100, 500, 2);
-        PostPositiveAdjustmentWithCO2e(Item, AccountCode, 10, ExpectedShipmentCO2e * 10);
-
-        // [GIVEN] A Sales Order shipping 1 pc is posted (ship only, not invoiced).
-        CreateAndShipSalesOrderWithItemTracking(SalesHeader, CountryRegion.Code, AccountCode, Item."No.", 1, '', '');
-        SalesShipmentHeader.SetRange("Order No.", SalesHeader."No.");
-        SalesShipmentHeader.FindFirst();
-        ShipmentNo := SalesShipmentHeader."No.";
-
-        // [THEN] The shipment created one negative Sustainability Value Entry.
-        VerifySustainabilityValueEntrySumForDocument(ShipmentNo, -ExpectedShipmentCO2e);
-
-        // [WHEN] The shipment is reversed with Undo Shipment.
-        SalesShipmentLine.SetRange("Document No.", ShipmentNo);
-#pragma warning disable AA0210
-        SalesShipmentLine.SetRange(Type, SalesShipmentLine.Type::Item);
-#pragma warning restore AA0210
-        SalesShipmentLine.FindFirst();
-        LibrarySales.UndoSalesShipmentLine(SalesShipmentLine);
-
-        // [THEN] Reversing Sustainability Value Entries are created and the shipment nets to zero.
-        VerifySustainabilityValueEntryCountForDocument(ShipmentNo, 4);
-        VerifySustainabilityValueEntrySumForDocument(ShipmentNo, 0);
-    end;
-
-    [Test]
     [HandlerFunctions('ConfirmHandler')]
     procedure VerifyUndoPurchaseReceiptCreatesReversingCO2eForNonTrackedItem()
     var
@@ -4839,6 +4793,117 @@ codeunit 148190 "Sust. Value Entry Test"
             LotTotalCO2e[1] + LotTotalCO2e[2],
             SustainabilityValueEntry."CO2e Amount (Actual)",
             StrSubstNo(ValueMustBeEqualErr, SustainabilityValueEntry.FieldCaption("CO2e Amount (Actual)"), LotTotalCO2e[1] + LotTotalCO2e[2], SustainabilityValueEntry.TableCaption()));
+    end;
+
+    [Test]
+    procedure VerifySalesAfterReclassUsesSpecificLotCO2eNotAverage()
+    var
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SustainabilityValueEntry: Record "Sustainability Value Entry";
+        FromLocation: Record Location;
+        ToLocation: Record Location;
+        CountryRegion: Record "Country/Region";
+        ItemJournalBatch: Record "Item Journal Batch";
+        ItemJournalLine: Record "Item Journal Line";
+        ReservationEntry: Record "Reservation Entry";
+        CategoryCode: Code[20];
+        SubcategoryCode: Code[20];
+        AccountCode: Code[20];
+        LotNo: array[2] of Code[50];
+        LotTotalCO2e: array[2] of Decimal;
+        Quantity: Decimal;
+        PostedInvoiceNo: Code[20];
+        ExpectedCO2ePerUnit: Decimal;
+        Index: Integer;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 641309] A sales order from a reclassified location must use the specific lot CO2e, not the item average.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] Enable Value Chain Tracking.
+        LibrarySustainability.UpdateValueChainTrackingInSustainabilitySetup(true);
+
+        // [GIVEN] Create source and destination Locations and a Country/Region.
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(FromLocation);
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(ToLocation);
+        LibraryERM.CreateCountryRegion(CountryRegion);
+
+        // [GIVEN] Create a Sustainability Account.
+        CreateSustainabilityAccount(AccountCode, CategoryCode, SubcategoryCode, LibraryRandom.RandInt(10));
+
+        // [GIVEN] Create a lot-tracked Item with Specific Carbon Tracking Method and a Default Sust. Account.
+        LibraryItemTracking.CreateLotItem(Item);
+        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
+        Item.Validate("Default Sust. Account", AccountCode);
+        Item.Modify();
+
+        // [GIVEN] Post two lots with clearly different CO2e so average differs from specific.
+        Quantity := LibraryRandom.RandIntInRange(10, 10);
+        PostTwoLotsWithSpecificCO2e(Item, FromLocation.Code, AccountCode, Quantity, LotNo, LotTotalCO2e);
+
+        // [GIVEN] Reclassify both lots (full quantity each) to the destination location.
+        CreateItemReclassLine(ItemJournalBatch, ItemJournalLine, Item."No.", FromLocation.Code, ToLocation.Code, AccountCode, Quantity * ArrayLen(LotNo));
+        ItemJournalLine.Validate("Total CO2e", LotTotalCO2e[1]);
+        ItemJournalLine.Modify(true);
+        for Index := 1 to ArrayLen(LotNo) do begin
+            LibraryItemTracking.CreateItemReclassJnLineItemTracking(ReservationEntry, ItemJournalLine, '', LotNo[Index], Quantity);
+            ReservationEntry.Validate("New Lot No.", ReservationEntry."Lot No.");
+            ReservationEntry.Modify();
+        end;
+        LibraryInventory.PostItemJournalBatch(ItemJournalBatch);
+
+        // [GIVEN] The specific CO2e per unit for the second lot.
+        ExpectedCO2ePerUnit := LotTotalCO2e[2] / Quantity;
+
+        // [WHEN] Post a Sales Order for 1 pc of the second lot from the destination location.
+        PostedInvoiceNo := CreateAndPostSalesFromLocationWithLotTracking(SalesHeader, CountryRegion.Code, AccountCode, Item."No.", ToLocation.Code, 1, '', LotNo[2]);
+
+        // [THEN] The Sustainability Value Entry uses the specific lot CO2e, not the item average.
+        SustainabilityValueEntry.SetRange("Document No.", PostedInvoiceNo);
+        SustainabilityValueEntry.FindFirst();
+        Assert.AreEqual(
+            -ExpectedCO2ePerUnit,
+            SustainabilityValueEntry."CO2e Amount (Actual)",
+            StrSubstNo(ValueMustBeEqualErr, SustainabilityValueEntry.FieldCaption("CO2e Amount (Actual)"), -ExpectedCO2ePerUnit, SustainabilityValueEntry.TableCaption()));
+    end;
+
+    [Test]
+    procedure VerifySettingSpecificCarbonTrackingErrorsWhenItemLacksItemTracking()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 641487] Setting the Carbon Tracking Method to Specific is blocked for an item without serial or lot-specific item tracking.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] An item without any item tracking code.
+        LibraryInventory.CreateItem(Item);
+
+        // [WHEN] The Carbon Tracking Method is set to Specific.
+        asserterror Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
+
+        // [THEN] An error blocks the change because per-unit emissions cannot be resolved without item tracking.
+        Assert.ExpectedError('requires serial or lot-specific tracking');
+    end;
+
+    [Test]
+    procedure VerifySettingSpecificCarbonTrackingIsAllowedForLotTrackedItem()
+    var
+        Item: Record Item;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 641487] Setting the Carbon Tracking Method to Specific is allowed for a lot-tracked item.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] A lot-tracked item.
+        LibraryItemTracking.CreateLotItem(Item);
+
+        // [WHEN] The Carbon Tracking Method is set to Specific.
+        Item.Validate("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
+
+        // [THEN] The Carbon Tracking Method is saved without error.
+        Item.TestField("Carbon Tracking Method", Item."Carbon Tracking Method"::Specific);
     end;
 
     local procedure CreateSustainabilityAccount(var AccountCode: Code[20]; var CategoryCode: Code[20]; var SubcategoryCode: Code[20]; i: Integer): Record "Sustainability Account"
@@ -5330,20 +5395,24 @@ codeunit 148190 "Sust. Value Entry Test"
         LibrarySales.PostSalesDocument(SalesHeader, true, false);
     end;
 
-    local procedure PostPositiveAdjustmentWithCO2e(Item: Record Item; AccountCode: Code[20]; Qty: Decimal; TotalCO2e: Decimal)
+    local procedure CreateAndPostSalesFromLocationWithLotTracking(var SalesHeader: Record "Sales Header"; CountryRegion: Code[10]; SustAccountNo: Code[20]; ItemNo: Code[20]; LocationCode: Code[10]; Quantity: Decimal; SerialNo: Code[50]; LotNo: Code[50]): Code[20]
     var
-        ItemJournalTemplate: Record "Item Journal Template";
-        ItemJournalBatch: Record "Item Journal Batch";
-        ItemJournalLine: Record "Item Journal Line";
+        SalesLine: Record "Sales Line";
+        ReservationEntry: Record "Reservation Entry";
     begin
-        LibraryInventory.CreateItemJournalBatchByType(ItemJournalBatch, ItemJournalTemplate.Type::Item);
-        LibraryInventory.CreateItemJournalLine(
-            ItemJournalLine, ItemJournalBatch, Item, '', '', WorkDate(),
-            ItemJournalLine."Entry Type"::"Positive Adjmt.", Qty, 0);
-        ItemJournalLine.Validate("Sust. Account No.", AccountCode);
-        ItemJournalLine.Validate("Total CO2e", TotalCO2e);
-        ItemJournalLine.Modify();
-        LibraryInventory.PostItemJournalBatch(ItemJournalBatch);
+        LibrarySales.CreateSalesHeader(SalesHeader, "Sales Document Type"::Order, LibrarySales.CreateCustomerNo());
+        SalesHeader."Bill-to Country/Region Code" := CountryRegion;
+        SalesHeader.Modify();
+
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, "Sales Line Type"::Item, ItemNo, Quantity);
+        SalesLine.Validate("Location Code", LocationCode);
+        SalesLine.Validate("Unit Price", LibraryRandom.RandIntInRange(10, 200));
+        SalesLine.Validate("Sust. Account No.", SustAccountNo);
+        SalesLine.Modify();
+
+        LibraryItemTracking.CreateSalesOrderItemTracking(ReservationEntry, SalesLine, SerialNo, LotNo, Quantity);
+
+        exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
     end;
 
     local procedure VerifySustainabilityValueEntrySumForDocument(DocumentNo: Code[20]; ExpectedSum: Decimal)
@@ -5428,6 +5497,19 @@ codeunit 148190 "Sust. Value Entry Test"
         ProdOrderComponent.SetRange("Item No.", CompItem."No.");
         if ProdOrderComponent.FindFirst() then
             LibraryManufacturing.CreateProdOrderCompItemTracking(ReservationEntry, ProdOrderComponent, '', LotNo, ProdOrderComponent."Expected Qty. (Base)");
+    end;
+
+    local procedure SetTrackingForProdOrderLine(ProdOrderLine: Record "Prod. Order Line"; LotNo: Code[50])
+    var
+        TempItemTrackingSetup: Record "Item Tracking Setup";
+        ReservationEntry: Record "Reservation Entry";
+    begin
+        TempItemTrackingSetup."Lot No." := LotNo;
+        LibraryItemTracking.InsertItemTracking(
+            ReservationEntry, true, ProdOrderLine."Item No.", '', ProdOrderLine."Variant Code",
+            ProdOrderLine."Quantity (Base)", ProdOrderLine."Qty. per Unit of Measure", TempItemTrackingSetup,
+            Database::"Prod. Order Line", ProdOrderLine.Status.AsInteger(), ProdOrderLine."Prod. Order No.",
+            '', ProdOrderLine."Line No.", 0, WorkDate());
     end;
 
     local procedure DefineEmissionArrays(var EmissionCO2: array[2] of Decimal; var EmissionCH4: array[2] of Decimal; var EmissionN2O: array[2] of Decimal)

--- a/src/Apps/W1/Sustainability/test/src/SustainabilityServiceTests.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/SustainabilityServiceTests.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Inventory.Item;
-using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Projects.Project.Job;
 using Microsoft.Projects.Resources.Resource;
@@ -2367,7 +2366,6 @@ codeunit 148218 "Sustainability Service Tests"
     end;
 
     [Test]
-    [HandlerFunctions('MessageHandler')]
     procedure VerifySustValueEntryForServiceOrderWithLotTrackedItemAndSpecificCarbon()
     var
         SustainabilityLedgerEntry: Record "Sustainability Ledger Entry";
@@ -2398,9 +2396,9 @@ codeunit 148218 "Sustainability Service Tests"
         CO2ePerUnit := LibraryRandom.RandIntInRange(100, 200);
         Quantity := LibraryRandom.RandIntInRange(10, 20);
 
-        // [GIVEN] Create an Item.
+        // [GIVEN] Create a lot-tracked Item with Specific Carbon Tracking Method.
         LibraryItemTracking.CreateLotItem(Item);
-        LibrarySustainability.CreateItemWithSpecificCarbonTrackingMethod(Item);
+        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
         AddInventoryForLotTrackedItem(Item, LotNo, ExpectedCO2eOnLot, AccountCode, Quantity);
 
         // [GIVEN] Create a Service Header.
@@ -2410,7 +2408,7 @@ codeunit 148218 "Sustainability Service Tests"
         ServiceLine.Modify();
 
         // [GIVEN] Create Item Tracking for Service Line.
-        CreateServiceLineItemTracking(ServiceLine, '', LotNo[2], ServiceLine.Quantity);
+        CreateServiceOrderItemTracking(ServiceLine, '', LotNo[2], ServiceLine.Quantity);
 
         // [WHEN] Post the Service Order with Ship and Invoice.
         LibraryService.PostServiceOrder(ServiceHeader, true, false, true);
@@ -2420,9 +2418,9 @@ codeunit 148218 "Sustainability Service Tests"
         SustainabilityValueEntry.FindFirst();
         Assert.RecordCount(SustainabilityValueEntry, 1);
         Assert.AreEqual(
-            -ExpectedCO2eOnLot[1],
+            -ExpectedCO2eOnLot[2],
             SustainabilityValueEntry."CO2e Amount (Actual)",
-            StrSubstNo(ValueMustBeEqualErr, SustainabilityValueEntry.FieldCaption("CO2e Amount (Actual)"), -ExpectedCO2eOnLot[1], SustainabilityValueEntry.TableCaption()));
+            StrSubstNo(ValueMustBeEqualErr, SustainabilityValueEntry.FieldCaption("CO2e Amount (Actual)"), -ExpectedCO2eOnLot[2], SustainabilityValueEntry.TableCaption()));
         Assert.AreEqual(
             0,
             SustainabilityValueEntry."CO2e Amount (Expected)",
@@ -2533,53 +2531,6 @@ codeunit 148218 "Sustainability Service Tests"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandler,MessageHandler')]
-    procedure VerifyUndoServiceShipmentCreatesReversingCO2eForSpecificNonTrackedItem()
-    var
-        ServiceHeader: Record "Service Header";
-        ServiceLine: Record "Service Line";
-        Item: Record Item;
-        ExpectedShipmentCO2e: Decimal;
-        ShipmentNo: Code[20];
-        CategoryCode: Code[20];
-        SubcategoryCode: Code[20];
-        AccountCode: Code[20];
-    begin
-        // [SCENARIO 641487] Undo of a Service Shipment for a Specific carbon item without item tracking creates a
-        // reversing (positive) Sustainability Value Entry so the item's emissions return to the pre-shipment value.
-        Initialize();
-
-        // [GIVEN] Enable Value Chain Tracking and create a Sustainability Account.
-        LibrarySustainability.UpdateValueChainTrackingInSustainabilitySetup(true);
-        CreateSustainabilityAccount(AccountCode, CategoryCode, SubcategoryCode, LibraryRandom.RandInt(10));
-
-        // [GIVEN] A Specific carbon item (no item tracking) with 10 pcs carrying a known CO2e per unit.
-        LibraryInventory.CreateItem(Item);
-        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
-        EnsureGeneralPostingSetupForItem(Item);
-        ExpectedShipmentCO2e := LibraryRandom.RandDecInRange(100, 500, 2);
-        PostPositiveAdjustmentWithCO2e(Item, AccountCode, 10, ExpectedShipmentCO2e * 10);
-
-        // [GIVEN] A Service Order shipping 1 pc is posted (ship only, not invoiced).
-        CreateServiceOrderWithItem(ServiceHeader, ServiceLine, LibrarySales.CreateCustomerNo(), '', Item."No.", 1);
-        ServiceLine.Validate("Sust. Account No.", AccountCode);
-        ServiceLine.Validate("CO2e per Unit", ExpectedShipmentCO2e);
-        ServiceLine.Modify();
-        LibraryService.PostServiceOrder(ServiceHeader, true, false, false);
-        ShipmentNo := FindServiceShipmentHeader(ServiceHeader."No.");
-
-        // [THEN] The shipment created one negative Sustainability Value Entry.
-        VerifySustValueEntrySumForDocument(ShipmentNo, -ExpectedShipmentCO2e);
-
-        // [WHEN] The shipment is reversed with Undo Shipment.
-        LibraryService.UndoShipmentLinesByServiceOrderNo(ServiceHeader."No.");
-
-        // [THEN] Reversing Sustainability Value Entries are created and the shipment nets to zero.
-        VerifySustValueEntryCountForDocument(ShipmentNo, 4);
-        VerifySustValueEntrySumForDocument(ShipmentNo, 0);
-    end;
-
-    [Test]
     [HandlerFunctions('ConfirmHandler')]
     procedure VerifyUndoServiceConsumptionCreatesReversingCO2eForSpecificLotTrackedItem()
     var
@@ -2667,54 +2618,6 @@ codeunit 148218 "Sustainability Service Tests"
         ServiceLine.Validate("Qty. to Consume", 1);
         ServiceLine.Modify();
         CreateServiceOrderItemTracking(ServiceLine, SerialNo, '', 1);
-        LibraryService.PostServiceOrder(ServiceHeader, true, true, false);
-        ShipmentNo := FindServiceShipmentHeader(ServiceHeader."No.");
-
-        // [THEN] The consumption created one negative Sustainability Value Entry.
-        VerifySustValueEntrySumForDocument(ShipmentNo, -ExpectedConsumptionCO2e);
-
-        // [WHEN] The consumption is reversed with Undo Consumption.
-        LibraryService.UndoConsumptionLinesByServiceOrderNo(ServiceHeader."No.");
-
-        // [THEN] A reversing (positive) Sustainability Value Entry is created and the consumption nets to zero.
-        VerifySustValueEntryCountForDocument(ShipmentNo, 2);
-        VerifySustValueEntrySumForDocument(ShipmentNo, 0);
-    end;
-
-    [Test]
-    [HandlerFunctions('ConfirmHandler,MessageHandler')]
-    procedure VerifyUndoServiceConsumptionCreatesReversingCO2eForSpecificNonTrackedItem()
-    var
-        ServiceHeader: Record "Service Header";
-        ServiceLine: Record "Service Line";
-        Item: Record Item;
-        ExpectedConsumptionCO2e: Decimal;
-        ShipmentNo: Code[20];
-        CategoryCode: Code[20];
-        SubcategoryCode: Code[20];
-        AccountCode: Code[20];
-    begin
-        // [SCENARIO 641487] Undo of a Service Consumption for a Specific carbon item without item tracking creates a
-        // reversing (positive) Sustainability Value Entry so the item's emissions return to the pre-consumption value.
-        Initialize();
-
-        // [GIVEN] Enable Value Chain Tracking and create a Sustainability Account.
-        LibrarySustainability.UpdateValueChainTrackingInSustainabilitySetup(true);
-        CreateSustainabilityAccount(AccountCode, CategoryCode, SubcategoryCode, LibraryRandom.RandInt(10));
-
-        // [GIVEN] A Specific carbon item (no item tracking) with 10 pcs carrying a known CO2e per unit.
-        LibraryInventory.CreateItem(Item);
-        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
-        EnsureGeneralPostingSetupForItem(Item);
-        ExpectedConsumptionCO2e := LibraryRandom.RandDecInRange(100, 500, 2);
-        PostPositiveAdjustmentWithCO2e(Item, AccountCode, 10, ExpectedConsumptionCO2e * 10);
-
-        // [GIVEN] A Service Order for 2 pcs consuming 1 pc is posted; the unhandled pc keeps the order open for Undo.
-        CreateServiceOrderWithItem(ServiceHeader, ServiceLine, LibrarySales.CreateCustomerNo(), '', Item."No.", 2);
-        ServiceLine.Validate("Sust. Account No.", AccountCode);
-        ServiceLine.Validate("CO2e per Unit", ExpectedConsumptionCO2e);
-        ServiceLine.Validate("Qty. to Consume", 1);
-        ServiceLine.Modify();
         LibraryService.PostServiceOrder(ServiceHeader, true, true, false);
         ShipmentNo := FindServiceShipmentHeader(ServiceHeader."No.");
 
@@ -3116,52 +3019,18 @@ codeunit 148218 "Sustainability Service Tests"
         LibrarySustainability.PostPositiveAdjustmentWithItemTracking(Item, '', AccountCode, '', Quantity, WorkDate(), '', LotNo[2], ExpectedCO2eOnLot[2]);
     end;
 
-    local procedure CreateServiceLineItemTracking(ServiceLine: Record "Service Line"; SerialNo: Code[50]; LotNo: Code[50]; QtyBase: Decimal)
+    local procedure CreateServiceOrderItemTracking(ServiceLine: Record "Service Line"; SerialNo: Code[50]; LotNo: Code[50]; QtyBase: Decimal)
     var
         ReservEntry: Record "Reservation Entry";
         TempItemTrackingSetup: Record "Item Tracking Setup";
     begin
         TempItemTrackingSetup."Serial No." := SerialNo;
         TempItemTrackingSetup."Lot No." := LotNo;
-        CreateAssemblyHeaderItemTracking(ReservEntry, ServiceLine, TempItemTrackingSetup, QtyBase);
-    end;
-
-    local procedure CreateServiceOrderItemTracking(ServiceLine: Record "Service Line"; SerialNo: Code[50]; LotNo: Code[50]; QtyBase: Decimal)
-    var
-        ReservEntry: Record "Reservation Entry";
-        ItemTrackingSetup: Record "Item Tracking Setup";
-    begin
-        ItemTrackingSetup."Serial No." := SerialNo;
-        ItemTrackingSetup."Lot No." := LotNo;
         LibraryItemTracking.InsertItemTracking(
             ReservEntry, false, ServiceLine."No.", ServiceLine."Location Code", ServiceLine."Variant Code",
-            -QtyBase, ServiceLine."Qty. per Unit of Measure", ItemTrackingSetup,
+            -QtyBase, ServiceLine."Qty. per Unit of Measure", TempItemTrackingSetup,
             Database::"Service Line", ServiceLine."Document Type".AsInteger(), ServiceLine."Document No.",
             '', 0, ServiceLine."Line No.", WorkDate());
-    end;
-
-    local procedure CreateAssemblyHeaderItemTracking(var ReservEntry: Record "Reservation Entry"; ServiceLine: Record "Service Line"; ItemTrackingSetup: Record "Item Tracking Setup"; QtyBase: Decimal)
-    var
-        RecRef: RecordRef;
-    begin
-        RecRef.GetTable(ServiceLine);
-        LibraryItemTracking.ItemTracking(ReservEntry, RecRef, ItemTrackingSetup, QtyBase);
-    end;
-
-    local procedure PostPositiveAdjustmentWithCO2e(Item: Record Item; AccountCode: Code[20]; Qty: Decimal; TotalCO2e: Decimal)
-    var
-        ItemJournalTemplate: Record "Item Journal Template";
-        ItemJournalBatch: Record "Item Journal Batch";
-        ItemJournalLine: Record "Item Journal Line";
-    begin
-        LibraryInventory.CreateItemJournalBatchByType(ItemJournalBatch, ItemJournalTemplate.Type::Item);
-        LibraryInventory.CreateItemJournalLine(
-            ItemJournalLine, ItemJournalBatch, Item, '', '', WorkDate(),
-            ItemJournalLine."Entry Type"::"Positive Adjmt.", Qty, 0);
-        ItemJournalLine.Validate("Sust. Account No.", AccountCode);
-        ItemJournalLine.Validate("Total CO2e", TotalCO2e);
-        ItemJournalLine.Modify();
-        LibraryInventory.PostItemJournalBatch(ItemJournalBatch);
     end;
 
     local procedure VerifySustValueEntrySumForDocument(DocumentNo: Code[20]; ExpectedSum: Decimal)


### PR DESCRIPTION
[AB#641309](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641309) [AB#641049](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641049)

**Issue 1:** No validation when setting Carbon Tracking Method to Specific

**Cause:** The Carbon Tracking Method field's OnValidate trigger only showed a non-blocking Message (warning) when the item lacked serial/lot-specific tracking. The GuiAllowed() guard also skipped it entirely in non-UI contexts (APIs, imports).

**Solution:** Replaced the Message with a blocking Error and removed the GuiAllowed() guard. The validation now fires from both the Carbon Tracking Method OnValidate and the Item Tracking Code OnAfterValidate triggers, ensuring the rule is enforced when either field changes, in all contexts.

**Issue 2:** Sales after reclassification uses average CO2e instead of specific lot CO2e

**Cause:** CanCreateSustValueEntry in SustItemPostSubscriber blocks Sustainability Value Entry creation for reclassification transfer-in ILEs (blank document type + positive valued quantity). When a subsequent sale applies to that transfer-in ILE, GetCO2eAmountAndQuantity finds no SVE, returns 0, and GetTotalCO2eAmount exits early — leaving the sale's CO2e at the item-card average.

**Solution:** Added fallback logic in GetCO2eAmountAndQuantity: when no SVE exists for an ILE, the new ResolveTransferInCO2e procedure checks if it's a transfer-in (positive quantity, Transfer entry type) and resolves the CO2e from the transfer-out counterpart in the same item register (matched by item, lot, and serial number). Transfer Orders are unaffected because their receipts already have SVEs.



