### PR TITLE
#10288 - Always load attachments

### DIFF
--- a/src/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
+++ b/src/Apps/W1/Email - Outlook REST API/app/src/EmailOutlookAPIHelper.Codeunit.al
@@ -435,8 +435,7 @@ codeunit 4509 "Email - Outlook API Helper"
             Body := KeepLastMessageOnly(Body);
         EmailMessage.Create('', Subject, Body, HTMLBody, not Filters.GetBypassBodySanitization());
 
-        if HasAttachments then
-            AddAttachmentsToMessage(EmailJsonObject, EmailMessage);
+        AddAttachmentsToMessage(EmailJsonObject, EmailMessage);
 
         if Filters."Load Headers" then
             SetMessageHeaders(EmailJsonObject, EmailMessage);

--- a/src/Apps/W1/Email - Outlook REST API/test/HttpResponseFiles/RetrieveEmailWithInlineAttachmentsOnly.txt
+++ b/src/Apps/W1/Email - Outlook REST API/test/HttpResponseFiles/RetrieveEmailWithInlineAttachmentsOnly.txt
@@ -1,0 +1,34 @@
+{
+  "@odata.count": 1,
+  "value": [
+    {
+      "id": "test-message-id-006",
+      "conversationId": "test-conversation-id-006",
+      "subject": "Test Inline Only Attachments",
+      "receivedDateTime": "2026-04-21T10:00:00Z",
+      "sentDateTime": "2026-04-21T09:55:00Z",
+      "sender": {
+        "emailAddress": {
+          "name": "Test Sender",
+          "address": "sender@test.com"
+        }
+      },
+      "body": {
+        "contentType": "HTML",
+        "content": "<p>Body with only inline image</p>"
+      },
+      "hasAttachments": false,
+      "isRead": false,
+      "isDraft": false,
+      "attachments": [
+        {
+          "name": "inline.txt",
+          "contentType": "text/plain",
+          "isInline": true,
+          "contentId": "cid456",
+          "contentBytes": "SW5saW5lQ29udGVudA=="
+        }
+      ]
+    }
+  ]
+}

--- a/src/Apps/W1/Email - Outlook REST API/test/OutlookAPIHelperTests.Codeunit.al
+++ b/src/Apps/W1/Email - Outlook REST API/test/OutlookAPIHelperTests.Codeunit.al
@@ -160,6 +160,65 @@ codeunit 139752 "Outlook API Helper Tests"
 
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
+    [HandlerFunctions('GraphRetrieveEmailsInlineAttachmentsOnlyHandler')]
+    procedure TestRetrieveEmailWithInlineAttachmentsWhenHasAttachmentsFalse()
+    var
+        OutlookAccount: Record "Email - Outlook Account";
+        EmailInbox: Record "Email Inbox";
+        TempFilters: Record "Email Retrieval Filters" temporary;
+        SkipTokenRequest: Codeunit "Skip Outlook API Token Request";
+        EmailMessage: Codeunit "Email Message";
+        EmailOutlookAPIHelper: Codeunit "Email - Outlook API Helper";
+        InStream: InStream;
+        AttachmentContent: Text;
+    begin
+        // [SCENARIO] Microsoft Graph reports hasAttachments=false when an email has only inline
+        // attachments. Those attachments must still be imported into the email message.
+
+        // [GIVEN] An Outlook account exists
+        OutlookAccount.Init();
+        OutlookAccount.Id := CreateGuid();
+        OutlookAccount."Email Address" := 'testuser@test.com';
+        OutlookAccount.Name := 'Test User';
+        OutlookAccount."Outlook API Email Connector" := Enum::"Email Connector"::"Test Outlook REST API";
+        OutlookAccount.Insert();
+
+        // [GIVEN] OAuth token request is skipped
+        BindSubscription(SkipTokenRequest);
+        SkipTokenRequest.SetSkipTokenRequest(true);
+
+        // [GIVEN] Filters are set to load attachments
+        TempFilters.Init();
+        TempFilters."Load Attachments" := true;
+        TempFilters."Max No. of Emails" := 10;
+        TempFilters."Body Type" := TempFilters."Body Type"::HTML;
+
+        // [WHEN] Emails are retrieved (response has hasAttachments=false but includes inline attachments)
+        EmailInbox.Init();
+        EmailOutlookAPIHelper.RetrieveEmails(OutlookAccount.Id, EmailInbox, TempFilters);
+
+        // [THEN] An email inbox record was created
+        EmailInbox.MarkedOnly(true);
+        LibraryAssert.IsTrue(EmailInbox.FindFirst(), 'Expected an email inbox record to be created');
+        LibraryAssert.AreEqual('Test Inline Only Attachments', EmailInbox.Description, 'Unexpected email subject');
+
+        // [THEN] The inline attachment is imported despite hasAttachments=false
+        EmailMessage.Get(EmailInbox."Message Id");
+        LibraryAssert.IsTrue(EmailMessage.Attachments_First(), 'Expected the inline attachment to be imported');
+        LibraryAssert.AreEqual('inline.txt', EmailMessage.Attachments_GetName(), 'Unexpected attachment name');
+        LibraryAssert.AreEqual('text/plain', EmailMessage.Attachments_GetContentType(), 'Unexpected content type');
+        LibraryAssert.IsTrue(EmailMessage.Attachments_IsInline(), 'Attachment should be inline');
+        LibraryAssert.AreEqual('cid456', EmailMessage.Attachments_GetContentId(), 'Unexpected contentId for inline attachment');
+
+        EmailMessage.Attachments_GetContent(InStream);
+        InStream.ReadText(AttachmentContent);
+        LibraryAssert.AreEqual('InlineContent', AttachmentContent, 'Unexpected inline attachment content');
+
+        LibraryAssert.AreEqual(0, EmailMessage.Attachments_Next(), 'Only the inline attachment should have been imported');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
     [HandlerFunctions('GraphRetrieveEmailsNullContentIdHandler')]
     procedure TestRetrieveEmailWithNullContentId()
     var
@@ -499,6 +558,16 @@ codeunit 139752 "Outlook API Helper Tests"
     procedure GraphRetrieveEmailsHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
     var
         RetrieveEmailFileTok: Label 'RetrieveEmailWithAttachments.txt', Locked = true;
+    begin
+        Response.Content.WriteFrom(NavApp.GetResourceAsText(RetrieveEmailFileTok, TextEncoding::UTF8));
+        Response.HttpStatusCode := 200;
+        exit(false);
+    end;
+
+    [HttpClientHandler]
+    procedure GraphRetrieveEmailsInlineAttachmentsOnlyHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    var
+        RetrieveEmailFileTok: Label 'RetrieveEmailWithInlineAttachmentsOnly.txt', Locked = true;
     begin
         Response.Content.WriteFrom(NavApp.GetResourceAsText(RetrieveEmailFileTok, TextEncoding::UTF8));
         Response.HttpStatusCode := 200;


### PR DESCRIPTION
## What & why

Fixes a defect in the Outlook/Graph email attachment retrieval logic where the hasAttachments property on a Graph message is used as a gate before fetching attachments. hasAttachments only reflects regular (non-inline) attachments, so messages containing only inline attachments (e.g. a screenshot pasted into the email body) report hasAttachments: false and are skipped entirely — even though the attachment is present and retrievable via $expand=attachments. This change removes the hasAttachments gate and instead always fetches attachments, applying inline/regular distinction afterward via isInline and contentId/cid: correlation.

## Linked work

Fixes #10288

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- New unit tests in OutlookAPIHelperTests.Codeunit.al pass locally; full module test suite green.


## Risk & compatibility

- Behavior change, not breaking change: Messages that previously had attachments silently skipped (inline-only case) will now have those attachments fetched and processed. Any downstream logic that assumed "no attachments" for these messages should be reviewed, but this is a bug fix restoring intended behavior, not an API surface change.
- Performance: Removing the hasAttachments gate means the attachment-fetch call ($expand=attachments or equivalent) now runs unconditionally, including for messages with genuinely zero attachments. This adds a Graph API call that was previously skipped in that case — likely negligible, but worth noting for high-volume inbound email scenarios.
- No data upgrade impact: This is a runtime logic change only; no schema, table, or field changes involved. 
- No permission changes: Does not touch permission sets or object access.
- No breaking changes to public interfaces: Internal fix to the Outlook API helper codeunit's fetch logic; no changes to published/public methods, events, or extensibility points expected (confirm this holds once you see the actual diff).
- Telemetry: No new telemetry added.
- Follow-up work: None anticipated beyond this fix.
