### PR TITLE
Consolidate minor release ruleset and fix strict mode branch detection

### DIFF
--- a/build/projects.json
+++ b/build/projects.json
@@ -23,7 +23,7 @@
       "dvdFolder": "Applications\\TestFramework\\TestLibraries\\Any",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Library Assert": {
@@ -32,7 +32,7 @@
       "dvdFolder": "Applications\\TestFramework\\TestLibraries\\Assert",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Library Variable Storage": {
@@ -41,7 +41,7 @@
       "dvdFolder": "Applications\\TestFramework\\TestLibraries\\Variable Storage",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Prevent Metadata Updates": {
@@ -51,7 +51,7 @@
       "dvdFolder": "Applications\\TestFramework\\TestStabilityTools\\PreventMetadataUpdates",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Permissions Mock": {
@@ -60,7 +60,7 @@
       "dvdFolder": "Applications\\TestFramework\\TestLibraries\\Permissions Mock",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Test Runner": {
@@ -69,7 +69,7 @@
       "dvdFolder": "Applications\\TestFramework\\TestRunner",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Performance Toolkit": {
@@ -78,7 +78,7 @@
       "dvdFolder": "Applications\\TestFramework\\PerformanceToolkit",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps"
     },
     "Performance Toolkit Tests": {
@@ -87,7 +87,7 @@
       "dvdFolder": "Applications\\TestFramework\\PerformanceToolkit",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isTest": true,
       "repositoryUrl": "https://github.com/microsoft/BCApps",
       "owningteam": "\\AI Business Solutions\\Integrations"
@@ -100,7 +100,7 @@
       "dvdFolder": "Applications\\TestFramework\\PerformanceToolkit",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "unsupportedCountries": [
         "NA"
       ],
@@ -113,7 +113,7 @@
       "dvdFolder": "Applications\\TestFramework\\AITestToolkit",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "repositoryUrl": "https://github.com/microsoft/BCApps",
       "installOnEnvironmentUpdate": true,
       "allowedEnvironmentTypes": [
@@ -126,7 +126,7 @@
       "dvdFolder": "Applications\\System Application\\Source",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "blockUninstall": true,
       "installOnEnvironmentUpdate": true,
       "hasTranslations": true,
@@ -192,7 +192,7 @@
       "dvdFolder": "Applications\\BusinessFoundation\\Source",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "blockUninstall": true,
       "installOnEnvironmentUpdate": true,
       "hasTranslations": true,
@@ -217,7 +217,7 @@
         "NA"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "allowedEnvironmentTypes": [
         "Sandbox"
       ]
@@ -246,8 +246,8 @@
       "dvdFolder": "Applications\\BaseApp\\Source",
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\base.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "blockUninstall": true,
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
@@ -258,7 +258,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Email": {
@@ -266,7 +266,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Comments": {
@@ -274,7 +274,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "User Task": {
@@ -282,7 +282,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Application Area": {
@@ -290,7 +290,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Azure AD Authentication": {
@@ -298,7 +298,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Code Coverage": {
@@ -306,7 +306,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Database Information": {
@@ -314,7 +314,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Designer Diagnostics": {
@@ -322,7 +322,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Exception Handling": {
@@ -330,7 +330,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Error Message": {
@@ -338,7 +338,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Event Recorder": {
@@ -346,7 +346,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "File Operations": {
@@ -354,7 +354,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Forward Links": {
@@ -362,7 +362,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "logLevel": "warning",
       "isInternal": true
     },
@@ -371,7 +371,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "logLevel": "warning",
       "isInternal": true
     },
@@ -380,7 +380,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Memory Storage": {
@@ -388,7 +388,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Notifications": {
@@ -396,7 +396,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Object Selection": {
@@ -404,7 +404,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Obsolete DotNet Wrappers": {
@@ -412,7 +412,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Onboarding Signal": {
@@ -420,7 +420,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Page Designer": {
@@ -428,7 +428,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Page Inspector": {
@@ -436,7 +436,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Permission Sets": {
@@ -444,7 +444,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Power Automate": {
@@ -452,7 +452,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Power BI": {
@@ -460,7 +460,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "logLevel": "warning",
       "isInternal": true
     },
@@ -469,7 +469,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Record Conversion": {
@@ -477,7 +477,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Record Lookup": {
@@ -485,7 +485,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Request Page": {
@@ -493,7 +493,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Date and Time": {
@@ -501,7 +501,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Device": {
@@ -509,7 +509,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Extension Management": {
@@ -517,7 +517,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Media": {
@@ -525,7 +525,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Translation": {
@@ -533,7 +533,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "System Printer Management": {
@@ -541,7 +541,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "User": {
@@ -549,7 +549,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Web Request": {
@@ -557,7 +557,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Xml": {
@@ -565,7 +565,7 @@
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isInternal": true
     },
     "Application": {
@@ -575,14 +575,14 @@
       "blockUninstall": true,
       "installOnEnvironmentUpdate": true,
       "allowedUpdates": "hotfix",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\application.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json"
     },
     "DemoTool": {
       "projectPath": "$env:INETROOT\\App\\Views\\$CountryCode\\DemoTool",
       "appJsonPath": "$env:INETROOT\\App\\Layers\\W1\\DemoTool\\app.json",
       "isGDLProject": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json"
     },
     "AlCosting": {
       "projectPath": "$env:INETROOT\\App\\Layers\\W1\\AlCosting",
@@ -601,7 +601,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true,
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -623,7 +623,7 @@
         "NA"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "allowedEnvironmentTypes": [
         "Sandbox"
       ]
@@ -647,7 +647,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test"
     },
     "Tests-Azure AI": {
@@ -666,7 +666,7 @@
       "isGDLProject": true,
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -689,7 +689,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -712,7 +712,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -735,7 +735,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -758,7 +758,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -781,7 +781,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -804,7 +804,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -827,7 +827,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -850,7 +850,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -873,7 +873,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -896,7 +896,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -919,7 +919,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -942,7 +942,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -965,7 +965,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -988,7 +988,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1011,7 +1011,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1034,7 +1034,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1057,7 +1057,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1080,7 +1080,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1103,7 +1103,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": ""
     },
@@ -1126,7 +1126,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1149,7 +1149,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1172,7 +1172,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1195,7 +1195,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1218,7 +1218,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1241,7 +1241,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1264,7 +1264,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1287,7 +1287,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1310,7 +1310,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1333,7 +1333,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1356,7 +1356,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1379,7 +1379,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1402,7 +1402,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1425,7 +1425,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1448,7 +1448,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1471,7 +1471,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1494,7 +1494,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -1517,7 +1517,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1540,7 +1540,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1563,7 +1563,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1586,7 +1586,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": ""
     },
@@ -1597,8 +1597,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Tests-VAT": {
       "projectPath": "$env:INETROOT\\App\\Views\\$CountryCode\\Tests\\VAT",
@@ -1619,7 +1619,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -1639,7 +1639,7 @@
       "isGDLProject": true,
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test"
     },
     "Tests-Workflow": {
@@ -1661,7 +1661,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "dvdFolder": "Applications\\BaseApp\\Test",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1682,7 +1682,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true,
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1705,7 +1705,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true,
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1728,7 +1728,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true
     },
     "TestRunner-Internal": {
@@ -1750,7 +1750,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true
     },
     "Tests-DotNet-Internal": {
@@ -1772,7 +1772,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true,
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1795,7 +1795,7 @@
       ],
       "isTest": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\basetest.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
       "isInternal": true,
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -1852,8 +1852,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "AMC Banking 365 Fundamentals Test Automations": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\AMCBanking365Fundamentals\\test",
@@ -1883,8 +1883,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Basic Experience": {
@@ -1898,8 +1898,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Basic Experience Test Automation": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\BasicExperience\\test",
@@ -1912,8 +1912,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_APIV1_": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\APIV1\\app",
@@ -1923,8 +1923,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_APIV1_ Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\APIV1\\test",
@@ -1935,8 +1935,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "_Exclude_APIV2_": {
@@ -1947,8 +1947,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_APIV2_ Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\APIV2\\test",
@@ -1960,8 +1960,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "_Exclude_Business_Events_": {
@@ -1972,8 +1972,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Business_Events_Test": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ExternalEvents\\test",
@@ -1982,8 +1982,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "_Exclude_PlanConfiguration_": {
@@ -1994,8 +1994,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_PlanConfiguration_ Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\PlanConfiguration\\test",
@@ -2003,8 +2003,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "C5 2012 Data Migration": {
@@ -2014,8 +2014,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "C5 2012 Data Migration Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\C52012DataMigration\\test",
@@ -2024,8 +2024,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Ceridian Payroll": {
@@ -2038,8 +2038,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_ClientAddIns_": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ClientAddIns\\app",
@@ -2048,8 +2048,8 @@
       "installOnEnvironmentUpdate": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "API Reports - Finance": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\APIReportsFinance\\App",
@@ -2060,7 +2060,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "API - Cross Environment Intercompany": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\CrossEnvironmentIntercompany\\app",
@@ -2070,8 +2070,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics BC Excel Reports": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\ExcelReports\\App",
@@ -2082,7 +2082,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics BC Excel Reports Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\ExcelReports\\Test",
@@ -2092,7 +2092,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "ELSTER VAT Localization for Germany": {
@@ -2103,8 +2103,8 @@
       "supportedCountries": "DE",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "ELSTER VAT Localization for Germany Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\Elster\\test",
@@ -2113,8 +2113,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Envestnet Yodlee Bank Feeds": {
@@ -2127,8 +2127,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Envestnet Yodlee Bank Feeds Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NA\\EnvestnetYodleeBankFeeds\\test",
@@ -2140,8 +2140,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Essential Business Headlines": {
@@ -2153,7 +2153,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Essential Business Headlines Test": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EssentialBusinessHeadlines\\Test",
@@ -2163,7 +2163,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "FI Core": {
@@ -2174,8 +2174,8 @@
       "supportedCountries": "FI",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "FI Core Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FI\\FICore\\test",
@@ -2184,8 +2184,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "DK Core": {
@@ -2196,8 +2196,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "DK Core Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\DKCore\\test",
@@ -2206,8 +2206,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Payment and Reconciliation Formats (DK)": {
@@ -2218,8 +2218,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payment and Reconciliation Formats (DK) Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\FIK\\test",
@@ -2228,8 +2228,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Shopify Connector": {
@@ -2240,7 +2240,7 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Shopify Connector Test": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\Shopify\\Test",
@@ -2250,7 +2250,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "assemblyProbingFolders": [
         "$env:ProgramFiles\\dotnet\\shared\\Microsoft.AspNetCore.App\\$env:dotNetVersion",
         "$env:ProgramFiles\\dotnet\\shared\\Microsoft.NetCore.App\\$env:dotNetVersion",
@@ -2271,8 +2271,8 @@
       "supportedCountries": "BE",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Shopify Connector BE Test": {
@@ -2282,8 +2282,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Company Hub": {
@@ -2293,8 +2293,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Data Archive Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\DataArchive\\Test",
@@ -2304,7 +2304,7 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Data Archive": {
@@ -2315,7 +2315,7 @@
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Data Search Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\DataSearch\\Test",
@@ -2325,7 +2325,7 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Error Messages with Recommendations": {
@@ -2337,7 +2337,7 @@
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Error Messages with Recommendations Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\ErrorMessagesWithRecommendations\\Test",
@@ -2347,7 +2347,7 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Data Search": {
@@ -2359,7 +2359,7 @@
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Troubleshoot FA Ledger Entries": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\DataCorrectionFA\\App",
@@ -2369,7 +2369,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intelligent Cloud Base": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridBaseDeployment\\app",
@@ -2378,8 +2378,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration API": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridAPI\\app",
@@ -2388,8 +2388,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Intelligent Cloud": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridBC\\app",
@@ -2398,8 +2398,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridBCLast\\app",
@@ -2408,8 +2408,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central 14 Historical Data": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridBC14HistoricalData\\app",
@@ -2418,8 +2418,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics 365 Business Central v14 Reimplementation": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridBC14\\app",
@@ -2428,8 +2428,8 @@
       "hasTranslations": true,
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics GP Historical Data": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\DynamicsGPHistoricalData\\app",
@@ -2444,8 +2444,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics GP Intelligent Cloud": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridGP\\app",
@@ -2460,8 +2460,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics GP Intelligent Cloud - US": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\HybridGP_US\\app",
@@ -2472,8 +2472,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics GP History SmartLists": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\DynamicsGPHistorySmartLists\\app",
@@ -2488,8 +2488,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics SL Historical Data": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\DynamicsSLHistoricalData\\app",
@@ -2501,8 +2501,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics SL Migration": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridSL\\app",
@@ -2514,8 +2514,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics SL Migration - US": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\HybridSL_US\\app",
@@ -2526,8 +2526,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Dynamics SL Migration - Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridSL\\test",
@@ -2539,8 +2539,8 @@
         "CA",
         "US"
       ],
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Dynamics SL Migration - US Tests": {
@@ -2552,8 +2552,8 @@
       "supportedCountries": [
         "US"
       ],
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Business Central Cloud Migration - Previous Release (AT)": {
@@ -2565,8 +2565,8 @@
         "AT"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (AU)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\AU\\HybridBCLast_AU\\app",
@@ -2577,8 +2577,8 @@
         "AU"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (BE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\BE\\HybridBCLast_BE\\app",
@@ -2589,8 +2589,8 @@
         "BE"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (CA)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CA\\HybridBCLast_CA\\app",
@@ -2601,8 +2601,8 @@
         "CA"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (CH)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CH\\HybridBCLast_CH\\app",
@@ -2613,8 +2613,8 @@
         "CH"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (CZ)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\HybridBCLast_CZ\\app",
@@ -2625,8 +2625,8 @@
         "CZ"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (DE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\HybridBCLast_DE\\app",
@@ -2637,8 +2637,8 @@
         "DE"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (ES)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\ES\\HybridBCLast_ES\\app",
@@ -2649,8 +2649,8 @@
         "ES"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (FR)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\HybridBCLast_FR\\app",
@@ -2661,8 +2661,8 @@
         "FR"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (IT)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IT\\HybridBCLast_IT\\app",
@@ -2673,8 +2673,8 @@
         "IT"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (MX)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\MX\\HybridBCLast_MX\\app",
@@ -2685,8 +2685,8 @@
         "MX"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (NZ)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NZ\\HybridBCLast_NZ\\app",
@@ -2697,8 +2697,8 @@
         "NZ"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Business Central Cloud Migration - Previous Release (US)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\HybridBCLast_US\\app",
@@ -2709,8 +2709,8 @@
         "US"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intelligent Cloud Base Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\HybridBaseDeployment\\test",
@@ -2719,8 +2719,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Business Central Intelligent Cloud Tests": {
@@ -2730,8 +2730,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Business Central Cloud Migration - Previous Release Tests": {
@@ -2741,8 +2741,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "BC14 Reimplementation Tool Tests": {
@@ -2752,8 +2752,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Image Analyzer": {
@@ -2771,8 +2771,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Image Analyzer Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ImageAnalysis\\test",
@@ -2789,8 +2789,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Payroll Data Import Definitions (DK)": {
@@ -2800,8 +2800,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payroll Data Import Definitions (DK) Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\ImportDKPayroll\\test",
@@ -2810,8 +2810,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Payroll Data Import Definition (NO)": {
@@ -2821,8 +2821,8 @@
       "supportedCountries": "NO",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payroll Data Import Definition (NO) Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NO\\ImportNOPayroll\\test",
@@ -2831,8 +2831,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Late Payment Prediction": {
@@ -2842,8 +2842,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Late Payment Prediction Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\LatePaymentPredictor\\test",
@@ -2852,8 +2852,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Microsoft Pay Payments": {
@@ -2863,8 +2863,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "DIOT - Localization for Mexico": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NA\\MX_DIOT\\app",
@@ -2878,8 +2878,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Tests for MX DIOT Extension.": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NA\\MX_DIOT\\test",
@@ -2892,8 +2892,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "IRS 1096": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\IRS1096\\app",
@@ -2905,8 +2905,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "IRS 1096 Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\IRS1096\\test",
@@ -2917,8 +2917,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "IRS Forms": {
@@ -2933,7 +2933,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "IRS Forms Test Library": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\IRSForms\\test library",
@@ -2946,7 +2946,7 @@
       "isTest": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "IRS Forms Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\IRSForms\\test",
@@ -2959,7 +2959,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Standard Audit File - Tax Localization for Norway": {
@@ -2972,8 +2972,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Standard Audit File - Tax Localization for Norway Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NO\\NorwegianSAFT\\test",
@@ -2984,8 +2984,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Electronic VAT submission for Norway": {
@@ -2996,8 +2996,8 @@
       "supportedCountries": "NO",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Electronic VAT Declaration for Denmark": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\ElectronicVATDeclarationDK\\app",
@@ -3007,8 +3007,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Electronic VAT Declaration for Denmark Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\ElectronicVATDeclarationDK\\test",
@@ -3017,8 +3017,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "OnPrem Permissions": {
@@ -3029,8 +3029,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Onprem Permissions\\test",
@@ -3040,8 +3040,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions DACH": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DACH\\Onprem Permissions DACH\\app",
@@ -3055,8 +3055,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions NA": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NA\\Onprem Permissions NA\\app",
@@ -3070,8 +3070,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions AU": {
       "projectPath": "$env:INETROOT\\App\\Apps\\AU\\Onprem Permissions AU\\app",
@@ -3083,8 +3083,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions CZ": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\Onprem Permissions CZ\\app",
@@ -3096,8 +3096,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions ES": {
       "projectPath": "$env:INETROOT\\App\\Apps\\ES\\Onprem Permissions ES\\app",
@@ -3109,8 +3109,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions FR": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\Onprem Permissions FR\\app",
@@ -3122,8 +3122,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OnPrem Permissions RU": {
       "projectPath": "$env:INETROOT\\App\\Apps\\RU\\Onprem Permissions RU\\app",
@@ -3135,8 +3135,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payment Links to PayPal": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\PayPalPaymentsStandard\\app",
@@ -3145,8 +3145,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PayPal Payments Standard Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\PayPalPaymentsStandard\\test",
@@ -3155,8 +3155,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Migration of QuickBooks Data": {
@@ -3169,8 +3169,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "QuickBooks Data Migration Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\QBMigration\\test",
@@ -3183,8 +3183,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Import of QuickBooks Payroll Files": {
@@ -3198,8 +3198,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Quickbooks Payroll File Import Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\QuickbooksPayrollFileImport\\test",
@@ -3212,8 +3212,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Sales and Inventory Forecast": {
@@ -3223,8 +3223,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sales and Inventory Forecast Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\SalesAndInventoryForecast\\test",
@@ -3233,8 +3233,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Email - Current User Connector": {
@@ -3244,8 +3244,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Email - Current User Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Email - Current User Connector\\test",
@@ -3254,8 +3254,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Email - Microsoft 365 Connector": {
@@ -3265,8 +3265,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Email - Microsoft 365 Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Email - Microsoft 365 Connector\\test",
@@ -3275,8 +3275,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Email - Outlook REST API": {
@@ -3286,8 +3286,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Library Outlook REST API": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Email - Outlook REST API\\test",
@@ -3297,8 +3297,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Email - SMTP API": {
@@ -3308,8 +3308,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Email - SMTP API Test Library": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Email - SMTP API\\test library",
@@ -3318,8 +3318,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Email - SMTP API Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Email - SMTP API\\test",
@@ -3328,8 +3328,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Email - SMTP Connector": {
@@ -3339,8 +3339,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Email - SMTP Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Email - SMTP Connector\\test",
@@ -3349,8 +3349,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "_Exclude_Email Logging Using Graph API": {
@@ -3361,8 +3361,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Email Logging Using Graph API Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EmailLogging\\test",
@@ -3371,8 +3371,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "_Exclude_Master_Data_Management": {
@@ -3383,8 +3383,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Master_Data_Management_Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\MasterDataManagement\\test",
@@ -3393,8 +3393,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "_Exclude_Master_Data_Management_Test_Library": {
@@ -3404,8 +3404,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Bank Deposits": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\BankDeposits\\app",
@@ -3415,8 +3415,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Bank Deposits Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\BankDeposits\\test",
@@ -3425,8 +3425,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "_Exclude_Microsoft Dynamics 365 - SmartList": {
@@ -3437,8 +3437,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_SyncBaseApp_": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\SyncBase\\app",
@@ -3448,8 +3448,8 @@
       "skipInstallOnPrem": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "installOnEnvironmentUpdate": true
     },
     "_Exclude_Onboarding Signals": {
@@ -3461,8 +3461,8 @@
       "hasTranslations": false,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Onboarding Signals Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\OnboardingSignals\\test",
@@ -3472,8 +3472,8 @@
       "hasTranslations": false,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "External File Storage - Azure Blob Service Connector": {
@@ -3484,7 +3484,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - Azure Blob Service Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - Azure Blob Service Connector\\Test",
@@ -3495,7 +3495,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - Azure File Service Connector": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - Azure File Service Connector\\App",
@@ -3505,7 +3505,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - Azure File Service Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - Azure File Service Connector\\Test",
@@ -3516,7 +3516,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - SharePoint Connector": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - SharePoint Connector\\App",
@@ -3526,7 +3526,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - SharePoint Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - SharePoint Connector\\Test",
@@ -3537,7 +3537,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - SFTP Connector": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - SFTP Connector\\App",
@@ -3547,7 +3547,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External File Storage - SFTP Connector Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External File Storage - SFTP Connector\\Test",
@@ -3558,7 +3558,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External Storage - Document Attachments": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External Storage - Document Attachments\\App",
@@ -3568,7 +3568,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "External Storage - Document Attachments Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\External Storage - Document Attachments\\Test",
@@ -3579,7 +3579,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Making Tax Digital Localization for United Kingdom": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\UKMakingTaxDigital\\app",
@@ -3589,8 +3589,8 @@
       "supportedCountries": "GB",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Making Tax Digital Localization for United Kingdom Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\UKMakingTaxDigital\\test",
@@ -3599,8 +3599,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "QR-Bill Management for Switzerland": {
@@ -3611,8 +3611,8 @@
       "supportedCountries": "CH",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "QR-Bill Management for Switzerland Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CH\\SwissQRBill\\test",
@@ -3621,8 +3621,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Digital Tax Declaration for the Netherlands": {
@@ -3633,8 +3633,8 @@
       "supportedCountries": "NL",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Digital Tax Declaration for the Netherlands Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NL\\NLDigitalTaxDeclaration\\test",
@@ -3643,8 +3643,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "IdealPostcodes": {
@@ -3655,7 +3655,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "IdealPostcodes Tests": {
@@ -3667,7 +3667,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Quality Management": {
@@ -3679,7 +3679,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Quality Management Test Library": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\Quality Management\\Test Library",
@@ -3689,7 +3689,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Quality Management-Tests": {
@@ -3700,7 +3700,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Subcontracting": {
@@ -3713,7 +3713,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Subcontracting-Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\Subcontracting\\Test",
@@ -3723,7 +3723,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Subcontracting Migration for IT": {
@@ -3735,8 +3735,8 @@
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Recommended Apps": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\RecommendedApps\\app",
@@ -3746,8 +3746,8 @@
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Recommended Apps Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\RecommendedApps\\test",
@@ -3756,8 +3756,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Review General Ledger Entries": {
@@ -3767,8 +3767,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Review_General_Ledger_Entries_Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ReviewGLEntries\\test",
@@ -3777,8 +3777,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "_Exclude_Connectivity Apps": {
@@ -3789,8 +3789,8 @@
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "_Exclude_Connectivity Apps Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ConnectivityApps\\test",
@@ -3799,8 +3799,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "SE Core": {
@@ -3811,8 +3811,8 @@
       "supportedCountries": "SE",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "SE Core Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\SECore\\test",
@@ -3821,8 +3821,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Send remittance advice by email": {
@@ -3842,7 +3842,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Send remittance advice by email Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\UKSendRemittanceAdvice\\Test",
@@ -3859,7 +3859,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Tax File Formats (DK)": {
@@ -3870,8 +3870,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Tax File Formats (DK) Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\VATReportsDK\\test",
@@ -3880,8 +3880,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "VAT Group Management": {
@@ -3903,8 +3903,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "VAT Group Management Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\VATGroupManagement\\test",
@@ -3924,8 +3924,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Simplified Bank Statement Import": {
@@ -3936,7 +3936,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Simplified Bank Statement Import Test": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\SimplifiedBankStatementImport\\Test",
@@ -3946,7 +3946,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Send To Email Printer": {
@@ -3957,7 +3957,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Universal Print Integration": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\MicrosoftUniversalPrint\\app",
@@ -3967,7 +3967,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Customs Declaration Tracking for Russia": {
       "projectPath": "$env:INETROOT\\App\\Apps\\RU\\CDTracking\\app",
@@ -3979,8 +3979,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Customs Declaration Tracking for Russia Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\RU\\CDTracking\\test",
@@ -3991,8 +3991,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "isTest": true,
       "owningteam": "\\AI Business Solutions\\SCM"
     },
@@ -4006,8 +4006,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Core Localization Pack for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\CoreLocalizationPack\\test",
@@ -4018,8 +4018,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Advanced Localization Pack for Czech": {
@@ -4032,8 +4032,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Advanced Localization Pack for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\AdvancedLocalizationPack\\test",
@@ -4044,8 +4044,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Cash Desk Localization for Czech": {
@@ -4058,8 +4058,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Cash Desk Localization for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\CashDeskLocalization\\test",
@@ -4070,8 +4070,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Cash Desk Localization for Czech Demo Data": {
@@ -4081,8 +4081,8 @@
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Compensation Localization for Czech": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\CompensationLocalization\\app",
@@ -4094,8 +4094,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Compensation Localization for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\CompensationLocalization\\test",
@@ -4106,8 +4106,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Compensation Localization for Czech Demo Data": {
@@ -4117,8 +4117,8 @@
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Fixed Asset Localization for Czech": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\FixedAssetLocalization\\app",
@@ -4130,8 +4130,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Fixed Asset Localization for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\FixedAssetLocalization\\test",
@@ -4142,8 +4142,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Fixed Asset Localization for Czech Demo Data": {
@@ -4153,8 +4153,8 @@
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Banking Documents Localization for Czech": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\BankingDocumentsLocalization\\app",
@@ -4166,8 +4166,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Banking Documents Localization for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\BankingDocumentsLocalization\\test",
@@ -4178,8 +4178,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Banking Documents Localization for Czech Demo Data": {
@@ -4189,8 +4189,8 @@
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Advance Payments Localization for Czech": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\AdvancePaymentsLocalization\\app",
@@ -4202,8 +4202,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Advance Payments Localization for Czech Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\AdvancePaymentsLocalization\\test",
@@ -4214,8 +4214,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Advance Payments Localization for Czech Demo Data": {
@@ -4225,8 +4225,8 @@
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Tax Engine": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\INTaxEngine\\app",
@@ -4238,8 +4238,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Tax Engine Test": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\INTaxEngine\\test",
@@ -4250,8 +4250,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\India"
     },
     "India Tax Base": {
@@ -4264,8 +4264,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "QR Generator": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\QRGeneration\\app",
@@ -4277,7 +4277,7 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json"
     },
     "India GST": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INGST\\app",
@@ -4289,8 +4289,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India TDS": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INTDS\\app",
@@ -4302,8 +4302,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India TCS": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INTCS\\app",
@@ -4315,8 +4315,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India Voucher Interface": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INVoucherInterface\\app",
@@ -4328,8 +4328,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India Gate Entry": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INGateEntry\\app",
@@ -4341,8 +4341,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Fixed Asset Depreciation for India": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INFADepreciation\\app",
@@ -4354,8 +4354,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India Charge Group": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INChargeGroup\\app",
@@ -4367,8 +4367,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India Reports": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INReports\\app",
@@ -4380,8 +4380,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India Data Migration": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INDataMigration",
@@ -4393,8 +4393,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India Tax Base Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INTaxBase\\test",
@@ -4405,8 +4405,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "India GST Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\INGST\\test",
@@ -4417,8 +4417,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "India TDS Tests": {
@@ -4430,8 +4430,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\India"
     },
     "India TCS Tests": {
@@ -4443,8 +4443,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\India"
     },
     "India Reports Tests": {
@@ -4456,8 +4456,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "India Voucher Interface Tests": {
@@ -4469,8 +4469,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "India Gate Entry Tests": {
@@ -4482,8 +4482,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Fixed Asset Depreciation Tests": {
@@ -4495,8 +4495,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "India Charge Group Tests": {
@@ -4508,8 +4508,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Contoso Coffee Demo Dataset": {
@@ -4521,8 +4521,8 @@
         "RU"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ContosoCoffeeDemoDataset\\test",
@@ -4533,8 +4533,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Contoso Coffee Demo Dataset (AT)": {
@@ -4544,8 +4544,8 @@
       "hasTranslations": true,
       "supportedCountries": "AT",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (AU)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\AU\\ContosoCoffeeDemoDatasetAU\\app",
@@ -4554,8 +4554,8 @@
       "hasTranslations": true,
       "supportedCountries": "AU",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (BE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\BE\\ContosoCoffeeDemoDatasetBE\\app",
@@ -4564,8 +4564,8 @@
       "hasTranslations": true,
       "supportedCountries": "BE",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (CA)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CA\\ContosoCoffeeDemoDatasetCA\\app",
@@ -4574,8 +4574,8 @@
       "hasTranslations": true,
       "supportedCountries": "CA",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (CH)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CH\\ContosoCoffeeDemoDatasetCH\\app",
@@ -4584,8 +4584,8 @@
       "hasTranslations": true,
       "supportedCountries": "CH",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (CZ)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\ContosoCoffeeDemoDatasetCZ\\app",
@@ -4594,8 +4594,8 @@
       "hasTranslations": true,
       "supportedCountries": "CZ",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (DE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\ContosoCoffeeDemoDatasetDE\\app",
@@ -4604,8 +4604,8 @@
       "hasTranslations": true,
       "supportedCountries": "DE",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (DK)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\ContosoCoffeeDemoDatasetDK\\app",
@@ -4614,8 +4614,8 @@
       "hasTranslations": true,
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (ES)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\ES\\ContosoCoffeeDemoDatasetES\\app",
@@ -4624,8 +4624,8 @@
       "hasTranslations": true,
       "supportedCountries": "ES",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (FI)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FI\\ContosoCoffeeDemoDatasetFI\\app",
@@ -4634,8 +4634,8 @@
       "hasTranslations": true,
       "supportedCountries": "FI",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (FR)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\ContosoCoffeeDemoDatasetFR\\app",
@@ -4644,8 +4644,8 @@
       "hasTranslations": true,
       "supportedCountries": "FR",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (GB)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\ContosoCoffeeDemoDatasetGB\\app",
@@ -4654,8 +4654,8 @@
       "hasTranslations": true,
       "supportedCountries": "GB",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (IS)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IS\\ContosoCoffeeDemoDatasetIS\\app",
@@ -4664,8 +4664,8 @@
       "hasTranslations": true,
       "supportedCountries": "IS",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (IT)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IT\\ContosoCoffeeDemoDatasetIT\\app",
@@ -4674,8 +4674,8 @@
       "hasTranslations": true,
       "supportedCountries": "IT",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (MX)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\MX\\ContosoCoffeeDemoDatasetMX\\app",
@@ -4684,8 +4684,8 @@
       "hasTranslations": true,
       "supportedCountries": "MX",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (NL)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NL\\ContosoCoffeeDemoDatasetNL\\app",
@@ -4694,8 +4694,8 @@
       "hasTranslations": true,
       "supportedCountries": "NL",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (NO)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NO\\ContosoCoffeeDemoDatasetNO\\app",
@@ -4704,8 +4704,8 @@
       "hasTranslations": true,
       "supportedCountries": "NO",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (NZ)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NZ\\ContosoCoffeeDemoDatasetNZ\\app",
@@ -4714,8 +4714,8 @@
       "hasTranslations": true,
       "supportedCountries": "NZ",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (SE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\ContosoCoffeeDemoDatasetSE\\app",
@@ -4724,8 +4724,8 @@
       "hasTranslations": true,
       "supportedCountries": "SE",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (US)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\ContosoCoffeeDemoDatasetUS\\app",
@@ -4734,8 +4734,8 @@
       "hasTranslations": true,
       "supportedCountries": "US",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Contoso Coffee Demo Dataset (IN)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IN\\ContosoCoffeeDemoDatasetIN\\app",
@@ -4744,8 +4744,8 @@
       "hasTranslations": true,
       "supportedCountries": "IN",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat Core": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Intrastat\\app",
@@ -4754,8 +4754,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "installOnEnvironmentUpdate": true
     },
     "Intrastat Core Tests": {
@@ -4768,8 +4768,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Intrastat AT": {
@@ -4780,8 +4780,8 @@
       "supportedCountries": "AT",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat BE": {
       "projectPath": "$env:INETROOT\\App\\Apps\\BE\\IntrastatBE\\app",
@@ -4791,8 +4791,8 @@
       "supportedCountries": "BE",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat CZ": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\IntrastatCZ\\app",
@@ -4802,8 +4802,8 @@
       "supportedCountries": "CZ",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat CZ Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\IntrastatCZ\\test",
@@ -4812,8 +4812,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance\\CZ"
     },
     "Intrastat DE": {
@@ -4824,8 +4824,8 @@
       "supportedCountries": "DE",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat DE Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\IntrastatDE\\test",
@@ -4834,8 +4834,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Intrastat ES": {
@@ -4846,8 +4846,8 @@
       "supportedCountries": "ES",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat FI": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FI\\IntrastatFI\\app",
@@ -4857,8 +4857,8 @@
       "supportedCountries": "FI",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat FR": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\IntrastatFR\\app",
@@ -4868,8 +4868,8 @@
       "supportedCountries": "FR",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat FR Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\IntrastatFR\\test",
@@ -4878,8 +4878,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Intrastat IT": {
@@ -4890,8 +4890,8 @@
       "supportedCountries": "IT",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat IT Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IT\\IntrastatIT\\test",
@@ -4900,8 +4900,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Intrastat GB": {
@@ -4912,8 +4912,8 @@
       "supportedCountries": "GB",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat GB Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\IntrastatGB\\test",
@@ -4922,8 +4922,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Intrastat NL": {
@@ -4934,8 +4934,8 @@
       "supportedCountries": "NL",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat SE": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\IntrastatSE\\app",
@@ -4945,8 +4945,8 @@
       "supportedCountries": "SE",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat Core Demo Data": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Intrastat\\demo data",
@@ -4958,8 +4958,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Intrastat CZ Demo Data": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\IntrastatCZ\\demo data",
@@ -4969,8 +4969,8 @@
       "supportedCountries": "CZ",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Service Declaration": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ServiceDeclaration\\app",
@@ -5007,8 +5007,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "installOnEnvironmentUpdate": true
     },
     "Service Declaration Tests": {
@@ -5045,8 +5045,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Service Declaration FR": {
@@ -5058,8 +5058,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "installOnEnvironmentUpdate": true
     },
     "Service Declaration FR Tests": {
@@ -5071,8 +5071,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Service Declaration IT": {
@@ -5084,8 +5084,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "installOnEnvironmentUpdate": true
     },
     "Service Declaration IT Tests": {
@@ -5097,8 +5097,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Manufacturing": {
@@ -5110,7 +5110,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Manufacturing Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Manufacturing\\test",
@@ -5119,8 +5119,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Service Management": {
@@ -5132,7 +5132,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Service Management Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ServiceManagement\\test",
@@ -5141,8 +5141,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Statistical Accounts": {
@@ -5153,8 +5153,8 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "hasTranslations": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Statistical Accounts Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\StatisticalAccounts\\test",
@@ -5163,8 +5163,8 @@
       "runStaticCodeAnalysis": true,
       "isTest": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "ESG Statistical Accounts Demo Tool": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ESGStatisticalAccountsDemoTool\\app",
@@ -5175,8 +5175,8 @@
         "RU"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sustainability": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Sustainability\\app",
@@ -5185,8 +5185,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sustainability Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\Sustainability\\test",
@@ -5195,8 +5195,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Calculate Sustainability Emission with Copilot": {
@@ -5207,7 +5207,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sustainability Copilot Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\SustainabilityCopilotSuggestion\\test",
@@ -5216,8 +5216,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sustainability Contoso Coffee Demo Dataset": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\SustainabilityContosoCoffeeDemoDataset\\app",
@@ -5228,8 +5228,8 @@
         "RU"
       ],
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sustainability Contoso Coffee Demo Dataset (NO)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NO\\SustainabilityContosoCoffeeDemoDatasetNO\\app",
@@ -5238,8 +5238,8 @@
       "hasTranslations": true,
       "supportedCountries": "NO",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sustainability Contoso Coffee Demo Dataset (ES)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\ES\\SustainabilityContosoCoffeeDemoDatasetES\\app",
@@ -5248,8 +5248,8 @@
       "hasTranslations": true,
       "supportedCountries": "ES",
       "runStaticCodeAnalysis": true,
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Quality Management Contoso Coffee Demo Dataset": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\Quality Management\\Demo Data",
@@ -5261,7 +5261,7 @@
       ],
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Expense Agent (Preview)": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\ExpenseAgent\\app",
@@ -5271,7 +5271,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5285,7 +5285,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5299,7 +5299,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5313,7 +5313,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5327,7 +5327,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5341,7 +5341,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5355,7 +5355,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5369,7 +5369,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5383,7 +5383,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5397,7 +5397,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5411,7 +5411,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5422,7 +5422,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -5444,7 +5444,7 @@
       ],
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (US)": {
@@ -5454,7 +5454,7 @@
       "supportedCountries": "US",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (GB)": {
@@ -5464,7 +5464,7 @@
       "supportedCountries": "GB",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (AU)": {
@@ -5474,7 +5474,7 @@
       "supportedCountries": "AU",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (NZ)": {
@@ -5484,7 +5484,7 @@
       "supportedCountries": "NZ",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (CA)": {
@@ -5494,7 +5494,7 @@
       "supportedCountries": "CA",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (ES)": {
@@ -5504,7 +5504,7 @@
       "supportedCountries": "ES",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (DK)": {
@@ -5514,7 +5514,7 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (FR)": {
@@ -5524,7 +5524,7 @@
       "supportedCountries": "FR",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (DE)": {
@@ -5534,7 +5534,7 @@
       "supportedCountries": "DE",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Expense Agent Demo Data (AT)": {
@@ -5544,7 +5544,7 @@
       "supportedCountries": "AT",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "OIOUBL": {
@@ -5557,8 +5557,8 @@
       "installOnEnvironmentUpdate": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "OIOUBL Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\OIOUBL\\test",
@@ -5569,8 +5569,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Dynamics GP Intelligent Cloud Tests": {
@@ -5586,8 +5586,8 @@
         "NZ",
         "US"
       ],
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Dynamics GP Intelligent Cloud - US Tests": {
@@ -5599,8 +5599,8 @@
       "supportedCountries": [
         "US"
       ],
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Bank Account Reconciliation With AI": {
@@ -5612,7 +5612,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Bank Account Reconciliation With AI Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\BankAccRecWithAI\\test",
@@ -5622,7 +5622,7 @@
       "isTest": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Sales Lines Suggestions": {
@@ -5634,7 +5634,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Sales Lines Suggestions Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\SalesLinesSuggestions\\test",
@@ -5644,7 +5644,7 @@
       "isTest": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\SCM"
     },
     "Create Product Information With Copilot": {
@@ -5656,7 +5656,7 @@
       "logLevel": "warning",
       "hasTranslations": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Automatic Account Codes": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\AutomaticAccountCodes\\app",
@@ -5669,8 +5669,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Automatic Account Codes Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\AutomaticAccountCodes\\test",
@@ -5682,8 +5682,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Audit File Export": {
@@ -5695,7 +5695,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Audit File Export Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\AuditFileExport\\test",
@@ -5705,7 +5705,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Standard Import Export (SIE)": {
@@ -5717,8 +5717,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "SIE Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\SIE\\test",
@@ -5729,8 +5729,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "FEC Audit File": {
@@ -5743,8 +5743,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "FEC Audit File Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\FECAuditFile\\test",
@@ -5755,8 +5755,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "EU 3-Party Trade Purchase": {
@@ -5797,8 +5797,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "EU 3-Party Trade Purchase Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EU3PartyTradePurchase\\test",
@@ -5837,8 +5837,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Payment Practices": {
@@ -5849,7 +5849,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payment Practices Test Library": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\PaymentPractices\\Test Library",
@@ -5859,7 +5859,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Payment Practices Tests": {
@@ -5870,7 +5870,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "SAF-T": {
@@ -5896,8 +5896,8 @@
       ],
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "SAF-T Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\SAF-T\\test",
@@ -5921,8 +5921,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "SAF-T Modification DK": {
@@ -5932,8 +5932,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "SAF-T Modification DK Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\SAFTModificationDK\\test",
@@ -5942,8 +5942,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     }, 
     "PEPPOL": {
@@ -5955,7 +5955,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\PEPPOL\\Test",
@@ -5967,7 +5967,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL NO": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NO\\PEPPOLNO\\app",
@@ -5978,7 +5978,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL BE": {
       "projectPath": "$env:INETROOT\\App\\Apps\\BE\\PEPPOLBE\\App",
@@ -5989,7 +5989,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL NA": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NA\\PEPPOLNA\\app",
@@ -6004,7 +6004,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL DE": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\PEPPOLDE\\app",
@@ -6015,7 +6015,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL SE": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\PeppolSE\\App",
@@ -6026,7 +6026,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PEPPOL SE Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\PeppolSE\\Test",
@@ -6036,7 +6036,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocument\\App",
@@ -6047,7 +6047,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocument\\Test",
@@ -6058,7 +6058,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "E-Document Core Demo Data": {
@@ -6072,7 +6072,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data IT": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IT\\EDocumentIT\\demo data",
@@ -6082,7 +6082,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (US)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\US\\EDocument_US\\demo data",
@@ -6092,7 +6092,7 @@
       "supportedCountries": "US",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (GB)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\EDocument_GB\\demo data",
@@ -6102,7 +6102,7 @@
       "supportedCountries": "GB",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (AU)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\AU\\EDocument_AU\\demo data",
@@ -6112,7 +6112,7 @@
       "supportedCountries": "AU",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (NZ)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NZ\\EDocument_NZ\\demo data",
@@ -6122,7 +6122,7 @@
       "supportedCountries": "NZ",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (FR)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\EDocument_FR\\demo data",
@@ -6132,7 +6132,7 @@
       "supportedCountries": "FR",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (NL)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NL\\EDocument_NL\\demo data",
@@ -6142,7 +6142,7 @@
       "supportedCountries": "NL",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data ES": {
       "projectPath": "$env:INETROOT\\App\\Apps\\ES\\EDocumentES\\demo data",
@@ -6152,7 +6152,7 @@
       "supportedCountries": "ES",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (DK)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\EDocument_DK\\demo data",
@@ -6162,7 +6162,7 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (CA)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CA\\EDocument_CA\\demo data",
@@ -6172,7 +6172,7 @@
       "supportedCountries": "CA",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (DE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\EDocumentDE\\demo data",
@@ -6183,7 +6183,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (BE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\BE\\EDocument_BE\\demo data",
@@ -6193,7 +6193,7 @@
       "supportedCountries": "BE",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (NO)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NO\\EDocument_NO\\demo data",
@@ -6203,7 +6203,7 @@
       "supportedCountries": "NO",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data (SE)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\SE\\EDocument_SE\\demo data",
@@ -6213,7 +6213,7 @@
       "supportedCountries": "SE",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data CH": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CH\\EDocument_CH\\demo data",
@@ -6223,7 +6223,7 @@
       "supportedCountries": "CH",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data CZ": {
       "projectPath": "$env:INETROOT\\App\\Apps\\CZ\\EDocument_CZ\\demo data",
@@ -6233,7 +6233,7 @@
       "supportedCountries": "CZ",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data FI": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FI\\EDocument_FI\\demo data",
@@ -6243,7 +6243,7 @@
       "supportedCountries": "FI",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Core Demo Data AT": {
       "projectPath": "$env:INETROOT\\App\\Apps\\AT\\EDocument_AT\\demo data",
@@ -6253,7 +6253,7 @@
       "supportedCountries": "AT",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Nemhandel Notification in Denmark": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\NemhandelNotification\\app",
@@ -6264,8 +6264,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Nemhandel Notification Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\NemhandelNotification\\test",
@@ -6274,8 +6274,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Transactions and Receipts Storage": {
@@ -6287,7 +6287,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "IS Core": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IS\\ISCore\\app",
@@ -6297,8 +6297,8 @@
       "supportedCountries": "IS",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "IS Core Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\IS\\ISCore\\test",
@@ -6307,8 +6307,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Enforced Digital Vouchers": {
@@ -6320,7 +6320,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Enforced Digital Vouchers Test Library": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EnforcedDigitalVouchers\\test library",
@@ -6330,7 +6330,7 @@
       "isTest": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Enforced Digital Vouchers Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EnforcedDigitalVouchers\\test",
@@ -6340,7 +6340,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Enforced Digital Vouchers (DK)": {
@@ -6352,7 +6352,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Enforced Digital Vouchers Tests (DK)": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\EnforcedDigitalVouchersDK\\test",
@@ -6361,8 +6361,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "E-Document Connector - Pagero": {
@@ -6373,7 +6373,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - Pagero Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EDocumentConnectors\\Pagero\\test",
@@ -6383,7 +6383,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "E-Document Connector - Avalara": {
@@ -6394,7 +6394,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - Avalara Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocumentConnectors\\Avalara\\Test",
@@ -6404,7 +6404,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "E-Document Connector - Microsoft 365": {
@@ -6415,7 +6415,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true
     },
     "E-Document Connector - Microsoft 365 Tests": {
@@ -6426,7 +6426,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Finance"
     },
@@ -6438,7 +6438,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - Logiq Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EDocumentConnectors\\Logiq\\test",
@@ -6448,7 +6448,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "E-Document Connector - SignUp": {
@@ -6459,7 +6459,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - SignUp Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EDocumentConnectors\\SignUp\\test",
@@ -6469,7 +6469,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "E-Document Connector - B2Brouter": {
@@ -6480,7 +6480,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - B2Brouter Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\EDocumentConnectors\\B2Brouter\\test",
@@ -6490,7 +6490,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - Continia": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocumentConnectors\\Continia\\app",
@@ -6500,7 +6500,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - Continia Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocumentConnectors\\Continia\\test",
@@ -6510,7 +6510,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - ForNAV": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocumentConnectors\\ForNAV\\App",
@@ -6520,7 +6520,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Connector - ForNAV Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\EDocumentConnectors\\ForNav\\Test",
@@ -6530,7 +6530,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document format for OIOUBL": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DK\\EDocumentFormatOIOUBL\\app",
@@ -6540,8 +6540,8 @@
       "supportedCountries": "DK",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Format for PINT A-NZ": {
       "projectPath": "$env:INETROOT\\App\\Apps\\APAC\\EDocumentFormats\\PINT A-NZ\\app",
@@ -6554,7 +6554,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Format for PINT A-NZ Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\APAC\\EDocumentFormats\\PINT A-NZ\\test",
@@ -6567,7 +6567,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "E-Document Format for Factura-E": {
@@ -6579,7 +6579,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document Format for Factura-E Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\ES\\EDocumentFormats\\FacturaE\\test",
@@ -6589,7 +6589,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Document Registration in Spain": {
@@ -6601,7 +6601,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Document Registration in Spain Tests": {
@@ -6614,7 +6614,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "E-Reporting FR": {
@@ -6626,7 +6626,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "E-Reporting FR Tests": {
@@ -6637,7 +6637,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "E-Document for Germany": {
@@ -6649,7 +6649,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "E-Document for Germany Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\DE\\EDocumentDE\\test",
@@ -6659,7 +6659,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
     "Field Service Integration": {
@@ -6670,7 +6670,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true
     },
     "Field Service Integration Test Library": {
@@ -6681,7 +6681,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true
     },
     "Field Service Integration Test": {
@@ -6692,7 +6692,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "owningteam": "\\AI Business Solutions\\Integrations"
     },
@@ -6705,7 +6705,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Subscription Billing Demo Data": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\Subscription Billing\\Demo Data",
@@ -6719,7 +6719,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Subscription Billing Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\Subscription Billing\\Test",
@@ -6730,7 +6730,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Agent Design Experience": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\AgentDesignExperience\\app",
@@ -6740,7 +6740,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "installOnEnvironmentUpdate": true,
@@ -6756,7 +6756,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true
     },
     "Agent Samples": {
@@ -6767,7 +6767,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "installOnEnvironmentUpdate": true,
@@ -6783,7 +6783,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "installOnEnvironmentUpdate": true,
       "allowedEnvironmentTypes": [
@@ -6821,7 +6821,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true
     },
@@ -6833,7 +6833,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "installOnEnvironmentUpdate": true,
@@ -6849,7 +6849,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "installOnEnvironmentUpdate": true,
@@ -6865,7 +6865,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "installOnEnvironmentUpdate": true,
@@ -6881,7 +6881,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true,
       "hasTranslations": true,
       "installOnEnvironmentUpdate": true,
@@ -6897,7 +6897,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true
     },
     "Power BI Report embeddings for Dynamics 365 Business Central": {
@@ -6908,7 +6908,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PowerBI Reports Test Library": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\PowerBIReports\\Test Library",
@@ -6918,7 +6918,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "PowerBI Reports Tests": {
       "projectPath": "$env:INETROOT\\App\\BCApps\\src\\Apps\\W1\\PowerBIReports\\Test",
@@ -6928,7 +6928,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     },
     "Payables Agent": {
@@ -6940,7 +6940,7 @@
       "installOnEnvironmentUpdate": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "skipInstallOnPrem": true
     },
     "VAT Audit Reports GB": {
@@ -6952,7 +6952,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "VAT Audit Reports GB Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\VATReporting\\test",
@@ -6962,7 +6962,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Reverse Charge VAT GB": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\ReverseChargeVAT\\app",
@@ -6973,7 +6973,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Reverse Charge VAT GB Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\ReverseChargeVAT\\test",
@@ -6983,7 +6983,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Extended Bank Deposit NA": {
       "projectPath": "$env:INETROOT\\App\\Apps\\NA\\ExtendedBankDepositNA\\app",
@@ -6998,7 +6998,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "GovTalk": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\GovTalk\\app",
@@ -7009,7 +7009,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "GovTalk Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\GovTalk\\test",
@@ -7019,7 +7019,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "GovTalk Demo Data": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\GovTalk\\demo data",
@@ -7030,7 +7030,7 @@
       "supportedCountries": "GB",
       "runStaticCodeAnalysis": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Reports GB": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\ReportsGB\\app",
@@ -7041,7 +7041,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Reports GB Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\ReportsGB\\test",
@@ -7051,7 +7051,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Posting Date Check On Posting": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\PostingDateCheckOnPosting\\app",
@@ -7062,7 +7062,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Posting Date Check On Posting Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\GB\\PostingDateCheckOnPosting\\test",
@@ -7072,7 +7072,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "FA Reports FR": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\FAReportsFR\\app",
@@ -7083,7 +7083,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "FA Reports FR Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\FAReportsFR\\test",
@@ -7093,7 +7093,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Withholding Tax": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\WithholdingTax\\app",
@@ -7122,8 +7122,8 @@
       "installOnEnvironmentUpdate": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Withholding Tax Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\WithholdingTax\\test",
@@ -7151,8 +7151,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Expense Withholding Tax": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ExpenseWithholdingTax\\app",
@@ -7182,7 +7182,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$ENV:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payment Management FR": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\PaymentManagementFR\\app",
@@ -7193,7 +7193,7 @@
       "logLevel": "warning",
       "installOnEnvironmentUpdate": true,
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Payment Management FR-Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\FR\\PaymentManagementFR\\test",
@@ -7203,7 +7203,7 @@
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
       "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
-      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\minorrelease.ruleset.json"
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Excise Taxes": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ExciseTaxes\\app",
@@ -7212,8 +7212,8 @@
       "supportedCountries": "All",
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json"
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json"
     },
     "Excise Taxes Tests": {
       "projectPath": "$env:INETROOT\\App\\Apps\\W1\\ExciseTaxes\\test",
@@ -7222,8 +7222,8 @@
       "isTest": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",
-      "ruleSetPath": "$ENV:INETROOT\\App\\Rulesets\\app.ruleset.json",
-      "ruleSetPathMinorRelease": "$ENV:INETROOT\\App\\Rulesets\\MinorRelease\\app.ruleset.json",
+      "ruleSetPath": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\base.ruleset.json",
+      "ruleSetPathMinorRelease": "$env:INETROOT\\App\\BCApps\\src\\rulesets\\baseminorrelease.ruleset.json",
       "owningteam": "\\AI Business Solutions\\Finance"
     }
   }

--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -29,6 +29,9 @@ function Get-BuildMode() {
 }
 
 function Get-CurrentBranch() {
+    if ($ENV:GITHUB_REF_NAME) {
+        return $ENV:GITHUB_REF_NAME
+    }
     return git rev-parse --abbrev-ref HEAD
 }
 

--- a/build/scripts/PreCompileApp.ps1
+++ b/build/scripts/PreCompileApp.ps1
@@ -287,7 +287,7 @@ if($appType -eq 'app')
                     return
                 } else {
                     Write-Host "Enabling minor release ruleset for strict mode breaking changes check"
-                    $parameters.Value["ruleset"] = Get-RulesetPath -Name "minorrelease.ruleset.json"
+                    $parameters.Value["ruleset"] = Get-RulesetPath -Name "baseminorrelease.ruleset.json"
                 }
             }
 

--- a/src/rulesets/baseminorrelease.ruleset.json
+++ b/src/rulesets/baseminorrelease.ruleset.json
@@ -1,0 +1,26 @@
+{
+    "name": "Ruleset for Minor Releases",
+    "includedRuleSets": [
+        {
+            "action": "Default",
+            "path": "./base.ruleset.json"
+        }
+    ],
+    "rules": [
+        {
+            "id": "AS0077",
+            "action": "Error",
+            "justification": "Adding or removing a var modifier in events is a runtime breaking change."
+        },
+        {
+            "id": "AS0078",
+            "action": "Error",
+            "justification": "Adding or removing a var modifier in procedures is a runtime breaking change."
+        },
+        {
+            "id": "AS0102",
+            "action": "Error",
+            "justification": "Adding a return type on procedures is a runtime breaking change."
+        }
+    ]
+}


### PR DESCRIPTION
## What & why

Two related build-configuration changes for the strict mode / minor-release breaking-changes check:

1. **Consolidate the minor-release ruleset.** `build/projects.json` had the `ruleSetPathMinorRelease` property spread across several different files with inconsistent paths and casing, and `ruleSetPath` likewise pointed at multiple different files. This unifies them: every `ruleSetPathMinorRelease` now points to a new shared `src/rulesets/baseminorrelease.ruleset.json`, and every `ruleSetPath` points to `src/rulesets/base.ruleset.json`. The new ruleset includes `base.ruleset.json` plus the minor-release breaking-change rules (AS0077, AS0078, AS0102). `PreCompileApp.ps1` is updated to resolve the new file name for the strict mode check.

2. **Fix strict mode detection on release-branch CI/CD.** On a push build against a release branch, `Test-IsStrictModeEnabled` resolved the branch via `Get-CurrentBranch`, which used `git rev-parse --abbrev-ref HEAD`. In GitHub Actions the checkout is a detached HEAD, so that returns the literal `HEAD`, which never matches `^releases/\d+\.\d+$`. The result was strict mode being silently skipped on release branches (only PR builds worked, via `GITHUB_BASE_REF`). `Get-CurrentBranch` now returns `GITHUB_REF_NAME` when it is set, falling back to git only for local runs.

Centralizing the fix in `Get-CurrentBranch` also corrects the same latent detached-HEAD issue in the baseline-storage `main` branch check.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

[AB#647333](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647333)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Verified all 493 `ruleSetPathMinorRelease` and all 550 `ruleSetPath` entries in `projects.json` now resolve to a single path each, and that `projects.json` remains valid JSON.
- Parse-checked the edited PowerShell modules.
- Simulated branch resolution: push on `releases/28.4` now resolves to `releases/28.4` and matches the strict mode regex (previously `HEAD`, no match); PR into a release branch still works via `GITHUB_BASE_REF`; `main` and `releases/NN.x` correctly stay disabled (no numeric StrictMode tag).
- No AL tests added; changes are build-script/config only.

## Risk & compatibility

- Behavior change: strict mode breaking-changes validation will now actually run on release-branch push builds where it was previously being skipped. This is the intended fix, but it may surface breaking-change analyzer errors that were not being reported before.
- The old `src/rulesets/minorrelease.ruleset.json` is now unreferenced. It was left in place in this PR; it can be removed in a follow-up if desired.


