### PR TITLE
Scope PR test runs to affected apps and cover .github in fullBuildPatterns

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -140,8 +140,7 @@
     "src/rulesets/*",
     "src/Layers/*",
     "src/DisabledTests/*",
-    ".github/workflows/PullRequestHandler.yaml",
-    ".github/workflows/_BuildALGoProject.yaml"
+    ".github/*"
   ],
   "PullRequestTrigger": "pull_request",
   "ALDoc": {

--- a/build/scripts/BuildOptimization.psm1
+++ b/build/scripts/BuildOptimization.psm1
@@ -231,11 +231,14 @@ function Get-ChangedFilesForCI {
     $ErrorActionPreference = 'Continue'
     try {
         # Best-effort fetch of base commit (may not be in shallow clone)
-        git fetch origin $baseSha --depth=1 2>$null
-
-        $files = @(git diff --name-only $baseSha $headSha 2>$null)
+        $fetchOutput = git fetch origin $baseSha --depth=1 2>&1
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "BUILD OPTIMIZATION: git diff failed (exitCode=$LASTEXITCODE)"
+            Write-Host "BUILD OPTIMIZATION: base fetch failed (exit=$LASTEXITCODE): $fetchOutput"
+        }
+
+        $files = @(git diff --name-only $baseSha $headSha 2>&1)
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "BUILD OPTIMIZATION: git diff failed (exitCode=$LASTEXITCODE): $files"
             return $null
         }
 

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -720,6 +720,16 @@ function Invoke-PerProjectTestRun {
     $installed = Get-InstalledTestAppNames -ContainerName $parameters.containerName -Tenant $parameters.tenant -Country $country
     $appNamesToTest = Get-AppNamesForBucket -InstalledTestAppNames $installed -TestType $testType -BucketNumber $bucketNumber
 
+    # Build optimization (PR builds only): drop test apps not affected by the changed files.
+    # Test-ShouldSkipTestApp returns $false (run) for every app when a full run is required
+    # (fullBuildPatterns match, unmapped src file, non-CI, or workflow_dispatch), so this is
+    # correctness-preserving and simply a no-op outside PRs.
+    Import-Module (Join-Path $PSScriptRoot "BuildOptimization.psm1" -Resolve)
+    $baseFolder = Get-BaseFolder
+    $appNamesToTest = @($appNamesToTest | Where-Object {
+        -not (Test-ShouldSkipTestApp -AppName $_ -BaseFolder $baseFolder)
+    })
+
     if ($appNamesToTest.Count -eq 0) {
         Write-Host "No test apps to run for testType '$testType' in this project."
         return $true


### PR DESCRIPTION
## What & why

BCApps currently runs the full test suite (~316 test apps) on every PR, even when a change touches a single app. The build-optimization logic to scope test runs to only the affected apps already existed in `BuildOptimization.psm1` (with unit tests), but nothing in the pipeline called it. This wires it in and fixes a related gap in `fullBuildPatterns`.

Two changes:

- **Wire up per-app test optimization.** `Invoke-PerProjectTestRun` now filters the per-project test-app list through `Test-ShouldSkipTestApp`, so a PR only runs tests for apps affected by its changed files plus their dependents. Filtering happens before dispatch, so skipped apps never occupy a tenant. This is correctness-preserving: a full run is still forced for `fullBuildPatterns` matches, unmapped files under `src/`, non-CI runs, and `workflow_dispatch`, so the failure mode is always "run too much," never "skip something it shouldn't."

- **Cover `.github/*` in `fullBuildPatterns`.** Previously only two specific workflow files were listed. A change to `.github/AL-Go-Settings.json` (which defines artifact version, analyzers, target country, and the patterns themselves) mapped to no app, produced an empty affected set, and would have skipped every test. Broadening to `.github/*` closes that hole and subsumes the two explicit workflow entries.

On a sample of 10 recent open PRs, 6 dropped from 316 test apps to 4 or fewer; the rest correctly stayed full (base-layer or infra changes).

## Linked work

<!-- No approved issue yet; opening as draft for discussion. -->

Fixes #

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Ran the existing `BuildOptimization.Test.ps1` Pester suite: 36/37 pass. The one failure (`Get-AffectedApps ... Expected 51, but got 56`) is a pre-existing hardcoded-count assertion that also fails on `main` with these changes stashed; it is dependency-graph drift from apps added since the count was written, unrelated to this change.
- Verified `.github/AL-Go-Settings.json` still parses and `ParallelTestExecution.psm1` imports cleanly.
- Replayed the affected-app computation against 10 open PRs to confirm scoping behaves as expected (single-app PRs scope down to 1-4 test apps; base-layer/infra PRs force a full run via `fullBuildPatterns`).
- No new behavior-specific tests added: the filtering reuses the already-tested `Test-ShouldSkipTestApp`, and this change is wiring plus a settings entry.

## Risk & compatibility

- The optimization only narrows test runs on PR builds; it is a no-op outside CI and whenever a full run is required, so it cannot cause fewer tests to run than intended in those cases.
- Scoping accuracy depends on `app.json` dependency declarations being correct (already how build order is resolved). A product app with no linked test app resolves to zero affected test apps; that is correct when the app genuinely has no tests, but a follow-up guard could warn when a changed product app has no associated test app.
- Broadening to `.github/*` means build-irrelevant edits (e.g. `PULL_REQUEST_TEMPLATE.md`, `CODEOWNERS`) now force a full run. This is intentional and consistent with the conservative, correctness-first intent of the list.
- Pre-existing stale test count (`51` vs `56`) is worth fixing separately so the suite goes green.

