### PR TITLE
Add integration event OnAfterGetRecordOnAfterConfirmAndModify in the General Posting Setup dataitem OnAfterGetRecord trigger after Modify.

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Setup/CopyGeneralPostingSetup.Report.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Setup/CopyGeneralPostingSetup.Report.al
@@ -66,8 +66,10 @@ report 87 "Copy - General Posting Setup"
 
                 OnAfterCopyGenPostingSetup("General Posting Setup", GenPostingSetup, CopySales, CopyPurchases, CopyInventory, CopyManufacturing);
 
-                if ConfirmManagement.GetResponseOrDefault(Text000, true) then
+                if ConfirmManagement.GetResponseOrDefault(Text000, true) then begin
                     Modify();
+                    OnAfterGetRecordOnAfterConfirmAndModify("General Posting Setup", GenPostingSetup);
+                end;
             end;
 
             trigger OnPreDataItem()
@@ -218,6 +220,16 @@ report 87 "Copy - General Posting Setup"
     /// <param name="CopyManufacturing">True when copying manufacturing accounts</param>
     [IntegrationEvent(true, false)]
     local procedure OnAfterCopyGenPostingSetup(var ToGeneralPostingSetup: Record "General Posting Setup"; FromGeneralPostingSetup: Record "General Posting Setup"; var CopySales: Boolean; var CopyPurchases: Boolean; var CopyInventory: Boolean; var CopyManufacturing: Boolean)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised after the target General Posting Setup is modified, once the user confirms the copy.
+    /// </summary>
+    /// <param name="ToGeneralPostingSetup">Target record that was modified</param>
+    /// <param name="FromGeneralPostingSetup">Source record</param>
+    [IntegrationEvent(true, false)]
+    local procedure OnAfterGetRecordOnAfterConfirmAndModify(var ToGeneralPostingSetup: Record "General Posting Setup"; FromGeneralPostingSetup: Record "General Posting Setup")
     begin
     end;
 


### PR DESCRIPTION
## What & why

Report 87 "Copy - General Posting Setup" only calls Modify when the user confirms, and there was no event inside that block. So, partners could not run follow up logic that should happen only on Yes and only after the record is modified.

This adds the integration event OnAfterGetRecordOnGeneralPostingSetupOnAfterConfirmAndModify right after Modify in the confirmation block. It is purely additive and changes no existing behavior.

Fixes [AB#646562](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646562)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior or explained below why none are needed.

**What I tested and the outcome**

No test added since this is an additive event with no behavior change, following the usual practice for event requests.

## Risk & compatibility

Low. Adds one integration event, nothing else. IncludeSender is true to match the sibling OnAfterCopyGenPostingSetup. No breaking changes.





