### PR TITLE
Bug 640428: Fix Production BOM Comment Line TableRelation filters

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMCommentLine.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMCommentLine.Table.al
@@ -23,7 +23,8 @@ table 99000776 "Production BOM Comment Line"
         {
             Caption = 'BOM Line No.';
             NotBlank = true;
-            TableRelation = "Production BOM Line"."Line No." where("Production BOM No." = field("Production BOM No."));
+            TableRelation = "Production BOM Line"."Line No." where("Production BOM No." = field("Production BOM No."),
+                                                                   "Version Code" = field("Version Code"));
         }
         field(3; "Line No."; Integer)
         {
@@ -32,8 +33,7 @@ table 99000776 "Production BOM Comment Line"
         field(4; "Version Code"; Code[20])
         {
             Caption = 'Version Code';
-            TableRelation = "Production BOM Version"."Version Code" where("Production BOM No." = field("Production BOM No."),
-                                                                           "Version Code" = field("Version Code"));
+            TableRelation = "Production BOM Version"."Version Code" where("Production BOM No." = field("Production BOM No."));
         }
         field(10; Date; Date)
         {

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryManufacturing.Codeunit.al
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryManufacturing.Codeunit.al
@@ -482,8 +482,8 @@ codeunit 132202 "Library - Manufacturing"
 
         ProductionBOMCommentLine.Init();
         ProductionBOMCommentLine.Validate("Production BOM No.", ProductionBOMLine."Production BOM No.");
-        ProductionBOMCommentLine.Validate("BOM Line No.", ProductionBOMLine."Line No.");
         ProductionBOMCommentLine.Validate("Version Code", ProductionBOMLine."Version Code");
+        ProductionBOMCommentLine.Validate("BOM Line No.", ProductionBOMLine."Line No.");
         ProductionBOMCommentLine.Validate("Line No.", LineNo);
         ProductionBOMCommentLine.Validate(Comment, LibraryUtility.GenerateGUID());
         ProductionBOMCommentLine.Insert(true);

--- a/src/Layers/W1/Tests/SCM-Manufacturing/ProdBOMCommentLineTest.Page.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/ProdBOMCommentLineTest.Page.al
@@ -20,14 +20,17 @@ page 137437 "Prod. BOM Comment Line Test"
                 field("Production BOM No."; Rec."Production BOM No.")
                 {
                     ApplicationArea = All;
+                    ToolTip = 'Specifies the production BOM that the comment applies to.';
                 }
                 field("BOM Line No."; Rec."BOM Line No.")
                 {
                     ApplicationArea = All;
+                    ToolTip = 'Specifies the production BOM line that the comment applies to.';
                 }
                 field("Version Code"; Rec."Version Code")
                 {
                     ApplicationArea = All;
+                    ToolTip = 'Specifies the production BOM version that the comment applies to.';
                 }
             }
         }

--- a/src/Layers/W1/Tests/SCM-Manufacturing/ProdBOMCommentLineTest.Page.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/ProdBOMCommentLineTest.Page.al
@@ -1,0 +1,35 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Manufacturing.Test;
+
+using Microsoft.Manufacturing.ProductionBOM;
+
+page 137437 "Prod. BOM Comment Line Test"
+{
+    PageType = Card;
+    SourceTable = "Production BOM Comment Line";
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field("Production BOM No."; Rec."Production BOM No.")
+                {
+                    ApplicationArea = All;
+                }
+                field("BOM Line No."; Rec."BOM Line No.")
+                {
+                    ApplicationArea = All;
+                }
+                field("Version Code"; Rec."Version Code")
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+}

--- a/src/Layers/W1/Tests/SCM-Manufacturing/ProdBOMCommentLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/ProdBOMCommentLineTests.Codeunit.al
@@ -136,6 +136,7 @@ codeunit 137436 "Prod. BOM Comment Line Tests"
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Prod. BOM Comment Line Tests");
+        LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
 
         if IsInitialized then

--- a/src/Layers/W1/Tests/SCM-Manufacturing/ProductionBOMCommentLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/ProductionBOMCommentLineTests.Codeunit.al
@@ -1,0 +1,173 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Manufacturing.Test;
+
+using Microsoft.Inventory.Item;
+using Microsoft.Manufacturing.ProductionBOM;
+using System.TestLibraries.Utilities;
+
+codeunit 137436 "Prod. BOM Comment Line Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryManufacturing: Codeunit "Library - Manufacturing";
+        LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryUtility: Codeunit "Library - Utility";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        IsInitialized: Boolean;
+
+    [Test]
+    [HandlerFunctions('ProdBOMVersionListModalPageHandler')]
+    procedure VersionCodeLookupShowsVersionsForProductionBOM()
+    var
+        Item: Record Item;
+        ProductionBOMCommentLine: Record "Production BOM Comment Line";
+        ProductionBOMHeader: Record "Production BOM Header";
+        OtherProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        ProductionBOMVersion: Record "Production BOM Version";
+        ProductionBOMCommentLineTest: TestPage "Prod. BOM Comment Line Test";
+        VersionCode1: Code[20];
+        VersionCode2: Code[20];
+        OtherVersionCode: Code[20];
+        ActualVersionCode1: Text;
+        ActualVersionCode2: Text;
+        ActualVersionCount: Integer;
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO 640428] Version Code lookup is not restricted to the comment line's current version.
+        Initialize();
+
+        // [GIVEN] Production BOM "B" with versions "V1" and "V2".
+        LibraryInventory.CreateItem(Item);
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, Item."Base Unit of Measure");
+        VersionCode1 := 'V1';
+        VersionCode2 := 'V2';
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, ProductionBOMHeader."No.", VersionCode1, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, ProductionBOMHeader."No.", VersionCode2, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLine, VersionCode1, ProductionBOMLine.Type::Item, Item."No.", 1);
+
+        // [GIVEN] Another Production BOM with version "V3".
+        LibraryManufacturing.CreateProductionBOMHeader(OtherProductionBOMHeader, Item."Base Unit of Measure");
+        OtherVersionCode := 'V3';
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, OtherProductionBOMHeader."No.", OtherVersionCode, Item."Base Unit of Measure");
+
+        // [GIVEN] Production BOM comment line for a line in "V1".
+        LibraryManufacturing.CreateProductionBOMCommentLine(ProductionBOMLine);
+        ProductionBOMCommentLine.Get(
+            ProductionBOMLine."Production BOM No.", ProductionBOMLine."Line No.", ProductionBOMLine."Version Code", 10000);
+        ProductionBOMCommentLineTest.OpenEdit();
+        ProductionBOMCommentLineTest.GoToRecord(ProductionBOMCommentLine);
+
+        // [WHEN] Version Code lookup is opened.
+        ProductionBOMCommentLineTest."Version Code".Lookup();
+
+        // [THEN] The lookup contains only "V1" and "V2".
+        ActualVersionCount := LibraryVariableStorage.DequeueInteger();
+        ActualVersionCode1 := LibraryVariableStorage.DequeueText();
+        ActualVersionCode2 := LibraryVariableStorage.DequeueText();
+        Assert.AreEqual(2, ActualVersionCount, 'The Version Code lookup must show all versions for the production BOM.');
+        Assert.AreEqual(VersionCode1, ActualVersionCode1, 'The first version in the lookup is incorrect.');
+        Assert.AreEqual(VersionCode2, ActualVersionCode2, 'The second version in the lookup is incorrect.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    procedure BOMLineNoRejectsLineFromDifferentVersion()
+    var
+        Item: Record Item;
+        ProductionBOMCommentLine: Record "Production BOM Comment Line";
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLineVersion1: Record "Production BOM Line";
+        ProductionBOMLineVersion2: Record "Production BOM Line";
+        ProductionBOMVersion: Record "Production BOM Version";
+        VersionCode1: Code[20];
+        VersionCode2: Code[20];
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO 640428] BOM Line No. rejects a line that belongs to another production BOM version.
+        Initialize();
+
+        // [GIVEN] Production BOM "B" with versions "V1" and "V2".
+        LibraryInventory.CreateItem(Item);
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, Item."Base Unit of Measure");
+        VersionCode1 := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(VersionCode1));
+        VersionCode2 := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(VersionCode2));
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, ProductionBOMHeader."No.", VersionCode1, Item."Base Unit of Measure");
+        LibraryManufacturing.CreateProductionBOMVersion(
+            ProductionBOMVersion, ProductionBOMHeader."No.", VersionCode2, Item."Base Unit of Measure");
+
+        // [GIVEN] Production BOM line "L1" belongs to "V1" and line "L2" belongs only to "V2".
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLineVersion1, VersionCode1,
+            ProductionBOMLineVersion1.Type::Item, Item."No.", 1);
+        LibraryManufacturing.CreateProductionBOMLine(
+            ProductionBOMHeader, ProductionBOMLineVersion2, VersionCode2,
+            ProductionBOMLineVersion2.Type::Item, Item."No.", 1);
+        ProductionBOMLineVersion2.Rename(
+            ProductionBOMLineVersion2."Production BOM No.", ProductionBOMLineVersion2."Version Code",
+            ProductionBOMLineVersion1."Line No." + 10000);
+
+        // [GIVEN] Production BOM comment line for "L1" in "V1".
+        LibraryManufacturing.CreateProductionBOMCommentLine(ProductionBOMLineVersion1);
+        ProductionBOMCommentLine.Get(
+            ProductionBOMLineVersion1."Production BOM No.", ProductionBOMLineVersion1."Line No.",
+            ProductionBOMLineVersion1."Version Code", 10000);
+
+        // [WHEN] BOM Line No. is changed to the line from "V2".
+        asserterror ProductionBOMCommentLine.Validate("BOM Line No.", ProductionBOMLineVersion2."Line No.");
+
+        // [THEN] The line is rejected because it does not belong to "V1".
+        Assert.ExpectedErrorCannotFind(Database::"Production BOM Line");
+    end;
+
+    local procedure Initialize()
+    begin
+        LibraryTestInitialize.OnTestInitialize(Codeunit::"Prod. BOM Comment Line Tests");
+        LibrarySetupStorage.Restore();
+
+        if IsInitialized then
+            exit;
+
+        LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Prod. BOM Comment Line Tests");
+        LibrarySetupStorage.SaveManufacturingSetup();
+        IsInitialized := true;
+        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Prod. BOM Comment Line Tests");
+    end;
+
+    [ModalPageHandler]
+    procedure ProdBOMVersionListModalPageHandler(var ProductionBOMVersionList: TestPage "Prod. BOM Version List")
+    var
+        VersionCode1: Text;
+        VersionCode2: Text;
+        VersionCount: Integer;
+    begin
+        if ProductionBOMVersionList.First() then
+            repeat
+                VersionCount += 1;
+                case VersionCount of
+                    1:
+                        VersionCode1 := ProductionBOMVersionList."Version Code".Value();
+                    2:
+                        VersionCode2 := ProductionBOMVersionList."Version Code".Value();
+                end;
+            until not ProductionBOMVersionList.Next();
+
+        LibraryVariableStorage.Enqueue(VersionCount);
+        LibraryVariableStorage.Enqueue(VersionCode1);
+        LibraryVariableStorage.Enqueue(VersionCode2);
+        ProductionBOMVersionList.Cancel().Invoke();
+    end;
+}


### PR DESCRIPTION
## Summary
Table 99000776 `"Production BOM Comment Line"` had two incorrect `TableRelation` filters (ADO bug 640428):
- **"Version Code"** (field 4) had a tautological self-referencing filter `where("Production BOM No." = field("Production BOM No."), "Version Code" = field("Version Code"))`. It now filters **only by "Production BOM No."**, so the version lookup lists all versions of the BOM.
- **"BOM Line No."** (field 2) was missing the version filter, so it listed BOM lines from all versions. It now filters by **both "Production BOM No." and "Version Code"**.

## Root cause
Production BOM lines are partitioned by version (`Production BOM Line` PK = Production BOM No., Version Code, Line No.). The comment-line relations did not account for the version dimension: the BOM Line No. relation ignored it (resolving to a line in any version), and the Version Code relation redundantly constrained the target by its own value.

## Fix
- Corrected both `TableRelation` filters in the table.
- Reordered `"Library - Manufacturing".CreateProductionBOMCommentLine` to validate **"Version Code" before "BOM Line No."** (the corrected BOM Line No. relation now depends on Version Code).

## Test
Added `codeunit 137436 "Prod. BOM Comment Line Tests"` (+ test page 137437):
- `VersionCodeLookupShowsVersionsForProductionBOM` — the Version Code lookup lists all versions of the BOM.
- `BOMLineNoRejectsLineFromDifferentVersion` — validating a BOM Line No. from another version is rejected.

Validated via the repo's AL tooling: Base Application, Application Test Library and Tests-SCM-Manufacturing compile & publish cleanly; both tests **fail against the unfixed table** and **pass after the fix** (2 passed, 0 failed).

[AB#640428](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640428)

🤖 Generated with GitHub Copilot






