### PR TITLE
Re-run a failed test app on a different tenant

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -15,6 +15,7 @@
   "repoVersion": "29.0",
   "memoryLimit": "16G",
   "numberOfTenantsForTesting": 4,
+  "maxTestAppReruns": 2,
   "failOn": "newWarning",
   "workspaceCompilation": {
     "enabled": true,

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -50,14 +50,16 @@ function Get-AppRerunBudget {
         return 0
     }
 
-    # Settings are free-form JSON, so guard against a non-numeric or negative value rather than
-    # letting it silently disable (or worse, corrupt) the budget comparison.
-    $budget = 0
-    if (-not [int]::TryParse("$configured", [ref]$budget) -or $budget -lt 0) {
+    # Settings are free-form JSON, so validate before trusting the value: a typo, a decimal or a
+    # negative number must switch reruns off rather than silently corrupt the budget comparison.
+    # Requiring plain digits keeps the accepted shape obvious at a glance.
+    $configuredText = "$configured".Trim()
+    if ($configuredText -notmatch '^\d+$') {
         Write-Host "::warning::AL-Go setting 'maxTestAppReruns' is '$configured', which is not a non-negative integer. Failed test apps will NOT be re-run."
         return 0
     }
 
+    $budget = [int]$configuredText
     Write-Host "Rerun budget for this job: $budget test app(s) may be re-run on a different tenant."
     return $budget
 }

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -50,16 +50,7 @@ function Get-AppRerunBudget {
         return 0
     }
 
-    # Settings are free-form JSON, so validate before trusting the value: a typo, a decimal or a
-    # negative number must switch reruns off rather than silently corrupt the budget comparison.
-    # Requiring plain digits keeps the accepted shape obvious at a glance.
-    $configuredText = "$configured".Trim()
-    if ($configuredText -notmatch '^\d+$') {
-        Write-Host "::warning::AL-Go setting 'maxTestAppReruns' is '$configured', which is not a non-negative integer. Failed test apps will NOT be re-run."
-        return 0
-    }
-
-    $budget = [int]$configuredText
+    $budget = $configured -as [int]
     Write-Host "Rerun budget for this job: $budget test app(s) may be re-run on a different tenant."
     return $budget
 }

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -23,26 +23,43 @@ Import-Module (Join-Path $PSScriptRoot "ALAppBuild.psm1" -Resolve)
     real state of the branch and they feed the unstable-tests data, so masking instability there
     would hide exactly what we want to measure. This mirrors the test tolerance check in
     RunTestsInBcContainer.ps1, which is also limited to pull request builds.
-.PARAMETER MaxAppReruns
-    Rerun budget granted to a pull request build. A failed app is re-run once on a DIFFERENT tenant
-    than the one it failed on: tests are not guaranteed to clean up after themselves, so a
-    same-tenant retry can re-fail on the residue the failed run just left behind. Deliberately
-    small - it exists to absorb instability, and more failures than this means something is
-    genuinely broken rather than flaky.
+
+    On a pull request the budget comes from the "maxTestAppReruns" AL-Go setting. Because AL-Go
+    merges repo, project and conditional settings before exposing them, the budget can be tuned per
+    project or per build mode (for example a higher budget for the long legacy buckets) without any
+    code change.
+
+    The budget is the number of DIFFERENT apps that may be re-run in one job; an individual app is
+    never re-run more than once (enforced separately via the rerun bookkeeping). A failed app is
+    re-run on a DIFFERENT tenant than the one it failed on: tests are not guaranteed to clean up
+    after themselves, so a same-tenant retry can re-fail on the residue the failed run just left
+    behind. Keep it small - it exists to absorb instability, and more failures than this means
+    something is genuinely broken rather than flaky.
 .OUTPUTS
-    [int] MaxAppReruns on pull request builds, otherwise 0.
+    [int] The configured budget on pull request builds, otherwise 0.
 #>
 function Get-AppRerunBudget {
-    param(
-        [int]$MaxAppReruns = 1
-    )
-
-    if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
-        return $MaxAppReruns
+    if ($env:GITHUB_EVENT_NAME -ne 'pull_request') {
+        Write-Host "Build event is '$($env:GITHUB_EVENT_NAME)', not 'pull_request'. Failed test apps will NOT be re-run."
+        return 0
     }
 
-    Write-Host "Build event is '$($env:GITHUB_EVENT_NAME)', not 'pull_request'. Failed test apps will NOT be re-run."
-    return 0
+    $configured = Get-ALGoSetting -Key "maxTestAppReruns"
+    if ($null -eq $configured) {
+        Write-Host "AL-Go setting 'maxTestAppReruns' is not set. Failed test apps will NOT be re-run."
+        return 0
+    }
+
+    # Settings are free-form JSON, so guard against a non-numeric or negative value rather than
+    # letting it silently disable (or worse, corrupt) the budget comparison.
+    $budget = 0
+    if (-not [int]::TryParse("$configured", [ref]$budget) -or $budget -lt 0) {
+        Write-Host "::warning::AL-Go setting 'maxTestAppReruns' is '$configured', which is not a non-negative integer. Failed test apps will NOT be re-run."
+        return 0
+    }
+
+    Write-Host "Rerun budget for this job: $budget test app(s) may be re-run on a different tenant."
+    return $budget
 }
 
 <#

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -23,6 +23,27 @@ $script:MaxAppReruns = 1
 
 <#
 .SYNOPSIS
+    Returns the rerun budget for the current build.
+.DESCRIPTION
+    Reruns are a pull request convenience: they keep unrelated instability from blocking a review.
+    CI/CD builds get a budget of 0 so a failure stays a failure. Those runs are the signal for the
+    real state of the branch and they feed the unstable-tests data, so masking instability there
+    would hide exactly what we want to measure. This mirrors the test tolerance check in
+    RunTestsInBcContainer.ps1, which is also limited to pull request builds.
+.OUTPUTS
+    [int] $script:MaxAppReruns on pull request builds, otherwise 0.
+#>
+function Get-AppRerunBudget {
+    if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
+        return $script:MaxAppReruns
+    }
+
+    Write-Host "Build event is '$($env:GITHUB_EVENT_NAME)', not 'pull_request'. Failed test apps will NOT be re-run."
+    return 0
+}
+
+<#
+.SYNOPSIS
     Returns the cached parallel-test-run result for a container, or $null if no run has finished.
 .DESCRIPTION
     The first call into Invoke-ParallelTestExecution dispatches every test app in parallel,
@@ -418,7 +439,9 @@ function Register-TestJobOutcome {
             if ($canRerun) {
                 $State.rerunBudget = $State.rerunBudget - 1
                 $State.rerunDone[$Result.AppName] = $true
-                $suffix = "rerun$($script:MaxAppReruns - $State.rerunBudget)"
+                # Suffix is derived from the number of reruns so far, so it stays unique and
+                # correct regardless of what the starting budget was.
+                $suffix = "rerun$($State.rerunDone.Count)"
                 Write-Host "::warning::Tests FAILED for '$($Result.AppName)' on tenant '$($Result.Tenant)'. Re-running the app once on a different tenant. A rerun that passes still means this app is unstable - please investigate it."
                 $State.rerun = @($State.rerun) + @([PSCustomObject]@{
                     appName       = $Result.AppName
@@ -748,7 +771,7 @@ function Invoke-ParallelTestExecution {
     $state = [PSCustomObject]@{
         jobs = @(); dispatched = $true; completed = $false; finalResult = $false; hasFailures = $false
         transient = @(); retried = @{}
-        rerun = @(); rerunDone = @{}; rerunBudget = $script:MaxAppReruns; tenantCount = $tenants.Count
+        rerun = @(); rerunDone = @{}; rerunBudget = (Get-AppRerunBudget); tenantCount = $tenants.Count
     }
     $state | ConvertTo-Json -Depth 5 | Set-Content $stateFile -Force
 
@@ -874,4 +897,4 @@ function Invoke-PerProjectTestRun {
     return (. $script -parameters $parameters -TestType $testType -AppNamesToTest $appNamesToTest)
 }
 
-Export-ModuleMember -Function Invoke-ParallelTestExecution, Get-AvailableBcTenants, Get-CachedTestRunResult, Get-InstalledTestAppNames, Get-AppNamesForBucket, Invoke-PerProjectTestRun, Get-AppNameFromMetadata, Invoke-WarmupDispatch, Merge-TestResultFiles
+Export-ModuleMember -Function Invoke-ParallelTestExecution, Get-AvailableBcTenants, Get-CachedTestRunResult, Get-InstalledTestAppNames, Get-AppNamesForBucket, Invoke-PerProjectTestRun, Get-AppNameFromMetadata, Invoke-WarmupDispatch, Merge-TestResultFiles, Get-AppRerunBudget

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -458,10 +458,12 @@ function Register-TestJobOutcome {
 
             if ($canRerun) {
                 $State.rerunBudget = $State.rerunBudget - 1
-                $State.rerunDone[$Result.AppName] = $true
                 # Suffix is derived from the number of reruns so far, so it stays unique and
-                # correct regardless of what the starting budget was.
-                $suffix = "rerun$($State.rerunDone.Count)"
+                # correct regardless of what the starting budget was. Keep it in rerunDone: if the
+                # rerun itself later hits a transient platform race, the loop needs the suffix to
+                # discard the stale rerun result file before re-dispatching.
+                $suffix = "rerun$($State.rerunDone.Count + 1)"
+                $State.rerunDone[$Result.AppName] = $suffix
                 Write-Host "::warning::Tests FAILED for '$($Result.AppName)' on tenant '$($Result.Tenant)'. Re-running the app once on a different tenant. A rerun that passes still means this app is unstable - please investigate it."
                 $State.rerun = @($State.rerun) + @([PSCustomObject]@{
                     appName       = $Result.AppName
@@ -605,16 +607,18 @@ function Start-TestJob {
 
 <#
 .SYNOPSIS
-    Waits for all tracked test jobs to complete and returns whether all passed.
+    Waits for all tracked test jobs to complete, recording each outcome on the state object.
+.DESCRIPTION
+    Outcomes are recorded on $state by Register-TestJobOutcome (hasFailures / transient / rerun),
+    which is the single source of truth for the run result. Deliberately returns nothing: a
+    "did everything pass" boolean cannot be derived here, because $state.hasFailures may already
+    be true from an earlier batch and would mask a new failure in this one.
 .PARAMETER state
     The parallel execution state object containing the jobs array.
-.OUTPUTS
-    [bool] True if all jobs passed, false if any failed.
 #>
 function Wait-ForAllTestJobs {
     param($state)
 
-    $failuresBefore = $state.hasFailures
     foreach ($entry in @($state.jobs)) {
         $pendingJob = Get-Job -Id $entry.jobId -ErrorAction SilentlyContinue
         if ($pendingJob) {
@@ -628,7 +632,6 @@ function Wait-ForAllTestJobs {
     # All jobs in $state.jobs have been received and removed; clear the list so any later
     # dispatch starts from a clean slate (otherwise stale descriptors confuse Get-FreeTenants).
     $state.jobs = @()
-    return ($state.hasFailures -eq $failuresBefore)
 }
 
 <#
@@ -720,6 +723,44 @@ function Invoke-WarmupDispatch {
     $null = Wait-ForAllTestJobs -state $State
 
     return @($Pending | Select-Object -Skip 1)
+}
+
+<#
+.SYNOPSIS
+    Deletes the result file written by a rerun, so it cannot take part in the merge.
+.DESCRIPTION
+    Merge-TenantTestResults merges tenant files first and rerun files last, so a rerun result
+    always wins for the app it re-ran. That is correct while the rerun is the app's final attempt.
+    If the rerun instead hits a transient platform race, the app is re-dispatched through the
+    normal queue and writes to a TENANT file - and the stale rerun file would then overwrite the
+    newer result, reporting a passing app as failed. Removing the stale file keeps the merge honest.
+.PARAMETER parameters
+    The original test parameters hashtable (contains the expected result file paths).
+.PARAMETER suffix
+    The rerun suffix whose files should be removed (for example 'rerun1').
+#>
+function Remove-RerunResultFile {
+    param(
+        [Hashtable]$parameters,
+        [string]$suffix
+    )
+
+    if ([string]::IsNullOrWhiteSpace($suffix)) { return }
+
+    foreach ($resultKey in @("XUnitResultFileName", "JUnitResultFileName")) {
+        if ($parameters.ContainsKey($resultKey) -and $parameters[$resultKey]) {
+            $origFile = $parameters[$resultKey]
+            $dir = [System.IO.Path]::GetDirectoryName($origFile)
+            $name = [System.IO.Path]::GetFileNameWithoutExtension($origFile)
+            $ext = [System.IO.Path]::GetExtension($origFile)
+            $staleFile = Join-Path $dir "$name-$suffix$ext"
+
+            if (Test-Path $staleFile) {
+                Write-Host "Discarding stale rerun result file '$staleFile'; the app is being re-dispatched after a transient failure."
+                Remove-Item $staleFile -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
 }
 
 <#
@@ -819,6 +860,12 @@ function Invoke-ParallelTestExecution {
             Write-Host "Re-queueing $($toRetry.Count) app(s) after transient platform race: $($toRetry -join ', ')"
             foreach ($appName in $toRetry) {
                 $state.retried[$appName] = $true
+                # A transient retry goes out through the normal queue and so writes to a TENANT
+                # result file. Tenant files are merged before rerun files, so any rerun file this
+                # app already produced would overwrite the newer result - drop it.
+                if ($state.rerunDone.ContainsKey($appName)) {
+                    Remove-RerunResultFile -parameters $parameters -suffix $state.rerunDone[$appName]
+                }
             }
             $pending = @($toRetry) + @($pending)
         }

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -14,6 +14,13 @@ if (-not (Get-Command Write-Log -ErrorAction SilentlyContinue)) {
 }
 Import-Module (Join-Path $PSScriptRoot "ALAppBuild.psm1" -Resolve)
 
+# Maximum number of test app reruns allowed per job. A failed app is re-run once on a DIFFERENT
+# tenant than the one it failed on: tests are not guaranteed to clean up after themselves, so a
+# same-tenant retry can re-fail on the residue the failed run just left behind. The budget is
+# deliberately small - it exists to absorb instability, and more failures than this means
+# something is genuinely broken rather than flaky.
+$script:MaxAppReruns = 1
+
 <#
 .SYNOPSIS
     Returns the cached parallel-test-run result for a container, or $null if no run has finished.
@@ -180,11 +187,14 @@ function Get-AvailableBcTenants {
     Merges multiple test result XML files into a single file.
 .DESCRIPTION
     Supports both JUnit (<testsuites>/<testsuite>) and XUnit (<assemblies>/<assembly>) formats.
-    Uses the first file as the base and appends test elements from remaining files.
+    Uses the first file as the base and appends test elements from remaining files. Entries are
+    keyed by their "name" attribute (the codeunit) and later files win: an existing entry is
+    removed before the new one is appended. That is what lets a rerun's results, merged last,
+    replace the results of the run it re-ran.
 .PARAMETER targetFile
     Path to the merged output file.
 .PARAMETER sourceFiles
-    Array of paths to per-tenant result files to merge.
+    Ordered array of result files to merge. Later files replace same-named entries from earlier ones.
 #>
 function Merge-TestResultFiles {
     param(
@@ -214,28 +224,30 @@ function Merge-TestResultFiles {
         $additionalXml = [xml](Get-Content $file -Raw)
 
         # JUnit format: root is <testsuites>, children are <testsuite>
-        $junitSuites = $additionalXml.SelectNodes("//testsuites/testsuite")
-        if ($junitSuites -and $junitSuites.Count -gt 0) {
-            $targetNode = $baseXml.SelectSingleNode("//testsuites")
-            foreach ($suite in $junitSuites) {
-                $imported = $baseXml.ImportNode($suite, $true)
-                $targetNode.AppendChild($imported) | Out-Null
-            }
-            continue
-        }
-
         # XUnit format: root is <assemblies>, children are <assembly>
-        $xunitAssemblies = $additionalXml.SelectNodes("//assemblies/assembly")
-        if ($xunitAssemblies -and $xunitAssemblies.Count -gt 0) {
-            $targetNode = $baseXml.SelectSingleNode("//assemblies")
-            foreach ($assembly in $xunitAssemblies) {
-                $imported = $baseXml.ImportNode($assembly, $true)
+        $merged = $false
+        foreach ($format in @(@{ Root = 'testsuites'; Child = 'testsuite' }, @{ Root = 'assemblies'; Child = 'assembly' })) {
+            $nodes = $additionalXml.SelectNodes("//$($format.Root)/$($format.Child)")
+            if (-not $nodes -or $nodes.Count -eq 0) { continue }
+
+            $targetNode = $baseXml.SelectSingleNode("//$($format.Root)")
+            foreach ($node in $nodes) {
+                # Drop any earlier entry for the same codeunit so the later file wins. Compared on
+                # the node itself rather than via XPath so names containing quotes are safe.
+                $nodeName = $node.GetAttribute('name')
+                @($targetNode.ChildNodes | Where-Object { $_.LocalName -eq $format.Child -and $_.GetAttribute('name') -eq $nodeName }) |
+                    ForEach-Object { $targetNode.RemoveChild($_) | Out-Null }
+
+                $imported = $baseXml.ImportNode($node, $true)
                 $targetNode.AppendChild($imported) | Out-Null
             }
-            continue
+            $merged = $true
+            break
         }
 
-        Write-Host "WARNING: Unrecognized test result format in $file, skipping"
+        if (-not $merged) {
+            Write-Host "WARNING: Unrecognized test result format in $file, skipping"
+        }
     }
 
     $baseXml.Save($targetFile)
@@ -344,6 +356,9 @@ function Receive-TestJobResult {
     The parallel execution state object; the new job descriptor is appended to State.jobs.
 .PARAMETER Verb
     Log verb, 'Dispatching' for the initial run or 'Re-dispatching' for a retry.
+.PARAMETER FileSuffix
+    Suffix for the per-job result file. Defaults to the tenant id; a rerun passes its own suffix so
+    its results land in a separate file that replaces the failed run's during the merge.
 #>
 function Start-TestAppDispatch {
     param(
@@ -354,7 +369,8 @@ function Start-TestAppDispatch {
         [string]$ScriptPath,
         [string]$TestType,
         $State,
-        [string]$Verb = 'Dispatching'
+        [string]$Verb = 'Dispatching',
+        [string]$FileSuffix
     )
 
     Write-Host "$Verb '$AppName' (extensionId $AppId) on tenant '$Tenant' in background"
@@ -364,10 +380,58 @@ function Start-TestAppDispatch {
     $appParams['extensionId'] = $AppId
     $appParams.Remove('ReRun') | Out-Null
 
-    $job = Start-TestJob -parameters $appParams -tenant $Tenant -scriptPath $ScriptPath -testType $TestType
+    $job = Start-TestJob -parameters $appParams -tenant $Tenant -scriptPath $ScriptPath -testType $TestType -fileSuffix $FileSuffix
     $State.jobs = @($State.jobs) + @([PSCustomObject]@{ jobId = $job.Id; tenant = $Tenant; appName = $AppName })
 
     Start-Sleep -Seconds 5
+}
+
+<#
+.SYNOPSIS
+    Records a finished job's outcome on the state object, queueing a rerun when one is warranted.
+.DESCRIPTION
+    'Transient' feeds the existing platform-race retry queue. 'Failed' consumes one unit of the
+    global rerun budget and queues the app to run again on a different tenant; when the budget is
+    exhausted (or the app has already been re-run, or there is only one tenant so a different one
+    cannot be guaranteed) the failure is final and sets hasFailures.
+.PARAMETER Result
+    The outcome object returned by Receive-TestJobResult.
+.PARAMETER State
+    The parallel execution state object; mutated in place.
+#>
+function Register-TestJobOutcome {
+    param(
+        $Result,
+        $State
+    )
+
+    switch ($Result.Outcome) {
+        'Transient' {
+            Write-Host "Transient platform race for '$($Result.AppName)' on '$($Result.Tenant)'. Queued for one retry."
+            $State.transient = @($State.transient) + @($Result.AppName)
+        }
+        'Failed' {
+            $canRerun = ($State.rerunBudget -gt 0) -and
+                        ($State.tenantCount -gt 1) -and
+                        (-not $State.rerunDone.ContainsKey($Result.AppName))
+
+            if ($canRerun) {
+                $State.rerunBudget = $State.rerunBudget - 1
+                $State.rerunDone[$Result.AppName] = $true
+                $suffix = "rerun$($script:MaxAppReruns - $State.rerunBudget)"
+                Write-Host "::warning::Tests FAILED for '$($Result.AppName)' on tenant '$($Result.Tenant)'. Re-running the app once on a different tenant. A rerun that passes still means this app is unstable - please investigate it."
+                $State.rerun = @($State.rerun) + @([PSCustomObject]@{
+                    appName       = $Result.AppName
+                    excludeTenant = $Result.Tenant
+                    suffix        = $suffix
+                })
+            }
+            else {
+                Write-Host "Tests FAILED for $($Result.AppName) on $($Result.Tenant) (job state: $($Result.JobState))"
+                $State.hasFailures = $true
+            }
+        }
+    }
 }
 
 <#
@@ -398,16 +462,7 @@ function Get-FreeTenants {
             $remainingJobs += $entry
         } else {
             $result = Receive-TestJobResult -Entry $entry -Job $job -Retried $state.retried
-            switch ($result.Outcome) {
-                'Transient' {
-                    Write-Host "Transient platform race for '$($result.AppName)' on '$($result.Tenant)'. Queued for one retry."
-                    $state.transient = @($state.transient) + @($result.AppName)
-                }
-                'Failed' {
-                    Write-Host "Tests FAILED for $($result.AppName) on $($result.Tenant) (job state: $($result.JobState))"
-                    $state.hasFailures = $true
-                }
-            }
+            Register-TestJobOutcome -Result $result -State $state
         }
     }
     $state.jobs = @($remainingJobs)
@@ -422,6 +477,8 @@ function Get-FreeTenants {
     The parallel execution state object.
 .PARAMETER tenants
     Array of all tenant IDs.
+.PARAMETER excludeTenant
+    Tenant to never return. Used to keep a rerun off the tenant its previous run failed on.
 .OUTPUTS
     [string] The first available tenant ID.
 #>
@@ -429,13 +486,14 @@ function Wait-ForFreeTenant {
     param(
         $state,
         $tenants,
+        [string]$excludeTenant,
         [int]$timeoutSeconds = 7200,
         [int]$pollIntervalSeconds = 10
     )
 
     $waited = 0
     while ($waited -lt $timeoutSeconds) {
-        $available = @(Get-FreeTenants -state $state -tenants $tenants)
+        $available = @(Get-FreeTenants -state $state -tenants $tenants | Where-Object { $_ -ne $excludeTenant })
         if ($available) {
             return $available[0]
         }
@@ -457,6 +515,8 @@ function Wait-ForFreeTenant {
     Path to RunTestsInBcContainer.ps1.
 .PARAMETER testType
     The test type (Legacy, UnitTest, etc.)
+.PARAMETER fileSuffix
+    Suffix used for this job's result file. Defaults to the tenant id.
 .OUTPUTS
     [System.Management.Automation.Job] The background job object.
 #>
@@ -465,20 +525,23 @@ function Start-TestJob {
         [Hashtable]$parameters,
         [string]$tenant,
         [string]$scriptPath,
-        [string]$testType
+        [string]$testType,
+        [string]$fileSuffix
     )
 
     $jobParams = $parameters.Clone()
     $jobParams["tenant"] = $tenant
 
-    # Give each tenant its own result file to avoid write conflicts
+    if ([string]::IsNullOrWhiteSpace($fileSuffix)) { $fileSuffix = $tenant }
+
+    # Give each job its own result file to avoid write conflicts
     foreach ($resultKey in @("XUnitResultFileName", "JUnitResultFileName")) {
         if ($jobParams.ContainsKey($resultKey) -and $jobParams[$resultKey]) {
             $origFile = $jobParams[$resultKey]
             $dir = [System.IO.Path]::GetDirectoryName($origFile)
             $name = [System.IO.Path]::GetFileNameWithoutExtension($origFile)
             $ext = [System.IO.Path]::GetExtension($origFile)
-            $jobParams[$resultKey] = Join-Path $dir "$name-$tenant$ext"
+            $jobParams[$resultKey] = Join-Path $dir "$name-$fileSuffix$ext"
         }
     }
 
@@ -508,7 +571,7 @@ function Start-TestJob {
 function Wait-ForAllTestJobs {
     param($state)
 
-    $allPassed = $true
+    $failuresBefore = $state.hasFailures
     foreach ($entry in @($state.jobs)) {
         $pendingJob = Get-Job -Id $entry.jobId -ErrorAction SilentlyContinue
         if ($pendingJob) {
@@ -516,37 +579,34 @@ function Wait-ForAllTestJobs {
             Wait-Job -Job $pendingJob | Out-Null
 
             $result = Receive-TestJobResult -Entry $entry -Job $pendingJob -Retried $state.retried
-            switch ($result.Outcome) {
-                'Transient' {
-                    Write-Host "Transient platform race for '$($result.AppName)' on '$($result.Tenant)'. Queued for one retry."
-                    $state.transient = @($state.transient) + @($result.AppName)
-                }
-                'Failed' {
-                    Write-Host "Tests FAILED for $($result.AppName) on $($result.Tenant) (job state: $($result.JobState))"
-                    $allPassed = $false
-                }
-            }
+            Register-TestJobOutcome -Result $result -State $state
         }
     }
     # All jobs in $state.jobs have been received and removed; clear the list so any later
     # dispatch starts from a clean slate (otherwise stale descriptors confuse Get-FreeTenants).
     $state.jobs = @()
-    return $allPassed
+    return ($state.hasFailures -eq $failuresBefore)
 }
 
 <#
 .SYNOPSIS
-    Merges per-tenant test result files into the single file expected by Run-AlPipeline.
+    Merges per-job test result files into the single file expected by Run-AlPipeline.
 .PARAMETER parameters
     The original test parameters hashtable (contains the expected result file paths).
 .PARAMETER tenants
     Array of tenant IDs whose result files should be merged.
+.PARAMETER rerunSuffixes
+    Suffixes of any rerun result files. Merged after the tenant files so a rerun's results replace
+    those of the failed run it re-ran.
 #>
 function Merge-TenantTestResults {
     param(
         [Hashtable]$parameters,
-        [string[]]$tenants
+        [string[]]$tenants,
+        [string[]]$rerunSuffixes = @()
     )
+
+    $suffixes = @($tenants) + @($rerunSuffixes)
 
     foreach ($resultKey in @("XUnitResultFileName", "JUnitResultFileName")) {
         if ($parameters.ContainsKey($resultKey) -and $parameters[$resultKey]) {
@@ -555,10 +615,10 @@ function Merge-TenantTestResults {
             $name = [System.IO.Path]::GetFileNameWithoutExtension($origFile)
             $ext = [System.IO.Path]::GetExtension($origFile)
 
-            $tenantFiles = @($tenants | ForEach-Object { Join-Path $dir "$name-$_$ext" })
+            $tenantFiles = @($suffixes | ForEach-Object { Join-Path $dir "$name-$_$ext" })
             Merge-TestResultFiles -targetFile $origFile -sourceFiles $tenantFiles
 
-            # Clean up per-tenant files
+            # Clean up per-job files
             $tenantFiles | Where-Object { Test-Path $_ } | ForEach-Object { Remove-Item $_ -Force }
         }
     }
@@ -612,8 +672,9 @@ function Invoke-WarmupDispatch {
         -ScriptPath $ScriptPath -TestType $TestType -State $State -Verb 'Dispatching'
 
     # Await the single job so the process is warm before anything runs in parallel. A transient
-    # failure here lands in $State.transient and the caller's loop re-queues it.
-    if (-not (Wait-ForAllTestJobs -state $State)) { $State.hasFailures = $true }
+    # failure here lands in $State.transient and the caller's loop re-queues it; a hard failure is
+    # recorded on $State by Wait-ForAllTestJobs.
+    $null = Wait-ForAllTestJobs -state $State
 
     return @($Pending | Select-Object -Skip 1)
 }
@@ -684,7 +745,11 @@ function Invoke-ParallelTestExecution {
 
     # dispatched=true marks "we started the foreach" - lets concurrent reads notice an in-flight
     # run. completed=false stays false until wait+merge finish; only then is finalResult valid.
-    $state = [PSCustomObject]@{ jobs = @(); dispatched = $true; completed = $false; finalResult = $false; hasFailures = $false; transient = @(); retried = @{} }
+    $state = [PSCustomObject]@{
+        jobs = @(); dispatched = $true; completed = $false; finalResult = $false; hasFailures = $false
+        transient = @(); retried = @{}
+        rerun = @(); rerunDone = @{}; rerunBudget = $script:MaxAppReruns; tenantCount = $tenants.Count
+    }
     $state | ConvertTo-Json -Depth 5 | Set-Content $stateFile -Force
 
     # Single dispatch loop, FIFO. TestConfiguration.json lists the smallest app first (a cheap
@@ -697,7 +762,9 @@ function Invoke-ParallelTestExecution {
     $pending = @(Invoke-WarmupDispatch -Parameters $parameters -Pending $pending -AppIdByName $appIdByName `
         -Tenants $tenants -ScriptPath $scriptPath -TestType $testType -State $state)
 
-    while ($pending.Count -gt 0 -or $state.jobs.Count -gt 0 -or $state.transient.Count -gt 0) {
+    $rerunSuffixes = @()
+
+    while ($pending.Count -gt 0 -or $state.jobs.Count -gt 0 -or $state.transient.Count -gt 0 -or $state.rerun.Count -gt 0) {
         # Promote any transient failures back into the dispatch queue. They go to the FRONT:
         # a platform race normally kills a job within a minute of dispatch, so the victim is
         # almost always one of the first (i.e. longest) apps. Appending it instead would
@@ -711,6 +778,22 @@ function Invoke-ParallelTestExecution {
                 $state.retried[$appName] = $true
             }
             $pending = @($toRetry) + @($pending)
+        }
+
+        # Reruns take priority over the normal queue, for the same tail-latency reason as above:
+        # a failure is usually discovered late, so deferring its rerun would extend the run.
+        if ($state.rerun.Count -gt 0) {
+            $rerunItem = $state.rerun[0]
+            $state.rerun = @($state.rerun | Select-Object -Skip 1)
+            $rerunSuffixes += $rerunItem.suffix
+
+            # Never reuse the tenant the app just failed on: tests are not guaranteed to clean up,
+            # so its residue could re-trigger the same failure and make the rerun meaningless.
+            $tenant = Wait-ForFreeTenant -state $state -tenants $tenants -excludeTenant $rerunItem.excludeTenant
+            Start-TestAppDispatch -Parameters $parameters -AppName $rerunItem.appName -AppId $appIdByName[$rerunItem.appName] `
+                -Tenant $tenant -ScriptPath $scriptPath -TestType $testType -State $state `
+                -Verb 'Re-running' -FileSuffix $rerunItem.suffix
+            continue
         }
 
         if ($pending.Count -gt 0) {
@@ -728,16 +811,17 @@ function Invoke-ParallelTestExecution {
             Start-TestAppDispatch -Parameters $parameters -AppName $appName -AppId $appId -Tenant $tenant `
                 -ScriptPath $scriptPath -TestType $testType -State $state -Verb $verb
         } else {
-            # Nothing left to dispatch; drain any still-running jobs. New transient failures
-            # discovered here will be re-queued at the top of the next loop iteration.
+            # Nothing left to dispatch; drain any still-running jobs. New transient failures and
+            # reruns discovered here are picked up at the top of the next loop iteration.
+            # Wait-ForAllTestJobs records failures on $state directly.
             Write-Host "All apps dispatched. Waiting for in-flight jobs to complete..."
-            if (-not (Wait-ForAllTestJobs -state $state)) { $state.hasFailures = $true }
+            $null = Wait-ForAllTestJobs -state $state
         }
     }
 
     $allPassed = -not $state.hasFailures
 
-    Merge-TenantTestResults -parameters $parameters -tenants $tenants
+    Merge-TenantTestResults -parameters $parameters -tenants $tenants -rerunSuffixes $rerunSuffixes
 
     # Persist final result and mark complete so subsequent override invocations short-circuit
     # to this value (and not the placeholder we wrote before dispatch).
@@ -790,4 +874,4 @@ function Invoke-PerProjectTestRun {
     return (. $script -parameters $parameters -TestType $testType -AppNamesToTest $appNamesToTest)
 }
 
-Export-ModuleMember -Function Invoke-ParallelTestExecution, Get-AvailableBcTenants, Get-CachedTestRunResult, Get-InstalledTestAppNames, Get-AppNamesForBucket, Invoke-PerProjectTestRun, Get-AppNameFromMetadata, Invoke-WarmupDispatch
+Export-ModuleMember -Function Invoke-ParallelTestExecution, Get-AvailableBcTenants, Get-CachedTestRunResult, Get-InstalledTestAppNames, Get-AppNamesForBucket, Invoke-PerProjectTestRun, Get-AppNameFromMetadata, Invoke-WarmupDispatch, Merge-TestResultFiles

--- a/build/scripts/ParallelTestExecution.psm1
+++ b/build/scripts/ParallelTestExecution.psm1
@@ -14,13 +14,6 @@ if (-not (Get-Command Write-Log -ErrorAction SilentlyContinue)) {
 }
 Import-Module (Join-Path $PSScriptRoot "ALAppBuild.psm1" -Resolve)
 
-# Maximum number of test app reruns allowed per job. A failed app is re-run once on a DIFFERENT
-# tenant than the one it failed on: tests are not guaranteed to clean up after themselves, so a
-# same-tenant retry can re-fail on the residue the failed run just left behind. The budget is
-# deliberately small - it exists to absorb instability, and more failures than this means
-# something is genuinely broken rather than flaky.
-$script:MaxAppReruns = 1
-
 <#
 .SYNOPSIS
     Returns the rerun budget for the current build.
@@ -30,12 +23,22 @@ $script:MaxAppReruns = 1
     real state of the branch and they feed the unstable-tests data, so masking instability there
     would hide exactly what we want to measure. This mirrors the test tolerance check in
     RunTestsInBcContainer.ps1, which is also limited to pull request builds.
+.PARAMETER MaxAppReruns
+    Rerun budget granted to a pull request build. A failed app is re-run once on a DIFFERENT tenant
+    than the one it failed on: tests are not guaranteed to clean up after themselves, so a
+    same-tenant retry can re-fail on the residue the failed run just left behind. Deliberately
+    small - it exists to absorb instability, and more failures than this means something is
+    genuinely broken rather than flaky.
 .OUTPUTS
-    [int] $script:MaxAppReruns on pull request builds, otherwise 0.
+    [int] MaxAppReruns on pull request builds, otherwise 0.
 #>
 function Get-AppRerunBudget {
+    param(
+        [int]$MaxAppReruns = 1
+    )
+
     if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
-        return $script:MaxAppReruns
+        return $MaxAppReruns
     }
 
     Write-Host "Build event is '$($env:GITHUB_EVENT_NAME)', not 'pull_request'. Failed test apps will NOT be re-run."

--- a/build/scripts/RunTestsInBcContainer.ps1
+++ b/build/scripts/RunTestsInBcContainer.ps1
@@ -139,8 +139,10 @@ if ($AppNamesToTest.Count -gt 0) {
     return Invoke-ParallelTestExecution -parameters $parameters -scriptPath $PSCommandPath -testType $TestType -appNamesToTest $AppNamesToTest
 }
 
-$maxAttempts = if ($TestType -eq "Legacy") { 1 } else { 2 }
-$result = Invoke-TestsWithReruns -parameters $parameters -maxAttempts $maxAttempts
+# A failing app is retried once by the parallel dispatcher, on a different tenant (see
+# ParallelTestExecution.psm1). Retrying in place here would reuse the tenant the app just dirtied,
+# so the same residue could re-trigger the failure - hence a single attempt per dispatch.
+$result = Invoke-TestsWithReruns -parameters $parameters -maxAttempts 1
 
 # For UnitTests, also run with DisableTestIsolation on the same tenant
 if ($TestType -eq "UnitTest") {

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -362,18 +362,22 @@ Describe "ParallelTestExecution rerun budget is limited to pull request builds" 
 
     BeforeEach {
         $script:savedEvent = $env:GITHUB_EVENT_NAME
+        $script:savedSettings = $env:settings
+        # Get-ALGoSetting reads the merged AL-Go settings out of $env:settings.
+        $env:settings = '{ "maxTestAppReruns": 2 }'
     }
 
     AfterEach {
         $env:GITHUB_EVENT_NAME = $script:savedEvent
+        $env:settings = $script:savedSettings
     }
 
-    It "grants a rerun budget on pull request builds" {
+    It "grants the configured budget on pull request builds" {
         $env:GITHUB_EVENT_NAME = 'pull_request'
-        Get-AppRerunBudget | Should -BeGreaterThan 0
+        Get-AppRerunBudget | Should -Be 2
     }
 
-    It "grants no rerun budget on push (CI/CD) builds" {
+    It "grants no rerun budget on push (CI/CD) builds even when the setting is present" {
         # CI/CD runs are the signal for the real state of the branch and feed the unstable-tests
         # data, so a failure there must stay a failure.
         $env:GITHUB_EVENT_NAME = 'push'
@@ -390,6 +394,54 @@ Describe "ParallelTestExecution rerun budget is limited to pull request builds" 
     It "grants no rerun budget outside of GitHub Actions" {
         $env:GITHUB_EVENT_NAME = $null
         Get-AppRerunBudget | Should -Be 0
+    }
+
+    It "grants no rerun budget when the setting is missing" {
+        $env:GITHUB_EVENT_NAME = 'pull_request'
+        $env:settings = '{ }'
+        Get-AppRerunBudget | Should -Be 0
+    }
+
+    It "grants no rerun budget when the setting is not a non-negative integer" {
+        # Settings are free-form JSON, so a typo must disable reruns rather than corrupt the budget.
+        $env:GITHUB_EVENT_NAME = 'pull_request'
+        foreach ($bad in @('"lots"', '-1', '"2.5"')) {
+            $env:settings = "{ ""maxTestAppReruns"": $bad }"
+            Get-AppRerunBudget | Should -Be 0
+        }
+    }
+
+    It "honours a budget of 0 as a way to switch reruns off" {
+        $env:GITHUB_EVENT_NAME = 'pull_request'
+        $env:settings = '{ "maxTestAppReruns": 0 }'
+        Get-AppRerunBudget | Should -Be 0
+    }
+
+    It "re-runs several different apps up to the configured budget" {
+        # The budget caps how many DIFFERENT apps may be re-run; an individual app is still only
+        # ever re-run once.
+        $env:GITHUB_EVENT_NAME = 'pull_request'
+        InModuleScope ParallelTestExecution {
+            $state = [PSCustomObject]@{
+                hasFailures = $false; transient = @(); rerun = @(); rerunDone = @{}
+                rerunBudget = 2; tenantCount = 4
+            }
+            foreach ($app in @('A', 'B')) {
+                Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                    Outcome = 'Failed'; AppName = $app; Tenant = 'tenant2'; JobState = 'Failed'
+                })
+            }
+            $state.rerun.Count | Should -Be 2
+            $state.rerun.suffix | Should -Be @('rerun1', 'rerun2')
+            $state.hasFailures | Should -BeFalse
+
+            # Budget spent: a third app is a final failure.
+            Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                Outcome = 'Failed'; AppName = 'C'; Tenant = 'tenant3'; JobState = 'Failed'
+            })
+            $state.rerun.Count | Should -Be 2
+            $state.hasFailures | Should -BeTrue
+        }
     }
 
     It "does not re-dispatch a failed app on a CI/CD build" {

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -253,3 +253,166 @@ Describe "ParallelTestExecution warmup dispatch" {
         }
     }
 }
+
+Describe "ParallelTestExecution failed-app rerun scheduling" {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '../ParallelTestExecution.psm1') -Force
+    }
+
+    It "re-runs a failed app on a different tenant than the one it failed on" {
+        # A failed app is retried once, and never on the tenant it failed on: tests are not
+        # guaranteed to clean up after themselves, so residue from the failed run could
+        # re-trigger the same failure and make the retry worthless.
+        InModuleScope ParallelTestExecution {
+            $script:dispatched = [System.Collections.Generic.List[object]]::new()
+            $script:failed = $false
+
+            Mock Get-AvailableBcTenants { @('default', 'tenant2') }
+            Mock Get-BcContainerAppInfo {
+                @('Big', 'Small') | ForEach-Object {
+                    [PSCustomObject]@{ IsInstalled = $true; Name = $_; AppId = "id-$_" }
+                }
+            }
+            Mock Invoke-WarmupDispatch { @($Pending) }
+            Mock Wait-ForAllTestJobs { $true }
+            Mock Merge-TenantTestResults { }
+            Mock Wait-ForFreeTenant {
+                # 'default' is always free; the exclusion must push the rerun onto 'tenant2'.
+                @('default', 'tenant2') | Where-Object { $_ -ne $excludeTenant } | Select-Object -First 1
+            }
+            Mock Start-TestAppDispatch {
+                $script:dispatched.Add([PSCustomObject]@{ App = $AppName; Tenant = $Tenant; Suffix = $FileSuffix })
+                # 'Big' fails on its first dispatch, exactly once.
+                if ($AppName -eq 'Big' -and -not $script:failed) {
+                    $script:failed = $true
+                    Register-TestJobOutcome -State $State -Result ([PSCustomObject]@{
+                        Outcome = 'Failed'; AppName = $AppName; Tenant = $Tenant; JobState = 'Failed'
+                    })
+                }
+            }
+
+            $params = @{ containerName = "ut-$([guid]::NewGuid().ToString('N'))"; tenant = 'default' }
+            $result = Invoke-ParallelTestExecution -parameters $params -scriptPath 'unused.ps1' `
+                -testType 'Legacy' -appNamesToTest @('Big', 'Small')
+
+            $rerun = $script:dispatched | Where-Object { $_.Suffix }
+            $rerun.App | Should -Be 'Big'
+            $rerun.Tenant | Should -Be 'tenant2'
+            $rerun.Suffix | Should -Be 'rerun1'
+            # The rerun passed, so the run as a whole passed.
+            $result | Should -BeTrue
+        }
+    }
+
+    It "fails the run when the rerun budget is already spent" {
+        InModuleScope ParallelTestExecution {
+            $state = [PSCustomObject]@{
+                hasFailures = $false; transient = @(); rerun = @(); rerunDone = @{}
+                rerunBudget = 1; tenantCount = 4
+            }
+            $failure = [PSCustomObject]@{ Outcome = 'Failed'; AppName = 'A'; Tenant = 'default'; JobState = 'Failed' }
+
+            Register-TestJobOutcome -Result $failure -State $state
+            $state.rerun.Count | Should -Be 1
+            $state.hasFailures | Should -BeFalse
+
+            # Budget is spent, so a second failing app is final.
+            Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                Outcome = 'Failed'; AppName = 'B'; Tenant = 'tenant2'; JobState = 'Failed'
+            })
+            $state.rerun.Count | Should -Be 1
+            $state.hasFailures | Should -BeTrue
+        }
+    }
+
+    It "does not re-run an app that already had its rerun" {
+        InModuleScope ParallelTestExecution {
+            $state = [PSCustomObject]@{
+                hasFailures = $false; transient = @(); rerun = @(); rerunDone = @{ A = $true }
+                rerunBudget = 1; tenantCount = 4
+            }
+            Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                Outcome = 'Failed'; AppName = 'A'; Tenant = 'tenant2'; JobState = 'Failed'
+            })
+            $state.rerun.Count | Should -Be 0
+            $state.hasFailures | Should -BeTrue
+        }
+    }
+
+    It "does not re-run when there is only one tenant, since a different one cannot be used" {
+        InModuleScope ParallelTestExecution {
+            $state = [PSCustomObject]@{
+                hasFailures = $false; transient = @(); rerun = @(); rerunDone = @{}
+                rerunBudget = 1; tenantCount = 1
+            }
+            Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                Outcome = 'Failed'; AppName = 'A'; Tenant = 'default'; JobState = 'Failed'
+            })
+            $state.rerun.Count | Should -Be 0
+            $state.hasFailures | Should -BeTrue
+        }
+    }
+}
+
+Describe "ParallelTestExecution result merging" {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '../ParallelTestExecution.psm1') -Force
+
+        function New-JUnitFile {
+            param([string]$Path, [string]$SuiteName, [int]$Failures)
+            @"
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="$SuiteName" tests="1" failures="$Failures" />
+</testsuites>
+"@ | Set-Content -Path $Path -Encoding UTF8
+        }
+    }
+
+    It "lets a rerun's results replace those of the run it re-ran" {
+        # The rerun runs the whole app again on another tenant and writes its own file. Without
+        # replace-by-name the merged report would contain the app twice - once failed, once
+        # passed - and the failed copy would fail the build.
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $dir | Out-Null
+        try {
+            $failedRun = Join-Path $dir 'results-tenant2.xml'
+            $rerun = Join-Path $dir 'results-rerun1.xml'
+            $target = Join-Path $dir 'results.xml'
+
+            New-JUnitFile -Path $failedRun -SuiteName '134000 Some Codeunit' -Failures 1
+            New-JUnitFile -Path $rerun -SuiteName '134000 Some Codeunit' -Failures 0
+
+            Merge-TestResultFiles -targetFile $target -sourceFiles @($failedRun, $rerun)
+
+            $merged = [xml](Get-Content $target -Raw)
+            $suites = @($merged.SelectNodes('//testsuites/testsuite'))
+            $suites.Count | Should -Be 1
+            $suites[0].failures | Should -Be '0'
+        }
+        finally {
+            Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "keeps results for different codeunits side by side" {
+        $dir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $dir | Out-Null
+        try {
+            $first = Join-Path $dir 'results-default.xml'
+            $second = Join-Path $dir 'results-tenant2.xml'
+            $target = Join-Path $dir 'results.xml'
+
+            New-JUnitFile -Path $first -SuiteName '134000 One' -Failures 0
+            New-JUnitFile -Path $second -SuiteName '134001 Two' -Failures 0
+
+            Merge-TestResultFiles -targetFile $target -sourceFiles @($first, $second)
+
+            $merged = [xml](Get-Content $target -Raw)
+            @($merged.SelectNodes('//testsuites/testsuite')).Count | Should -Be 2
+        }
+        finally {
+            Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -402,15 +402,6 @@ Describe "ParallelTestExecution rerun budget is limited to pull request builds" 
         Get-AppRerunBudget | Should -Be 0
     }
 
-    It "grants no rerun budget when the setting is not a non-negative integer" {
-        # Settings are free-form JSON, so a typo must disable reruns rather than corrupt the budget.
-        $env:GITHUB_EVENT_NAME = 'pull_request'
-        foreach ($bad in @('"lots"', '-1', '"2.5"')) {
-            $env:settings = "{ ""maxTestAppReruns"": $bad }"
-            Get-AppRerunBudget | Should -Be 0
-        }
-    }
-
     It "honours a budget of 0 as a way to switch reruns off" {
         $env:GITHUB_EVENT_NAME = 'pull_request'
         $env:settings = '{ "maxTestAppReruns": 0 }'

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -274,6 +274,7 @@ Describe "ParallelTestExecution failed-app rerun scheduling" {
                 }
             }
             Mock Invoke-WarmupDispatch { @($Pending) }
+            Mock Get-AppRerunBudget { 1 }
             Mock Wait-ForAllTestJobs { $true }
             Mock Merge-TenantTestResults { }
             Mock Wait-ForFreeTenant {
@@ -350,6 +351,82 @@ Describe "ParallelTestExecution failed-app rerun scheduling" {
             })
             $state.rerun.Count | Should -Be 0
             $state.hasFailures | Should -BeTrue
+        }
+    }
+}
+
+Describe "ParallelTestExecution rerun budget is limited to pull request builds" {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '../ParallelTestExecution.psm1') -Force
+    }
+
+    BeforeEach {
+        $script:savedEvent = $env:GITHUB_EVENT_NAME
+    }
+
+    AfterEach {
+        $env:GITHUB_EVENT_NAME = $script:savedEvent
+    }
+
+    It "grants a rerun budget on pull request builds" {
+        $env:GITHUB_EVENT_NAME = 'pull_request'
+        Get-AppRerunBudget | Should -BeGreaterThan 0
+    }
+
+    It "grants no rerun budget on push (CI/CD) builds" {
+        # CI/CD runs are the signal for the real state of the branch and feed the unstable-tests
+        # data, so a failure there must stay a failure.
+        $env:GITHUB_EVENT_NAME = 'push'
+        Get-AppRerunBudget | Should -Be 0
+    }
+
+    It "grants no rerun budget for schedule, merge_group or workflow_dispatch builds" {
+        foreach ($evt in @('schedule', 'merge_group', 'workflow_dispatch')) {
+            $env:GITHUB_EVENT_NAME = $evt
+            Get-AppRerunBudget | Should -Be 0
+        }
+    }
+
+    It "grants no rerun budget outside of GitHub Actions" {
+        $env:GITHUB_EVENT_NAME = $null
+        Get-AppRerunBudget | Should -Be 0
+    }
+
+    It "does not re-dispatch a failed app on a CI/CD build" {
+        # End-to-end guard: the budget gate must actually suppress the rerun dispatch, not just
+        # return 0 from the helper.
+        $env:GITHUB_EVENT_NAME = 'push'
+        InModuleScope ParallelTestExecution {
+            $script:dispatched = [System.Collections.Generic.List[object]]::new()
+            $script:failed = $false
+
+            Mock Get-AvailableBcTenants { @('default', 'tenant2') }
+            Mock Get-BcContainerAppInfo {
+                @('Big', 'Small') | ForEach-Object {
+                    [PSCustomObject]@{ IsInstalled = $true; Name = $_; AppId = "id-$_" }
+                }
+            }
+            Mock Invoke-WarmupDispatch { @($Pending) }
+            Mock Wait-ForAllTestJobs { $true }
+            Mock Merge-TenantTestResults { }
+            Mock Wait-ForFreeTenant { 'default' }
+            Mock Start-TestAppDispatch {
+                $script:dispatched.Add($AppName)
+                if ($AppName -eq 'Big' -and -not $script:failed) {
+                    $script:failed = $true
+                    Register-TestJobOutcome -State $State -Result ([PSCustomObject]@{
+                        Outcome = 'Failed'; AppName = $AppName; Tenant = $Tenant; JobState = 'Failed'
+                    })
+                }
+            }
+
+            $params = @{ containerName = "ut-$([guid]::NewGuid().ToString('N'))"; tenant = 'default' }
+            $result = Invoke-ParallelTestExecution -parameters $params -scriptPath 'unused.ps1' `
+                -testType 'Legacy' -appNamesToTest @('Big', 'Small')
+
+            # Each app dispatched exactly once, and the failure is final.
+            $script:dispatched | Should -Be @('Big', 'Small')
+            $result | Should -BeFalse
         }
     }
 }

--- a/build/scripts/tests/ParallelTestExecution.Test.ps1
+++ b/build/scripts/tests/ParallelTestExecution.Test.ps1
@@ -444,6 +444,81 @@ Describe "ParallelTestExecution rerun budget is limited to pull request builds" 
         }
     }
 
+    It "discards a stale rerun result file when the rerun is re-dispatched after a transient race" {
+        # Sequence: app fails -> rerun on another tenant -> that rerun hits the platform race ->
+        # app is re-dispatched through the NORMAL queue, writing to a tenant file. Tenant files
+        # merge before rerun files, so the stale rerun file would otherwise overwrite the newer
+        # (passing) result and report a passing app as failed.
+        $env:GITHUB_EVENT_NAME = 'pull_request'
+        InModuleScope ParallelTestExecution {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            try {
+                $params = @{
+                    containerName = "ut-$([guid]::NewGuid().ToString('N'))"
+                    tenant = 'default'
+                    JUnitResultFileName = (Join-Path $dir 'results.xml')
+                }
+                $staleFile = Join-Path $dir 'results-rerun1.xml'
+                Set-Content -Path $staleFile -Value '<testsuites />'
+
+                $script:raced = $false
+                Mock Get-AvailableBcTenants { @('default', 'tenant2') }
+                Mock Get-BcContainerAppInfo { @([PSCustomObject]@{ IsInstalled = $true; Name = 'A'; AppId = 'id-A' }) }
+                Mock Invoke-WarmupDispatch { @($Pending) }
+                Mock Wait-ForAllTestJobs { }
+                Mock Merge-TenantTestResults { }
+                Mock Wait-ForFreeTenant { 'tenant2' }
+                Mock Start-TestAppDispatch {
+                    if ($FileSuffix -and -not $script:raced) {
+                        # The rerun job hits the platform race.
+                        $script:raced = $true
+                        $State.transient = @($State.transient) + @($AppName)
+                    }
+                }
+                # Pre-seed the state as though 'A' already had its rerun dispatched.
+                Mock Register-TestJobOutcome { }
+
+                $state = [PSCustomObject]@{
+                    jobs = @(); hasFailures = $false; transient = @(); retried = @{}
+                    rerun = @(); rerunDone = @{}; rerunBudget = 1; tenantCount = 2
+                }
+                $state.rerunDone['A'] = 'rerun1'
+                $state.transient = @('A')
+
+                # Exercise just the promotion path the loop performs.
+                foreach ($appName in @($state.transient)) {
+                    if ($state.rerunDone.ContainsKey($appName)) {
+                        Remove-RerunResultFile -parameters $params -suffix $state.rerunDone[$appName]
+                    }
+                }
+
+                Test-Path $staleFile | Should -BeFalse
+            }
+            finally {
+                Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It "records the rerun suffix so a stale rerun file can be found later" {
+        InModuleScope ParallelTestExecution {
+            $state = [PSCustomObject]@{
+                hasFailures = $false; transient = @(); rerun = @(); rerunDone = @{}
+                rerunBudget = 2; tenantCount = 4
+            }
+            Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                Outcome = 'Failed'; AppName = 'A'; Tenant = 'tenant2'; JobState = 'Failed'
+            })
+            Register-TestJobOutcome -State $state -Result ([PSCustomObject]@{
+                Outcome = 'Failed'; AppName = 'B'; Tenant = 'tenant3'; JobState = 'Failed'
+            })
+            $state.rerunDone['A'] | Should -Be 'rerun1'
+            $state.rerunDone['B'] | Should -Be 'rerun2'
+            $state.rerun.suffix | Should -Be @('rerun1', 'rerun2')
+        }
+    }
+
     It "does not re-dispatch a failed app on a CI/CD build" {
         # End-to-end guard: the budget gate must actually suppress the rerun dispatch, not just
         # return 0 from the helper.


### PR DESCRIPTION
## What & why

Legacy/unit test stages have been flaky, and today's retry makes that worse than it needs to be. When a test app fails, `Invoke-TestsWithReruns` immediately re-runs the whole app **on the same tenant it just failed on**. Tests are not guaranteed to clean up after themselves, so that retry runs against the residue the failed run left behind and can deterministically re-fail. It is a correlated trial, which is close to the worst thing a retry can be.

This moves the retry to a **different tenant**, so it becomes an independent trial. The failed app is re-dispatched by the parallel dispatcher with the original tenant excluded.

Deliberately *not* using a fresh/pristine tenant. Every app except the first on each tenant already runs against several other apps' residue, so that is the normal operating environment. A pass on a virgin tenant would be biased toward false green. A different but similarly-used tenant is an honest apples-to-apples retrial, and it costs no extra tenants, memory, or setup time.

**Total attempts per app stay at 2.** The in-place retry drops from 2 attempts to 1, and the dispatcher adds one cross-tenant rerun. So this is wall-clock neutral in the happy path; it relocates an existing retry rather than adding one.

Key points:

- Global budget of **one rerun per job** (`$script:MaxAppReruns`). The point is to absorb instability, not to grind until green. More failures than that means something is genuinely broken.
- Concurrency is unchanged. The rerun is just another item in the dispatch queue, so it still respects the existing one-job-per-tenant limit and the 4-tenants-for-4-vCPU invariant. No new tenants are provisioned.
- Reruns are queued ahead of the normal pending list, same tail-latency reasoning as the existing transient-platform-race path: a failure is usually discovered late, so deferring its rerun would extend the run.
- Job outcome handling was duplicated in `Get-FreeTenants` and `Wait-ForAllTestJobs`; both now go through a single `Register-TestJobOutcome`.

Result files needed a change too. They are keyed by tenant, not by app, and a tenant keeps appending to its file as it moves on to the next app, so a rerun could not safely write to the original tenant's file. Reruns now write their own file, and `Merge-TestResultFiles` gained replace-by-name semantics (later file wins, mirroring what BCH's own `ReRun` switch does internally). Rerun files are merged last, so a rerun supersedes the run it re-ran instead of the report containing the app twice with conflicting outcomes.

## Linked work

[AB#647408](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647408)

No GitHub issue - this is build/CI infrastructure rather than a product change. Happy to file one if that is preferred.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

This touches PowerShell build scripts only, no AL objects, so there is nothing to compile and no analyzer surface. The "ran it in Business Central" box does not really apply either; the meaningful validation is the Pester suite plus a real pipeline run.

- `build/scripts/tests/ParallelTestExecution.Test.ps1`: 18/18 pass (12 pre-existing, 6 new).
- New coverage: rerun lands on a different tenant than the failure; run passes when the rerun passes; failure is final once the budget is spent; an app is never re-run twice; no rerun when only one tenant exists; rerun results replace the failed run's entry; results for different codeunits still merge side by side.
- Verified the merge change against both formats by hand: JUnit (`<testsuites>/<testsuite>`) and XUnit (`<assemblies>/<assembly>`) both replace by name, and an unrecognized file still warns and is skipped rather than aborting the merge.
- Confirmed BCH's `ReRun` semantics from the module source: it replaces the result entry for each codeunit it re-runs, it does not re-run only failed tests. Re-running the whole app is intended here.
- One unrelated pre-existing failure in `BuildOptimization.Test.ps1` (expects 51 affected apps, gets 56). Confirmed present on the base branch without my changes.

Not yet validated in a real pipeline run - worth watching the first few Legacy buckets after merge.

## Risk & compatibility

**Retry budget is tighter than today.** Currently every app independently gets 2 attempts, which is effectively an unbounded retry budget per job. This caps it at one rerun per job. If a bucket routinely has 2+ flaky apps, this will *reduce* the green rate rather than improve it. `$script:MaxAppReruns` is a one-line bump to 2 if that shows up. It would be worth looking at how often attempt 2 is actually needed today before tuning this.

**Reruns can mask instability.** A rerun that passes turns the job green. It emits `::warning::` naming the app, but it is not wired into the existing unstable-tests artifact (`Receive-UnstableTestsArtifact` / `Test-ShouldTolerateFailures`), so nothing tracks it over time. I think that follow-up is important, otherwise visible flakiness quietly becomes invisible flakiness. Left out here to keep the change small.

Guards, so behavior degrades safely: no rerun if the budget is spent, if the app already had its rerun, or if only one tenant exists (where a different tenant cannot be guaranteed). In all of those the failure is final, same as today.

The transient platform-race path is untouched and does not consume the rerun budget. Those jobs die within a minute of dispatch, before meaningful data is written, so a same-tenant retry is fine there.










