### PR TITLE
Route Expense Agent ownership to Finance

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -456,17 +456,20 @@
 /tools/ @microsoft/d365-bc-integrations
 /src/Layers/.config/ @microsoft/d365-bc-finance-1
 
-# TIER 7 - reconciliation pending (NOT generated).
-# The triage agent routes these to SCM, today's CODEOWNERS routes them to
-# Finance. Current ownership is preserved here so this change takes nothing away
-# from a team. Settle it in ownership-rules.js in BCAppsTriage, then regenerate
-# and delete this tier.
+# TIER 7 - documented review overrides (NOT generated).
+# The triage agent routes PowerBIReports and ServiceManagement to SCM, while
+# today's CODEOWNERS routes them to Finance. Current ownership is preserved here
+# so this change takes nothing away from a team. Settle those two mappings in
+# ownership-rules.js in BCAppsTriage, then regenerate.
 #   PowerBIReports per-area report folders: triage resolves App/<Area> to the
 #     area owner (e.g. App/Sales -> SCM); CODEOWNERS has owned the whole app as
 #     Finance since #9752.
 #   ServiceManagement: appFolderRules says SCM; CODEOWNERS says Finance.
+#   ExpenseAgent: review ownership follows the Finance app team, matching the
+#     other expense-management apps. Its ownership label is managed separately.
 /src/Apps/W1/PowerBIReports @microsoft/d365-bc-finance-1
 /src/Apps/W1/ServiceManagement @microsoft/d365-bc-finance-1
+/src/Apps/W1/ExpenseAgent/ @microsoft/d365-bc-finance-1
 
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -150,6 +150,7 @@
 /src/Apps/W1/EU3PartyTradePurchase/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/ExcelReports/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/ExciseTaxes/ @microsoft/d365-bc-finance-1
+/src/Apps/W1/ExpenseAgent/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/ExpenseWithholdingTax/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/FieldServiceIntegration/ @microsoft/d365-bc-scm
 /src/Apps/W1/ImageAnalysis/ @microsoft/d365-bc-scm
@@ -456,20 +457,17 @@
 /tools/ @microsoft/d365-bc-integrations
 /src/Layers/.config/ @microsoft/d365-bc-finance-1
 
-# TIER 7 - documented review overrides (NOT generated).
-# The triage agent routes PowerBIReports and ServiceManagement to SCM, while
-# today's CODEOWNERS routes them to Finance. Current ownership is preserved here
-# so this change takes nothing away from a team. Settle those two mappings in
-# ownership-rules.js in BCAppsTriage, then regenerate.
+# TIER 7 - reconciliation pending (NOT generated).
+# The triage agent routes these to SCM, today's CODEOWNERS routes them to
+# Finance. Current ownership is preserved here so this change takes nothing away
+# from a team. Settle it in ownership-rules.js in BCAppsTriage, then regenerate
+# and delete this tier.
 #   PowerBIReports per-area report folders: triage resolves App/<Area> to the
 #     area owner (e.g. App/Sales -> SCM); CODEOWNERS has owned the whole app as
 #     Finance since #9752.
 #   ServiceManagement: appFolderRules says SCM; CODEOWNERS says Finance.
-#   ExpenseAgent: review ownership follows the Finance app team, matching the
-#     other expense-management apps. Its ownership label is managed separately.
 /src/Apps/W1/PowerBIReports @microsoft/d365-bc-finance-1
 /src/Apps/W1/ServiceManagement @microsoft/d365-bc-finance-1
-/src/Apps/W1/ExpenseAgent/ @microsoft/d365-bc-finance-1
 
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets

--- a/docs/process/ReviewRouting.md
+++ b/docs/process/ReviewRouting.md
@@ -52,13 +52,14 @@ classify issues and pull requests:
 - `microsoft/BCAppsTriage` → `plugins/triage/skills/triage/scripts/ownership/ownership-resolver.js`
 
 which are in turn seeded from the Business Central Ownership Matrix. That agent already decides which
-team owns an issue or pull request; deriving `CODEOWNERS` from the same data keeps the team label
-and requested reviewer aligned by default. Explicit review-only exceptions are documented below.
+team owns an issue or pull request; deriving `CODEOWNERS` from the same data means **the team label
+on an item and the reviewer GitHub requests cannot disagree**.
 
 Previously this file was going to be hand-derived from the ownership matrix separately. That was a
 mistake: a second, hand-maintained copy of the same mapping drifts from the first one immediately.
 It also got several areas wrong — most of `src/Layers/*` and the country localization trees were not
-routed at all, and `Intrastat`, `Projects` and `Invoicing` were assigned to the wrong team.
+routed at all, and `ExpenseAgent`, `Intrastat`, `Projects` and `Invoicing` were assigned to the wrong
+team.
 
 ### Structure
 
@@ -119,7 +120,7 @@ Exact one-to-one agreement is neither expected nor desirable, for two structural
   namespace, and only then path. `CODEOWNERS` can only ever see the path, so the two must diverge
   wherever a file's namespace or object id disagrees with its folder.
 
-### Documented exceptions and disagreements
+### Two disagreements left unresolved on purpose
 
 The triage rules and today's `CODEOWNERS` genuinely disagree in two places. Taking ownership away
 from a team is not something this change should do silently, so current ownership is preserved in
@@ -131,12 +132,6 @@ tier 7 and the disagreement is recorded instead:
 
 Both should be settled in `ownership-rules.js`, after which tier 7 disappears on the next
 regeneration.
-
-Tier 7 also contains one deliberate review-only exception:
-
-- **`ExpenseAgent`** — review requests go to the Finance app team, matching the other
-  expense-management apps. Its ownership label is managed separately and does not drive the
-  required reviewer.
 
 ### Findings for whoever maintains `ownership-rules.js`
 
@@ -172,10 +167,11 @@ Integration changes the most: it previously owned almost nothing in `CODEOWNERS`
 System Application, Business Foundation, the migration and connector apps, and every unlisted W1 app.
 
 ### Regenerating
-Edit `ownership-rules.js` in `BCAppsTriage` and regenerate. The generator reads `ownership-rules.js`
-and `ownership-resolver.js` directly, so it lives alongside them in `BCAppsTriage` rather than here.
-Do not hand-edit the generated block.
-Hand edits are lost on the next regeneration and silently diverge from issue and pull request triage.
+Edit `ownership-rules.js` in `BCAppsTriage`, add a resolver regression test, and update the generated
+block here from the same rules. The original generator is not currently checked in or run by
+automation, so the BCAppsTriage and BCApps changes must be submitted together and their path
+resolution verified explicitly. Do not change only the generated block: doing so silently diverges
+from issue and pull request triage.
 ## What still needs to change (requires an administrator)
 `CODEOWNERS` alone does not finish the job. The `Official Branches` ruleset still contains:
 

--- a/docs/process/ReviewRouting.md
+++ b/docs/process/ReviewRouting.md
@@ -52,14 +52,13 @@ classify issues and pull requests:
 - `microsoft/BCAppsTriage` → `plugins/triage/skills/triage/scripts/ownership/ownership-resolver.js`
 
 which are in turn seeded from the Business Central Ownership Matrix. That agent already decides which
-team owns an issue or pull request; deriving `CODEOWNERS` from the same data means **the team label
-on an item and the reviewer GitHub requests cannot disagree**.
+team owns an issue or pull request; deriving `CODEOWNERS` from the same data keeps the team label
+and requested reviewer aligned by default. Explicit review-only exceptions are documented below.
 
 Previously this file was going to be hand-derived from the ownership matrix separately. That was a
 mistake: a second, hand-maintained copy of the same mapping drifts from the first one immediately.
 It also got several areas wrong — most of `src/Layers/*` and the country localization trees were not
-routed at all, and `ExpenseAgent`, `Intrastat`, `Projects` and `Invoicing` were assigned to the wrong
-team.
+routed at all, and `Intrastat`, `Projects` and `Invoicing` were assigned to the wrong team.
 
 ### Structure
 
@@ -120,7 +119,7 @@ Exact one-to-one agreement is neither expected nor desirable, for two structural
   namespace, and only then path. `CODEOWNERS` can only ever see the path, so the two must diverge
   wherever a file's namespace or object id disagrees with its folder.
 
-### Two disagreements left unresolved on purpose
+### Documented exceptions and disagreements
 
 The triage rules and today's `CODEOWNERS` genuinely disagree in two places. Taking ownership away
 from a team is not something this change should do silently, so current ownership is preserved in
@@ -132,6 +131,12 @@ tier 7 and the disagreement is recorded instead:
 
 Both should be settled in `ownership-rules.js`, after which tier 7 disappears on the next
 regeneration.
+
+Tier 7 also contains one deliberate review-only exception:
+
+- **`ExpenseAgent`** — review requests go to the Finance app team, matching the other
+  expense-management apps. Its ownership label is managed separately and does not drive the
+  required reviewer.
 
 ### Findings for whoever maintains `ownership-rules.js`
 


### PR DESCRIPTION
## Summary

- add the generated Expense Agent CODEOWNERS rule for the Finance app team
- remove the earlier manual tier-7 exception
- document that regeneration is currently a paired manual process because no generator is checked in or automated

## Work item

Fixes [AB#647288](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647288)

## Issues

- This repo: closes #10387
- Sibling repo: https://github.com/microsoft/BCAppsTriage/issues/56

## Linked PRs

- Source ownership rule and regression test: https://github.com/microsoft/BCAppsTriage/pull/57

## Validation

- `git diff --check`
- verified `/src/Apps/W1/ExpenseAgent/` resolves to `@microsoft/d365-bc-finance-1` after the broader W1 Integration rule
- verified the final PR diff no longer contains the old manual tier-7 exception

