### PR TITLE
[Extensibility][SubscriptionBilling] Make procedures necessary for custom Usage Data Connector externally accessible

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/CreateUsageDataBilling.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Codeunits/CreateUsageDataBilling.Codeunit.al
@@ -36,7 +36,7 @@ codeunit 8023 "Create Usage Data Billing"
         UsageDataProcessing.CreateBillingData(UsageDataImport);
     end;
 
-    internal procedure CollectServiceCommitments(var TempServiceCommitment: Record "Subscription Line" temporary; ServiceObjectNo: Code[20]; SubscriptionEndDate: Date)
+    procedure CollectServiceCommitments(var TempServiceCommitment: Record "Subscription Line" temporary; ServiceObjectNo: Code[20]; SubscriptionEndDate: Date)
     begin
         FillTempServiceCommitment(TempServiceCommitment, ServiceObjectNo, SubscriptionEndDate);
         OnAfterCollectServiceCommitments(TempServiceCommitment, ServiceObjectNo, SubscriptionEndDate);

--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Tables/UsageDataBilling.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Tables/UsageDataBilling.Table.al
@@ -363,7 +363,7 @@ table 8006 "Usage Data Billing"
         ServiceCommitment.Modify();
     end;
 
-    internal procedure SetReason(ReasonText: Text)
+    procedure SetReason(ReasonText: Text)
     var
         TextManagement: Codeunit "Text Management";
         RRef: RecordRef;
@@ -379,7 +379,7 @@ table 8006 "Usage Data Billing"
         end;
     end;
 
-    internal procedure InitFrom(UsageDataImportEntryNo: Integer; SubscriptionHeaderNo: Code[20]; ProductID: Text[80]; ProductName: Text[100];
+    procedure InitFrom(UsageDataImportEntryNo: Integer; SubscriptionHeaderNo: Code[20]; ProductID: Text[80]; ProductName: Text[100];
         BillingPeriodStartDate: Date; BillingPeriodEndDate: Date; NewQuantity: Decimal)
     begin
         Rec.Init();
@@ -394,7 +394,7 @@ table 8006 "Usage Data Billing"
         Rec.UpdateChargedPeriod();
     end;
 
-    internal procedure AlignContractCurrency(TempSubscriptionLine: Record "Subscription Line"; ImportCurrencyCode: Code[10])
+    procedure AlignContractCurrency(TempSubscriptionLine: Record "Subscription Line"; ImportCurrencyCode: Code[10])
     var
         AllowDiffCurrency: Boolean;
         CurrencyMismatchErr: Text;
@@ -437,7 +437,7 @@ table 8006 "Usage Data Billing"
         CurrencyMismatchErr := StrSubstNo(CustomerContractCurrencyMismatchErr, ContractNo, CustomerContract."Currency Code", ImportCurrencyCode);
     end;
 
-    internal procedure CalculateAmounts(UsageDataSupplier: Record "Usage Data Supplier"; ImportCurrencyCode: Code[10]; NewUnitCost: Decimal; NewCostAmount: Decimal; NewUnitPrice: Decimal; NewAmount: Decimal)
+    procedure CalculateAmounts(UsageDataSupplier: Record "Usage Data Supplier"; ImportCurrencyCode: Code[10]; NewUnitCost: Decimal; NewCostAmount: Decimal; NewUnitPrice: Decimal; NewAmount: Decimal)
     var
         Currency: Record Currency;
         NeedsCurrencyConversion: Boolean;
@@ -769,7 +769,7 @@ table 8006 "Usage Data Billing"
         exit(not Rec.IsEmpty());
     end;
 
-    internal procedure UpdateRebilling()
+    procedure UpdateRebilling()
     var
         UsageDataBillingMetadata: Record "Usage Data Billing Metadata";
     begin
@@ -781,7 +781,7 @@ table 8006 "Usage Data Billing"
         Rec.Rebilling := not UsageDataBillingMetadata.IsEmpty;
     end;
 
-    internal procedure InsertMetadata()
+    procedure InsertMetadata()
     var
         UsageDataBillingMetadata: Record "Usage Data Billing Metadata";
     begin


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
When one wants to implement a custom Usage Data Connector using the interface "Usage Data Processing", one needs to create an implementation of the procedure CreateBillingData(var UsageDataImport: Record "Usage Data Import"). However, all necessary procedures for creating billing data are internal and not accessible to a dependent app.

### What changed
Removed the internal keyword from the following procedures in `UsageDataBilling.Table.al` :
- `internal procedure SetReason(ReasonText: Text)`
- `internal procedure InitFrom(UsageDataImportEntryNo: Integer; SubscriptionHeaderNo: Code[20]; ProductID: Text[80]; ProductName: Text[100]; BillingPeriodStartDate: Date; BillingPeriodEndDate: Date; NewQuantity: Decimal)`
- `internal procedure AlignContractCurrency(TempSubscriptionLine: Record "Subscription Line"; ImportCurrencyCode: Code[10])`
- `internal procedure CalculateAmounts(UsageDataSupplier: Record "Usage Data Supplier"; ImportCurrencyCode: Code[10]; NewUnitCost: Decimal; NewCostAmount: Decimal; NewUnitPrice: Decimal; NewAmount: Decimal)`
- `internal procedure UpdateRebilling()`
- `internal procedure InsertMetadata()`

As well as the following procedure in `CreateUsageDataBilling.Codeunit.al`
- `procedure CollectServiceCommitments(var TempServiceCommitment: Record "Subscription Line" temporary; ServiceObjectNo: Code[20]; SubscriptionEndDate: Date)`

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #10019

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** 

- Validated that the above extensibility changes are necessary and sufficient for creating a custom connector in a dependent extension
- No Tests added or updated because functionality of the Subscription Billing App is unchanged only a few procedure are now externally accessible.

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility
Very low. No impact on existing functionality using the generic connector.
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

