### PR TITLE
Add activity lifecycle E2E test fixture

### DIFF
--- a/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
@@ -97,6 +97,7 @@ codeunit 148307 "Expense Test Handler API"
         ExistingApprovalExpenseUser.SetRange("User Id For Approvals", CurrentApprovalUserId);
         ExistingApprovalExpenseUser.ModifyAll("User Id For Approvals", '');
 
+        ApproverExpenseUser.GetBySystemId(approverExpenseUserId);
         ApproverExpenseUser."User Id For Approvals" := CurrentApprovalUserId;
         ApproverExpenseUser.Validate("Can Approve", true);
         ApproverExpenseUser.Modify(true);

--- a/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
@@ -75,6 +75,10 @@ codeunit 148307 "Expense Test Handler API"
     /// The approver uses the current BC service user's ID without exercising the email-based
     /// Expense User onboarding validation, which is outside the lifecycle test's scope.
     /// </summary>
+    /// <remarks>
+    /// This endpoint intentionally mutates approval master data in the dedicated integration-test company.
+    /// The configured approver identity and disabled standard approval workflow remain until a later fixture run changes them.
+    /// </remarks>
     /// <param name="submitterExpenseUserId">The SystemId of the Expense User that submits the expenses.</param>
     /// <param name="approverExpenseUserId">The SystemId of the Expense User that approves the expenses.</param>
     /// <returns>A completion message after the approval scenario is configured.</returns>
@@ -85,11 +89,13 @@ codeunit 148307 "Expense Test Handler API"
         ApproverExpenseUser: Record "Expense User";
         ExistingApprovalExpenseUser: Record "Expense User";
         ExpenseApprovalSetup: Record "Expense Approval Setup";
-        ExpenseAgentSetup: Record "Expense Agent Setup";
+        LibraryExpense: Codeunit "Library - Expense";
         CurrentApprovalUserId: Code[50];
     begin
-        SubmitterExpenseUser.GetBySystemId(submitterExpenseUserId);
-        ApproverExpenseUser.GetBySystemId(approverExpenseUserId);
+        if not SubmitterExpenseUser.GetBySystemId(submitterExpenseUserId) then
+            Error(SubmitterExpenseUserNotFoundErr, submitterExpenseUserId);
+        if not ApproverExpenseUser.GetBySystemId(approverExpenseUserId) then
+            Error(ApproverExpenseUserNotFoundErr, approverExpenseUserId);
         if SubmitterExpenseUser."No." = ApproverExpenseUser."No." then
             Error(SameExpenseUserErr);
 
@@ -104,16 +110,10 @@ codeunit 148307 "Expense Test Handler API"
 
         ExpenseApprovalSetup.SetRange("Expense User No.", SubmitterExpenseUser."No.");
         ExpenseApprovalSetup.DeleteAll(true);
-        ExpenseApprovalSetup.Init();
-        ExpenseApprovalSetup.Validate("Expense User No.", SubmitterExpenseUser."No.");
-        ExpenseApprovalSetup.Validate("Approver No.", ApproverExpenseUser."No.");
-        ExpenseApprovalSetup.Insert(true);
+        LibraryExpense.CreateExpenseApprovalSetup(
+            ExpenseApprovalSetup, SubmitterExpenseUser."No.", ApproverExpenseUser."No.");
 
-        ExpenseAgentSetup.Get();
-        if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            ExpenseAgentSetup.Validate("Enable Approval Workflow", false);
-            ExpenseAgentSetup.Modify(true);
-        end;
+        LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(false);
 
         exit('ConfigureApprovalScenario completed');
     end;
@@ -376,5 +376,7 @@ codeunit 148307 "Expense Test Handler API"
     end;
 
     var
+        ApproverExpenseUserNotFoundErr: Label 'The approver Expense User with SystemId %1 does not exist.', Comment = '%1 = Expense User SystemId';
         SameExpenseUserErr: Label 'The submitter and approver must be different Expense Users.';
+        SubmitterExpenseUserNotFoundErr: Label 'The submitter Expense User with SystemId %1 does not exist.', Comment = '%1 = Expense User SystemId';
 }

--- a/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
@@ -80,8 +80,10 @@ codeunit 148307 "Expense Test Handler API"
     var
         SubmitterExpenseUser: Record "Expense User";
         ApproverExpenseUser: Record "Expense User";
+        ExistingApprovalExpenseUser: Record "Expense User";
         ExpenseApprovalSetup: Record "Expense Approval Setup";
         ExpenseAgentSetup: Record "Expense Agent Setup";
+        CurrentApprovalUserId: Code[50];
         SameExpenseUserErr: Label 'The submitter and approver must be different Expense Users.';
     begin
         SubmitterExpenseUser.GetBySystemId(submitterExpenseUserId);
@@ -89,8 +91,11 @@ codeunit 148307 "Expense Test Handler API"
         if SubmitterExpenseUser."No." = ApproverExpenseUser."No." then
             Error(SameExpenseUserErr);
 
-        ApproverExpenseUser."User Id For Approvals" :=
-            CopyStr(UserId(), 1, MaxStrLen(ApproverExpenseUser."User Id For Approvals"));
+        CurrentApprovalUserId := CopyStr(UserId(), 1, MaxStrLen(ApproverExpenseUser."User Id For Approvals"));
+        ExistingApprovalExpenseUser.SetRange("User Id For Approvals", CurrentApprovalUserId);
+        ExistingApprovalExpenseUser.ModifyAll("User Id For Approvals", '');
+
+        ApproverExpenseUser."User Id For Approvals" := CurrentApprovalUserId;
         ApproverExpenseUser.Validate("Can Approve", true);
         ApproverExpenseUser.Modify(true);
 

--- a/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
@@ -75,6 +75,9 @@ codeunit 148307 "Expense Test Handler API"
     /// The approver uses the current BC service user's ID without exercising the email-based
     /// Expense User onboarding validation, which is outside the lifecycle test's scope.
     /// </summary>
+    /// <param name="submitterExpenseUserId">The SystemId of the Expense User that submits the expenses.</param>
+    /// <param name="approverExpenseUserId">The SystemId of the Expense User that approves the expenses.</param>
+    /// <returns>A completion message after the approval scenario is configured.</returns>
     [ServiceEnabled]
     procedure ConfigureApprovalScenario(submitterExpenseUserId: Guid; approverExpenseUserId: Guid): Text[50]
     var
@@ -84,7 +87,6 @@ codeunit 148307 "Expense Test Handler API"
         ExpenseApprovalSetup: Record "Expense Approval Setup";
         ExpenseAgentSetup: Record "Expense Agent Setup";
         CurrentApprovalUserId: Code[50];
-        SameExpenseUserErr: Label 'The submitter and approver must be different Expense Users.';
     begin
         SubmitterExpenseUser.GetBySystemId(submitterExpenseUserId);
         ApproverExpenseUser.GetBySystemId(approverExpenseUserId);
@@ -371,4 +373,7 @@ codeunit 148307 "Expense Test Handler API"
             exit(Customer."No.");
         exit('');
     end;
+
+    var
+        SameExpenseUserErr: Label 'The submitter and approver must be different Expense Users.';
 }

--- a/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
@@ -70,6 +70,46 @@ codeunit 148307 "Expense Test Handler API"
         exit(ExpenseUser.SystemId);
     end;
 
+    /// <summary>
+    /// Configures two existing Expense Users as a submitter and approver for integration tests.
+    /// The approver uses the current BC service user's ID without exercising the email-based
+    /// Expense User onboarding validation, which is outside the lifecycle test's scope.
+    /// </summary>
+    [ServiceEnabled]
+    procedure ConfigureApprovalScenario(submitterExpenseUserId: Guid; approverExpenseUserId: Guid): Text[50]
+    var
+        SubmitterExpenseUser: Record "Expense User";
+        ApproverExpenseUser: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+        SameExpenseUserErr: Label 'The submitter and approver must be different Expense Users.';
+    begin
+        SubmitterExpenseUser.GetBySystemId(submitterExpenseUserId);
+        ApproverExpenseUser.GetBySystemId(approverExpenseUserId);
+        if SubmitterExpenseUser."No." = ApproverExpenseUser."No." then
+            Error(SameExpenseUserErr);
+
+        ApproverExpenseUser."User Id For Approvals" :=
+            CopyStr(UserId(), 1, MaxStrLen(ApproverExpenseUser."User Id For Approvals"));
+        ApproverExpenseUser.Validate("Can Approve", true);
+        ApproverExpenseUser.Modify(true);
+
+        ExpenseApprovalSetup.SetRange("Expense User No.", SubmitterExpenseUser."No.");
+        ExpenseApprovalSetup.DeleteAll(true);
+        ExpenseApprovalSetup.Init();
+        ExpenseApprovalSetup.Validate("Expense User No.", SubmitterExpenseUser."No.");
+        ExpenseApprovalSetup.Validate("Approver No.", ApproverExpenseUser."No.");
+        ExpenseApprovalSetup.Insert(true);
+
+        ExpenseAgentSetup.Get();
+        if ExpenseAgentSetup."Enable Approval Workflow" then begin
+            ExpenseAgentSetup.Validate("Enable Approval Workflow", false);
+            ExpenseAgentSetup.Modify(true);
+        end;
+
+        exit('ConfigureApprovalScenario completed');
+    end;
+
     local procedure CreateExpenseUser(var ExpenseUser: Record "Expense User"; No: Code[20])
     begin
         ExpenseUser.Init();

--- a/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/Helper/ExpenseTestHandlerAPI.Codeunit.al
@@ -92,12 +92,13 @@ codeunit 148307 "Expense Test Handler API"
         LibraryExpense: Codeunit "Library - Expense";
         CurrentApprovalUserId: Code[50];
     begin
+        if submitterExpenseUserId = approverExpenseUserId then
+            Error(SameExpenseUserErr);
+
         if not SubmitterExpenseUser.GetBySystemId(submitterExpenseUserId) then
             Error(SubmitterExpenseUserNotFoundErr, submitterExpenseUserId);
         if not ApproverExpenseUser.GetBySystemId(approverExpenseUserId) then
             Error(ApproverExpenseUserNotFoundErr, approverExpenseUserId);
-        if SubmitterExpenseUser."No." = ApproverExpenseUser."No." then
-            Error(SameExpenseUserErr);
 
         CurrentApprovalUserId := CopyStr(UserId(), 1, MaxStrLen(ApproverExpenseUser."User Id For Approvals"));
         ExistingApprovalExpenseUser.SetRange("User Id For Approvals", CurrentApprovalUserId);
@@ -108,10 +109,12 @@ codeunit 148307 "Expense Test Handler API"
         ApproverExpenseUser.Validate("Can Approve", true);
         ApproverExpenseUser.Modify(true);
 
-        ExpenseApprovalSetup.SetRange("Expense User No.", SubmitterExpenseUser."No.");
-        ExpenseApprovalSetup.DeleteAll(true);
-        LibraryExpense.CreateExpenseApprovalSetup(
-            ExpenseApprovalSetup, SubmitterExpenseUser."No.", ApproverExpenseUser."No.");
+        if ExpenseApprovalSetup.Get(SubmitterExpenseUser."No.") then begin
+            ExpenseApprovalSetup.Validate("Approver No.", ApproverExpenseUser."No.");
+            ExpenseApprovalSetup.Modify(true);
+        end else
+            LibraryExpense.CreateExpenseApprovalSetup(
+                ExpenseApprovalSetup, SubmitterExpenseUser."No.", ApproverExpenseUser."No.");
 
         LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(false);
 


### PR DESCRIPTION
## Summary

Add deterministic Business Central setup for the Expense Agent activity lifecycle E2E tests.

- Add `ExpenseTestHandler_ConfigureApprovalScenario`.
- Configure a distinct approver Expense User for the current BC service account.
- Create or replace the submitter-to-approver `Expense Approval Setup`.
- Keep the standard BC approval workflow disabled so the tests exercise Expense Agent service approval routing without a `User Setup` dependency.
- Reject using the same Expense User as both submitter and approver.

This is the BCApps companion to [BC-ExpenseAgent PR #2391](https://microsoft.ghe.com/bic/BC-ExpenseAgent/pull/2391).

## Tracking

- [AB#646914](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646914)

## Validation

- [x] `git diff --check`
- [x] Test app compiled and published manually.
- [x] Live BC lifecycle E2E: submit/approve passed.
- [x] Live BC lifecycle E2E: reject/resubmit/reapprove passed.







