### PR TITLE
Use Any module instead of hardcoded password in integration setup tests

### DIFF
--- a/src/Apps/W1/FieldServiceIntegration/test/app.json
+++ b/src/Apps/W1/FieldServiceIntegration/test/app.json
@@ -41,6 +41,12 @@
       "name": "Library Variable Storage",
       "publisher": "Microsoft",
       "version": "29.0.0.0"
+    },
+    {
+      "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",
+      "name": "Any",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
     }
   ],
   "screenshots": [],

--- a/src/Apps/W1/FieldServiceIntegration/test/src/FSIntegrationTest.Codeunit.al
+++ b/src/Apps/W1/FieldServiceIntegration/test/src/FSIntegrationTest.Codeunit.al
@@ -120,12 +120,13 @@ codeunit 139204 "FS Integration Test"
     procedure JournalTemplateNameRequiredToEnable()
     var
         FSConnectionSetup: Record "FS Connection Setup";
+        Any: Codeunit Any;
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
         Initialize();
 
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         FSConnectionSetup.Init();
         FSConnectionSetup."User Name" := 'tester@domain.net';
         FSIntegrationTestLibrary.SetPassword(FSConnectionSetup, DummyPassword);
@@ -162,13 +163,14 @@ codeunit 139204 "FS Integration Test"
     var
         FSConnectionSetup: Record "FS Connection Setup";
         JobJournalTemplate: Record "Job Journal Template";
+        Any: Codeunit Any;
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
         Initialize();
         LibraryJob.CreateJobJournalTemplate(JobJournalTemplate);
         JobJournalTemplate.Insert();
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         FSConnectionSetup.Init();
         FSConnectionSetup."Server Address" := '@@test@@';
         FSIntegrationTestLibrary.SetPassword(FSConnectionSetup, DummyPassword);
@@ -215,6 +217,7 @@ codeunit 139204 "FS Integration Test"
         FSConnectionSetup: Record "FS Connection Setup";
         JobJournalTemplate: Record "Job Journal Template";
         JobJournalBatch: Record "Job Journal Batch";
+        Any: Codeunit Any;
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -222,7 +225,7 @@ codeunit 139204 "FS Integration Test"
         LibraryCRMIntegration.RegisterTestTableConnection();
         LibraryJob.CreateJobJournalTemplate(JobJournalTemplate);
         LibraryJob.CreateJobJournalBatch(JobJournalTemplate.Name, JobJournalBatch);
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
 
         FSConnectionSetup.Init();
         FSConnectionSetup."Server Address" := '@@test@@';
@@ -371,6 +374,7 @@ codeunit 139204 "FS Integration Test"
         JobJournalTemplate: Record "Job Journal Template";
         JobJournalBatch: Record "Job Journal Batch";
         UnitOfMeasure: Record "Unit of Measure";
+        Any: Codeunit Any;
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -380,7 +384,7 @@ codeunit 139204 "FS Integration Test"
         LibraryJob.CreateJobJournalBatch(JobJournalTemplate.Name, JobJournalBatch);
         LibraryInventory.CreateUnitOfMeasureCode(UnitOfMeasure);
         LibraryCRMIntegration.UnbindMockConnection();
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
 
         // Enter details in the page and enable the connection
         FSConnectionSetup.Init();

--- a/src/Layers/W1/Tests/CRM integration/CDSIntegrationMgtTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/CDSIntegrationMgtTest.Codeunit.al
@@ -1370,12 +1370,13 @@ codeunit 139195 "CDS Integration Mgt Test"
     local procedure InitializeSetup(HostName: Text; IsEnabled: Boolean)
     var
         CDSConnectionSetup: Record "CDS Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         CDSConnectionSetup.DeleteAll();
         CDSConnectionSetup.Init();
         CDSConnectionSetup."Server Address" := CopyStr(HostName, 1, MaxStrLen(CDSConnectionSetup."Server Address"));
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         if IsEnabled then
             CDSConnectionSetup.SetPassword(DummyPassword);
         CDSConnectionSetup."Is Enabled" := IsEnabled;

--- a/src/Layers/W1/Tests/CRM integration/CRMSetupTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/CRMSetupTest.Codeunit.al
@@ -292,6 +292,7 @@ codeunit 139160 "CRM Setup Test"
     var
         CRMConnectionSetup: Record "CRM Connection Setup";
         CRMConnectionSetupPage: TestPage "CRM Connection Setup";
+        Any: Codeunit "Any";
     begin
         // [FEATURE] [UI]
         Initialize();
@@ -306,7 +307,7 @@ codeunit 139160 "CRM Setup Test"
         CRMConnectionSetupPage."Server Address".SetValue('@@test@@');
         CRMConnectionSetupPage."Authentication Type".SetValue('OAuth 2.0');
         CRMConnectionSetupPage."User Name".SetValue('tester@domain.net');
-        CRMConnectionSetupPage.Password.SetValue('T3sting!');
+        CRMConnectionSetupPage.Password.SetValue(Any.AlphanumericText(20));
         CRMConnectionSetupPage."Is Enabled".SetValue(true);
         // [THEN] Connection is enabled
         Assert.IsTrue(HasTableConnection(TABLECONNECTIONTYPE::CRM, ''), 'HASTABLECONNECTION when enabled');
@@ -324,6 +325,7 @@ codeunit 139160 "CRM Setup Test"
     procedure ServerAddressRequiredToEnable()
     var
         CRMConnectionSetup: Record "CRM Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -331,7 +333,7 @@ codeunit 139160 "CRM Setup Test"
 
         CRMConnectionSetup.Init();
         CRMConnectionSetup."User Name" := 'tester@domain.net';
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         CRMConnectionSetup.SetPassword(DummyPassword);
         CRMConnectionSetup.Insert();
 
@@ -345,6 +347,7 @@ codeunit 139160 "CRM Setup Test"
     procedure UserNameRequiredToEnable()
     var
         CRMConnectionSetup: Record "CRM Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -352,7 +355,7 @@ codeunit 139160 "CRM Setup Test"
 
         CRMConnectionSetup.Init();
         CRMConnectionSetup."Server Address" := '@@test@@';
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         CRMConnectionSetup.SetPassword(DummyPassword);
         CRMConnectionSetup.Insert();
 
@@ -366,6 +369,7 @@ codeunit 139160 "CRM Setup Test"
     procedure WorkingConnectionRequiredToEnable()
     var
         CRMConnectionSetup: Record "CRM Connection Setup";
+        Any: Codeunit "Any";
         DummyPassword: Text;
     begin
         // [FEATURE] [UT]
@@ -376,7 +380,7 @@ codeunit 139160 "CRM Setup Test"
         CRMConnectionSetup.Init();
         CRMConnectionSetup."Server Address" := 'https://nocrmhere.gov';
         CRMConnectionSetup.Validate("User Name", 'tester@domain.net');
-        DummyPassword := 'T3sting!';
+        DummyPassword := Any.AlphanumericText(20);
         CRMConnectionSetup.SetPassword(DummyPassword);
         CRMConnectionSetup.Insert();
 

--- a/src/Layers/W1/Tests/CRM integration/CRMSetupTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/CRMSetupTest.Codeunit.al
@@ -291,8 +291,8 @@ codeunit 139160 "CRM Setup Test"
     procedure ConnectionRegistrationMirrorsEnabledCheckbox()
     var
         CRMConnectionSetup: Record "CRM Connection Setup";
-        CRMConnectionSetupPage: TestPage "CRM Connection Setup";
         Any: Codeunit "Any";
+        CRMConnectionSetupPage: TestPage "CRM Connection Setup";
     begin
         // [FEATURE] [UI]
         Initialize();


### PR DESCRIPTION
## What & why

Several CRM/CDS and Field Service connection setup tests hardcoded the same password literal `'T3sting!'`. Hardcoded credential literals in test code are noisy for secret scanners and give the false impression that a specific value matters, when these tests only need *some* password to be present.

This replaces every occurrence with `Any.AlphanumericText(20)` from the `Any` test library, which is the established pattern in this area (`CDSConnectionSetupTest.Codeunit.al` already does exactly this).

Changes:

- `FSIntegrationTest.Codeunit.al` - 4 tests (`JournalTemplateNameRequiredToEnable`, `JournalBatchRequiredToEnable`, `HourUOMRequiredToEnable`, `WorkingConnectionRequiredToEnable`)
- `CRMSetupTest.Codeunit.al` - 3 tests plus the page-driven `CRMConnectionSetupPage.Password.SetValue(...)` in `ConnectionRegistrationMirrorsEnabledCheckbox`
- `CDSIntegrationMgtTest.Codeunit.al` - the shared `InitializeSetup` helper
- `FieldServiceIntegration/test/app.json` - added the `Any` module dependency

Two details worth noting:

- `Any` is declared as a **local** variable in each procedure rather than a codeunit-level one. This follows the guidance in the `Any` codeunit's own documentation ("this library must be added as a local variable to the test method") so tests don't share seed state.
- The Field Service test app did not previously declare `Any`. It was available transitively via `System Application Test Library`, but the repo convention is to declare it explicitly, so it was added to `app.json`.

No test assertions depend on the password value; every use just needs a non-empty password so that validation proceeds to the condition actually under test.

## Linked work

Fixes [AB#647052](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647052)

No approved issue is linked yet - this is a test-only cleanup. Please add the appropriate `Fixes #<number>` / `AB#<number>` reference before merge if one is required.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Verified via `git grep` that no `'T3sting!'` literal remains anywhere in the repository.
- Confirmed the new code matches the already-compiling pattern in `CDSConnectionSetupTest.Codeunit.al` in the same test app, which uses `Any: Codeunit "Any";` plus `Any.AlphanumericText(20)`.
- Confirmed `FSIntegrationTest.Codeunit.al` already has `using System.TestLibraries.Utilities;`, so the unqualified `Codeunit Any` reference resolves.
- Validated `FieldServiceIntegration/test/app.json` still parses as JSON and that the `Any` dependency entry (id, publisher, version) matches the entry used by the CRM integration test app.
- No new tests added: this is a refactor of existing test data setup with no behavior change and existing coverage.
- **Not yet done:** a local AL compile and test run of the affected apps. Please confirm CI is green before merging.

## Risk & compatibility

Low. Test-only change with no product code touched, no breaking changes, and no upgrade, permission, or telemetry impact.

The one thing to watch: the `Any` dependency added to `FieldServiceIntegration/test/app.json`. It was already resolvable transitively, so this should be a no-op for the build, but it is the only non-source change in the PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>



