### PR TITLE
Bug 647080: [28.x] Fix: migrating a document attachment deletes shared Tenant Media

### DIFF
--- a/src/Apps/W1/External Storage - Document Attachments/Test/src/DAExtStorageImplTests.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/Test/src/DAExtStorageImplTests.Codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.ExternalStorage.DocumentAttachments.Test;
 
 using Microsoft.ExternalStorage.DocumentAttachments;
 using Microsoft.Foundation.Attachment;
+using System.Environment;
 using System.ExternalFileStorage;
 using System.TestLibraries.ExternalFileStorage;
 using System.TestLibraries.Utilities;
@@ -17,6 +18,7 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
     Subtype = Test;
     TestPermissions = Disabled;
     Permissions = tabledata "Document Attachment" = rimd,
+                  tabledata "Tenant Media" = r,
                   tabledata "DA External Storage Setup" = rimd;
 
     var
@@ -752,6 +754,110 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
 
     #endregion
 
+    #region Shared Tenant Media Tests
+
+    [Test]
+    procedure DeleteFromInternalKeepsMediaSharedWithCopiedAttachment()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        CopiedDocumentAttachment: Record "Document Attachment";
+        TenantMedia: Record "Tenant Media";
+        DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+        SharedMediaId: Guid;
+    begin
+        // [SCENARIO] Deleting an attachment from internal storage must not remove the Tenant Media
+        // while a copied attachment still references it.
+        Initialize();
+
+        // [GIVEN] An attachment with content that has been copied to another document
+        CreateDocumentAttachmentWithContent(DocumentAttachment);
+        SharedMediaId := DocumentAttachment."Document Reference ID".MediaId();
+        CreateCopyOfDocumentAttachment(DocumentAttachment, CopiedDocumentAttachment);
+
+        // [GIVEN] The original attachment is stored externally
+        DocumentAttachment."Stored Externally" := true;
+        DocumentAttachment.Modify();
+
+        // [WHEN] The original is deleted from internal storage
+        Assert.IsTrue(DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment), 'Delete from internal should succeed');
+
+        // [THEN] The shared Tenant Media is kept
+        Assert.IsTrue(TenantMedia.Get(SharedMediaId), 'Shared Tenant Media should not be deleted');
+
+        // [THEN] The copied attachment still has its content
+        RefreshAttachment(CopiedDocumentAttachment);
+        Assert.IsTrue(CopiedDocumentAttachment."Document Reference ID".HasValue(), 'Copied attachment should still have content');
+
+        // [THEN] The original has released its own reference
+        RefreshAttachment(DocumentAttachment);
+        Assert.IsFalse(DocumentAttachment."Document Reference ID".HasValue(), 'Original attachment should have released its media reference');
+        Assert.IsFalse(DocumentAttachment."Stored Internally", 'Original should not be marked as stored internally');
+    end;
+
+    [Test]
+    procedure DeleteFromInternalRemovesMediaWhenNotShared()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        TenantMedia: Record "Tenant Media";
+        DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+        MediaId: Guid;
+    begin
+        // [SCENARIO] Database space is still reclaimed when the attachment is the only owner
+        Initialize();
+
+        // [GIVEN] An attachment with content that is not shared and is stored externally
+        CreateDocumentAttachmentWithContent(DocumentAttachment);
+        MediaId := DocumentAttachment."Document Reference ID".MediaId();
+        DocumentAttachment."Stored Externally" := true;
+        DocumentAttachment.Modify();
+
+        // [WHEN] It is deleted from internal storage
+        Assert.IsTrue(DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment), 'Delete from internal should succeed');
+
+        // [THEN] The Tenant Media is removed
+        Assert.IsFalse(TenantMedia.Get(MediaId), 'Tenant Media should be deleted when no other attachment references it');
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmYesHandler')]
+    procedure UploadSucceedsForCopiedAttachmentAfterSourceIsMigrated()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        CopiedDocumentAttachment: Record "Document Attachment";
+        DAExternalStorageImpl: Codeunit "DA External Storage Impl.";
+    begin
+        // [SCENARIO] A copied attachment can still be migrated after the attachment it was copied from
+        // has been moved to external storage. The shared Tenant Media used to be deleted together with
+        // the source, which left the copy with neither internal content nor an external file.
+        Initialize();
+        SetupFileScenarioWithTestConnector();
+        EnableFeature();
+
+        // [GIVEN] An attachment that has been copied to another document
+        CreateDocumentAttachmentWithContent(DocumentAttachment);
+        CreateCopyOfDocumentAttachment(DocumentAttachment, CopiedDocumentAttachment);
+
+        // [GIVEN] The source attachment has been moved to external storage
+        Assert.IsTrue(DAExternalStorageImpl.UploadToExternalStorage(DocumentAttachment), 'Upload of the source should succeed');
+        RefreshAttachment(DocumentAttachment);
+        Assert.IsTrue(DAExternalStorageImpl.DeleteFromInternalStorage(DocumentAttachment), 'Delete from internal should succeed for the source');
+
+        // [WHEN] The copied attachment is uploaded
+        RefreshAttachment(CopiedDocumentAttachment);
+        Assert.IsTrue(CopiedDocumentAttachment."Document Reference ID".HasValue(), 'Copied attachment should still have content');
+
+        // [THEN] The upload succeeds
+        Assert.IsTrue(DAExternalStorageImpl.UploadToExternalStorage(CopiedDocumentAttachment), 'Upload of the copied attachment should succeed');
+
+        // [THEN] Both attachments are stored externally, each in its own file
+        RefreshAttachment(DocumentAttachment);
+        RefreshAttachment(CopiedDocumentAttachment);
+        Assert.IsTrue(CopiedDocumentAttachment."Stored Externally", 'Copied attachment should be marked as stored externally');
+        Assert.AreNotEqual(DocumentAttachment."External File Path", CopiedDocumentAttachment."External File Path", 'Each attachment should have its own external file');
+    end;
+
+    #endregion
+
     #region Helper Functions
 
     local procedure Initialize()
@@ -848,6 +954,23 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
         DocumentAttachment.Modify(false);
     end;
 
+    local procedure CreateCopyOfDocumentAttachment(var DocumentAttachment: Record "Document Attachment"; var CopiedDocumentAttachment: Record "Document Attachment")
+    begin
+        // Mirrors Document Attachment Mgmt, which copies attachments onto posted documents with
+        // TransferFields. That copies the media reference itself, so both records end up sharing
+        // a single Tenant Media row.
+        CopiedDocumentAttachment.Init();
+        CopiedDocumentAttachment.TransferFields(DocumentAttachment);
+        CopiedDocumentAttachment.ID := DocumentAttachment.ID + 1;
+        CopiedDocumentAttachment."No." := CopyStr(Any.AlphanumericText(20), 1, 20);
+        CopiedDocumentAttachment.Insert(false);
+
+        Assert.AreEqual(
+            DocumentAttachment."Document Reference ID".MediaId(),
+            CopiedDocumentAttachment."Document Reference ID".MediaId(),
+            'The copied attachment is expected to share the media of the attachment it was copied from');
+    end;
+
     local procedure CreateExternallyStoredDocument(var DocumentAttachment: Record "Document Attachment")
     begin
         CreateDocumentAttachmentWithContent(DocumentAttachment);
@@ -855,6 +978,16 @@ codeunit 136820 "DA Ext. Storage Impl. Tests"
         DocumentAttachment."External File Path" := 'test/environment/Document_Attachment/file-' + Format(CreateGuid()) + '.txt';
         DocumentAttachment."External Upload Date" := CurrentDateTime();
         DocumentAttachment.Modify();
+    end;
+
+    local procedure RefreshAttachment(var DocumentAttachment: Record "Document Attachment")
+    begin
+        DocumentAttachment.Get(
+            DocumentAttachment."Table ID",
+            DocumentAttachment."No.",
+            DocumentAttachment."Document Type",
+            DocumentAttachment."Line No.",
+            DocumentAttachment.ID);
     end;
 
     [ConfirmHandler]

--- a/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
+++ b/src/Apps/W1/External Storage - Document Attachments/app/src/DocumentAttachmentIntegration/DAExternalStorageImpl.Codeunit.al
@@ -432,16 +432,31 @@ codeunit 8751 "DA External Storage Impl." implements "File Scenario"
         if not DocumentAttachment."Stored Externally" then
             exit(false);
 
-        // Delete from Tenant Media
-        if TenantMedia.Get(DocumentAttachment."Document Reference ID".MediaId()) then begin
+        if not TenantMedia.Get(DocumentAttachment."Document Reference ID".MediaId()) then
+            exit(false);
+
+        // Attachments copied onto other documents share this Tenant Media row, so it may only be
+        // deleted once this attachment is its last owner. Deleting it earlier destroys the content
+        // of every attachment copied from this one.
+        if not IsDocumentReferenceShared(DocumentAttachment) then
             TenantMedia.Delete();
 
-            // Mark Document Attachment as Not Stored Internally
-            DocumentAttachment.MarkAsDeletedInternally();
-            exit(true);
-        end;
+        // Mark Document Attachment as Not Stored Internally
+        DocumentAttachment.MarkAsDeletedInternally();
+        exit(true);
+    end;
 
-        exit(false);
+    /// <summary>
+    /// Checks whether more than one document attachment references the same media content.
+    /// </summary>
+    /// <param name="DocumentAttachment">The document attachment whose media reference is checked.</param>
+    /// <returns>True if another document attachment references the same media, false otherwise.</returns>
+    local procedure IsDocumentReferenceShared(var DocumentAttachment: Record "Document Attachment"): Boolean
+    var
+        OtherDocumentAttachment: Record "Document Attachment";
+    begin
+        OtherDocumentAttachment.SetRange("Document Reference ID", DocumentAttachment."Document Reference ID");
+        exit(OtherDocumentAttachment.Count() > 1);
     end;
 
     /// <summary>


### PR DESCRIPTION
#### Summary

Backport of #10055 to `releases/28.x` for the September release (28.5).

`DA External Storage Impl.DeleteFromInternalStorage` deleted the `Tenant Media` row unconditionally after moving an attachment to external storage. `Tenant Media` is shared storage: `Document Attachment Mgmt.CopyAttachments` copies the media *reference* rather than the bytes, so Vendor → Purchase Header → Purch. Inv. Header attachments all end up referencing a single row. Deleting that row on behalf of one attachment destroyed the content of every attachment copied from it.

Those attachments were then skipped **silently** by `UploadToExternalStorage` — the `HasValue()` guard sits above `LogFeatureUsed()`, so no telemetry was emitted — leaving `Stored Externally = false`, a blank `External File Path` and no internal content. Opening one raises `Tenant Media does not exist. ID='{00000000-0000-0000-0000-000000000000}'` from `GetAsTempBlob`.

On a production tenant migrating 5,226 attachments in one company, 4,810 uploaded successfully and 416 were silently skipped with their content destroyed.

The fix only deletes the `Tenant Media` row when no other `Document Attachment` references it, index-backed by the existing `key(Key2; "Document Reference ID")` on table 1173.

#### Work Item(s)

Fixes [AB#647080](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647080) (backport of [AB#646505](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646505))

#### Cherry-pick

Cherry-pick of 473bb07683d69a4637515209367837b444b3a43e (`-x`). The AL change is byte-identical to the change merged to `main` (2 files, 155 insertions, 7 deletions).

**One deliberate omission.** The original PR also registered the *External Storage - Document Attachments* test app in the build, via `build/groups.json` and 24 × `build/projects/Apps <CC>/.AL-Go/settings.json`. Those files do not exist on `releases/28.x`, which still uses the earlier build layout:

- there is no `build/groups.json` on this branch (and no equivalent grouping file — `AllExtensions` appears nowhere on `releases/28.x`);
- `build/projects/Apps (W1)/.AL-Go/settings.json` declares `testFolders` with wildcards (`../../../src/Apps/W1/*/Test`), which already matches `src/Apps/W1/External Storage - Document Attachments/Test`.

So the test app is picked up automatically here and no registration change is needed.

#### Validation

Tests in `DA Ext. Storage Impl. Tests`:

| Test | Asserts |
|---|---|
| `DeleteFromInternalKeepsMediaSharedWithCopiedAttachment` | Shared `Tenant Media` survives; the copy keeps its content |
| `DeleteFromInternalRemovesMediaWhenNotShared` | Space is still reclaimed when the attachment is the sole owner |
| `UploadSucceedsForCopiedAttachmentAfterSourceIsMigrated` | After the source is migrated, the copy still uploads and gets its own external file |

The first and third fail before the fix and pass after; the middle one passes both before and after, proving the fix does not stop reclaiming database space.


