### PR TITLE
[28.x] [Backport] Hide Provide feedback action on E-Document Purchase Draft when user-initiated feedback is disabled in PPAC

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseDraft.Page.al
@@ -10,6 +10,7 @@ using Microsoft.Foundation.Attachment;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Setup;
 using Microsoft.Purchases.Vendor;
+using System.Environment.Configuration;
 using System.Feedback;
 using System.Telemetry;
 using System.Text;
@@ -403,6 +404,7 @@ page 6181 "E-Document Purchase Draft"
                     Caption = 'Provide feedback';
                     ToolTip = 'Provide feedback on the Payables Agent experience.';
                     Image = Comment;
+                    Visible = FeedbackActionVisible;
 
                     trigger OnAction()
                     begin
@@ -514,6 +516,7 @@ page 6181 "E-Document Purchase Draft"
         HasErrorsOrWarnings := false;
         HasErrors := false;
         PageEditable := IsEditable();
+        FeedbackActionVisible := IsUserInitiatedFeedbackEnabled();
         EDocumentNotification.SendPurchaseDocumentDraftNotifications(Rec."Entry No");
         if PurchasesPayablesSetup.Get() then
             ApplyVATDiffEnabled := PurchasesPayablesSetup."Apply VAT Diff. For Purch EDoc";
@@ -717,6 +720,13 @@ page 6181 "E-Document Purchase Draft"
         EDocumentErrorHelper.ThrowIfHasErrors(Rec);
     end;
 
+    local procedure IsUserInitiatedFeedbackEnabled(): Boolean
+    var
+        TenantFeedbackSettings: Codeunit "Tenant Feedback Settings";
+    begin
+        exit(TenantFeedbackSettings.GetUserInitiatedFeedbackEnabled());
+    end;
+
     local procedure ProvideFeedback()
     var
         EDocumentDataStorage: Record "E-Doc. Data Storage";
@@ -727,6 +737,9 @@ page 6181 "E-Document Purchase Draft"
         InStream: InStream;
         ContextFiles, ContextProperties : Dictionary of [Text, Text];
     begin
+        if not IsUserInitiatedFeedbackEnabled() then
+            exit;
+
         if EDocDraftFeedback.RunModal() = Action::Yes then begin
             if EDocumentDataStorage.Get(Rec."Unstructured Data Entry No.") then begin
                 EDocumentDataStorage.GetTempBlob().CreateInStream(InStream);
@@ -777,5 +790,6 @@ page 6181 "E-Document Purchase Draft"
         ResetDraftQst: Label 'All the changes that you may have made on the document draft will be lost. Do you want to continue?';
         PageEditable, HasPDFSource : Boolean;
         ApplyVATDiffEnabled: Boolean;
+        FeedbackActionVisible: Boolean;
         AppliedVATAmountDiff: Decimal;
 }


### PR DESCRIPTION
## What & why

On the E-Document Purchase Draft page the Provide feedback action was always visible. When an admin turns off user-initiated feedback in the Power Platform admin center, that action should not be there. Now we read the Tenant Feedback Settings when the page opens and only show the action when the setting is on.

This is the 28.x backport of #9257.

## Linked work

Fixes [AB#641590](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641590)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Deployed to a private fast prod environment and opened an E-Document Purchase Draft. With user-initiated feedback enabled in PPAC the Provide feedback action shows up. Turned the setting off in PPAC, reopened the draft, and the action was gone. 

## Risk & compatibility

Low. Only affects whether the Provide feedback action shows on page 6181. No schema, data, or permission changes.



