### PR TITLE
Add activity history to posted demo reports

### DIFF
--- a/src/Apps/W1/ExpenseAgent/demo data/Demo Data/4. Historical/CreatePostedExpenseReport.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/demo data/Demo Data/4. Historical/CreatePostedExpenseReport.Codeunit.al
@@ -145,12 +145,15 @@ codeunit 8217 "Create Posted Expense Report"
     local procedure PostExpenseReport()
     var
         ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseActivityLogMgt: Codeunit "Expense Activity Log Mgt.";
     begin
         if FromExpenseReportNo <> '' then
             ExpenseReportHeader.SetFilter("No.", '>%1', FromExpenseReportNo);
 
         if ExpenseReportHeader.FindSet() then
             repeat
+                if not ExpenseActivityLogMgt.HasEntriesForSource(Database::"Expense Report Header", ExpenseReportHeader.SystemId) then
+                    ExpenseActivityLogMgt.LogExpenseReportCreatedEvent(ExpenseReportHeader);
                 Codeunit.Run(Codeunit::"Expense Report-Post", ExpenseReportHeader);
             until ExpenseReportHeader.Next() = 0;
     end;


### PR DESCRIPTION
## Summary

Attach activity history to the existing posted Expense Agent demo-data scenario.

- Create a real `Created` activity entry before posting.
- Let the existing posting flow append `Posted` and reassign the timeline to the posted report.
- Do not fabricate submitter, approver, or approval events while demo data has no deterministic approval setup.

The richer Created → Submitted → Approved → Posted scenario remains parked until the demo-data setup provides a real approver relationship.

## Issue

Fixes [AB#646813](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646813)

## Validation

- [x] Diff validation passed.
- [ ] Generate Expense Agent historical demo data.
- [ ] Verify the posted report timeline contains Created → Posted and is safe to regenerate.



