### PR TITLE
Let subscribers override the half-year new year date in SetHalfYearConventionMethod

### DIFF
--- a/src/Layers/FR/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/FR/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -682,9 +682,10 @@ codeunit 5611 "Calculate Normal Depreciation"
         AccountingPeriod: Record "Accounting Period";
         Result: Boolean;
         IsHandled: Boolean;
+        NewYearDateOverride: Date;
     begin
         IsHandled := false;
-        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled);
+        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled, NewYearDateOverride);
         if IsHandled then
             exit(Result);
 
@@ -702,7 +703,10 @@ codeunit 5611 "Calculate Normal Depreciation"
           "Starting Date", '>=%1',
           DepreciationCalc.ToMorrow(FADeprBook."Depreciation Starting Date", Year365Days, DeprBook."Use Accounting Period"));
         AccountingPeriod.FindFirst();
-        NewYearDate := AccountingPeriod."Starting Date";
+        if NewYearDateOverride <> 0D then
+            NewYearDate := NewYearDateOverride
+        else
+            NewYearDate := AccountingPeriod."Starting Date";
         if FirstDeprDate >= NewYearDate then
             exit(false);
 
@@ -1156,7 +1160,7 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean; var NewYearDateOverride: Date)
     begin
     end;
 }

--- a/src/Layers/GB/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/GB/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -668,9 +668,10 @@ codeunit 5611 "Calculate Normal Depreciation"
         AccountingPeriod: Record "Accounting Period";
         Result: Boolean;
         IsHandled: Boolean;
+        NewYearDateOverride: Date;
     begin
         IsHandled := false;
-        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled);
+        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled, NewYearDateOverride);
         if IsHandled then
             exit(Result);
 
@@ -688,7 +689,10 @@ codeunit 5611 "Calculate Normal Depreciation"
           "Starting Date", '>=%1',
           DepreciationCalc.ToMorrow(FADeprBook."Depreciation Starting Date", Year365Days, DeprBook."Use Accounting Period"));
         AccountingPeriod.FindFirst();
-        NewYearDate := AccountingPeriod."Starting Date";
+        if NewYearDateOverride <> 0D then
+            NewYearDate := NewYearDateOverride
+        else
+            NewYearDate := AccountingPeriod."Starting Date";
         if FirstDeprDate >= NewYearDate then
             exit(false);
 
@@ -1143,7 +1147,7 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean; var NewYearDateOverride: Date)
     begin
     end;
 }

--- a/src/Layers/IT/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/IT/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -729,9 +729,10 @@ codeunit 5611 "Calculate Normal Depreciation"
         AccountingPeriod: Record "Accounting Period";
         Result: Boolean;
         IsHandled: Boolean;
+        NewYearDateOverride: Date;
     begin
         IsHandled := false;
-        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled);
+        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled, NewYearDateOverride);
         if IsHandled then
             exit(Result);
 
@@ -749,7 +750,10 @@ codeunit 5611 "Calculate Normal Depreciation"
           "Starting Date", '>=%1',
           DepreciationCalc.ToMorrow(FADeprBook."Depreciation Starting Date", Year365Days, DeprBook."Use Accounting Period"));
         AccountingPeriod.FindFirst();
-        NewYearDate := AccountingPeriod."Starting Date";
+        if NewYearDateOverride <> 0D then
+            NewYearDate := NewYearDateOverride
+        else
+            NewYearDate := AccountingPeriod."Starting Date";
         if FirstDeprDate >= NewYearDate then
             exit(false);
 
@@ -1203,7 +1207,7 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean; var NewYearDateOverride: Date)
     begin
     end;
 }

--- a/src/Layers/RU/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/RU/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -810,9 +810,10 @@ codeunit 5611 "Calculate Normal Depreciation"
         AccountingPeriod: Record "Accounting Period";
         Result: Boolean;
         IsHandled: Boolean;
+        NewYearDateOverride: Date;
     begin
         IsHandled := false;
-        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled);
+        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled, NewYearDateOverride);
         if IsHandled then
             exit(Result);
 
@@ -830,7 +831,10 @@ codeunit 5611 "Calculate Normal Depreciation"
           "Starting Date", '>=%1',
           DepreciationCalc.ToMorrow(FADeprBook."Depreciation Starting Date", Year365Days, DeprBook."Use Accounting Period"));
         AccountingPeriod.FindFirst();
-        NewYearDate := AccountingPeriod."Starting Date";
+        if NewYearDateOverride <> 0D then
+            NewYearDate := NewYearDateOverride
+        else
+            NewYearDate := AccountingPeriod."Starting Date";
         if FirstDeprDate >= NewYearDate then
             exit(false);
 
@@ -1382,7 +1386,7 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean; var NewYearDateOverride: Date)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
+++ b/src/Layers/W1/BaseApp/FixedAssets/Depreciation/CalculateNormalDepreciation.Codeunit.al
@@ -666,9 +666,10 @@ codeunit 5611 "Calculate Normal Depreciation"
         AccountingPeriod: Record "Accounting Period";
         Result: Boolean;
         IsHandled: Boolean;
+        NewYearDateOverride: Date;
     begin
         IsHandled := false;
-        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled);
+        OnBeforeSetHalfYearConventionMethod(FADeprBook, DeprMethod, Year365Days, FirstDeprDate, NewYearDate, Result, IsHandled, NewYearDateOverride);
         if IsHandled then
             exit(Result);
 
@@ -686,7 +687,10 @@ codeunit 5611 "Calculate Normal Depreciation"
           "Starting Date", '>=%1',
           DepreciationCalc.ToMorrow(FADeprBook."Depreciation Starting Date", Year365Days, DeprBook."Use Accounting Period"));
         AccountingPeriod.FindFirst();
-        NewYearDate := AccountingPeriod."Starting Date";
+        if NewYearDateOverride <> 0D then
+            NewYearDate := NewYearDateOverride
+        else
+            NewYearDate := AccountingPeriod."Starting Date";
         if FirstDeprDate >= NewYearDate then
             exit(false);
 
@@ -1140,7 +1144,7 @@ codeunit 5611 "Calculate Normal Depreciation"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeSetHalfYearConventionMethod(FADeprBook: Record "FA Depreciation Book"; DeprMethod: Enum "FA Depr. Method Internal"; Year365Days: Boolean; FirstDeprDate: Date; NewYearDate: Date; var Result: Boolean; var IsHandled: Boolean; var NewYearDateOverride: Date)
     begin
     end;
 }


### PR DESCRIPTION
## What & why

Codeunit 5611 raises OnBeforeSetHalfYearConventionMethod, but NewYearDate was passed by value and then always overwritten with the accounting period start. So a subscriber could set it, but it never took effect.

This keeps the existing event signature unchanged and appends a trailing var NewYearDateOverride parameter. When a subscriber sets it, the base uses that date instead of the accounting period start. With no subscriber the behavior is unchanged. The same change is applied to every copy of codeunit 5611, so the event behaves the same across the W1, FR, GB, IT, and RU layers.

Fixes [AB#646465](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646465)

## How I validated this

- [x] I read the full diff, and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior or explained below why none are needed.

**What I tested and the outcome**

No test added since this is an additive event parameter with existing coverage.

## Risk & compatibility

Additive and non-breaking. The existing event keeps its shipped signature, a trailing var NewYearDateOverride parameter is appended, and existing subscribers that omit it continue to compile.

