### PR TITLE
28.x: Fixes in Excel reports for Aged Accounts.

### DIFF
--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccPayableExcel.Report.al
@@ -307,7 +307,6 @@ report 4403 "EXR Aged Acc Payable Excel"
 
     local procedure InitReport()
     var
-        FirstStartDate: Date;
         WorkingEndDate: Date;
         WorkingStartDate: Date;
         i: Integer;
@@ -331,12 +330,15 @@ report 4403 "EXR Aged Acc Payable Excel"
             WorkingStartDate := CalcDate(PeriodLength, WorkingStartDate);
             WorkingEndDate := CalcDate(PeriodLength, WorkingEndDate);
         until i >= PeriodCount;
-        FirstStartDate := WorkingStartDate;
 
-        VendorAgingData.SetAutoCalcFields("Net Change (LCY)");
-        VendorAgingData.SetRange("Date Filter", FirstStartDate, EndingDate);
-        if SkipZeroBalanceVendors then
+        PeriodStarts.Add(0D);
+        PeriodEnds.Add(WorkingEndDate);
+
+        VendorAgingData.SetRange("Date Filter", 0D, EndingDate);
+        if SkipZeroBalanceVendors then begin
+            VendorAgingData.SetAutoCalcFields("Net Change (LCY)");
             VendorAgingData.SetFilter("Net Change (LCY)", '<>0');
+        end;
     end;
 
     local procedure InsertAgingData(var Vendor: Record "Vendor")
@@ -351,8 +353,6 @@ report 4403 "EXR Aged Acc Payable Excel"
         VendorLedgerEntry.SetRange("Date Filter", 0D, EndingDate);
 
         case TempEXRAgingReportBuffer."Aged By" of
-            TempEXRAgingReportBuffer."Aged By"::"Due Date":
-                VendorLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
             TempEXRAgingReportBuffer."Aged By"::"Posting Date":
                 VendorLedgerEntry.SetRange("Posting Date", EarliestPeriodStart, EndingDate);
             TempEXRAgingReportBuffer."Aged By"::"Document Date":

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgedAccountsRecExcel.Report.al
@@ -306,7 +306,6 @@ report 4402 "EXR Aged Accounts Rec Excel"
 
     local procedure InitReport()
     var
-        FirstStartDate: Date;
         WorkingEndDate: Date;
         WorkingStartDate: Date;
         i: Integer;
@@ -330,12 +329,15 @@ report 4402 "EXR Aged Accounts Rec Excel"
             WorkingStartDate := CalcDate(PeriodLength, WorkingStartDate);
             WorkingEndDate := CalcDate(PeriodLength, WorkingEndDate);
         until i >= PeriodCount;
-        FirstStartDate := WorkingStartDate;
 
-        CustomerAgingData.SetAutoCalcFields("Net Change (LCY)");
-        CustomerAgingData.SetRange("Date Filter", FirstStartDate, EndingDate);
-        if SkipZeroBalanceCustomers then
+        PeriodStarts.Add(0D);
+        PeriodEnds.Add(WorkingEndDate);
+
+        CustomerAgingData.SetRange("Date Filter", 0D, EndingDate);
+        if SkipZeroBalanceCustomers then begin
+            CustomerAgingData.SetAutoCalcFields("Net Change (LCY)");
             CustomerAgingData.SetFilter("Net Change (LCY)", '<>0');
+        end;
     end;
 
     local procedure InsertAgingData(var Customer: Record Customer)
@@ -350,8 +352,6 @@ report 4402 "EXR Aged Accounts Rec Excel"
         CustLedgerEntry.SetRange("Date Filter", 0D, EndingDate);
 
         case TempEXRAgingReportBuffer."Aged By" of
-            TempEXRAgingReportBuffer."Aged By"::"Due Date":
-                CustLedgerEntry.SetRange("Due Date", EarliestPeriodStart, EndingDate);
             TempEXRAgingReportBuffer."Aged By"::"Posting Date":
                 CustLedgerEntry.SetRange("Posting Date", EarliestPeriodStart, EndingDate);
             TempEXRAgingReportBuffer."Aged By"::"Document Date":

--- a/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgingReportBuffer.Table.al
+++ b/src/Apps/W1/ExcelReports/App/src/Financials/EXRAgingReportBuffer.Table.al
@@ -163,14 +163,7 @@ table 4401 "EXR Aging Report Buffer"
 
     internal procedure SetReportingDate()
     begin
-        case Rec."Aged By" of
-            Rec."Aged By"::"Due Date":
-                Rec."Reporting Date" := Rec."Due Date";
-            Rec."Aged By"::"Posting Date":
-                Rec."Reporting Date" := Rec."Posting Date";
-            Rec."Aged By"::"Document Date":
-                Rec."Reporting Date" := Rec."Document Date";
-        end;
+        Rec."Reporting Date" := GetAgingDate();
 
         Rec."Reporting Date Month" := Date2DMY(Rec."Reporting Date", 2);
         Rec."Reporting Date Year" := Date2DMY(Rec."Reporting Date", 3);
@@ -183,46 +176,41 @@ table 4401 "EXR Aging Report Buffer"
     end;
 
     internal procedure SetPeriodStartAndEndDate(PeriodStarts: List of [Date]; PeriodEnds: List of [Date])
+    var
+        PeriodIndex: Integer;
+    begin
+        PeriodIndex := FindPeriodIndex(GetAgingDate(), PeriodStarts);
+        if PeriodIndex = 0 then begin
+            Clear(Rec."Period Start Date");
+            Clear(Rec."Period End Date");
+            exit;
+        end;
+
+        Rec."Period Start Date" := PeriodStarts.Get(PeriodIndex);
+        Rec."Period End Date" := PeriodEnds.Get(PeriodIndex);
+    end;
+
+    local procedure GetAgingDate(): Date
     begin
         case Rec."Aged By" of
             Rec."Aged By"::"Due Date":
-                begin
-                    Rec."Period Start Date" := FindPeriodStart(Rec."Due Date", PeriodStarts);
-                    Rec."Period End Date" := FindPeriodEnd(Rec."Due Date", PeriodEnds);
-                end;
+                exit(Rec."Due Date");
             Rec."Aged By"::"Posting Date":
-                begin
-                    Rec."Period Start Date" := FindPeriodStart(Rec."Posting Date", PeriodStarts);
-                    Rec."Period End Date" := FindPeriodEnd(Rec."Posting Date", PeriodEnds);
-                end;
+                exit(Rec."Posting Date");
             Rec."Aged By"::"Document Date":
-                begin
-                    Rec."Period Start Date" := FindPeriodStart(Rec."Document Date", PeriodStarts);
-                    Rec."Period End Date" := FindPeriodEnd(Rec."Document Date", PeriodEnds);
-                end;
+                exit(Rec."Document Date");
         end;
     end;
 
-    local procedure FindPeriodStart(WhatDate: Date; PeriodStarts: List of [Date]): Date
+    local procedure FindPeriodIndex(WhatDate: Date; PeriodStarts: List of [Date]): Integer
     var
-        PossibleDate: Date;
+        Index: Integer;
     begin
-        foreach PossibleDate in PeriodStarts do
-            if WhatDate >= PossibleDate then
-                exit(PossibleDate);
+        for Index := 1 to PeriodStarts.Count() do
+            if WhatDate >= PeriodStarts.Get(Index) then
+                exit(Index);
 
-        exit(PossibleDate);
-    end;
-
-    local procedure FindPeriodEnd(WhatDate: Date; PeriodEnds: List of [Date]): Date
-    var
-        PossibleDate: Date;
-    begin
-        foreach PossibleDate in PeriodEnds do
-            if WhatDate < PossibleDate then
-                exit(PossibleDate);
-
-        exit(PossibleDate);
+        exit(0);
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
+++ b/src/Apps/W1/ExcelReports/Test/src/TrialBalanceExcelReports.Codeunit.al
@@ -906,59 +906,232 @@ codeunit 139544 "Trial Balance Excel Reports"
 
     [Test]
     [HandlerFunctions('EXRAgedAccountsRecExcelHandlerWorkdate')]
-    procedure AgedAccountsReceivableExcelReportExportsAsPerPeriodCount()
+    procedure AgedAccountsRecExcelReportIncludesNotYetDueEntries()
+    var
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+        ReportDocumentNo: Text;
+    begin
+        // [SCENARIO] Aged Accounts Receivable Excel report includes open entries that are not yet due as of the Aged As Of date.
+        InitializeAgingData();
+
+        // [GIVEN] Customer "C" with an open ledger entry posted on WorkDate and due 30 days later
+        CreateMinimalCustomer(Customer);
+        CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
+        Commit();
+
+        // [WHEN] Running the report with Aged As Of = WorkDate, Period Count = 1 and Aging by = Due Date
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
+
+        // [THEN] The entry is still exported, even though its Due Date is after the Aged As Of date
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'The not yet due entry should be exported');
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.FindCurrentRowValue('DocumentNo', Variant);
+        ReportDocumentNo := Variant;
+        Assert.AreEqual(CustLedgerEntry."Document No.", ReportDocumentNo, DocumentNoShouldMatchErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccPayableExcelHandlerWorkdate')]
+    procedure AgedAccountsPayableExcelReportIncludesNotYetDueEntries()
+    var
+        Vendor: Record Vendor;
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+        ReportDocumentNo: Text;
+    begin
+        // [SCENARIO] Aged Accounts Payable Excel report includes open entries that are not yet due as of the Aged As Of date.
+        InitializeAgingData();
+
+        // [GIVEN] Vendor "V" with an open ledger entry posted on WorkDate and due 30 days later
+        CreateMinimalVendor(Vendor);
+        CreateVendorLedgerEntry(VendorLedgerEntry, Vendor."No.", "Gen. Journal Document Type"::Invoice);
+        Commit();
+
+        // [WHEN] Running the report with Aged As Of = WorkDate, Period Count = 1 and Aging by = Due Date
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Acc Payable Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Acc Payable Excel", Variant, RequestPageXml);
+
+        // [THEN] The entry is still exported, even though its Due Date is after the Aged As Of date
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'The not yet due entry should be exported');
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.FindCurrentRowValue('DocumentNo', Variant);
+        ReportDocumentNo := Variant;
+        Assert.AreEqual(VendorLedgerEntry."Document No.", ReportDocumentNo, DocumentNoShouldMatchErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccountsRecPostingDatePeriodCountHandler')]
+    procedure AgedAccountsRecExcelReportPutsOlderEntriesInCatchAllBucket()
+    var
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+        PeriodEndText: Text;
+        PeriodEnd: Date;
+    begin
+        // [SCENARIO] Entries older than the earliest period are exported into the open ended catch all bucket.
+        InitializeAgingData();
+
+        // [GIVEN] Customer "C" with an open ledger entry posted two months before the Aged As Of date
+        CreateMinimalCustomer(Customer);
+        CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
+        MoveCustLedgerEntryToDate(CustLedgerEntry, CalcDate('<-2M>', WorkDate()));
+        Commit();
+
+        // [WHEN] Running the report with Aging By = Posting Date, Aged As Of = WorkDate and Period Count = 1
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
+
+        // [THEN] The entry is exported in the catch all bucket, which ends where the oldest requested period starts
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'The entry older than the earliest period should be exported');
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.FindCurrentRowValue('PeriodEnd', Variant);
+        PeriodEndText := Variant;
+        Evaluate(PeriodEnd, PeriodEndText);
+        Assert.AreEqual(CalcDate('<-1M>', WorkDate()), PeriodEnd, 'The catch all bucket should end where the oldest requested period starts');
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccPayablePostingDatePeriodCountHandler')]
+    procedure AgedAccountsPayableExcelReportPutsOlderEntriesInCatchAllBucket()
+    var
+        Vendor: Record Vendor;
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+        PeriodEndText: Text;
+        PeriodEnd: Date;
+    begin
+        // [SCENARIO] Entries older than the earliest period are exported into the open ended catch all bucket.
+        InitializeAgingData();
+
+        // [GIVEN] Vendor "V" with an open ledger entry posted two months before the Aged As Of date
+        CreateMinimalVendor(Vendor);
+        CreateVendorLedgerEntry(VendorLedgerEntry, Vendor."No.", "Gen. Journal Document Type"::Invoice);
+        MoveVendorLedgerEntryToDate(VendorLedgerEntry, CalcDate('<-2M>', WorkDate()));
+        Commit();
+
+        // [WHEN] Running the report with Aging By = Posting Date, Aged As Of = WorkDate and Period Count = 1
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Acc Payable Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Acc Payable Excel", Variant, RequestPageXml);
+
+        // [THEN] The entry is exported in the catch all bucket, which ends where the oldest requested period starts
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'The entry older than the earliest period should be exported');
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.FindCurrentRowValue('PeriodEnd', Variant);
+        PeriodEndText := Variant;
+        Evaluate(PeriodEnd, PeriodEndText);
+        Assert.AreEqual(CalcDate('<-1M>', WorkDate()), PeriodEnd, 'The catch all bucket should end where the oldest requested period starts');
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccountsRecPostingDateThreePeriodsHandler')]
+    procedure AgedAccountsRecExcelPeriodStartAndEndComeFromSameBucket()
+    var
+        Customer: Record Customer;
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        Variant: Variant;
+        RequestPageXml: Text;
+        PeriodStartText: Text;
+        PeriodEndText: Text;
+        PeriodStart: Date;
+        PeriodEnd: Date;
+        FirstPeriodStart: Date;
+        SecondPeriodStart: Date;
+    begin
+        // [SCENARIO] Period Start Date and Period End Date are always read from the same bucket.
+        InitializeAgingData();
+
+        // [GIVEN] The period boundaries the report builds for Period Length = -1M and Aged As Of = WorkDate
+        FirstPeriodStart := CalcDate('<-1M>', WorkDate());
+        SecondPeriodStart := CalcDate('<-1M>', FirstPeriodStart);
+
+        // [GIVEN] Customer "C" with an open ledger entry posted one day before the newest period starts
+        CreateMinimalCustomer(Customer);
+        CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
+        MoveCustLedgerEntryToDate(CustLedgerEntry, FirstPeriodStart - 1);
+        Commit();
+
+        // [WHEN] Running the report with Aging By = Posting Date, Aged As Of = WorkDate and Period Count = 3
+        RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
+        LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
+
+        // [THEN] The entry is bucketed into the second period, and its end is that period's end, not the newest one
+        LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'One aging entry should be exported');
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.FindCurrentRowValue('PeriodStart', Variant);
+        PeriodStartText := Variant;
+        Evaluate(PeriodStart, PeriodStartText);
+        Assert.AreEqual(SecondPeriodStart, PeriodStart, 'The entry should start in the second period');
+        LibraryReportDataset.FindCurrentRowValue('PeriodEnd', Variant);
+        PeriodEndText := Variant;
+        Evaluate(PeriodEnd, PeriodEndText);
+        Assert.AreEqual(FirstPeriodStart, PeriodEnd, 'The period end should belong to the same bucket as the period start');
+    end;
+
+    [Test]
+    [HandlerFunctions('EXRAgedAccountsRecSkipZeroBalanceHandler')]
+    procedure AgedAccountsRecExcelSkipZeroBalanceKeepsCustomerWithOldOpenEntry()
     var
         Customer: Record Customer;
         CustLedgerEntry: Record "Cust. Ledger Entry";
         Variant: Variant;
         RequestPageXml: Text;
     begin
-        // [FEATURE] [AI test]
-        // [SCENARIO 640052] Aged Accounts Receivable Excel report exports as per Period count.
+        // [SCENARIO] Skip Customers with Zero Balance compares the balance as of the Aged As Of date, not the net change over the reported periods, so a customer whose only open entry predates those periods is still reported.
         InitializeAgingData();
 
-        // [GIVEN] Customer "C" with an open customer ledger entry of type Invoice
-        // Create customer directly to avoid VAT posting setup requirements in some localizations
+        // [GIVEN] Customer "C" whose only open ledger entry was posted six months before the Aged As Of date
         CreateMinimalCustomer(Customer);
         CreateCustLedgerEntry(CustLedgerEntry, Customer."No.", "Gen. Journal Document Type"::Invoice);
+        MoveCustLedgerEntryToDate(CustLedgerEntry, CalcDate('<-6M>', WorkDate()));
         Commit();
 
-        // [WHEN] Running the Aged Accounts Receivable Excel report
+        // [WHEN] Running the report with Skip Customers with Zero Balance enabled and Period Count = 1
         RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Accounts Rec Excel", RequestPageXml);
         LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Accounts Rec Excel", Variant, RequestPageXml);
 
-        // [THEN] The exported data does not exist.
+        // [THEN] The customer is not skipped, because the balance as of the Aged As Of date is not zero
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
-        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'The customer with an outstanding balance should not be skipped');
     end;
 
     [Test]
-    [HandlerFunctions('EXRAgedAccPayablePostingDatePeriodCountHandler')]
-    procedure AgedAccountsPayableExcelReportPostingDateRespectsPeriodCount()
+    [HandlerFunctions('EXRAgedAccPayableSkipZeroBalanceHandler')]
+    procedure AgedAccountsPayableExcelSkipZeroBalanceKeepsVendorWithOldOpenEntry()
     var
         Vendor: Record Vendor;
         VendorLedgerEntry: Record "Vendor Ledger Entry";
         Variant: Variant;
         RequestPageXml: Text;
     begin
-        // [FEATURE] [AI test]
-        // [SCENARIO 640052] Aged Accounts Payable Excel report, when Aging by = Posting Date, respects Period Count.
+        // [SCENARIO] Skip Vendors with Zero Balance compares the balance as of the Aged As Of date, not the net change over the reported periods.
         InitializeAgingData();
 
-        // [GIVEN] Vendor "V" with an open vendor ledger entry whose Posting Date is before the earliest selected period
+        // [GIVEN] Vendor "V" whose only open ledger entry was posted six months before the Aged As Of date
         CreateMinimalVendor(Vendor);
         CreateVendorLedgerEntry(VendorLedgerEntry, Vendor."No.", "Gen. Journal Document Type"::Invoice);
-        VendorLedgerEntry."Posting Date" := CalcDate('<-2M>', WorkDate());
-        VendorLedgerEntry.Modify();
+        MoveVendorLedgerEntryToDate(VendorLedgerEntry, CalcDate('<-6M>', WorkDate()));
         Commit();
 
-        // [WHEN] Running the Aged Accounts Payable Excel report with Aging By = Posting Date and Period Count = 1
+        // [WHEN] Running the report with Skip Vendors with Zero Balance enabled and Period Count = 1
         RequestPageXml := Report.RunRequestPage(Report::"EXR Aged Acc Payable Excel", RequestPageXml);
         LibraryReportDataset.RunReportAndLoad(Report::"EXR Aged Acc Payable Excel", Variant, RequestPageXml);
 
-        // [THEN] The exported data does not include entries whose Posting Date is outside the selected period
+        // [THEN] The vendor is not skipped, because the balance as of the Aged As Of date is not zero
         LibraryReportDataset.SetXmlNodeList('DataItem[@name="AgingData"]');
-        Assert.AreEqual(0, LibraryReportDataset.RowCount(), 'No aging entry should be exported');
+        Assert.AreEqual(1, LibraryReportDataset.RowCount(), 'The vendor with an outstanding balance should not be skipped');
     end;
 
     local procedure CreateSampleBusinessUnits(HowMany: Integer)
@@ -1228,6 +1401,32 @@ codeunit 139544 "Trial Balance Excel Reports"
         DetailedCustLedgEntry.Insert();
     end;
 
+    local procedure MoveCustLedgerEntryToDate(var CustLedgerEntry: Record "Cust. Ledger Entry"; NewPostingDate: Date)
+    var
+        DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry";
+    begin
+        CustLedgerEntry."Posting Date" := NewPostingDate;
+        CustLedgerEntry."Document Date" := NewPostingDate;
+        CustLedgerEntry."Due Date" := NewPostingDate + 30;
+        CustLedgerEntry.Modify();
+
+        DetailedCustLedgEntry.SetRange("Cust. Ledger Entry No.", CustLedgerEntry."Entry No.");
+        DetailedCustLedgEntry.ModifyAll("Posting Date", NewPostingDate);
+    end;
+
+    local procedure MoveVendorLedgerEntryToDate(var VendorLedgerEntry: Record "Vendor Ledger Entry"; NewPostingDate: Date)
+    var
+        DetailedVendorLedgEntry: Record "Detailed Vendor Ledg. Entry";
+    begin
+        VendorLedgerEntry."Posting Date" := NewPostingDate;
+        VendorLedgerEntry."Document Date" := NewPostingDate;
+        VendorLedgerEntry."Due Date" := NewPostingDate + 30;
+        VendorLedgerEntry.Modify();
+
+        DetailedVendorLedgEntry.SetRange("Vendor Ledger Entry No.", VendorLedgerEntry."Entry No.");
+        DetailedVendorLedgEntry.ModifyAll("Posting Date", NewPostingDate);
+    end;
+
     [RequestPageHandler]
     procedure EXRTrialBalanceExcelHandler(var EXRTrialBalanceExcel: TestRequestPage "EXR Trial Balance Excel")
     begin
@@ -1299,6 +1498,25 @@ codeunit 139544 "Trial Balance Excel Reports"
     procedure EXRAgedAccountsRecExcelHandlerWorkdate(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
     begin
         EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.AgingbyOption.SetValue('Due Date');
+        EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccountsRecExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccPayableExcelHandlerWorkdate(var EXRAgedAccPayableExcel: TestRequestPage "EXR Aged Acc Payable Excel")
+    begin
+        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccPayableExcel.AgingbyOption.SetValue('Due Date');
+        EXRAgedAccPayableExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccPayableExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccountsRecPostingDatePeriodCountHandler(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
+    begin
+        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.AgingbyOption.SetValue('Posting Date');
         EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
         EXRAgedAccountsRecExcel.OK().Invoke();
     end;
@@ -1309,6 +1527,35 @@ codeunit 139544 "Trial Balance Excel Reports"
         EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
         EXRAgedAccPayableExcel.AgingbyOption.SetValue('Posting Date');
         EXRAgedAccPayableExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccPayableExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccountsRecPostingDateThreePeriodsHandler(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
+    begin
+        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.AgingbyOption.SetValue('Posting Date');
+        EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(3);
+        EXRAgedAccountsRecExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccountsRecSkipZeroBalanceHandler(var EXRAgedAccountsRecExcel: TestRequestPage "EXR Aged Accounts Rec Excel")
+    begin
+        EXRAgedAccountsRecExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccountsRecExcel.AgingbyOption.SetValue('Due Date');
+        EXRAgedAccountsRecExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccountsRecExcel."Skip Zero Balance Customers".SetValue(true);
+        EXRAgedAccountsRecExcel.OK().Invoke();
+    end;
+
+    [RequestPageHandler]
+    procedure EXRAgedAccPayableSkipZeroBalanceHandler(var EXRAgedAccPayableExcel: TestRequestPage "EXR Aged Acc Payable Excel")
+    begin
+        EXRAgedAccPayableExcel.AgedAsOfOption.SetValue(WorkDate());
+        EXRAgedAccPayableExcel.AgingbyOption.SetValue('Due Date');
+        EXRAgedAccPayableExcel.PeriodCountOption.SetValue(1);
+        EXRAgedAccPayableExcel."Skip Zero Balance Vendors".SetValue(true);
         EXRAgedAccPayableExcel.OK().Invoke();
     end;
 


### PR DESCRIPTION
Backport of #10412 to `releases/28.x`.

Both the receivables and payables reports had the following problems:

- The aged buckets were not covering the whole history for a customer, only bounded to the end date supplied and the starting date according to the number of periods. Therefore a customer that historically had a debt that is before the inspected period, would not show up.
    - A new bucket from `0D` to the next date is added
    - The filtering for skipping customers/vendors without due balance is considering all the history, not only those that didn't have activity on the period (this is in line with the legacy report 120)
- The logic to get the bucket that a given date belongs to was wrong for the ending dates, the list had entries sorted descending, hence the first comparison would always win, resulting in weird period ends.
    - Instead we keep the same computation approach for the start date, but return an index; since the index corresponds to the ending period, we retrieve the corresponding one.
- Due date filter was removed: a customer as of a given date (say 19th Aug 2016) that has some balance due posted in the 17th but not yet due until the 19th of Sept, should appear on the report, the customer owes something, even if not yet in effect. This is in agreement with legacy report 120, but in contrast to that one, we don't put these entries under a special bucket for "not yet due".

Xlsx was not changed, but I verified the new bucket with 0D renders correctly.

Fixes [AB#647305](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647305)





