### PR TITLE
[Quality Management] Add OptimizeForTextSearch to searchable Qlty. Inspection Header fields (AB#620381)

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionHeader.Table.al
@@ -79,6 +79,7 @@ table 20405 "Qlty. Inspection Header"
         field(6; Description; Text[250])
         {
             Caption = 'Description';
+            OptimizeForTextSearch = true;
             ToolTip = 'Specifies a description of the Quality Inspection itself.';
         }
         field(8; "Status"; Enum "Qlty. Inspection Status")
@@ -338,6 +339,7 @@ table 20405 "Qlty. Inspection Header"
         field(58; "Source Task No."; Code[20])
         {
             Caption = 'Task No.';
+            OptimizeForTextSearch = true;
             ToolTip = 'Specifies a reference to the source task no. that this Quality Inspection is referring to. This typically refers to an operation.';
         }
         field(61; "Source Item No."; Code[20])


### PR DESCRIPTION
## What & why

Adds `OptimizeForTextSearch = true` to two user-searchable fields on table 20405 `Qlty. Inspection Header`:

- `Description` (field 6, `Text[250]`) — the primary free-text field shown in the Brick field group and used in list search.
- `Source Task No.` (field 58, `Code[20]`) — brings it in line with the sibling source-identity fields (`Source Document No.`, `Source Item No.`, `Source Lot No.`, etc.) that already have the property.

This lets text search on these fields use the optimized search path instead of falling back to unindexed `LIKE '%value%'` scans, improving list-page search performance on large datasets.

## Linked work

ADO: [AB#620381](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620381) — *[Quality Management] [Performance] [Agentic review] Missing OptimizeForTextSearch on Key Fields* (Severity: Low).

Fixes #

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Change is a metadata-only property addition (`OptimizeForTextSearch = true`) on two non-FlowField Text/Code fields — valid AL with no logic impact. It does not alter behavior, data, or APIs; it only affects the SQL search path.
- No automated tests added: `OptimizeForTextSearch` is a declarative field property with no behavioral logic to unit-test; the measurable effect (search-path optimization) requires a large dataset and SQL profiling rather than an AL test.
- Not built/run in a container in this environment. Recommend a reviewer build of the Quality Management app to confirm no new analyzer warnings before merge.

## Risk & compatibility

Low. Additive, metadata-only property change on two fields; no schema/data migration, no breaking change, no behavior change. Only the internal text-search query plan for these fields is affected.



