### PR TITLE
[Shopify] Fix Order Totals factbox opening an unrelated sales order for a linked posted invoice

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
@@ -7,6 +7,7 @@ namespace Microsoft.Integration.Shopify;
 
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Sales.Document;
+using Microsoft.Sales.History;
 using Microsoft.Utilities;
 
 page 30172 "Shpfy Order Totals FactBox"
@@ -164,14 +165,19 @@ page 30172 "Shpfy Order Totals FactBox"
                     ToolTip = 'Specifies the sales document number.';
 
                     trigger OnDrillDown()
+                    var
+                        IOpenBCDocument: Interface "Shpfy IOpenBCDocument";
                     begin
-                        Page.Run(Page::"Sales Order", SalesHeader);
+                        if DocumentNo = '' then
+                            exit;
+                        IOpenBCDocument := SalesDocumentType;
+                        IOpenBCDocument.OpenDocument(DocumentNo);
                     end;
                 }
-                field(TotalAmountExclVAT; TotalSalesLine.Amount)
+                field(TotalAmountExclVAT; TotalAmountExclVAT)
                 {
                     ApplicationArea = All;
-                    AutoFormatExpression = SalesHeader."Currency Code";
+                    AutoFormatExpression = CurrencyCode;
                     AutoFormatType = 1;
                     CaptionClass = DocumentTotals.GetTotalExclVATCaption(CurrencyCode);
                     Caption = 'Total Amount Excl. VAT';
@@ -180,16 +186,16 @@ page 30172 "Shpfy Order Totals FactBox"
                 field("Total VAT Amount"; VATAmount)
                 {
                     ApplicationArea = All;
-                    AutoFormatExpression = SalesHeader."Currency Code";
+                    AutoFormatExpression = CurrencyCode;
                     AutoFormatType = 1;
                     CaptionClass = DocumentTotals.GetTotalVATCaption(CurrencyCode);
                     Caption = 'Total VAT';
                     ToolTip = 'Specifies the sum of VAT amounts on all lines in the document.';
                 }
-                field("Total Amount Incl. VAT"; TotalSalesLine."Amount Including VAT")
+                field("Total Amount Incl. VAT"; TotalAmountInclVAT)
                 {
                     ApplicationArea = All;
-                    AutoFormatExpression = SalesHeader."Currency Code";
+                    AutoFormatExpression = CurrencyCode;
                     AutoFormatType = 1;
                     CaptionClass = DocumentTotals.GetTotalInclVATCaption(CurrencyCode);
                     Caption = 'Total Amount Incl. VAT';
@@ -210,9 +216,24 @@ page 30172 "Shpfy Order Totals FactBox"
                     trigger OnDrillDown()
                     var
                         SalesLine: Record "Sales Line";
+                        SalesInvoiceLine: Record "Sales Invoice Line";
                     begin
-                        SalesLine.SetRange("Document No.", DocumentNo);
-                        Page.Run(Page::"Sales Lines", SalesLine);
+                        if DocumentNo = '' then
+                            exit;
+                        case SalesDocumentType of
+                            SalesDocumentType::"Sales Order",
+                            SalesDocumentType::"Sales Invoice":
+                                begin
+                                    SalesLine.SetRange("Document Type", GetSalesDocumentType());
+                                    SalesLine.SetRange("Document No.", DocumentNo);
+                                    Page.Run(Page::"Sales Lines", SalesLine);
+                                end;
+                            SalesDocumentType::"Posted Sales Invoice":
+                                begin
+                                    SalesInvoiceLine.SetRange("Document No.", DocumentNo);
+                                    Page.Run(Page::"Posted Sales Invoice Lines", SalesInvoiceLine);
+                                end;
+                        end;
                     end;
                 }
                 field(CurrencyCode; CurrencyCode)
@@ -226,42 +247,159 @@ page 30172 "Shpfy Order Totals FactBox"
     }
 
     trigger OnAfterGetRecord()
-    var
-        SalesLine: Record "Sales Line";
-        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
         PresentmentVisible := Rec.IsPresentmentCurrencyOrder();
-        if Rec."Sales Order No." <> '' then
-            if not SalesHeader.Get(SalesHeader."Document Type"::Order, Rec."Sales Order No.") then
-                exit;
+        UpdateSalesDocumentInfo();
+    end;
 
-        if Rec."Sales Invoice No." <> '' then
-            if not SalesHeader.Get(SalesHeader."Document Type"::Invoice, Rec."Sales Invoice No.") then
-                exit;
-
-        DocumentNo := SalesHeader."No.";
-        PricesIncludingVAT := SalesHeader."Prices Including VAT";
-        if SalesHeader."Currency Code" <> '' then
-            CurrencyCode := SalesHeader."Currency Code"
-        else begin
-            GeneralLedgerSetup.Get();
-            CurrencyCode := GeneralLedgerSetup."LCY Code";
+    local procedure UpdateSalesDocumentInfo()
+    begin
+        ClearSalesDocumentInfo();
+        if not ResolveSalesDocument(SalesDocumentType, DocumentNo) then begin
+            DocumentNo := '';
+            exit;
         end;
 
+        case SalesDocumentType of
+            SalesDocumentType::"Sales Order",
+            SalesDocumentType::"Sales Invoice":
+                UpdateOpenSalesDocumentTotals();
+            SalesDocumentType::"Posted Sales Invoice":
+                UpdatePostedSalesInvoiceTotals();
+        end;
+    end;
+
+    local procedure ResolveSalesDocument(var DocumentType: Enum "Shpfy Document Type"; var SalesDocumentNo: Code[20]): Boolean
+    begin
+        if FindLinkedDocument("Shpfy Document Type"::"Posted Sales Invoice", SalesDocumentNo) then begin
+            DocumentType := "Shpfy Document Type"::"Posted Sales Invoice";
+            exit(true);
+        end;
+        if FindLinkedDocument("Shpfy Document Type"::"Sales Invoice", SalesDocumentNo) then begin
+            DocumentType := "Shpfy Document Type"::"Sales Invoice";
+            exit(true);
+        end;
+        if FindLinkedDocument("Shpfy Document Type"::"Sales Order", SalesDocumentNo) then begin
+            DocumentType := "Shpfy Document Type"::"Sales Order";
+            exit(true);
+        end;
+
+        // Fallback for orders processed before the document link table was populated.
+        if Rec."Sales Invoice No." <> '' then begin
+            DocumentType := "Shpfy Document Type"::"Sales Invoice";
+            SalesDocumentNo := Rec."Sales Invoice No.";
+            exit(true);
+        end;
+        if Rec."Sales Order No." <> '' then begin
+            DocumentType := "Shpfy Document Type"::"Sales Order";
+            SalesDocumentNo := Rec."Sales Order No.";
+            exit(true);
+        end;
+        exit(false);
+    end;
+
+    local procedure FindLinkedDocument(DocumentType: Enum "Shpfy Document Type"; var SalesDocumentNo: Code[20]): Boolean
+    var
+        DocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
+    begin
+        DocLinkToBCDoc.SetRange("Shopify Document Type", "Shpfy Shop Document Type"::"Shopify Shop Order");
+        DocLinkToBCDoc.SetRange("Shopify Document Id", Rec."Shopify Order Id");
+        DocLinkToBCDoc.SetRange("Document Type", DocumentType);
+        if DocLinkToBCDoc.FindLast() then begin
+            SalesDocumentNo := DocLinkToBCDoc."Document No.";
+            exit(true);
+        end;
+        exit(false);
+    end;
+
+    local procedure UpdateOpenSalesDocumentTotals()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        TotalSalesLine: Record "Sales Line";
+    begin
+        if not SalesHeader.Get(GetSalesDocumentType(), DocumentNo) then begin
+            ClearSalesDocumentInfo();
+            exit;
+        end;
+
+        PricesIncludingVAT := SalesHeader."Prices Including VAT";
+        CurrencyCode := GetCurrencyCode(SalesHeader."Currency Code");
+
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         NumberOfLines := SalesLine.Count();
-        if SalesLine.FindLast() then
+        if SalesLine.FindLast() then begin
             DocumentTotals.CalculateSalesTotals(TotalSalesLine, VATAmount, SalesLine);
+            TotalAmountExclVAT := TotalSalesLine.Amount;
+            TotalAmountInclVAT := TotalSalesLine."Amount Including VAT";
+        end;
+    end;
+
+    local procedure UpdatePostedSalesInvoiceTotals()
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesInvoiceLine: Record "Sales Invoice Line";
+    begin
+        if not SalesInvoiceHeader.Get(DocumentNo) then begin
+            ClearSalesDocumentInfo();
+            exit;
+        end;
+
+        PricesIncludingVAT := SalesInvoiceHeader."Prices Including VAT";
+        CurrencyCode := GetCurrencyCode(SalesInvoiceHeader."Currency Code");
+
+        SalesInvoiceLine.SetRange("Document No.", SalesInvoiceHeader."No.");
+        NumberOfLines := SalesInvoiceLine.Count();
+        if SalesInvoiceLine.FindFirst() then
+            DocumentTotals.CalculatePostedSalesInvoiceTotals(SalesInvoiceHeader, VATAmount, SalesInvoiceLine);
+
+        SalesInvoiceHeader.CalcFields(Amount, "Amount Including VAT");
+        TotalAmountExclVAT := SalesInvoiceHeader.Amount;
+        TotalAmountInclVAT := SalesInvoiceHeader."Amount Including VAT";
+    end;
+
+    local procedure ClearSalesDocumentInfo()
+    begin
+        Clear(SalesDocumentType);
+        DocumentNo := '';
+        PricesIncludingVAT := false;
+        NumberOfLines := 0;
+        CurrencyCode := '';
+        VATAmount := 0;
+        TotalAmountExclVAT := 0;
+        TotalAmountInclVAT := 0;
+    end;
+
+    local procedure GetSalesDocumentType(): Enum "Sales Document Type"
+    begin
+        case SalesDocumentType of
+            SalesDocumentType::"Sales Order":
+                exit("Sales Document Type"::Order);
+            SalesDocumentType::"Sales Invoice":
+                exit("Sales Document Type"::Invoice);
+        end;
+    end;
+
+    local procedure GetCurrencyCode(DocumentCurrencyCode: Code[10]): Code[10]
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+    begin
+        if DocumentCurrencyCode <> '' then
+            exit(DocumentCurrencyCode);
+        GeneralLedgerSetup.Get();
+        exit(GeneralLedgerSetup."LCY Code");
     end;
 
     var
-        SalesHeader: Record "Sales Header";
-        TotalSalesLine: Record "Sales Line";
         DocumentTotals: Codeunit "Document Totals";
-        DocumentNo: Text[20];
+        SalesDocumentType: Enum "Shpfy Document Type";
+        DocumentNo: Code[20];
         PricesIncludingVAT: Boolean;
         PresentmentVisible: Boolean;
         NumberOfLines: Integer;
         CurrencyCode: Code[10];
         VATAmount: Decimal;
+        TotalAmountExclVAT: Decimal;
+        TotalAmountInclVAT: Decimal;
 }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
@@ -269,17 +269,17 @@ page 30172 "Shpfy Order Totals FactBox"
         end;
     end;
 
-    local procedure ResolveSalesDocument(var DocumentType: Enum "Shpfy Document Type"; var SalesDocumentNo: Code[20]): Boolean
+    local procedure ResolveSalesDocument(var DocumentType: Enum "Shpfy Document Type"; var ResolvedDocumentNo: Code[20]): Boolean
     begin
-        if FindLinkedDocument("Shpfy Document Type"::"Posted Sales Invoice", SalesDocumentNo) then begin
+        if FindLinkedDocument("Shpfy Document Type"::"Posted Sales Invoice", ResolvedDocumentNo) then begin
             DocumentType := "Shpfy Document Type"::"Posted Sales Invoice";
             exit(true);
         end;
-        if FindLinkedDocument("Shpfy Document Type"::"Sales Invoice", SalesDocumentNo) then begin
+        if FindLinkedDocument("Shpfy Document Type"::"Sales Invoice", ResolvedDocumentNo) then begin
             DocumentType := "Shpfy Document Type"::"Sales Invoice";
             exit(true);
         end;
-        if FindLinkedDocument("Shpfy Document Type"::"Sales Order", SalesDocumentNo) then begin
+        if FindLinkedDocument("Shpfy Document Type"::"Sales Order", ResolvedDocumentNo) then begin
             DocumentType := "Shpfy Document Type"::"Sales Order";
             exit(true);
         end;
@@ -287,18 +287,18 @@ page 30172 "Shpfy Order Totals FactBox"
         // Fallback for orders processed before the document link table was populated.
         if Rec."Sales Invoice No." <> '' then begin
             DocumentType := "Shpfy Document Type"::"Sales Invoice";
-            SalesDocumentNo := Rec."Sales Invoice No.";
+            ResolvedDocumentNo := Rec."Sales Invoice No.";
             exit(true);
         end;
         if Rec."Sales Order No." <> '' then begin
             DocumentType := "Shpfy Document Type"::"Sales Order";
-            SalesDocumentNo := Rec."Sales Order No.";
+            ResolvedDocumentNo := Rec."Sales Order No.";
             exit(true);
         end;
         exit(false);
     end;
 
-    local procedure FindLinkedDocument(DocumentType: Enum "Shpfy Document Type"; var SalesDocumentNo: Code[20]): Boolean
+    local procedure FindLinkedDocument(DocumentType: Enum "Shpfy Document Type"; var ResolvedDocumentNo: Code[20]): Boolean
     var
         DocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
     begin
@@ -306,7 +306,7 @@ page 30172 "Shpfy Order Totals FactBox"
         DocLinkToBCDoc.SetRange("Shopify Document Id", Rec."Shopify Order Id");
         DocLinkToBCDoc.SetRange("Document Type", DocumentType);
         if DocLinkToBCDoc.FindLast() then begin
-            SalesDocumentNo := DocLinkToBCDoc."Document No.";
+            ResolvedDocumentNo := DocLinkToBCDoc."Document No.";
             exit(true);
         end;
         exit(false);

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTotalsFBTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTotalsFBTest.Codeunit.al
@@ -1,0 +1,461 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Integration.Shopify.Test;
+
+using Microsoft.Finance.GeneralLedger.Setup;
+using Microsoft.Integration.Shopify;
+using Microsoft.Sales.Document;
+using Microsoft.Sales.History;
+using System.TestLibraries.Utilities;
+
+codeunit 139587 "Shpfy Order Totals FB Test"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    TestPermissions = Disabled;
+
+    var
+        LibrarySales: Codeunit "Library - Sales";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        LibraryAssert: Codeunit "Library Assert";
+        Any: Codeunit Any;
+
+    local procedure Initialize()
+    begin
+        LibraryVariableStorage.Clear();
+    end;
+
+    [Test]
+    [HandlerFunctions('SalesOrderPageHandler')]
+    procedure TestOpenSalesOrderResolvedAndNavigated()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] The Order Totals factbox resolves and opens the linked open sales order.
+        Initialize();
+
+        // [GIVEN] A Shopify order linked to an open sales order
+        CreateShopifyOrderHeader(OrderHeader);
+        LibrarySales.CreateSalesOrder(SalesHeader);
+        OrderHeader."Sales Order No." := SalesHeader."No.";
+        OrderHeader.Modify();
+        CreateDocumentLink(OrderHeader."Shopify Order Id", "Shpfy Document Type"::"Sales Order", SalesHeader."No.");
+
+        // [WHEN] Opening the Order Totals factbox for the Shopify order
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The whole Sales Document section resolves from the open sales order
+        VerifyOpenSalesDocumentSection(OrderTotalsFactBox, SalesHeader);
+
+        // [WHEN] Drilling down on the sales document number
+        OrderTotalsFactBox.SalesDocumentNo.Drilldown();
+
+        // [THEN] The open sales order page opens for the exact linked document
+        LibraryAssert.AreEqual(Format(SalesHeader."No."), LibraryVariableStorage.DequeueText(), 'The linked open sales order must open.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('SalesInvoicePageHandler')]
+    procedure TestOpenSalesInvoiceResolvedAndNavigated()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] The Order Totals factbox resolves and opens the linked open sales invoice.
+        Initialize();
+
+        // [GIVEN] A Shopify order linked to an open sales invoice
+        CreateShopifyOrderHeader(OrderHeader);
+        LibrarySales.CreateSalesInvoice(SalesHeader);
+        OrderHeader."Sales Invoice No." := SalesHeader."No.";
+        OrderHeader.Modify();
+        CreateDocumentLink(OrderHeader."Shopify Order Id", "Shpfy Document Type"::"Sales Invoice", SalesHeader."No.");
+
+        // [WHEN] Opening the Order Totals factbox for the Shopify order
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The whole Sales Document section resolves from the open sales invoice
+        VerifyOpenSalesDocumentSection(OrderTotalsFactBox, SalesHeader);
+
+        // [WHEN] Drilling down on the sales document number
+        OrderTotalsFactBox.SalesDocumentNo.Drilldown();
+
+        // [THEN] The open sales invoice page opens for the exact linked document
+        LibraryAssert.AreEqual(Format(SalesHeader."No."), LibraryVariableStorage.DequeueText(), 'The linked open sales invoice must open.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('PostedSalesInvoicePageHandler')]
+    procedure TestPostedSalesInvoiceResolvedAndNavigated()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        DocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+        OpenInvoiceNo: Code[20];
+        PostedInvoiceNo: Code[20];
+    begin
+        // [SCENARIO] After posting, the Order Totals factbox resolves and opens the posted sales invoice.
+        Initialize();
+
+        // [GIVEN] A Shopify order linked to an open sales invoice that is then posted
+        CreateShopifyOrderHeader(OrderHeader);
+        LibrarySales.CreateSalesInvoice(SalesHeader);
+        OpenInvoiceNo := SalesHeader."No.";
+        OrderHeader."Sales Invoice No." := OpenInvoiceNo;
+        OrderHeader.Modify();
+        CreateDocumentLink(OrderHeader."Shopify Order Id", "Shpfy Document Type"::"Sales Invoice", OpenInvoiceNo);
+
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, false, true);
+        SalesInvoiceHeader.Get(PostedInvoiceNo);
+
+        // [GIVEN] Posting created a posted-sales-invoice document link
+        DocLinkToBCDoc.SetRange("Shopify Document Type", "Shpfy Shop Document Type"::"Shopify Shop Order");
+        DocLinkToBCDoc.SetRange("Shopify Document Id", OrderHeader."Shopify Order Id");
+        DocLinkToBCDoc.SetRange("Document Type", "Shpfy Document Type"::"Posted Sales Invoice");
+        LibraryAssert.IsTrue(DocLinkToBCDoc.FindFirst(), 'A posted sales invoice link should exist after posting.');
+        LibraryAssert.AreEqual(PostedInvoiceNo, DocLinkToBCDoc."Document No.", 'The posted sales invoice link must point to the posted invoice.');
+
+        // [WHEN] Opening the Order Totals factbox for the Shopify order
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The whole Sales Document section resolves from the posted sales invoice, not the stale open invoice
+        VerifyPostedSalesInvoiceSection(OrderTotalsFactBox, SalesInvoiceHeader);
+
+        // [WHEN] Drilling down on the sales document number
+        OrderTotalsFactBox.SalesDocumentNo.Drilldown();
+
+        // [THEN] The posted sales invoice page opens for the exact linked document
+        LibraryAssert.AreEqual(Format(PostedInvoiceNo), LibraryVariableStorage.DequeueText(), 'The linked posted sales invoice must open.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    procedure TestUnresolvableDocumentClearsStaleValues()
+    var
+        LinkedOrderHeader: Record "Shpfy Order Header";
+        UnlinkedOrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] Selecting an order without a resolvable sales document clears the previously shown values.
+        Initialize();
+
+        // [GIVEN] A Shopify order linked to an open sales invoice
+        CreateShopifyOrderHeader(LinkedOrderHeader);
+        LibrarySales.CreateSalesInvoice(SalesHeader);
+        LinkedOrderHeader."Sales Invoice No." := SalesHeader."No.";
+        LinkedOrderHeader.Modify();
+        CreateDocumentLink(LinkedOrderHeader."Shopify Order Id", "Shpfy Document Type"::"Sales Invoice", SalesHeader."No.");
+
+        // [GIVEN] A Shopify order with a stale sales invoice number but no resolvable document
+        CreateShopifyOrderHeader(UnlinkedOrderHeader);
+        UnlinkedOrderHeader."Sales Invoice No." := 'NONEXISTENT-INV';
+        UnlinkedOrderHeader.Modify();
+
+        // [WHEN] Showing the resolvable order in the factbox
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(LinkedOrderHeader);
+
+        // [THEN] The factbox shows the linked document values
+        LibraryAssert.AreEqual(Format(SalesHeader."No."), OrderTotalsFactBox.SalesDocumentNo.Value, 'The resolvable order must show its sales document.');
+        LibraryAssert.AreNotEqual(0, OrderTotalsFactBox."Total Amount Incl. VAT".AsDecimal(), 'The resolvable order must show non-zero totals.');
+
+        // [WHEN] Switching to the order without a resolvable document
+        OrderTotalsFactBox.GoToRecord(UnlinkedOrderHeader);
+
+        // [THEN] The factbox clears the document number and totals instead of retaining stale values
+        LibraryAssert.AreEqual('', OrderTotalsFactBox.SalesDocumentNo.Value, 'Sales Document No. must be cleared when no document resolves.');
+        LibraryAssert.AreEqual(0, OrderTotalsFactBox.TotalAmountExclVAT.AsDecimal(), 'Total Amount Excl. VAT must be cleared when no document resolves.');
+        LibraryAssert.AreEqual(0, OrderTotalsFactBox."Total VAT Amount".AsDecimal(), 'Total VAT must be cleared when no document resolves.');
+        LibraryAssert.AreEqual(0, OrderTotalsFactBox."Total Amount Incl. VAT".AsDecimal(), 'Total Amount Incl. VAT must be cleared when no document resolves.');
+        LibraryAssert.AreEqual(0, OrderTotalsFactBox.NumberOfLines.AsInteger(), 'Number of Lines must be cleared when no document resolves.');
+    end;
+
+    [Test]
+    [HandlerFunctions('SalesLinesPageHandler')]
+    procedure TestNumberOfLinesDrillDownOpenDocument()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] The Number of Lines drill-down opens the open document's sales lines.
+        Initialize();
+
+        // [GIVEN] A Shopify order linked to an open sales order
+        CreateShopifyOrderHeader(OrderHeader);
+        LibrarySales.CreateSalesOrder(SalesHeader);
+        OrderHeader."Sales Order No." := SalesHeader."No.";
+        OrderHeader.Modify();
+        CreateDocumentLink(OrderHeader."Shopify Order Id", "Shpfy Document Type"::"Sales Order", SalesHeader."No.");
+
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [WHEN] Drilling down on the number of lines
+        OrderTotalsFactBox.NumberOfLines.Drilldown();
+
+        // [THEN] The sales lines list opens filtered to the open sales order
+        LibraryAssert.AreEqual(Format(SalesHeader."No."), LibraryVariableStorage.DequeueText(), 'Sales Lines must be filtered to the open sales order.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('PostedSalesInvoiceLinesPageHandler')]
+    procedure TestNumberOfLinesDrillDownPostedInvoice()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+        PostedInvoiceNo: Code[20];
+    begin
+        // [SCENARIO] The Number of Lines drill-down opens the posted invoice's lines after posting.
+        Initialize();
+
+        // [GIVEN] A Shopify order whose sales invoice has been posted
+        CreateShopifyOrderHeader(OrderHeader);
+        LibrarySales.CreateSalesInvoice(SalesHeader);
+        OrderHeader."Sales Invoice No." := SalesHeader."No.";
+        OrderHeader.Modify();
+        CreateDocumentLink(OrderHeader."Shopify Order Id", "Shpfy Document Type"::"Sales Invoice", SalesHeader."No.");
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, false, true);
+
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [WHEN] Drilling down on the number of lines
+        OrderTotalsFactBox.NumberOfLines.Drilldown();
+
+        // [THEN] The posted sales invoice lines list opens filtered to the posted invoice
+        LibraryAssert.AreEqual(Format(PostedInvoiceNo), LibraryVariableStorage.DequeueText(), 'Posted Sales Invoice Lines must be filtered to the posted invoice.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ShpfyOrderPageHandler')]
+    procedure TestShopifyOrderNoDrillDownOpensShopifyOrder()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+        ShopifyOrderNo: Code[50];
+    begin
+        // [SCENARIO] The Shopify Order No. drill-down opens the Shopify order card.
+        Initialize();
+
+        // [GIVEN] A Shopify order with a known Shopify order number
+        CreateShopifyOrderHeader(OrderHeader);
+        ShopifyOrderNo := CopyStr(Any.AlphabeticText(10), 1, MaxStrLen(ShopifyOrderNo));
+        OrderHeader."Shopify Order No." := ShopifyOrderNo;
+        OrderHeader.Modify();
+
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [WHEN] Drilling down on the Shopify order number
+        OrderTotalsFactBox."Shopify Order No.".Drilldown();
+
+        // [THEN] The Shopify order card opens for the same order
+        LibraryAssert.AreEqual(Format(ShopifyOrderNo), LibraryVariableStorage.DequeueText(), 'The Shopify order card must open for the same order.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    procedure TestShopifyTotalsSectionShowsShopValues()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] For a shop-currency order the Shopify totals section is shown with the shop amounts.
+        Initialize();
+
+        // [GIVEN] A shop-currency Shopify order with Shopify totals
+        CreateShopifyOrderHeader(OrderHeader);
+        OrderHeader."Processed Currency Handling" := "Shpfy Currency Handling"::"Shop Currency";
+        OrderHeader."Subtotal Amount" := 100;
+        OrderHeader."Shipping Charges Amount" := 15;
+        OrderHeader."VAT Amount" := 25;
+        OrderHeader."Payment Rounding Amount" := 2;
+        OrderHeader."Total Amount" := 142;
+        OrderHeader.Modify();
+
+        // [WHEN] Opening the Order Totals factbox
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The Shopify totals section is visible and shows the shop amounts
+        LibraryAssert.IsTrue(OrderTotalsFactBox."Total Amount".Visible(), 'Shopify totals must be visible for a shop-currency order.');
+        LibraryAssert.IsFalse(OrderTotalsFactBox."Presentment Total Amount".Visible(), 'Presentment totals must be hidden for a shop-currency order.');
+        LibraryAssert.AreEqual(100, OrderTotalsFactBox."Subtotal Amount".AsDecimal(), 'Subtotal Amount must be shown.');
+        LibraryAssert.AreEqual(15, OrderTotalsFactBox."Shipping Charges Amount".AsDecimal(), 'Shipping Charges Amount must be shown.');
+        LibraryAssert.AreEqual(25, OrderTotalsFactBox.VATAmount.AsDecimal(), 'VAT Amount must be shown.');
+        LibraryAssert.AreEqual(2, OrderTotalsFactBox.RoundingAmount.AsDecimal(), 'Payment Rounding Amount must be shown.');
+        LibraryAssert.AreEqual(142, OrderTotalsFactBox."Total Amount".AsDecimal(), 'Total Amount must be shown.');
+    end;
+
+    [Test]
+    procedure TestPresentmentTotalsSectionShownForPresentmentOrder()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] For a presentment-currency order the presentment totals section is shown instead of the shop totals.
+        Initialize();
+
+        // [GIVEN] A presentment-currency Shopify order with presentment totals
+        CreateShopifyOrderHeader(OrderHeader);
+        OrderHeader."Processed Currency Handling" := "Shpfy Currency Handling"::"Presentment Currency";
+        OrderHeader."Presentment Subtotal Amount" := 200;
+        OrderHeader."Pres. Shipping Charges Amount" := 30;
+        OrderHeader."Presentment VAT Amount" := 50;
+        OrderHeader."Pres. Payment Rounding Amount" := 4;
+        OrderHeader."Presentment Total Amount" := 284;
+        OrderHeader.Modify();
+
+        // [WHEN] Opening the Order Totals factbox
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The presentment totals section is visible and shows the presentment amounts
+        LibraryAssert.IsTrue(OrderTotalsFactBox."Presentment Total Amount".Visible(), 'Presentment totals must be visible for a presentment-currency order.');
+        LibraryAssert.IsFalse(OrderTotalsFactBox."Total Amount".Visible(), 'Shopify totals must be hidden for a presentment-currency order.');
+        LibraryAssert.AreEqual(200, OrderTotalsFactBox."Presentment Subtotal Amount".AsDecimal(), 'Presentment Subtotal Amount must be shown.');
+        LibraryAssert.AreEqual(30, OrderTotalsFactBox."Presentment Shipping Charges Amount".AsDecimal(), 'Presentment Shipping Charges Amount must be shown.');
+        LibraryAssert.AreEqual(50, OrderTotalsFactBox."Presentment VAT Amount".AsDecimal(), 'Presentment VAT Amount must be shown.');
+        LibraryAssert.AreEqual(4, OrderTotalsFactBox."Presentment Payment Rounding Amount".AsDecimal(), 'Presentment Payment Rounding Amount must be shown.');
+        LibraryAssert.AreEqual(284, OrderTotalsFactBox."Presentment Total Amount".AsDecimal(), 'Presentment Total Amount must be shown.');
+    end;
+
+    local procedure VerifyOpenSalesDocumentSection(var OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox"; SalesHeader: Record "Sales Header")
+    var
+        SalesLine: Record "Sales Line";
+        ExpectedExclVAT: Decimal;
+        ExpectedInclVAT: Decimal;
+    begin
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.CalcSums(Amount, "Amount Including VAT");
+        ExpectedExclVAT := SalesLine.Amount;
+        ExpectedInclVAT := SalesLine."Amount Including VAT";
+
+        LibraryAssert.AreEqual(Format(SalesHeader."No."), OrderTotalsFactBox.SalesDocumentNo.Value, 'Sales Document No. must be the linked open document.');
+        LibraryAssert.AreEqual(ExpectedExclVAT, OrderTotalsFactBox.TotalAmountExclVAT.AsDecimal(), 'Total Amount Excl. VAT must match the open document.');
+        LibraryAssert.AreEqual(ExpectedInclVAT - ExpectedExclVAT, OrderTotalsFactBox."Total VAT Amount".AsDecimal(), 'Total VAT must match the open document.');
+        LibraryAssert.AreEqual(ExpectedInclVAT, OrderTotalsFactBox."Total Amount Incl. VAT".AsDecimal(), 'Total Amount Incl. VAT must match the open document.');
+        LibraryAssert.AreEqual(SalesLine.Count(), OrderTotalsFactBox.NumberOfLines.AsInteger(), 'Number of Lines must match the open document.');
+        LibraryAssert.AreEqual(SalesHeader."Prices Including VAT", OrderTotalsFactBox.PricesIncludingVAT.AsBoolean(), 'Prices Including VAT must match the open document.');
+        LibraryAssert.AreEqual(Format(GetDocumentCurrencyCode(SalesHeader."Currency Code")), OrderTotalsFactBox.CurrencyCode.Value, 'Currency Code must match the open document.');
+    end;
+
+    local procedure VerifyPostedSalesInvoiceSection(var OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox"; SalesInvoiceHeader: Record "Sales Invoice Header")
+    var
+        SalesInvoiceLine: Record "Sales Invoice Line";
+    begin
+        SalesInvoiceHeader.CalcFields(Amount, "Amount Including VAT");
+        SalesInvoiceLine.SetRange("Document No.", SalesInvoiceHeader."No.");
+
+        LibraryAssert.AreEqual(Format(SalesInvoiceHeader."No."), OrderTotalsFactBox.SalesDocumentNo.Value, 'Sales Document No. must be the posted sales invoice.');
+        LibraryAssert.AreEqual(SalesInvoiceHeader.Amount, OrderTotalsFactBox.TotalAmountExclVAT.AsDecimal(), 'Total Amount Excl. VAT must match the posted sales invoice.');
+        LibraryAssert.AreEqual(SalesInvoiceHeader."Amount Including VAT" - SalesInvoiceHeader.Amount, OrderTotalsFactBox."Total VAT Amount".AsDecimal(), 'Total VAT must match the posted sales invoice.');
+        LibraryAssert.AreEqual(SalesInvoiceHeader."Amount Including VAT", OrderTotalsFactBox."Total Amount Incl. VAT".AsDecimal(), 'Total Amount Incl. VAT must match the posted sales invoice.');
+        LibraryAssert.AreEqual(SalesInvoiceLine.Count(), OrderTotalsFactBox.NumberOfLines.AsInteger(), 'Number of Lines must match the posted sales invoice.');
+        LibraryAssert.AreEqual(SalesInvoiceHeader."Prices Including VAT", OrderTotalsFactBox.PricesIncludingVAT.AsBoolean(), 'Prices Including VAT must match the posted sales invoice.');
+        LibraryAssert.AreEqual(Format(GetDocumentCurrencyCode(SalesInvoiceHeader."Currency Code")), OrderTotalsFactBox.CurrencyCode.Value, 'Currency Code must match the posted sales invoice.');
+    end;
+
+    local procedure GetDocumentCurrencyCode(DocumentCurrencyCode: Code[10]): Code[10]
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+    begin
+        if DocumentCurrencyCode <> '' then
+            exit(DocumentCurrencyCode);
+        GeneralLedgerSetup.Get();
+        exit(GeneralLedgerSetup."LCY Code");
+    end;
+
+    local procedure CreateShopifyOrderHeader(var OrderHeader: Record "Shpfy Order Header")
+    begin
+        OrderHeader.Init();
+        OrderHeader."Shopify Order Id" := GetUnusedShopifyOrderId();
+        OrderHeader.Processed := true;
+        OrderHeader.Insert();
+    end;
+
+    local procedure GetUnusedShopifyOrderId(): BigInteger
+    var
+        ExistingOrderHeader: Record "Shpfy Order Header";
+        DocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
+        CandidateId: BigInteger;
+    begin
+        // The shared database can contain leftover order headers and document links from other tests,
+        // so pick an id that is not used by any existing header or document link.
+        repeat
+            CandidateId := Any.IntegerInRange(1000000, 2147483647);
+            ExistingOrderHeader.SetRange("Shopify Order Id", CandidateId);
+            DocLinkToBCDoc.SetRange("Shopify Document Id", CandidateId);
+        until ExistingOrderHeader.IsEmpty() and DocLinkToBCDoc.IsEmpty();
+        exit(CandidateId);
+    end;
+
+    local procedure CreateDocumentLink(ShopifyOrderId: BigInteger; DocumentType: Enum "Shpfy Document Type"; DocumentNo: Code[20])
+    var
+        DocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
+    begin
+        DocLinkToBCDoc.Init();
+        DocLinkToBCDoc."Shopify Document Type" := "Shpfy Shop Document Type"::"Shopify Shop Order";
+        DocLinkToBCDoc."Shopify Document Id" := ShopifyOrderId;
+        DocLinkToBCDoc."Document Type" := DocumentType;
+        DocLinkToBCDoc."Document No." := DocumentNo;
+        DocLinkToBCDoc.Insert();
+    end;
+
+    [PageHandler]
+    procedure SalesOrderPageHandler(var SalesOrder: TestPage "Sales Order")
+    begin
+        LibraryVariableStorage.Enqueue(SalesOrder."No.".Value);
+    end;
+
+    [PageHandler]
+    procedure SalesInvoicePageHandler(var SalesInvoice: TestPage "Sales Invoice")
+    begin
+        LibraryVariableStorage.Enqueue(SalesInvoice."No.".Value);
+    end;
+
+    [PageHandler]
+    procedure PostedSalesInvoicePageHandler(var PostedSalesInvoice: TestPage "Posted Sales Invoice")
+    begin
+        LibraryVariableStorage.Enqueue(PostedSalesInvoice."No.".Value);
+    end;
+
+    [PageHandler]
+    procedure SalesLinesPageHandler(var SalesLines: TestPage "Sales Lines")
+    begin
+        SalesLines.First();
+        LibraryVariableStorage.Enqueue(SalesLines."Document No.".Value);
+    end;
+
+    [PageHandler]
+    procedure PostedSalesInvoiceLinesPageHandler(var PostedSalesInvoiceLines: TestPage "Posted Sales Invoice Lines")
+    begin
+        PostedSalesInvoiceLines.First();
+        LibraryVariableStorage.Enqueue(PostedSalesInvoiceLines."Document No.".Value);
+    end;
+
+    [PageHandler]
+    procedure ShpfyOrderPageHandler(var ShpfyOrder: TestPage "Shpfy Order")
+    begin
+        LibraryVariableStorage.Enqueue(ShpfyOrder.ShopifyOrderNo.Value);
+    end;
+}


### PR DESCRIPTION
## What & why

On the **Shopify Orders** page, the **Order Totals** factbox (page 30172) was not document-type aware. The **Sales Document No.** drill-down always opened the **Sales Order** page, and the factbox resolved totals only from the open `Sales Header`. When the linked document was an invoice — or the order had already been posted — this opened an unrelated sales order and could display stale totals, because the open header no longer exists but `Sales Invoice No.` still held the old number.

This change resolves the sales document through the same `Shpfy Doc. Link To Doc.` link table that the **Linked Documents** factbox uses, so the factbox stays correct after posting:

- Resolution prefers **Posted Sales Invoice → open Sales Invoice → open Sales Order**, with a fallback to the header fields for legacy orders processed before the link table existed.
- Totals are computed per document type — open documents via `CalculateSalesTotals`, posted invoices via `CalculatePostedSalesInvoiceTotals`.
- The **Sales Document No.** drill-down now dispatches through the `Shpfy IOpenBCDocument` interface (opens the correct open order / open invoice / posted invoice), and the **Number of Lines** drill-down is type-aware (`Sales Lines` vs `Posted Sales Invoice Lines`).
- When no document resolves, the section is cleared instead of retaining stale values.

## Linked work

Fixes [AB#647019](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647019)

<!-- ADO-tracked bug; no separate public GitHub issue. -->

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the **Shopify Connector** app locally (`al_build`) — package generated, 0 errors, no new analyzer warnings.
- Added a new test codeunit `ShpfyOrderTotalsFBTest` (139587, `Order Handling/`) with 9 tests:
  - Resolution + navigation for **open sales order**, **open sales invoice**, and **posted sales invoice**, asserting the resolved `Sales Document No.`, Excl./Incl. VAT, VAT, Number of Lines, Prices Including VAT, and Currency Code.
  - **Number of Lines** drill-down opens `Sales Lines` (open) and `Posted Sales Invoice Lines` (posted).
  - Values are **cleared** when the linked document no longer resolves.
  - General factbox coverage that previously had none: the **Shopify** vs **Presentment** totals sections and their visibility toggle, and the **Shopify Order No.** drill-down.
- Ran the tests in a BC environment; this surfaced a test-isolation issue (a random Shopify Order Id colliding with a leftover document link in the shared database), now fixed by drawing a hermetic Shopify Order Id with no existing header or link.

## Risk & compatibility

- UI-only behavior change to a display-only factbox; no schema, API, or permission changes.
- Navigation now uses the actual linked document type; totals for posted invoices are read from the posted invoice header. No upgrade/data impact.
- The fallback to `Sales Order No.` / `Sales Invoice No.` preserves behavior for orders created before the document link table was populated.



