### PR TITLE
[Master]-Bug 647018: Withholding tax for Employees and GL Accounts

### DIFF
--- a/src/Apps/W1/ExpenseWithholdingTax/app/src/WHTExpenseCategoryMgt.Codeunit.al
+++ b/src/Apps/W1/ExpenseWithholdingTax/app/src/WHTExpenseCategoryMgt.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.ExpenseTaxIntegration;
 
 using Microsoft.ExpenseAgent;
+using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.WithholdingTax;
@@ -27,6 +28,23 @@ codeunit 7056 "WHT Expense Category Mgt."
             Rec."Wthldg. Tax Prod. Post. Group" := ExpenseCategory."Wthldg. Tax Prod. Post. Group"
         else
             Rec."Wthldg. Tax Prod. Post. Group" := '';
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Gen. Journal Line", OnAfterAccountNoOnValidateGetGLBalAccount, '', false, false)]
+    local procedure OnAfterBalAccountNoValidateEmployee(var GenJournalLine: Record "Gen. Journal Line"; var GLAccount: Record "G/L Account")
+    begin
+        if CheckWithholdingTaxDisabled() then
+            exit;
+
+        if (GenJournalLine."Account Type" <> GenJournalLine."Account Type"::Employee) and
+           (GenJournalLine."Bal. Account Type" <> GenJournalLine."Bal. Account Type"::Employee)
+        then
+            exit;
+
+        if GenJournalLine."Expense Category" <> '' then
+            exit;
+
+        GenJournalLine."Wthldg. Tax Prod. Post. Group" := GLAccount."Wthldg. Tax Prod. Post. Group";
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"WHT Employee Calculation", OnBeforeCheckCalcEmployeeWHT, '', false, false)]


### PR DESCRIPTION
Fixes [AB#647018](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647018)

WHT for Employees will be primarily used for expense management, but it should be designed to use for other cases as well (other payments to employees, such as dividends, stocks compensations, project-based or professional services...).
So, it must be possible to have WHT product posting group inherited from GL account to the General Journal line when used GL as a balance account.




