### PR TITLE
[Main]- Incorrect calculation of single-level capacity and material cost for Stockkeeping Units (SKU) when running cost changes in the Standard Cost Worksheet and implementing the Standard Cost change

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/StandardCost/ImplementStandardCostChange.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/StandardCost/ImplementStandardCostChange.Report.al
@@ -343,7 +343,7 @@ report 5855 "Implement Standard Cost Change"
         StdCostWkshName := NewStdCostWkshName;
     end;
 
-    local procedure GetMessage() TheMsg: Text[250]
+    local procedure GetMessage() TheMsg: Text
     var
         Item: Record Item;
         MachCtr: Record "Machine Center";

--- a/src/Layers/W1/BaseApp/Manufacturing/StandardCost/ImplementStandardCostChange.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/StandardCost/ImplementStandardCostChange.Report.al
@@ -11,6 +11,7 @@ using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Journal;
 using Microsoft.Inventory.Location;
 using Microsoft.Manufacturing.MachineCenter;
+using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Pricing.Calculation;
 using Microsoft.Pricing.PriceList;
@@ -72,6 +73,7 @@ report 5855 "Implement Standard Cost Change"
                 LockTable();
 
                 RevalJnlCreated := false;
+                LoadSKUCostOnMfg := LoadSKUCostOnManufacturing();
             end;
         }
     }
@@ -189,6 +191,8 @@ report 5855 "Implement Standard Cost Change"
         WorkCtrCostsUpdated: Boolean;
         ResCostsUpdated: Boolean;
         SKUCostsUpdated: Boolean;
+        SKUCostUpdateSkipped: Boolean;
+        LoadSKUCostOnMfg: Boolean;
         NoMessage: Boolean;
         HideDuplWarning: Boolean;
 #pragma warning disable AA0074
@@ -199,6 +203,7 @@ report 5855 "Implement Standard Cost Change"
         Text013: Label 'Standard Cost Worksheet %1 is empty.';
 #pragma warning restore AA0470
 #pragma warning restore AA0074
+        SKUCalcStdCostInstructionMsg: Label 'To update the standard cost on stockkeeping units, open the Stockkeeping Unit Card and use the Calc. Standard Cost action.';
 
     protected var
         PostingDate: Date;
@@ -238,6 +243,10 @@ report 5855 "Implement Standard Cost Change"
     begin
         SKU.SetRange("Item No.", StdCostWksh."No.");
         if SKU.Find('-') then begin
+            if LoadSKUCostOnMfg then begin
+                SKUCostUpdateSkipped := true;
+                exit;
+            end;
             SKUCostsUpdated := true;
             repeat
                 IsHandled := false;
@@ -247,6 +256,15 @@ report 5855 "Implement Standard Cost Change"
                 SKU.Modify(true);
             until SKU.Next() = 0;
         end;
+    end;
+
+    local procedure LoadSKUCostOnManufacturing(): Boolean
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+    begin
+        if not ManufacturingSetup.Get() then
+            exit(false);
+        exit(ManufacturingSetup."Load SKU Cost on Manufacturing");
     end;
 
     local procedure UpdateMachCenter(StdCostWksh: Record "Standard Cost Worksheet")
@@ -357,6 +375,11 @@ report 5855 "Implement Standard Cost Change"
         end;
         if TheMsg <> '' then
             TheMsg := Text010 + TheMsg + Text012;
+        if SKUCostUpdateSkipped then begin
+            if TheMsg <> '' then
+                TheMsg += '\';
+            TheMsg += SKUCalcStdCostInstructionMsg;
+        end;
         if RevalJnlCreated then
             TheMsg := TheMsg + Text009;
         exit(TheMsg);

--- a/src/Layers/W1/Tests/SCM-Costing/SCMCostingBatch.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Costing/SCMCostingBatch.Codeunit.al
@@ -1810,7 +1810,7 @@ codeunit 137402 "SCM Costing Batch"
     end;
 
     [Test]
-    [HandlerFunctions('AdjustCostItemEntriesHandler,ImplementStandardCostChangeHandler,MessageHandler')]
+    [HandlerFunctions('ImplementStandardCostChangeHandler,MessageHandler')]
     procedure SKUCostNotUpdatedWhenLoadSKUCostOnMfgEnabled()
     var
         Item: Record Item;
@@ -1822,7 +1822,6 @@ codeunit 137402 "SCM Costing Batch"
     begin
         // [FEATURE] [AI test 0.4]
         // [SCENARIO 637759] SKU Standard Cost is not updated when "Load SKU Cost on Manufacturing" is enabled
-        Initialize();
 
         // [GIVEN] Item "I" with Standard Cost
         CreateItem(Item);
@@ -1856,7 +1855,7 @@ codeunit 137402 "SCM Costing Batch"
     end;
 
     [Test]
-    [HandlerFunctions('AdjustCostItemEntriesHandler,StrMenuHandler,ImplementStandardCostChangeHandler,MessageHandler')]
+    [HandlerFunctions('StrMenuHandler,ImplementStandardCostChangeHandler,MessageHandler')]
     procedure SKUWithOwnRoutingRetainsCostWhenLoadSKUCostOnMfgEnabled()
     var
         Item: Record Item;
@@ -1873,7 +1872,6 @@ codeunit 137402 "SCM Costing Batch"
     begin
         // [FEATURE] [AI test 0.4]
         // [SCENARIO 637759] SKU with its own routing retains its independently calculated Standard Cost after Implement Standard Cost Change when "Load SKU Cost on Manufacturing" is enabled
-        Initialize();
 
         // [GIVEN] Two Work Centers "WC1" and "WC2" with different unit costs
         LibraryManufacturing.CreateWorkCenterWithCalendar(WorkCenter[1]);
@@ -1929,7 +1927,7 @@ codeunit 137402 "SCM Costing Batch"
     end;
 
     [Test]
-    [HandlerFunctions('AdjustCostItemEntriesHandler,ImplementStandardCostChangeHandler,CaptureMessageHandler')]
+    [HandlerFunctions('ImplementStandardCostChangeHandler,CaptureMessageHandler')]
     procedure InstructionMsgShownWhenSKUCostUpdateSkipped()
     var
         Item: Record Item;
@@ -1940,7 +1938,6 @@ codeunit 137402 "SCM Costing Batch"
     begin
         // [FEATURE] [AI test 0.4]
         // [SCENARIO 637759] Instruction message is shown when SKU cost update is skipped due to "Load SKU Cost on Manufacturing" being enabled
-        Initialize();
 
         // [GIVEN] Item "I" with Standard Cost
         CreateItem(Item);

--- a/src/Layers/W1/Tests/SCM-Costing/SCMCostingBatch.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Costing/SCMCostingBatch.Codeunit.al
@@ -52,6 +52,7 @@ codeunit 137402 "SCM Costing Batch"
         SingleLevelMaterialCostMustMatchErr: Label 'Single-Level Material Cost of Item and SKU must match for Item No. %1', Comment = '%1 = Item No.';
         SingleLevelMaterialCostMustNotMatchErr: Label 'Single-Level Material Cost of Item and SKU must not match for Item No. %1', Comment = '%1 = Item No.';
         CostAmountMustNotMatchErr: Label 'Cost Amount for Item and SKU must not match for Item No. %1 in Prod. Order Line.', Comment = '%1 = Item No.';
+        SKUCostShouldNotBeUpdatedErr: Label 'SKU Standard Cost should not be updated when Load SKU Cost on Manufacturing is enabled for Item No. %1', Comment = '%1 = Item No.';
         CurrentSaveValuesId: Integer;
 
     [Test]
@@ -1808,6 +1809,169 @@ codeunit 137402 "SCM Costing Batch"
             StrSubstNo(AmountErr, ProdOrderLine.FieldCaption("Cost Amount"), Item."Standard Cost", ProdOrderLine.TableCaption()));
     end;
 
+    [Test]
+    [HandlerFunctions('AdjustCostItemEntriesHandler,ImplementStandardCostChangeHandler,MessageHandler')]
+    procedure SKUCostNotUpdatedWhenLoadSKUCostOnMfgEnabled()
+    var
+        Item: Record Item;
+        ManufacturingSetup: Record "Manufacturing Setup";
+        StockkeepingUnit: Record "Stockkeeping Unit";
+        StandardCostWorksheet: Record "Standard Cost Worksheet";
+        StandardCostWorksheetName: Code[10];
+        OriginalSKUStandardCost: Decimal;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 637759] SKU Standard Cost is not updated when "Load SKU Cost on Manufacturing" is enabled
+        Initialize();
+
+        // [GIVEN] Item "I" with Standard Cost
+        CreateItem(Item);
+        Item.Validate("Costing Method", Item."Costing Method"::Standard);
+        Item.Validate("Standard Cost", LibraryRandom.RandIntInRange(100, 200));
+        Item.Modify(true);
+
+        // [GIVEN] Stockkeeping Unit "S" for Item "I"
+        CreateStockkeepingUnit(Item);
+        FindStockkeepingUnit(StockkeepingUnit, Item."No.");
+        OriginalSKUStandardCost := StockkeepingUnit."Standard Cost";
+
+        // [GIVEN] "Load SKU Cost on Manufacturing" is enabled in Manufacturing Setup
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Load SKU Cost on Manufacturing", true);
+        ManufacturingSetup.Modify(true);
+
+        // [GIVEN] Standard Cost Worksheet with suggested item standard cost
+        StandardCostWorksheetName := CreateStandardCostWorksheetName();
+        LibraryCosting.SuggestItemStandardCost(Item, StandardCostWorksheetName, LibraryRandom.RandIntInRange(2, 5), '');
+
+        // [WHEN] Run Implement Standard Cost Change
+        RunImplementStandardCostChange(StandardCostWorksheetName, StandardCostWorksheet.Type::Item, Item."No.");
+
+        // [THEN] SKU Standard Cost remains unchanged
+        FindStockkeepingUnit(StockkeepingUnit, Item."No.");
+        Assert.AreEqual(
+            OriginalSKUStandardCost,
+            StockkeepingUnit."Standard Cost",
+            StrSubstNo(SKUCostShouldNotBeUpdatedErr, Item."No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('AdjustCostItemEntriesHandler,StrMenuHandler,ImplementStandardCostChangeHandler,MessageHandler')]
+    procedure SKUWithOwnRoutingRetainsCostWhenLoadSKUCostOnMfgEnabled()
+    var
+        Item: Record Item;
+        Location: Record Location;
+        ManufacturingSetup: Record "Manufacturing Setup";
+        ProductionBOMLine: Record "Production BOM Line";
+        RoutingHeader: array[2] of Record "Routing Header";
+        StockkeepingUnit: Record "Stockkeeping Unit";
+        StandardCostWorksheet: Record "Standard Cost Worksheet";
+        WorkCenter: array[2] of Record "Work Center";
+        CalculateStandardCost: Codeunit "Calculate Standard Cost";
+        StandardCostWorksheetName: Code[10];
+        OriginalSKUStandardCost: Decimal;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 637759] SKU with its own routing retains its independently calculated Standard Cost after Implement Standard Cost Change when "Load SKU Cost on Manufacturing" is enabled
+        Initialize();
+
+        // [GIVEN] Two Work Centers "WC1" and "WC2" with different unit costs
+        LibraryManufacturing.CreateWorkCenterWithCalendar(WorkCenter[1]);
+        WorkCenter[1].Validate("Unit Cost", LibraryRandom.RandIntInRange(10, 20));
+        WorkCenter[1].Modify(true);
+        LibraryManufacturing.CreateWorkCenterWithCalendar(WorkCenter[2]);
+        WorkCenter[2].Validate("Unit Cost", LibraryRandom.RandIntInRange(30, 50));
+        WorkCenter[2].Modify(true);
+
+        // [GIVEN] Two Routings "R1" and "R2" with different Work Centers
+        CreateRouting(RoutingHeader[1], WorkCenter[1]."No.");
+        CreateRouting(RoutingHeader[2], WorkCenter[2]."No.");
+
+        // [GIVEN] Item "I" with Routing "R1" and Production BOM
+        CreateItemWithRoutingAndProdBOM(Item, RoutingHeader[1], ProductionBOMLine);
+
+        // [GIVEN] Calculate Standard Cost for Item "I"
+        Clear(CalculateStandardCost);
+        CalculateStandardCost.CalcItem(Item."No.", false);
+
+        // [GIVEN] Location "L" and Stockkeeping Unit "S" for Item "I" with Routing "R2"
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location);
+        LibraryInventory.CreateStockKeepingUnit(Item, Enum::"SKU Creation Method"::"Location & Variant", false, false);
+        StockkeepingUnit.SetRange("Item No.", Item."No.");
+        StockkeepingUnit.FindFirst();
+        StockkeepingUnit.Validate("Location Code", Location.Code);
+        StockkeepingUnit.Validate("Routing No.", RoutingHeader[2]."No.");
+        StockkeepingUnit.Modify(true);
+
+        // [GIVEN] Calculate Standard Cost for SKU "S"
+        CalculateStandardCost.CalcItemSKU(StockkeepingUnit."Item No.", StockkeepingUnit."Location Code", StockkeepingUnit."Variant Code");
+        StockkeepingUnit.Get(StockkeepingUnit."Location Code", StockkeepingUnit."Item No.", StockkeepingUnit."Variant Code");
+        OriginalSKUStandardCost := StockkeepingUnit."Standard Cost";
+
+        // [GIVEN] "Load SKU Cost on Manufacturing" is enabled
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Load SKU Cost on Manufacturing", true);
+        ManufacturingSetup.Modify(true);
+
+        // [GIVEN] Standard Cost Worksheet with suggested item standard cost
+        StandardCostWorksheetName := CreateStandardCostWorksheetName();
+        LibraryCosting.SuggestItemStandardCost(Item, StandardCostWorksheetName, LibraryRandom.RandIntInRange(2, 5), '');
+
+        // [WHEN] Run Implement Standard Cost Change
+        RunImplementStandardCostChange(StandardCostWorksheetName, StandardCostWorksheet.Type::Item, Item."No.");
+
+        // [THEN] SKU Standard Cost remains at its independently calculated value
+        StockkeepingUnit.Get(StockkeepingUnit."Location Code", StockkeepingUnit."Item No.", StockkeepingUnit."Variant Code");
+        Assert.AreEqual(
+            OriginalSKUStandardCost,
+            StockkeepingUnit."Standard Cost",
+            StrSubstNo(SKUCostShouldNotBeUpdatedErr, Item."No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('AdjustCostItemEntriesHandler,ImplementStandardCostChangeHandler,CaptureMessageHandler')]
+    procedure InstructionMsgShownWhenSKUCostUpdateSkipped()
+    var
+        Item: Record Item;
+        ManufacturingSetup: Record "Manufacturing Setup";
+        StandardCostWorksheet: Record "Standard Cost Worksheet";
+        StandardCostWorksheetName: Code[10];
+        CapturedMessage: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 637759] Instruction message is shown when SKU cost update is skipped due to "Load SKU Cost on Manufacturing" being enabled
+        Initialize();
+
+        // [GIVEN] Item "I" with Standard Cost
+        CreateItem(Item);
+        Item.Validate("Costing Method", Item."Costing Method"::Standard);
+        Item.Validate("Standard Cost", LibraryRandom.RandIntInRange(100, 200));
+        Item.Modify(true);
+
+        // [GIVEN] Stockkeeping Unit "S" for Item "I"
+        CreateStockkeepingUnit(Item);
+
+        // [GIVEN] "Load SKU Cost on Manufacturing" is enabled in Manufacturing Setup
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Load SKU Cost on Manufacturing", true);
+        ManufacturingSetup.Modify(true);
+
+        // [GIVEN] Standard Cost Worksheet with suggested item standard cost
+        StandardCostWorksheetName := CreateStandardCostWorksheetName();
+        LibraryCosting.SuggestItemStandardCost(Item, StandardCostWorksheetName, LibraryRandom.RandIntInRange(2, 5), '');
+        LibraryVariableStorage.Clear();
+
+        // [WHEN] Run Implement Standard Cost Change
+        RunImplementStandardCostChange(StandardCostWorksheetName, StandardCostWorksheet.Type::Item, Item."No.");
+
+        // [THEN] Message contains instruction to use Calc. Standard Cost action on SKU Card
+        CapturedMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage('Stockkeeping Unit Card', CapturedMessage);
+        Assert.ExpectedMessage('Calc. Standard Cost', CapturedMessage);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -2569,6 +2733,13 @@ codeunit 137402 "SCM Costing Batch"
     [Scope('OnPrem')]
     procedure MessageHandler(Message: Text[1024])
     begin
+    end;
+
+    [MessageHandler]
+    [Scope('OnPrem')]
+    procedure CaptureMessageHandler(Message: Text[1024])
+    begin
+        LibraryVariableStorage.Enqueue(Message);
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
Workitem [Bug 637759](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/637759): [ALL-E] Incorrect calculation of single-level capacity and material cost for Stockkeeping Units (SKU) when running cost changes in the Standard Cost Worksheet and implementing the Standard Cost change.

Fixed [AB#637759](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/637759)

Issue: Incorrect calculation of single-level capacity and material cost for Stockkeeping Units (SKU) when running cost changes in the Standard Cost Worksheet and implementing the Standard Cost change.
Cause: The Implement Standard Cost Change report unconditionally copied the item’s updated cost shares to its SKUs, ignoring the Load SKU Cost on Manufacturing setting.
Solution: Skip SKU cost updates in this mode and instruct users to recalculate SKU costs using Calc. Standard Cost on the Stockkeeping Unit Card.






