### PR TITLE
[SOA] Fix missing Agent Task Message read permission in contact search

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAContactSearchImpl.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAContactSearchImpl.Codeunit.al
@@ -13,6 +13,7 @@ codeunit 4411 "SOA Contact Search Impl"
     EventSubscriberInstance = Manual;
     InherentEntitlements = X;
     InherentPermissions = X;
+    Permissions = tabledata "Agent Task Message" = r;
 
     var
         AgentTaskID: BigInteger;


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Add read permission for **Agent Task Message** to **SOA Contact Search Impl.**

The contact-mapping flow queries the latest input task message when opening the Contacts list. Without this object-level permission, the Sales Order Agent pauses with an **AR-PERMISSION** intervention instead of completing the workflow.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#647042](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647042)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Low risk. The change only grants read access to data already queried by the codeunit. It does not change contact matching, filtering, task overrides, reply routing, or persisted data. Existing behavior remains compatible.

