### PR TITLE
[Main][ALL-E] Sales Price from customer card and Purcase Price from vendor card is showing "All Customers/All Vendors" as header instead of the specific customer/vendor informationInitial  commit

### DIFF
--- a/src/Layers/W1/BaseApp/Pricing/PriceList/PriceUXManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Pricing/PriceList/PriceUXManagement.Codeunit.al
@@ -428,9 +428,9 @@ codeunit 7018 "Price UX Management"
         if IsHandled then
             exit;
         PriceSourceList.Init();
+        AddAllSourceType(PriceSourceList, PriceSource."Source Type");
         PriceSourceList.AddChildren(PriceSource);
         PriceSourceList.Add(PriceSource);
-        AddAllSourceType(PriceSourceList, PriceSource."Source Type");
         PriceListLineReview.Set(PriceSourceList, AmountType);
         PriceListLineReview.Run();
     end;

--- a/src/Layers/W1/Tests/ERM/PriceListsUI.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/PriceListsUI.Codeunit.al
@@ -36,6 +36,9 @@
         AllCustomersLinesNotShownErr: Label 'All Customers lines are not all shown';
         MixedSourceLinesNotShownErr: Label 'Not all applicable price lines are shown for the customer';
         UnrelatedLinesShownErr: Label 'Unrelated price lines are shown for the customer';
+        CustomerPriceListCaptionTxt: Label 'Price List Lines - Customer %1 %2', Comment = '%1 = Customer No., %2 = Customer Name';
+        VendorPriceListCaptionTxt: Label 'Price List Lines - Vendor %1 %2', Comment = '%1 = Vendor No., %2 = Vendor Name';
+        UnexpectedPageCaptionErr: Label 'Unexpected page caption';
 
     [Test]
     procedure T000_SalesPriceListsPageIsNotEditable()
@@ -4989,6 +4992,78 @@
                 ShownCount += 1;
             until not PriceListLineReview.Next();
         Assert.AreEqual(0, ShownCount, UnrelatedLinesShownErr);
+    end;
+
+    [Test]
+    procedure T217_SalesPriceLinesFromCustomerCardShowCustomerInCaption()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        CustomerCard: TestPage "Customer Card";
+        PriceListLineReview: TestPage "Price List Line Review";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647261] Sales Price lines opened from a Customer Card identify the customer in the page caption.
+        Initialize(true);
+
+        // [GIVEN] Customer "C" with a sales price for Item "I".
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        LibraryPriceCalculation.CreatePriceHeader(
+            PriceListHeader, "Price Type"::Sale, "Price Source Type"::Customer, Customer."No.");
+        LibraryPriceCalculation.CreatePriceListLine(
+            PriceListLine, PriceListHeader, "Price Amount Type"::Price, "Price Asset Type"::Item, Item."No.");
+
+        // [GIVEN] Open Customer Card for Customer "C".
+        CustomerCard.OpenEdit();
+        CustomerCard.Filter.SetFilter("No.", Customer."No.");
+
+        // [WHEN] Run action "Sales Prices".
+        PriceListLineReview.Trap();
+        CustomerCard.PriceLines.Invoke();
+
+        // [THEN] The page caption identifies Customer "C".
+        Assert.AreEqual(
+            StrSubstNo(CustomerPriceListCaptionTxt, Customer."No.", Customer.Name),
+            PriceListLineReview.Caption, UnexpectedPageCaptionErr);
+    end;
+
+    [Test]
+    procedure T218_PurchPriceLinesFromVendorCardShowVendorInCaption()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        VendorCard: TestPage "Vendor Card";
+        PriceListLineReview: TestPage "Price List Line Review";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647261] Purchase Price lines opened from a Vendor Card identify the vendor in the page caption.
+        Initialize(true);
+
+        // [GIVEN] Vendor "V" with a purchase price for Item "I".
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPriceCalculation.CreatePriceHeader(
+            PriceListHeader, "Price Type"::Purchase, "Price Source Type"::Vendor, Vendor."No.");
+        LibraryPriceCalculation.CreatePriceListLine(
+            PriceListLine, PriceListHeader, "Price Amount Type"::Price, "Price Asset Type"::Item, Item."No.");
+
+        // [GIVEN] Open Vendor Card for Vendor "V".
+        VendorCard.OpenEdit();
+        VendorCard.Filter.SetFilter("No.", Vendor."No.");
+
+        // [WHEN] Run action "Purchase Prices".
+        PriceListLineReview.Trap();
+        VendorCard.PriceLines.Invoke();
+
+        // [THEN] The page caption identifies Vendor "V".
+        Assert.AreEqual(
+            StrSubstNo(VendorPriceListCaptionTxt, Vendor."No.", Vendor.Name),
+            PriceListLineReview.Caption, UnexpectedPageCaptionErr);
     end;
 
     local procedure Initialize(Enable: Boolean)


### PR DESCRIPTION
[Bug 647261](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647261): [Main][ALL-E] Sales Price from customer card and Purcase Price from vendor card is showing "All Customers/All Vendors" as header instead of the specific customer/vendor information

Fixes [AB#647261](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647261)


Issue:
When opening Sales Prices from a Customer Card or Purchase Prices from a Vendor Card, the Price List Lines page displayed All Customers or All Vendors in its caption instead of the selected customer or vendor.

Cause:
The universal price source was appended after the specific customer or vendor in the Price Source List. The page builds its caption from the last source in that list, so the universal source incorrectly became the caption source.

Solution:
Add the universal source before the related and specific sources. This preserves universal price-line filtering while leaving the selected customer or vendor as the final source used for the caption. Separate customer and vendor regression tests were added to verify both captions.

