### PR TITLE
Add activity log amount formatting metadata

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Tables/ExpenseActivityLogEntry.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Tables/ExpenseActivityLogEntry.Table.al
@@ -105,31 +105,43 @@ table 7100 "Expense Activity Log Entry"
         }
         field(15; "Amount (LCY)"; Decimal)
         {
+            AutoFormatExpression = '';
+            AutoFormatType = 1;
             Caption = 'Amount (LCY)';
             DataClassification = AccountData;
         }
         field(16; "Non-Refundable Amount (LCY)"; Decimal)
         {
+            AutoFormatExpression = '';
+            AutoFormatType = 1;
             Caption = 'Non-Refundable Amount (LCY)';
             DataClassification = AccountData;
         }
         field(17; "Reimbursable Amount"; Decimal)
         {
+            AutoFormatExpression = "Reimbursement Currency Code";
+            AutoFormatType = 1;
             Caption = 'Reimbursable Amount';
             DataClassification = AccountData;
         }
         field(18; "Reimbursable Amount (LCY)"; Decimal)
         {
+            AutoFormatExpression = '';
+            AutoFormatType = 1;
             Caption = 'Reimbursable Amount (LCY)';
             DataClassification = AccountData;
         }
         field(19; "Refundable Amount"; Decimal)
         {
+            AutoFormatExpression = "Reimbursement Currency Code";
+            AutoFormatType = 1;
             Caption = 'Refundable Amount';
             DataClassification = AccountData;
         }
         field(20; "Refundable Amount (LCY)"; Decimal)
         {
+            AutoFormatExpression = '';
+            AutoFormatType = 1;
             Caption = 'Refundable Amount (LCY)';
             DataClassification = AccountData;
         }


### PR DESCRIPTION
## Summary

Add currency-aware display metadata to the Expense Activity Log Entry amount snapshots.

- LCY fields use local-currency formatting.
- Native reimbursable and refundable fields use the stored reimbursement currency.
- API decimal values and activity snapshot behavior are unchanged.

## Issue

Fixes [AB#647062](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647062)

## Validation

- [x] Diff validation passed.
- [x] Compile the Expense Agent app.
- [x] Verify amount formatting for LCY and reimbursement-currency scenarios.





