### PR TITLE
[28.x] Renewal Term field on the Create Contract Renewal Quote page does not accept the entered value such as 12M- #10276

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Contract Renewal/Pages/ContractRenewalSelection.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Contract Renewal/Pages/ContractRenewalSelection.Page.al
@@ -280,7 +280,8 @@ page 8006 "Contract Renewal Selection"
     trigger OnAfterGetRecord()
     begin
         Rec.GetServiceObject(ServiceObject);
-        Rec.LoadServiceCommitmentForContractLine(TempServiceCommitment);
+        if not TempServiceCommitment.Get(Rec."Subscription Line Entry No.") then
+            Rec.LoadServiceCommitmentForContractLine(TempServiceCommitment);
         RenewalTerm := TempServiceCommitment."Renewal Term";
         RenewalTermEnabled := TempServiceCommitment."Subscription Header No." <> '';
 

--- a/src/Apps/W1/Subscription Billing/Test/Contract Renewal/ContractRenewalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Renewal/ContractRenewalTest.Codeunit.al
@@ -740,6 +740,51 @@ codeunit 139692 "Contract Renewal Test"
         until SalesLine.Next() = 0;
     end;
 
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    [Test]
+    procedure RenewalTermEnteredValueIsRetainedOnPage()
+    var
+        ServiceCommitment: Record "Subscription Line";
+        CurrentRenewalTerm: DateFormula;
+        EmptyDateFormula: DateFormula;
+        NewRenewalTerm: DateFormula;
+        ContractRenewalSelection: TestPage "Contract Renewal Selection";
+        RenewalTermDateFormulaLbl: Label '<%1D>', Locked = true;
+        RenewalTermNotRetainedFirstLineErr: Label 'Renewal Term should retain the entered value on the first line.';
+        RenewalTermNotRetainedNextLineErr: Label 'Renewal Term should retain the entered value on the next line.';
+    begin
+        // [SCENARIO 645198] Renewal Term entered on the Create Contract Renewal Quote page is retained after leaving the field.
+        Initialize();
+        Evaluate(NewRenewalTerm, StrSubstNo(RenewalTermDateFormulaLbl, LibraryRandom.RandInt(365)));
+
+        // [GIVEN] A Customer Subscription Contract whose Subscription Lines have no Renewal Term.
+        CreateBaseData();
+        ServiceCommitment.Reset();
+        ServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        ServiceCommitment.ModifyAll("Renewal Term", EmptyDateFormula, false);
+
+        // [GIVEN] The Create Contract Renewal Quote page is open.
+        ContractRenewalSelection.OpenEdit();
+
+        // [WHEN] A Renewal Term is entered on the first line and the field is left.
+        ContractRenewalSelection.First();
+        ContractRenewalSelection.RenewalTermCtrl.SetValue(NewRenewalTerm);
+
+        // [THEN] The entered Renewal Term is retained and not reset to blank.
+        Evaluate(CurrentRenewalTerm, ContractRenewalSelection.RenewalTermCtrl.Value());
+        Assert.AreEqual(NewRenewalTerm, CurrentRenewalTerm, RenewalTermNotRetainedFirstLineErr);
+
+        // [WHEN] A Renewal Term is entered on the next line and the field is left.
+        ContractRenewalSelection.Next();
+        ContractRenewalSelection.RenewalTermCtrl.SetValue(NewRenewalTerm);
+
+        // [THEN] Verify the entered Renewal Term is retained and not reset to blank.
+        Evaluate(CurrentRenewalTerm, ContractRenewalSelection.RenewalTermCtrl.Value());
+        Assert.AreEqual(NewRenewalTerm, CurrentRenewalTerm, RenewalTermNotRetainedNextLineErr);
+
+        ContractRenewalSelection.Close();
+    end;
+
     #endregion Tests
 
     #region Procedures


### PR DESCRIPTION
Workitem : [Bug 645198](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/645198): [all-e][FTE][SaaS] Renewal Term field on the Create Contract Renewal Quote page does not accept the entered value such as '12M'

Fixes [AB#645198](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645198)

**Issue:** On the Create Contract Renewal Quote page, entering a Renewal Term (e.g. 12M) resets to blank when leaving the field.

**Cause:** OnAfterGetRecord always reloaded the persistent Subscription Line via LoadServiceCommitmentForContractLine, overwriting the just-entered value held in the temporary buffer after CurrPage.Update.

**Solution:** Read the current row from the temporary buffer first and only fall back to loading the persistent record when it isn't buffered, preserving the entered Renewal Term.






