### PR TITLE
Add GLN information to XRechnung and ZUGFeRD exports

### DIFF
--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
@@ -539,12 +539,14 @@ codeunit 13916 "Export XRechnung Document"
         Customer: Record Customer;
         ShipToAddress: Record "Ship-to Address";
     begin
+        if not Customer.Get(CustomerNo) then
+            exit('');
+        if not Customer."Use GLN in Electronic Document" then
+            exit('');
         if ShipToAddress.Get(CustomerNo, ShipToCode) then
             if ShipToAddress.GLN <> '' then
                 exit(ShipToAddress.GLN);
-        if Customer.Get(CustomerNo) then
-            if Customer."Use GLN in Electronic Document" then
-                exit(Customer.GLN);
+        exit(Customer.GLN);
     end;
 
     local procedure InsertAddress(var RootElement: XmlElement; ElementName: Text; Address: Record "Standard Address");

--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
@@ -497,7 +497,7 @@ codeunit 13916 "Export XRechnung Document"
         if SalesInvoiceHeader."Shipment Date" <> CalcDate('<0D>') then
             DeliveryElement.Add(XmlElement.Create('ActualDeliveryDate', XmlNamespaceCBC, FormatDate(SalesInvoiceHeader."Shipment Date")));
 
-        InsertDeliveryLocation(DeliveryElement, DeliveryAddress);
+        InsertDeliveryLocation(DeliveryElement, DeliveryAddress, GetDeliveryGLN(SalesInvoiceHeader."Sell-to Customer No.", SalesInvoiceHeader."Ship-to Code"));
 
         RootXMLNode.Add(DeliveryElement);
     end;
@@ -518,18 +518,32 @@ codeunit 13916 "Export XRechnung Document"
         if SalesCrMemoHeader."Shipment Date" <> CalcDate('<0D>') then
             DeliveryElement.Add(XmlElement.Create('ActualDeliveryDate', XmlNamespaceCBC, FormatDate(SalesCrMemoHeader."Shipment Date")));
 
-        InsertDeliveryLocation(DeliveryElement, DeliveryAddress);
+        InsertDeliveryLocation(DeliveryElement, DeliveryAddress, GetDeliveryGLN(SalesCrMemoHeader."Sell-to Customer No.", SalesCrMemoHeader."Ship-to Code"));
 
         RootXMLNode.Add(DeliveryElement);
     end;
 
-    local procedure InsertDeliveryLocation(var DeliveryElement: XmlElement; DeliveryAddress: Record "Standard Address");
+    local procedure InsertDeliveryLocation(var DeliveryElement: XmlElement; DeliveryAddress: Record "Standard Address"; DeliveryGLN: Code[13]);
     var
         DeliveryLocationElement: XmlElement;
     begin
         DeliveryLocationElement := XmlElement.Create('DeliveryLocation', XmlNamespaceCAC);
+        if DeliveryGLN <> '' then
+            DeliveryLocationElement.Add(XmlElement.Create('ID', XmlNamespaceCBC, XmlAttribute.Create('schemeID', GLNSchemeIDTok), DeliveryGLN));
         InsertAddress(DeliveryLocationElement, 'Address', DeliveryAddress);
         DeliveryElement.Add(DeliveryLocationElement);
+    end;
+
+    local procedure GetDeliveryGLN(CustomerNo: Code[20]; ShipToCode: Code[10]): Code[13]
+    var
+        Customer: Record Customer;
+        ShipToAddress: Record "Ship-to Address";
+    begin
+        if ShipToAddress.Get(CustomerNo, ShipToCode) then
+            if ShipToAddress.GLN <> '' then
+                exit(ShipToAddress.GLN);
+        if Customer.Get(CustomerNo) then
+            exit(Customer.GLN);
     end;
 
     local procedure InsertAddress(var RootElement: XmlElement; ElementName: Text; Address: Record "Standard Address");
@@ -745,18 +759,20 @@ codeunit 13916 "Export XRechnung Document"
         PartyLegalEntityElement := XmlElement.Create('PartyLegalEntity', XmlNamespaceCAC);
         PartyLegalEntityElement.Add(XmlElement.Create('RegistrationName', XmlNamespaceCBC, CompanyInformation.Name));
         if CompanyInformation."Use GLN in Electronic Document" and (CompanyInformation.GLN <> '') then
-            PartyLegalEntityElement.Add(XmlElement.Create('CompanyID', XmlNamespaceCBC, CompanyInformation.GLN))
+            PartyLegalEntityElement.Add(XmlElement.Create('CompanyID', XmlNamespaceCBC, XmlAttribute.Create('schemeID', GLNSchemeIDTok), CompanyInformation.GLN))
         else
             PartyLegalEntityElement.Add(XmlElement.Create('CompanyID', XmlNamespaceCBC, GetVATRegistrationNo(CompanyInformation."VAT Registration No.", CompanyInformation."Country/Region Code")));
         PartyElement.Add(PartyLegalEntityElement);
     end;
 
-    local procedure InsertCustomerPartyLegalEntity(var PartyElement: XmlElement; CustomerName: Text[100]);
+    local procedure InsertCustomerPartyLegalEntity(var PartyElement: XmlElement; CustomerName: Text[100]; CustomerGLN: Code[13]);
     var
         PartyLegalEntityElement: XmlElement;
     begin
         PartyLegalEntityElement := XmlElement.Create('PartyLegalEntity', XmlNamespaceCAC);
         PartyLegalEntityElement.Add(XmlElement.Create('RegistrationName', XmlNamespaceCBC, CustomerName));
+        if CustomerGLN <> '' then
+            PartyLegalEntityElement.Add(XmlElement.Create('CompanyID', XmlNamespaceCBC, XmlAttribute.Create('schemeID', GLNSchemeIDTok), CustomerGLN));
         PartyElement.Add(PartyLegalEntityElement);
     end;
 
@@ -848,7 +864,7 @@ codeunit 13916 "Export XRechnung Document"
         BillToAddress."Post Code" := SalesInvoiceHeader."Bill-to Post Code";
         BillToAddress."Country/Region Code" := SalesInvoiceHeader."Bill-to Country/Region Code";
 
-        if Customer.Get(SalesInvoiceHeader."Sell-to Customer No.") then;
+        if Customer.Get(SalesInvoiceHeader."Bill-to Customer No.") then;
         AccountingCustomerParty := XmlElement.Create('AccountingCustomerParty', XmlNamespaceCAC);
         if Customer."Use GLN in Electronic Document" then
             CustomerGLN := Customer.GLN;
@@ -876,7 +892,7 @@ codeunit 13916 "Export XRechnung Document"
         BillToAddress."Post Code" := SalesCrMemoHeader."Bill-to Post Code";
         BillToAddress."Country/Region Code" := SalesCrMemoHeader."Bill-to Country/Region Code";
 
-        if Customer.Get(SalesCrMemoHeader."Sell-to Customer No.") then;
+        if Customer.Get(SalesCrMemoHeader."Bill-to Customer No.") then;
         AccountingCustomerParty := XmlElement.Create('AccountingCustomerParty', XmlNamespaceCAC);
         if Customer."Use GLN in Electronic Document" then
             CustomerGLN := Customer.GLN;
@@ -907,7 +923,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertAddress(PartyElement, 'PostalAddress', PostalAddress);
         if not AllLinesNotSubjectToVAT then
             InsertPartyTaxScheme(PartyElement, VATRegNo, PostalAddress."Country/Region Code");
-        InsertCustomerPartyLegalEntity(PartyElement, CustomerName);
+        InsertCustomerPartyLegalEntity(PartyElement, CustomerName, CustomerGLN);
         InsertContact(PartyElement, ContactName, ContactEMail);
         AccountingCustomerParty.Add(PartyElement);
     end;

--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
@@ -543,7 +543,8 @@ codeunit 13916 "Export XRechnung Document"
             if ShipToAddress.GLN <> '' then
                 exit(ShipToAddress.GLN);
         if Customer.Get(CustomerNo) then
-            exit(Customer.GLN);
+            if Customer."Use GLN in Electronic Document" then
+                exit(Customer.GLN);
     end;
 
     local procedure InsertAddress(var RootElement: XmlElement; ElementName: Text; Address: Record "Standard Address");
@@ -864,7 +865,7 @@ codeunit 13916 "Export XRechnung Document"
         BillToAddress."Post Code" := SalesInvoiceHeader."Bill-to Post Code";
         BillToAddress."Country/Region Code" := SalesInvoiceHeader."Bill-to Country/Region Code";
 
-        if Customer.Get(SalesInvoiceHeader."Bill-to Customer No.") then;
+        if Customer.Get(SalesInvoiceHeader."Sell-to Customer No.") then;
         AccountingCustomerParty := XmlElement.Create('AccountingCustomerParty', XmlNamespaceCAC);
         if Customer."Use GLN in Electronic Document" then
             CustomerGLN := Customer.GLN;
@@ -892,7 +893,7 @@ codeunit 13916 "Export XRechnung Document"
         BillToAddress."Post Code" := SalesCrMemoHeader."Bill-to Post Code";
         BillToAddress."Country/Region Code" := SalesCrMemoHeader."Bill-to Country/Region Code";
 
-        if Customer.Get(SalesCrMemoHeader."Bill-to Customer No.") then;
+        if Customer.Get(SalesCrMemoHeader."Sell-to Customer No.") then;
         AccountingCustomerParty := XmlElement.Create('AccountingCustomerParty', XmlNamespaceCAC);
         if Customer."Use GLN in Electronic Document" then
             CustomerGLN := Customer.GLN;

--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
@@ -539,11 +539,13 @@ codeunit 13916 "Export XRechnung Document"
         Customer: Record Customer;
         ShipToAddress: Record "Ship-to Address";
     begin
+        Customer.SetLoadFields("Use GLN in Electronic Document", GLN);
         if not Customer.Get(CustomerNo) then
             exit('');
         if not Customer."Use GLN in Electronic Document" then
             exit('');
-        if ShipToAddress.Get(CustomerNo, ShipToCode) then
+        ShipToAddress.SetLoadFields(GLN);
+        if (ShipToCode <> '') and ShipToAddress.Get(CustomerNo, ShipToCode) then
             if ShipToAddress.GLN <> '' then
                 exit(ShipToAddress.GLN);
         exit(Customer.GLN);

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -604,6 +604,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         end;
 
         GetSellerPostalAddr(RespCentrCode, SellerStreetName, SellerAdditionalStreetName, SellerCityName, SellerPostalZone, SellerCountryCode);
+        Customer.SetLoadFields("Use GLN in Electronic Document", GLN);
         if Customer.Get(CustomerNo) then
             if Customer."Use GLN in Electronic Document" then
                 CustomerGLN := Customer.GLN;
@@ -766,11 +767,13 @@ codeunit 13917 "Export ZUGFeRD Document"
         ShipToAddress: Record "Ship-to Address";
         DeliveryGLN: Code[13];
     begin
+        Customer.SetLoadFields("Use GLN in Electronic Document", GLN);
         if not Customer.Get(CustomerNo) then
             exit;
         if not Customer."Use GLN in Electronic Document" then
             exit;
-        if ShipToAddress.Get(CustomerNo, ShipToCode) then
+        ShipToAddress.SetLoadFields(GLN);
+        if (ShipToCode <> '') and ShipToAddress.Get(CustomerNo, ShipToCode) then
             DeliveryGLN := ShipToAddress.GLN;
         if DeliveryGLN = '' then
             DeliveryGLN := Customer.GLN;

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -527,7 +527,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         DataTypeManagement: Codeunit "Data Type Management";
         HeaderRecordRef: RecordRef;
         HeaderTradeAgreementElement, SellerTradePartyElement, BuyerTradePartyElement, SpecifiedTaxRegistrationElement, IDElement : XmlElement;
-        SellerOrderReferencedDocumentElement, BuyerOrderReferencedDocumentElement: XmlElement;
+        SellerOrderReferencedDocumentElement, BuyerOrderReferencedDocumentElement : XmlElement;
         PostalTradeAddressElement, ContactElement : XmlElement;
         SellerIDAttr, BuyerIDAttr : XmlAttribute;
         CustomerNo: Code[20];
@@ -624,8 +624,8 @@ codeunit 13917 "Export ZUGFeRD Document"
             ContactElement.Add(XmlElement.Create('TelephoneUniversalCommunication', XmlNamespaceRAM,
                 XmlElement.Create('CompleteNumber', XmlNamespaceRAM, SellerPhoneNumber)));
             if SellerEmailAddress <> '' then
-            ContactElement.Add(XmlElement.Create('EmailURIUniversalCommunication', XmlNamespaceRAM,
-                XmlElement.Create('URIID', XmlNamespaceRAM, SellerEmailAddress)));
+                ContactElement.Add(XmlElement.Create('EmailURIUniversalCommunication', XmlNamespaceRAM,
+                    XmlElement.Create('URIID', XmlNamespaceRAM, SellerEmailAddress)));
             SellerTradePartyElement.Add(ContactElement);
         end;
 

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -18,6 +18,7 @@ using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Location;
 using Microsoft.Peppol;
+using Microsoft.Sales.Customer;
 using Microsoft.Sales.History;
 using Microsoft.Service.History;
 using System.IO;

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -40,6 +40,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         FeatureNameTok: Label 'E-document ZUGFeRD Format', Locked = true;
         StartEventNameTok: Label 'E-document ZUGFeRD export started', Locked = true;
         EndEventNameTok: Label 'E-document ZUGFeRD export completed', Locked = true;
+        GLNSchemeIDTok: Label '0088', Locked = true;
         XmlNamespaceRSM: Text;
         XmlNamespaceRAM: Text;
         XmlNamespaceUDT: Text;
@@ -612,7 +613,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         // Seller
         SellerTradePartyElement := XmlElement.Create('SellerTradeParty', XmlNamespaceRAM);
         if CompanyInformation."Use GLN in Electronic Document" and (CompanyInformation.GLN <> '') then begin
-            SellerIDAttr := XmlAttribute.Create('schemeID', '0088');
+            SellerIDAttr := XmlAttribute.Create('schemeID', GLNSchemeIDTok);
             SellerTradePartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, SellerIDAttr, CompanyInformation.GLN));
         end;
         SellerTradePartyElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, CompanyInformation.Name));
@@ -656,7 +657,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         // Buyer
         BuyerTradePartyElement := XmlElement.Create('BuyerTradeParty', XmlNamespaceRAM);
         if CustomerGLN <> '' then
-            BuyerTradePartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, XmlAttribute.Create('schemeID', '0088'), CustomerGLN));
+            BuyerTradePartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, XmlAttribute.Create('schemeID', GLNSchemeIDTok), CustomerGLN));
         BuyerTradePartyElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, CustomerName));
 
         // Buyer Contact
@@ -765,12 +766,16 @@ codeunit 13917 "Export ZUGFeRD Document"
         ShipToAddress: Record "Ship-to Address";
         DeliveryGLN: Code[13];
     begin
+        if not Customer.Get(CustomerNo) then
+            exit;
+        if not Customer."Use GLN in Electronic Document" then
+            exit;
         if ShipToAddress.Get(CustomerNo, ShipToCode) then
             DeliveryGLN := ShipToAddress.GLN;
-        if (DeliveryGLN = '') and Customer.Get(CustomerNo) then
+        if DeliveryGLN = '' then
             DeliveryGLN := Customer.GLN;
         if DeliveryGLN <> '' then
-            ShipToPartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, XmlAttribute.Create('schemeID', '0088'), DeliveryGLN));
+            ShipToPartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, XmlAttribute.Create('schemeID', GLNSchemeIDTok), DeliveryGLN));
     end;
 
     local procedure InsertApplicableHeaderTradeSettlement(var RootXMLNode: XmlElement; var SalesInvHeader: Record "Sales Invoice Header"; var SalesInvLine: Record "Sales Invoice Line"; CurrencyCode: Code[10]; var LineAmount: Dictionary of [Decimal, Decimal]; var LineVATAmount: Dictionary of [Decimal, Decimal]; var LineAmounts: Dictionary of [Text, Decimal]; var LineDiscAmount: Dictionary of [Decimal, Decimal])

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/ExportZUGFeRDDocument.Codeunit.al
@@ -519,6 +519,7 @@ codeunit 13917 "Export ZUGFeRD Document"
 
     local procedure InsertApplicableHeaderTradeAgreement(var RootXMLNode: XmlElement; RecordVariant: Variant)
     var
+        Customer: Record Customer;
         SalesInvoiceHeader: Record "Sales Invoice Header";
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         TempBodyReportSelections: Record "Report Selections" temporary;
@@ -530,6 +531,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         PostalTradeAddressElement, ContactElement : XmlElement;
         SellerIDAttr, BuyerIDAttr : XmlAttribute;
         CustomerNo: Code[20];
+        CustomerGLN: Code[13];
         CustomerName: Text[100];
         Address: Text[100];
         Address2: Text[100];
@@ -601,6 +603,9 @@ codeunit 13917 "Export ZUGFeRD Document"
         end;
 
         GetSellerPostalAddr(RespCentrCode, SellerStreetName, SellerAdditionalStreetName, SellerCityName, SellerPostalZone, SellerCountryCode);
+        if Customer.Get(CustomerNo) then
+            if Customer."Use GLN in Electronic Document" then
+                CustomerGLN := Customer.GLN;
         HeaderTradeAgreementElement := XmlElement.Create('ApplicableHeaderTradeAgreement', XmlNamespaceRAM);
         HeaderTradeAgreementElement.Add(XmlElement.Create('BuyerReference', XmlNamespaceRAM, GetBuyerReference(RecordVariant)));
 
@@ -650,6 +655,8 @@ codeunit 13917 "Export ZUGFeRD Document"
 
         // Buyer
         BuyerTradePartyElement := XmlElement.Create('BuyerTradeParty', XmlNamespaceRAM);
+        if CustomerGLN <> '' then
+            BuyerTradePartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, XmlAttribute.Create('schemeID', '0088'), CustomerGLN));
         BuyerTradePartyElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, CustomerName));
 
         // Buyer Contact
@@ -703,6 +710,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         DeliveryElement := XmlElement.Create('ApplicableHeaderTradeDelivery', XmlNamespaceRAM);
 
         ShipToPartyElement := XmlElement.Create('ShipToTradeParty', XmlNamespaceRAM);
+        InsertDeliveryGLN(ShipToPartyElement, SalesInvoiceHeader."Sell-to Customer No.", SalesInvoiceHeader."Ship-to Code");
         ShipToPartyElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, SalesInvoiceHeader."Sell-to Customer Name"));
 
         PostalAddressElement := XmlElement.Create('PostalTradeAddress', XmlNamespaceRAM);
@@ -730,6 +738,7 @@ codeunit 13917 "Export ZUGFeRD Document"
         DeliveryElement := XmlElement.Create('ApplicableHeaderTradeDelivery', XmlNamespaceRAM);
 
         ShipToPartyElement := XmlElement.Create('ShipToTradeParty', XmlNamespaceRAM);
+        InsertDeliveryGLN(ShipToPartyElement, SalesCrMemoHeader."Sell-to Customer No.", SalesCrMemoHeader."Ship-to Code");
         ShipToPartyElement.Add(XmlElement.Create('Name', XmlNamespaceRAM, SalesCrMemoHeader."Sell-to Customer Name"));
 
         PostalAddressElement := XmlElement.Create('PostalTradeAddress', XmlNamespaceRAM);
@@ -748,6 +757,20 @@ codeunit 13917 "Export ZUGFeRD Document"
         DeliveryElement.Add(ActualDeliveryDateElement);
 
         RootXMLNode.Add(DeliveryElement);
+    end;
+
+    local procedure InsertDeliveryGLN(var ShipToPartyElement: XmlElement; CustomerNo: Code[20]; ShipToCode: Code[10])
+    var
+        Customer: Record Customer;
+        ShipToAddress: Record "Ship-to Address";
+        DeliveryGLN: Code[13];
+    begin
+        if ShipToAddress.Get(CustomerNo, ShipToCode) then
+            DeliveryGLN := ShipToAddress.GLN;
+        if (DeliveryGLN = '') and Customer.Get(CustomerNo) then
+            DeliveryGLN := Customer.GLN;
+        if DeliveryGLN <> '' then
+            ShipToPartyElement.Add(XmlElement.Create('GlobalID', XmlNamespaceRAM, XmlAttribute.Create('schemeID', '0088'), DeliveryGLN));
     end;
 
     local procedure InsertApplicableHeaderTradeSettlement(var RootXMLNode: XmlElement; var SalesInvHeader: Record "Sales Invoice Header"; var SalesInvLine: Record "Sales Invoice Line"; CurrencyCode: Code[10]; var LineAmount: Dictionary of [Decimal, Decimal]; var LineVATAmount: Dictionary of [Decimal, Decimal]; var LineAmounts: Dictionary of [Text, Decimal]; var LineDiscAmount: Dictionary of [Decimal, Decimal])

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -1618,6 +1618,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
         SupplierPartyIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
+        SupplierLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
     begin
         // [SCENARIO 588110] Supplier GLN is exported with schemeID 0088 in XRechnung format
         Initialize();
@@ -1634,6 +1635,8 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [THEN] Supplier PartyIdentification ID is the GLN with schemeID = 0088
         Assert.AreEqual(SupplierGLN(), GetNodeByPathWithError(TempXMLBuffer, SupplierPartyIdTok), StrSubstNo(IncorrectValueErr, SupplierPartyIdTok));
         Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, SupplierPartyIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, SupplierPartyIdTok + '/@schemeID'));
+        Assert.AreEqual(SupplierGLN(), GetNodeByPathWithError(TempXMLBuffer, SupplierLegalEntityIdTok), StrSubstNo(IncorrectValueErr, SupplierLegalEntityIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, SupplierLegalEntityIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, SupplierLegalEntityIdTok + '/@schemeID'));
     end;
 
     [Test]
@@ -1642,12 +1645,14 @@ codeunit 13918 "XRechnung XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
         CustomerPartyIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
+        CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
+        DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
     begin
         // [SCENARIO 588110] Customer GLN is exported with schemeID 0088 in XRechnung format
         Initialize();
 
         // [GIVEN] Create and Post Sales Invoice for a customer that uses GLN in electronic documents
-        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLN(CustomerGLN()));
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN()));
 
         // [WHEN] Export XRechnung Electronic Document.
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
@@ -1655,6 +1660,34 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [THEN] Customer PartyIdentification ID is the GLN with schemeID = 0088
         Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
         Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CustomerPartyIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok + '/@schemeID'));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(IncorrectValueErr, CustomerLegalEntityIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CustomerLegalEntityIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CustomerLegalEntityIdTok + '/@schemeID'));
+        Assert.AreEqual(ShipToGLN(), GetNodeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok + '/@schemeID'));
+    end;
+
+    [Test]
+    procedure ExportPostedSalesInvoiceInXRechnungFormatUsesBillToGLNForCustomerParty();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        CustomerPartyIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
+        CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
+        DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
+    begin
+        // [SCENARIO 646443] Bill-to GLN identifies the customer party while sell-to GLN identifies delivery
+        Initialize();
+
+        // [GIVEN] A posted sales invoice with different sell-to and bill-to customer GLNs
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceWithDifferentSellToAndBillToGLNs(CustomerGLN(), SupplierGLN()));
+
+        // [WHEN] Export XRechnung Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] Customer party uses bill-to GLN and delivery falls back to sell-to GLN
+        Assert.AreEqual(SupplierGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
+        Assert.AreEqual(SupplierGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(IncorrectValueErr, CustomerLegalEntityIdTok));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok));
     end;
 
     [Test]
@@ -2058,11 +2091,35 @@ codeunit 13918 "XRechnung XML Document Tests"
         exit(Customer."No.");
     end;
 
-    local procedure CreateAndPostSalesInvoiceForCustomerWithGLN(GLN: Code[13]): Code[20]
+    local procedure CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(GLN: Code[13]; NewShipToGLN: Code[13]): Code[20]
     var
         SalesHeader: Record "Sales Header";
+        ShipToAddress: Record "Ship-to Address";
+        CustomerNo: Code[20];
     begin
-        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CreateCustomerWithGLN(GLN));
+        CustomerNo := CreateCustomerWithGLN(GLN);
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CustomerNo);
+        LibrarySales.CreateShipToAddress(ShipToAddress, CustomerNo);
+        ShipToAddress.GLN := NewShipToGLN;
+        ShipToAddress.Modify(true);
+        SalesHeader.Validate("Ship-to Code", ShipToAddress.Code);
+        SalesHeader.Modify(true);
+        CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
+        exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
+    end;
+
+    local procedure CreateAndPostSalesInvoiceWithDifferentSellToAndBillToGLNs(SellToGLN: Code[13]; BillToGLN: Code[13]): Code[20]
+    var
+        BillToCustomer: Record Customer;
+        SalesHeader: Record "Sales Header";
+    begin
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CreateCustomerWithGLN(SellToGLN));
+        LibrarySales.CreateCustomer(BillToCustomer);
+        BillToCustomer.GLN := BillToGLN;
+        BillToCustomer."Use GLN in Electronic Document" := true;
+        BillToCustomer.Modify(true);
+        SalesHeader.Validate("Bill-to Customer No.", BillToCustomer."No.");
+        SalesHeader.Modify(true);
         CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
         exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
     end;
@@ -2092,6 +2149,11 @@ codeunit 13918 "XRechnung XML Document Tests"
     local procedure CustomerGLN(): Code[13]
     begin
         exit('4313205158428');
+    end;
+
+    local procedure ShipToGLN(): Code[13]
+    begin
+        exit('1234567890128');
     end;
 
     local procedure CreateResponsibilityCenter(var ResponsibilityCenter: Record "Responsibility Center")

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -1675,6 +1675,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 646443] Customer GLN is used when the ship-to address GLN is blank
         Initialize();
 
@@ -1685,8 +1686,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
         // [THEN] Delivery location uses the customer GLN with schemeID 0088
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok));
-        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok + '/@schemeID'));
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, DeliveryLocationIdTok);
     end;
 
     [Test]
@@ -1695,6 +1695,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 646443] Customer GLN is not exported in XRechnung format when GLN use is disabled
         Initialize();
 
@@ -1705,9 +1706,9 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
         // [THEN] Customer and delivery GLN identifiers are not exported
-        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(UnexpectedNodeErr, CustomerPartyIdTok));
-        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(UnexpectedNodeErr, CustomerLegalEntityIdTok));
-        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(UnexpectedNodeErr, DeliveryLocationIdTok));
+        VerifyNodeDoesNotExist(TempXMLBuffer, CustomerPartyIdTok);
+        VerifyNodeDoesNotExist(TempXMLBuffer, CustomerLegalEntityIdTok);
+        VerifyNodeDoesNotExist(TempXMLBuffer, DeliveryLocationIdTok);
     end;
 
     [Test]
@@ -1716,6 +1717,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 646443] Sell-to GLN identifies the customer party and delivery
         Initialize();
 
@@ -1725,10 +1727,10 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [WHEN] Export XRechnung Electronic Document.
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
-        // [THEN] Customer party and delivery use sell-to GLN
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(IncorrectValueErr, CustomerLegalEntityIdTok));
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok));
+        // [THEN] Customer party and delivery use sell-to GLN with schemeID 0088
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, CustomerPartyIdTok);
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, CustomerLegalEntityIdTok);
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, DeliveryLocationIdTok);
     end;
 
     [Test]
@@ -2471,6 +2473,17 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportXRechnungFormat.Create(EDocumentService, EDocument, SourceDocumentHeader, SourceDocumentLines, TempBlob);
         TempBlob.CreateInStream(FileInStream);
         TempXMLBuffer.LoadFromStream(FileInStream);
+    end;
+
+    local procedure VerifyGLNIdentifier(ExpectedGLN: Code[13]; var TempXMLBuffer: Record "XML Buffer" temporary; XPath: Text)
+    begin
+        Assert.AreEqual(ExpectedGLN, GetNodeByPathWithError(TempXMLBuffer, XPath), StrSubstNo(IncorrectValueErr, XPath));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, XPath, 'schemeID'), StrSubstNo(IncorrectValueErr, XPath + '/@schemeID'));
+    end;
+
+    local procedure VerifyNodeDoesNotExist(var TempXMLBuffer: Record "XML Buffer" temporary; XPath: Text)
+    begin
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, XPath), StrSubstNo(UnexpectedNodeErr, XPath));
     end;
 
     local procedure VerifyHeaderData(SalesInvoiceHeader: Record "Sales Invoice Header"; var TempXMLBuffer: Record "XML Buffer" temporary);

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -1667,7 +1667,7 @@ codeunit 13918 "XRechnung XML Document Tests"
     end;
 
     [Test]
-    procedure ExportPostedSalesInvoiceInXRechnungFormatUsesBillToGLNForCustomerParty();
+    procedure ExportPostedSalesInvoiceInXRechnungFormatUsesSellToGLNForCustomerParty();
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
@@ -1675,7 +1675,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
         DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
     begin
-        // [SCENARIO 646443] Bill-to GLN identifies the customer party while sell-to GLN identifies delivery
+        // [SCENARIO 646443] Sell-to GLN identifies the customer party and delivery
         Initialize();
 
         // [GIVEN] A posted sales invoice with different sell-to and bill-to customer GLNs
@@ -1684,9 +1684,9 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [WHEN] Export XRechnung Electronic Document.
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
-        // [THEN] Customer party uses bill-to GLN and delivery falls back to sell-to GLN
-        Assert.AreEqual(SupplierGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
-        Assert.AreEqual(SupplierGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(IncorrectValueErr, CustomerLegalEntityIdTok));
+        // [THEN] Customer party and delivery use sell-to GLN
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(IncorrectValueErr, CustomerLegalEntityIdTok));
         Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok));
     end;
 

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -60,6 +60,12 @@ codeunit 13918 "XRechnung XML Document Tests"
         IncorrectValueErr: Label 'Incorrect value for %1', Locked = true;
         AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true;
         UnexpectedNodeErr: Label 'Node %1 must not exist.', Locked = true;
+        SupplierPartyIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
+        SupplierLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
+        CustomerPartyIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
+        CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
+        DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
+        CreditMemoCustomerPartyIdTok: Label '/ns0:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
         IsInitialized: Boolean;
 
     #region SalesInvoice
@@ -1617,8 +1623,6 @@ codeunit 13918 "XRechnung XML Document Tests"
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
-        SupplierPartyIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
-        SupplierLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
     begin
         // [SCENARIO 588110] Supplier GLN is exported with schemeID 0088 in XRechnung format
         Initialize();
@@ -1644,15 +1648,12 @@ codeunit 13918 "XRechnung XML Document Tests"
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
-        CustomerPartyIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
-        CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
-        DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
     begin
         // [SCENARIO 588110] Customer GLN is exported with schemeID 0088 in XRechnung format
         Initialize();
 
         // [GIVEN] Create and Post Sales Invoice for a customer that uses GLN in electronic documents
-        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN()));
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN(), true));
 
         // [WHEN] Export XRechnung Electronic Document.
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
@@ -1667,13 +1668,31 @@ codeunit 13918 "XRechnung XML Document Tests"
     end;
 
     [Test]
+    procedure ExportPostedSalesInvoiceInXRechnungFormatDoesNotExportCustomerGLNWhenDisabled();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+    begin
+        // [SCENARIO 646443] Customer GLN is not exported in XRechnung format when GLN use is disabled
+        Initialize();
+
+        // [GIVEN] A customer and ship-to address with GLNs, but GLN use in electronic documents disabled
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN(), false));
+
+        // [WHEN] Export XRechnung Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] Customer and delivery GLN identifiers are not exported
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(UnexpectedNodeErr, CustomerPartyIdTok));
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, CustomerLegalEntityIdTok), StrSubstNo(UnexpectedNodeErr, CustomerLegalEntityIdTok));
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(UnexpectedNodeErr, DeliveryLocationIdTok));
+    end;
+
+    [Test]
     procedure ExportPostedSalesInvoiceInXRechnungFormatUsesSellToGLNForCustomerParty();
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
-        CustomerPartyIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
-        CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
-        DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
     begin
         // [SCENARIO 646443] Sell-to GLN identifies the customer party and delivery
         Initialize();
@@ -1695,7 +1714,6 @@ codeunit 13918 "XRechnung XML Document Tests"
     var
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
-        CustomerPartyIdTok: Label '/ns0:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
     begin
         // [SCENARIO 588110] Customer GLN is exported with schemeID 0088 in XRechnung credit memo format
         Initialize();
@@ -1707,8 +1725,8 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
 
         // [THEN] Customer PartyIdentification ID is the GLN with schemeID = 0088
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
-        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CustomerPartyIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CustomerPartyIdTok + '/@schemeID'));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CreditMemoCustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CreditMemoCustomerPartyIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CreditMemoCustomerPartyIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CreditMemoCustomerPartyIdTok + '/@schemeID'));
     end;
     #endregion
 
@@ -2080,24 +2098,24 @@ codeunit 13918 "XRechnung XML Document Tests"
         exit(Customer."No.");
     end;
 
-    local procedure CreateCustomerWithGLN(GLN: Code[13]): Code[20]
+    local procedure CreateCustomerWithGLN(GLN: Code[13]; UseGLNInElectronicDocument: Boolean): Code[20]
     var
         Customer: Record Customer;
     begin
         Customer.Get(CreateCustomer());
         Customer.GLN := GLN;
-        Customer."Use GLN in Electronic Document" := true;
+        Customer."Use GLN in Electronic Document" := UseGLNInElectronicDocument;
         Customer.Modify(true);
         exit(Customer."No.");
     end;
 
-    local procedure CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(GLN: Code[13]; NewShipToGLN: Code[13]): Code[20]
+    local procedure CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(GLN: Code[13]; NewShipToGLN: Code[13]; UseGLNInElectronicDocument: Boolean): Code[20]
     var
         SalesHeader: Record "Sales Header";
         ShipToAddress: Record "Ship-to Address";
         CustomerNo: Code[20];
     begin
-        CustomerNo := CreateCustomerWithGLN(GLN);
+        CustomerNo := CreateCustomerWithGLN(GLN, UseGLNInElectronicDocument);
         CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CustomerNo);
         LibrarySales.CreateShipToAddress(ShipToAddress, CustomerNo);
         ShipToAddress.GLN := NewShipToGLN;
@@ -2113,7 +2131,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         BillToCustomer: Record Customer;
         SalesHeader: Record "Sales Header";
     begin
-        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CreateCustomerWithGLN(SellToGLN));
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CreateCustomerWithGLN(SellToGLN, true));
         LibrarySales.CreateCustomer(BillToCustomer);
         BillToCustomer.GLN := BillToGLN;
         BillToCustomer."Use GLN in Electronic Document" := true;
@@ -2128,7 +2146,7 @@ codeunit 13918 "XRechnung XML Document Tests"
     var
         SalesHeader: Record "Sales Header";
     begin
-        CreateSalesHeader(SalesHeader, "Sales Document Type"::"Credit Memo", CreateCustomerWithGLN(GLN));
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::"Credit Memo", CreateCustomerWithGLN(GLN, true));
         CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
         exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
     end;

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -1692,6 +1692,7 @@ codeunit 13918 "XRechnung XML Document Tests"
     [Test]
     procedure ExportPostedSalesInvoiceInXRechnungFormatDoesNotExportCustomerGLNWhenDisabled();
     var
+        Customer: Record Customer;
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
@@ -1705,13 +1706,18 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [WHEN] Export XRechnung Electronic Document.
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
-        // [THEN] Customer and delivery GLN identifiers are not exported
-        VerifyNodeDoesNotExist(TempXMLBuffer, CustomerPartyIdTok);
+        // [THEN] Customer party uses the VAT registration number and GLN identifiers are not exported
+        Customer.Get(SalesInvoiceHeader."Sell-to Customer No.");
+        Assert.AreEqual(
+            GetVATRegistrationNo(Customer."VAT Registration No.", SalesInvoiceHeader."Bill-to Country/Region Code"),
+            GetNodeByPathWithError(TempXMLBuffer, CustomerPartyIdTok),
+            StrSubstNo(IncorrectValueErr, CustomerPartyIdTok));
         VerifyNodeDoesNotExist(TempXMLBuffer, CustomerLegalEntityIdTok);
         VerifyNodeDoesNotExist(TempXMLBuffer, DeliveryLocationIdTok);
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
     procedure ExportPostedSalesInvoiceInXRechnungFormatUsesSellToGLNForCustomerParty();
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -58,7 +58,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportXRechnungFormat: Codeunit "XRechnung Format";
         ExportXRechnungDocument: Codeunit "Export XRechnung Document";
         IncorrectValueErr: Label 'Incorrect value for %1', Locked = true;
-        AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true;
+        AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true, Comment = '%1 = XML attribute name, %2 = XML element XPath';
         UnexpectedNodeErr: Label 'Node %1 must not exist.', Locked = true;
         SupplierPartyIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
         SupplierLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingSupplierParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
@@ -66,6 +66,8 @@ codeunit 13918 "XRechnung XML Document Tests"
         CustomerLegalEntityIdTok: Label '/ubl:Invoice/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
         DeliveryLocationIdTok: Label '/ubl:Invoice/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
         CreditMemoCustomerPartyIdTok: Label '/ns0:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PartyIdentification/cbc:ID', Locked = true;
+        CreditMemoCustomerLegalEntityIdTok: Label '/ns0:CreditNote/cac:AccountingCustomerParty/cac:Party/cac:PartyLegalEntity/cbc:CompanyID', Locked = true;
+        CreditMemoDeliveryLocationIdTok: Label '/ns0:CreditNote/cac:Delivery/cac:DeliveryLocation/cbc:ID', Locked = true;
         IsInitialized: Boolean;
 
     #region SalesInvoice
@@ -1668,6 +1670,26 @@ codeunit 13918 "XRechnung XML Document Tests"
     end;
 
     [Test]
+    procedure ExportPostedSalesInvoiceInXRechnungFormatFallsBackToCustomerGLNWhenShipToGLNIsBlank();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+    begin
+        // [SCENARIO 646443] Customer GLN is used when the ship-to address GLN is blank
+        Initialize();
+
+        // [GIVEN] A customer with GLN and a ship-to address without GLN
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), '', true));
+
+        // [WHEN] Export XRechnung Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] Delivery location uses the customer GLN with schemeID 0088
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, DeliveryLocationIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, DeliveryLocationIdTok + '/@schemeID'));
+    end;
+
+    [Test]
     procedure ExportPostedSalesInvoiceInXRechnungFormatDoesNotExportCustomerGLNWhenDisabled();
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
@@ -1724,9 +1746,13 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [WHEN] Export XRechnung Electronic Document.
         ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
 
-        // [THEN] Customer PartyIdentification ID is the GLN with schemeID = 0088
+        // [THEN] Customer and delivery identifiers contain the customer GLN with schemeID 0088
         Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CreditMemoCustomerPartyIdTok), StrSubstNo(IncorrectValueErr, CreditMemoCustomerPartyIdTok));
         Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CreditMemoCustomerPartyIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CreditMemoCustomerPartyIdTok + '/@schemeID'));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CreditMemoCustomerLegalEntityIdTok), StrSubstNo(IncorrectValueErr, CreditMemoCustomerLegalEntityIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CreditMemoCustomerLegalEntityIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CreditMemoCustomerLegalEntityIdTok + '/@schemeID'));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, CreditMemoDeliveryLocationIdTok), StrSubstNo(IncorrectValueErr, CreditMemoDeliveryLocationIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, CreditMemoDeliveryLocationIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, CreditMemoDeliveryLocationIdTok + '/@schemeID'));
     end;
     #endregion
 

--- a/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -57,6 +57,7 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         ZUGFeRDFormat: Codeunit "ZUGFeRD Format";
         ExportZUGFeRDDocument: Codeunit "Export ZUGFeRD Document";
         IncorrectValueErr: Label 'Incorrect value for %1', Locked = true;
+        AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true;
         UnexpectedNodeErr: Label 'Node %1 must not exist.', Locked = true;
         DocumentLineTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem', Locked = true;
         IsInitialized: Boolean;
@@ -286,6 +287,30 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
 
         // [THEN] ZUGFeRD Electronic Document is created with customer data
         VerifyBuyerData(SalesInvoiceHeader, TempXMLBuffer);
+    end;
+
+    [Test]
+    procedure ExportPostedSalesInvoiceInZUGFeRDFormatVerifyCustomerGLN();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+        BuyerGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:GlobalID', Locked = true;
+        ShipToGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty/ram:GlobalID', Locked = true;
+    begin
+        // [SCENARIO 646443] Customer GLN is exported for buyer and ship-to parties in ZUGFeRD format
+        Initialize();
+
+        // [GIVEN] Create and post a sales invoice for a customer that uses GLN in electronic documents
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN()));
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] Buyer and ship-to GlobalID contain the customer GLN with schemeID 0088
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok + '/@schemeID'));
+        Assert.AreEqual(ShipToGLN(), GetNodeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok + '/@schemeID'));
     end;
 
     [Test]
@@ -2179,6 +2204,44 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         exit(Customer."No.");
     end;
 
+    local procedure CreateCustomerWithGLN(GLN: Code[13]): Code[20]
+    var
+        Customer: Record Customer;
+    begin
+        Customer.Get(CreateCustomer());
+        Customer.GLN := GLN;
+        Customer."Use GLN in Electronic Document" := true;
+        Customer.Modify(true);
+        exit(Customer."No.");
+    end;
+
+    local procedure CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(GLN: Code[13]; NewShipToGLN: Code[13]): Code[20]
+    var
+        SalesHeader: Record "Sales Header";
+        ShipToAddress: Record "Ship-to Address";
+        CustomerNo: Code[20];
+    begin
+        CustomerNo := CreateCustomerWithGLN(GLN);
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CustomerNo);
+        LibrarySales.CreateShipToAddress(ShipToAddress, CustomerNo);
+        ShipToAddress.GLN := NewShipToGLN;
+        ShipToAddress.Modify(true);
+        SalesHeader.Validate("Ship-to Code", ShipToAddress.Code);
+        SalesHeader.Modify(true);
+        CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
+        exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
+    end;
+
+    local procedure CustomerGLN(): Code[13]
+    begin
+        exit('4313205158428');
+    end;
+
+    local procedure ShipToGLN(): Code[13]
+    begin
+        exit('1234567890128');
+    end;
+
     local procedure CreateResponsibilityCenter(var ResponsibilityCenter: Record "Responsibility Center")
     begin
         ResponsibilityCenter.Init();
@@ -3115,6 +3178,25 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         if TempXMLBuffer.FindFirst() then
             exit(TempXMLBuffer.GetValue());
         Error('Node not found: %1', XPath);
+    end;
+
+    local procedure GetAttributeByPathWithError(var TempXMLBuffer: Record "XML Buffer" temporary; ElementXPath: Text; AttributeName: Text): Text
+    var
+        TempXMLBufferAttribute: Record "XML Buffer" temporary;
+    begin
+        TempXMLBuffer.Reset();
+        TempXMLBuffer.SetRange(Type, TempXMLBuffer.Type::Element);
+        TempXMLBuffer.SetRange(Path, ElementXPath);
+        if TempXMLBuffer.FindFirst() then begin
+            TempXMLBufferAttribute.Copy(TempXMLBuffer, true);
+            TempXMLBufferAttribute.Reset();
+            TempXMLBufferAttribute.SetRange("Parent Entry No.", TempXMLBuffer."Entry No.");
+            TempXMLBufferAttribute.SetRange(Type, TempXMLBufferAttribute.Type::Attribute);
+            TempXMLBufferAttribute.SetRange(Name, AttributeName);
+            if TempXMLBufferAttribute.FindFirst() then
+                exit(TempXMLBufferAttribute.Value);
+        end;
+        Error(AttributeNotFoundErr, AttributeName, ElementXPath);
     end;
 
     local procedure NodeExistsByPath(var TempXMLBuffer: Record "XML Buffer" temporary; XPath: Text): Boolean

--- a/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -57,7 +57,7 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         ZUGFeRDFormat: Codeunit "ZUGFeRD Format";
         ExportZUGFeRDDocument: Codeunit "Export ZUGFeRD Document";
         IncorrectValueErr: Label 'Incorrect value for %1', Locked = true;
-        AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true;
+        AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true, Comment = '%1 = XML attribute name, %2 = XML element XPath';
         UnexpectedNodeErr: Label 'Node %1 must not exist.', Locked = true;
         DocumentLineTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem', Locked = true;
         BuyerGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:GlobalID', Locked = true;
@@ -927,6 +927,28 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
 
         // [THEN] ZUGFeRD Electronic Document is created with buyer reference XX
         VerifyBuyerReference(SalesCrMemoHeader."Your Reference", TempXMLBuffer, '/rsm:CrossIndustryInvoice');
+    end;
+
+    [Test]
+    procedure ExportPostedSalesCrMemoInZUGFeRDFormatVerifyCustomerGLN();
+    var
+        SalesCrMemoHeader: Record "Sales Cr.Memo Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+    begin
+        // [SCENARIO 646443] Customer GLN is exported for buyer and ship-to parties in ZUGFeRD credit memo format
+        Initialize();
+
+        // [GIVEN] Create and post a sales credit memo for a customer that uses GLN in electronic documents
+        SalesCrMemoHeader.Get(CreateAndPostSalesCrMemoForCustomerWithGLN(CustomerGLN()));
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
+
+        // [THEN] Buyer and ship-to GlobalID contain the customer GLN with schemeID 0088
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok + '/@schemeID'));
+        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok + '/@schemeID'));
     end;
 
     [Test]
@@ -2248,6 +2270,15 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         ShipToAddress.Modify(true);
         SalesHeader.Validate("Ship-to Code", ShipToAddress.Code);
         SalesHeader.Modify(true);
+        CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
+        exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
+    end;
+
+    local procedure CreateAndPostSalesCrMemoForCustomerWithGLN(GLN: Code[13]): Code[20]
+    var
+        SalesHeader: Record "Sales Header";
+    begin
+        CreateSalesHeader(SalesHeader, "Sales Document Type"::"Credit Memo", CreateCustomerWithGLN(GLN, true));
         CreateSalesLine(SalesHeader, Enum::"Sales Line Type"::Item, false);
         exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
     end;

--- a/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -60,6 +60,8 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         AttributeNotFoundErr: Label 'Attribute %1 not found for node: %2', Locked = true;
         UnexpectedNodeErr: Label 'Node %1 must not exist.', Locked = true;
         DocumentLineTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:IncludedSupplyChainTradeLineItem', Locked = true;
+        BuyerGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:GlobalID', Locked = true;
+        ShipToGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty/ram:GlobalID', Locked = true;
         IsInitialized: Boolean;
 
     #region SalesInvoice
@@ -294,14 +296,12 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
-        BuyerGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty/ram:GlobalID', Locked = true;
-        ShipToGlobalIdTok: Label '/rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty/ram:GlobalID', Locked = true;
     begin
         // [SCENARIO 646443] Customer GLN is exported for buyer and ship-to parties in ZUGFeRD format
         Initialize();
 
         // [GIVEN] Create and post a sales invoice for a customer that uses GLN in electronic documents
-        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN()));
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN(), true));
 
         // [WHEN] Export ZUGFeRD Electronic Document.
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
@@ -311,6 +311,26 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok + '/@schemeID'));
         Assert.AreEqual(ShipToGLN(), GetNodeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok));
         Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok + '/@schemeID'));
+    end;
+
+    [Test]
+    procedure ExportPostedSalesInvoiceInZUGFeRDFormatDoesNotExportCustomerGLNWhenDisabled();
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempXMLBuffer: Record "XML Buffer" temporary;
+    begin
+        // [SCENARIO 646443] Customer GLN is not exported in ZUGFeRD format when GLN use is disabled
+        Initialize();
+
+        // [GIVEN] A customer and ship-to address with GLNs, but GLN use in electronic documents disabled
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(CustomerGLN(), ShipToGLN(), false));
+
+        // [WHEN] Export ZUGFeRD Electronic Document.
+        ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
+
+        // [THEN] Buyer and ship-to GLN identifiers are not exported
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, BuyerGlobalIdTok), StrSubstNo(UnexpectedNodeErr, BuyerGlobalIdTok));
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(UnexpectedNodeErr, ShipToGlobalIdTok));
     end;
 
     [Test]
@@ -2204,24 +2224,24 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         exit(Customer."No.");
     end;
 
-    local procedure CreateCustomerWithGLN(GLN: Code[13]): Code[20]
+    local procedure CreateCustomerWithGLN(GLN: Code[13]; UseGLNInElectronicDocument: Boolean): Code[20]
     var
         Customer: Record Customer;
     begin
         Customer.Get(CreateCustomer());
         Customer.GLN := GLN;
-        Customer."Use GLN in Electronic Document" := true;
+        Customer."Use GLN in Electronic Document" := UseGLNInElectronicDocument;
         Customer.Modify(true);
         exit(Customer."No.");
     end;
 
-    local procedure CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(GLN: Code[13]; NewShipToGLN: Code[13]): Code[20]
+    local procedure CreateAndPostSalesInvoiceForCustomerWithGLNAndShipToGLN(GLN: Code[13]; NewShipToGLN: Code[13]; UseGLNInElectronicDocument: Boolean): Code[20]
     var
         SalesHeader: Record "Sales Header";
         ShipToAddress: Record "Ship-to Address";
         CustomerNo: Code[20];
     begin
-        CustomerNo := CreateCustomerWithGLN(GLN);
+        CustomerNo := CreateCustomerWithGLN(GLN, UseGLNInElectronicDocument);
         CreateSalesHeader(SalesHeader, "Sales Document Type"::Invoice, CustomerNo);
         LibrarySales.CreateShipToAddress(ShipToAddress, CustomerNo);
         ShipToAddress.GLN := NewShipToGLN;

--- a/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/ZUGFeRDXMLDocumentTests.Codeunit.al
@@ -297,6 +297,7 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 646443] Customer GLN is exported for buyer and ship-to parties in ZUGFeRD format
         Initialize();
 
@@ -307,10 +308,8 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
         // [THEN] Buyer and ship-to GlobalID contain the customer GLN with schemeID 0088
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok));
-        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok + '/@schemeID'));
-        Assert.AreEqual(ShipToGLN(), GetNodeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok));
-        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok + '/@schemeID'));
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, BuyerGlobalIdTok);
+        VerifyGLNIdentifier(ShipToGLN(), TempXMLBuffer, ShipToGlobalIdTok);
     end;
 
     [Test]
@@ -319,6 +318,7 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         SalesInvoiceHeader: Record "Sales Invoice Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 646443] Customer GLN is not exported in ZUGFeRD format when GLN use is disabled
         Initialize();
 
@@ -329,8 +329,8 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         ExportInvoice(SalesInvoiceHeader, TempXMLBuffer);
 
         // [THEN] Buyer and ship-to GLN identifiers are not exported
-        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, BuyerGlobalIdTok), StrSubstNo(UnexpectedNodeErr, BuyerGlobalIdTok));
-        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(UnexpectedNodeErr, ShipToGlobalIdTok));
+        VerifyNodeDoesNotExist(TempXMLBuffer, BuyerGlobalIdTok);
+        VerifyNodeDoesNotExist(TempXMLBuffer, ShipToGlobalIdTok);
     end;
 
     [Test]
@@ -935,6 +935,7 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         TempXMLBuffer: Record "XML Buffer" temporary;
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 646443] Customer GLN is exported for buyer and ship-to parties in ZUGFeRD credit memo format
         Initialize();
 
@@ -945,10 +946,8 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
 
         // [THEN] Buyer and ship-to GlobalID contain the customer GLN with schemeID 0088
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok));
-        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, BuyerGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, BuyerGlobalIdTok + '/@schemeID'));
-        Assert.AreEqual(CustomerGLN(), GetNodeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok));
-        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, ShipToGlobalIdTok, 'schemeID'), StrSubstNo(IncorrectValueErr, ShipToGlobalIdTok + '/@schemeID'));
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, BuyerGlobalIdTok);
+        VerifyGLNIdentifier(CustomerGLN(), TempXMLBuffer, ShipToGlobalIdTok);
     end;
 
     [Test]
@@ -2588,6 +2587,17 @@ codeunit 13922 "ZUGFeRD XML Document Tests"
         PDFDocument.GetDocumentAttachmentStream(PdfInStream, TempBlob2);
         TempBlob2.CreateInStream(PdfAttachmentStream);
         TempXMLBuffer.LoadFromStream(PdfAttachmentStream);
+    end;
+
+    local procedure VerifyGLNIdentifier(ExpectedGLN: Code[13]; var TempXMLBuffer: Record "XML Buffer" temporary; XPath: Text)
+    begin
+        Assert.AreEqual(ExpectedGLN, GetNodeByPathWithError(TempXMLBuffer, XPath), StrSubstNo(IncorrectValueErr, XPath));
+        Assert.AreEqual('0088', GetAttributeByPathWithError(TempXMLBuffer, XPath, 'schemeID'), StrSubstNo(IncorrectValueErr, XPath + '/@schemeID'));
+    end;
+
+    local procedure VerifyNodeDoesNotExist(var TempXMLBuffer: Record "XML Buffer" temporary; XPath: Text)
+    begin
+        Assert.IsFalse(NodeExistsByPath(TempXMLBuffer, XPath), StrSubstNo(UnexpectedNodeErr, XPath));
     end;
 
     local procedure VerifyHeaderData(SalesInvoiceHeader: Record "Sales Invoice Header"; var TempXMLBuffer: Record "XML Buffer" temporary);


### PR DESCRIPTION
## Summary

Adds GLN information to the German XRechnung and ZUGFeRD exports, aligning their identifier handling with the existing electronic-document setup.

## Linked work

[AB#646443](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646443)

## Changes

- Emit GLNs with `schemeID="0088"` in the relevant XRechnung supplier, customer, and delivery identifiers.
- Respect the customer `Use GLN in Electronic Document` setting when XRechnung resolves customer GLNs.
- Preserve the existing sell-to customer lookup for XRechnung customer-party identifiers.
- Resolve XRechnung delivery GLNs from the ship-to address first, with the opted-in sell-to customer as fallback.
- Emit buyer and ship-to GLNs with `schemeID="0088"` in ZUGFeRD documents.
- Add regression coverage for supplier, customer, sell-to, and ship-to precedence scenarios.

## Validation

- AL editor diagnostics pass for all changed files.
- `git diff --check` passes.
- Runtime AL tests were not run locally because Docker is unavailable in the current environment.

Fixes

[AB#646443](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646443)









