### PR TITLE
Ruleset hardening: promote AS0052 (manifest url) from Warning to Error

### DIFF
--- a/src/Apps/W1/BasicExperience/app/app.json
+++ b/src/Apps/W1/BasicExperience/app/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2130900",
   "help": "https://go.microsoft.com/fwlink/?linkid=2130800",
-  "url": "https://go.microsoft.com/fwlink/?LinkId=",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "contextSensitiveHelpUrl": "https://AL16.com/help/",
   "logo": "logo/ExtensionLogo.png",
   "screenshots": [],

--- a/src/Apps/W1/BasicExperience/test/app.json
+++ b/src/Apps/W1/BasicExperience/test/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=",
   "help": "https://go.microsoft.com/fwlink/?linkid=",
-  "url": "https://go.microsoft.com/fwlink/?LinkId=",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "contextSensitiveHelpUrl": "https://AL16.com/help/",
   "logo": "logo/ExtensionLogo.png",
   "dependencies": [

--- a/src/DemoTool/app.json
+++ b/src/DemoTool/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "logo": "",
   "dependencies": [],
   "screenshots": [],

--- a/src/Layers/BE/Tests/Local/app.json
+++ b/src/Layers/BE/Tests/Local/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/CZ/DemoTool/app.json
+++ b/src/Layers/CZ/DemoTool/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "target": "OnPrem",
   "dependencies": [
     {

--- a/src/Layers/IN/DemoTool/app.json
+++ b/src/Layers/IN/DemoTool/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "target": "OnPrem",
   "dependencies": [
     {

--- a/src/Layers/MX/Tests/Local/app.json
+++ b/src/Layers/MX/Tests/Local/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/SE/DemoTool/app.json
+++ b/src/Layers/SE/DemoTool/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "target": "OnPrem",
   "dependencies": [
     {

--- a/src/Layers/W1/AlCosting/app.json
+++ b/src/Layers/W1/AlCosting/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/DemoTool/app.json
+++ b/src/Layers/W1/DemoTool/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "target": "OnPrem",
   "dependencies": [],
   "resourceExposurePolicy": {

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/app.json
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "e7320ebb-08b3-4406-b1ec-b4927d3e280b",

--- a/src/Layers/W1/Tests/Azure AI/app.json
+++ b/src/Layers/W1/Tests/Azure AI/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "application": "29.0.0.0",
   "dependencies": [
     {

--- a/src/Layers/W1/Tests/Bank/app.json
+++ b/src/Layers/W1/Tests/Bank/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/CRM integration/app.json
+++ b/src/Layers/W1/Tests/CRM integration/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Cash Flow/app.json
+++ b/src/Layers/W1/Tests/Cash Flow/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Cost Accounting/app.json
+++ b/src/Layers/W1/Tests/Cost Accounting/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Data Exchange/app.json
+++ b/src/Layers/W1/Tests/Data Exchange/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Dimension/app.json
+++ b/src/Layers/W1/Tests/Dimension/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/DotNet-Internal/app.json
+++ b/src/Layers/W1/Tests/DotNet-Internal/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/ERM-Application/app.json
+++ b/src/Layers/W1/Tests/ERM-Application/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/ERM-Finance/app.json
+++ b/src/Layers/W1/Tests/ERM-Finance/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/ERM-Purchase/app.json
+++ b/src/Layers/W1/Tests/ERM-Purchase/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/ERM-Sales/app.json
+++ b/src/Layers/W1/Tests/ERM-Sales/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/ERM/app.json
+++ b/src/Layers/W1/Tests/ERM/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Fixed Asset/app.json
+++ b/src/Layers/W1/Tests/Fixed Asset/app.json
@@ -31,5 +31,6 @@
     "includeSourceInSymbolFile": true
   },
   "application": "29.0.0.0",
-  "brief": "Tests-Fixed Asset (W1)"
+  "brief": "Tests-Fixed Asset (W1)",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
 }

--- a/src/Layers/W1/Tests/Fixed Asset/app.json
+++ b/src/Layers/W1/Tests/Fixed Asset/app.json
@@ -32,5 +32,5 @@
   },
   "application": "29.0.0.0",
   "brief": "Tests-Fixed Asset (W1)",
-  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011"
 }

--- a/src/Layers/W1/Tests/General Journal/app.json
+++ b/src/Layers/W1/Tests/General Journal/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Graph/app.json
+++ b/src/Layers/W1/Tests/Graph/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",

--- a/src/Layers/W1/Tests/Integration-Internal/app.json
+++ b/src/Layers/W1/Tests/Integration-Internal/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",

--- a/src/Layers/W1/Tests/Integration/app.json
+++ b/src/Layers/W1/Tests/Integration/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "9856ae4f-d1a7-46ef-89bb-6ef056398228",

--- a/src/Layers/W1/Tests/Job/app.json
+++ b/src/Layers/W1/Tests/Job/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Local/app.json
+++ b/src/Layers/W1/Tests/Local/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/MOCKSERVICETESTS-Internal/app.json
+++ b/src/Layers/W1/Tests/MOCKSERVICETESTS-Internal/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Marketing/app.json
+++ b/src/Layers/W1/Tests/Marketing/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Misc/app.json
+++ b/src/Layers/W1/Tests/Misc/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Monitor Sensitive Fields/app.json
+++ b/src/Layers/W1/Tests/Monitor Sensitive Fields/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "application": "29.0.0.0",
   "dependencies": [
     {

--- a/src/Layers/W1/Tests/NewObjectTests-Internal/app.json
+++ b/src/Layers/W1/Tests/NewObjectTests-Internal/app.json
@@ -2,6 +2,7 @@
   "id": "c75079ef-aa88-45c3-a2e0-e7df91ae2ff9",
   "name": "Tests-NewObjects-Internal",
   "description": "This test solution contains all tests that are checking if the properties or permissions are set correctly for new objects. It is an internal test solution that is aligned to our processes. If you need to add more tests that are checking if the AL objects are setup in the correct way, use this solution so we have all tests grouped and we do not spend additional time in the gate.",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",

--- a/src/Layers/W1/Tests/Permissions/app.json
+++ b/src/Layers/W1/Tests/Permissions/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Physical Inventory/app.json
+++ b/src/Layers/W1/Tests/Physical Inventory/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Prepayment/app.json
+++ b/src/Layers/W1/Tests/Prepayment/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Rapid Start/app.json
+++ b/src/Layers/W1/Tests/Rapid Start/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Report/app.json
+++ b/src/Layers/W1/Tests/Report/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Resource/app.json
+++ b/src/Layers/W1/Tests/Resource/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Reverse/app.json
+++ b/src/Layers/W1/Tests/Reverse/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/SCM-Service/app.json
+++ b/src/Layers/W1/Tests/SCM-Service/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/SINGLESERVER-Internal/app.json
+++ b/src/Layers/W1/Tests/SINGLESERVER-Internal/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/SINGLESERVER/app.json
+++ b/src/Layers/W1/Tests/SINGLESERVER/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/SMB/app.json
+++ b/src/Layers/W1/Tests/SMB/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/TestLibraries/app.json
+++ b/src/Layers/W1/Tests/TestLibraries/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "propagateDependencies": true,
   "dependencies": [
     {

--- a/src/Layers/W1/Tests/TestRunner-Internal/app.json
+++ b/src/Layers/W1/Tests/TestRunner-Internal/app.json
@@ -25,5 +25,6 @@
     "includeSourceInSymbolFile": true
   },
   "brief": "TestRunner-Internal (W1)",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "application": "29.0.0.0"
 }

--- a/src/Layers/W1/Tests/Upgrade/app.json
+++ b/src/Layers/W1/Tests/Upgrade/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "dd0be2ea-f733-4d65-bb34-a28f4624fb14",

--- a/src/Layers/W1/Tests/User/app.json
+++ b/src/Layers/W1/Tests/User/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/VAT/app.json
+++ b/src/Layers/W1/Tests/VAT/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/Layers/W1/Tests/Workflow/app.json
+++ b/src/Layers/W1/Tests/Workflow/app.json
@@ -4,6 +4,7 @@
   "publisher": "Microsoft",
   "version": "29.0.0.0",
   "platform": "29.0.0.0",
+  "url": "https://go.microsoft.com/fwlink/?LinkId=724011",
   "dependencies": [
     {
       "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",

--- a/src/System Application/App/Retention Policy/app.json
+++ b/src/System Application/App/Retention Policy/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test Library/DotNet Aliases/app.json
+++ b/src/System Application/Test Library/DotNet Aliases/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [],
   "screenshots": [],

--- a/src/System Application/Test/Cryptography Management/app.json
+++ b/src/System Application/Test/Cryptography Management/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Data Compression/app.json
+++ b/src/System Application/Test/Data Compression/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Date-Time Dialog/app.json
+++ b/src/System Application/Test/Date-Time Dialog/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Filter Tokens/app.json
+++ b/src/System Application/Test/Filter Tokens/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Headlines/app.json
+++ b/src/System Application/Test/Headlines/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Json/app.json
+++ b/src/System Application/Test/Json/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Rest Client/app.json
+++ b/src/System Application/Test/Rest Client/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "https://go.microsoft.com/fwlink/?LinkId=724009",
   "EULA": "https://go.microsoft.com/fwlink/?linkid=2182906",
   "help": "https://go.microsoft.com/fwlink/?linkid=2206603",
-  "url": "https://go.microsoft.com/fwlink/?LinkId=72401",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "dependencies": [
     {
       "id": "812b339d-a9db-4a6e-84e4-fe35cbef0c44",

--- a/src/System Application/Test/Retention Policy/app.json
+++ b/src/System Application/Test/Retention Policy/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Telemetry/app.json
+++ b/src/System Application/Test/Telemetry/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Tenant License State/app.json
+++ b/src/System Application/Test/Tenant License State/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Time Zone Selection/app.json
+++ b/src/System Application/Test/Time Zone Selection/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/Translation/app.json
+++ b/src/System Application/Test/Translation/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/System Application/Test/XmlWriter/app.json
+++ b/src/System Application/Test/XmlWriter/app.json
@@ -8,7 +8,7 @@
   "privacyStatement": "",
   "EULA": "",
   "help": "",
-  "url": "",
+  "url": "https://go.microsoft.com/fwlink/?linkid=724011",
   "logo": "",
   "dependencies": [
     {

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -107,11 +107,6 @@
       "justification": "The manifest property 'contextSensitiveHelpUrl' must be specified and contain a meaningful value."
     },
     {
-      "id": "AS0052",
-      "action": "Warning",
-      "justification": "The manifest property 'url' must be specified and contain a valid URL."
-    },
-    {
       "id": "AS0062",
       "action": "Warning",
       "justification": "Action must have a value for the ApplicationArea property so that they are visible to users. From runtime 11.0, you can specify on the application object level the ApplicationArea to use as default for all its controls and actions."


### PR DESCRIPTION
Continues the post-migration ruleset hardening tracked by [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773), following on from #10251.

## What this does

Promotes **`AS0052`** ("The manifest property `url` must be specified and contain a valid URL") from `Warning` to `Error` in `src/rulesets/base.ruleset.json`, taking the override count from 94 down to 93.

**No code changes are required for this rule — every edit is manifest metadata.**

## The violations

65 `app.json` manifests either omitted `url` entirely or set it to an empty string:

| Area | Count |
|---|---|
| `src/Layers/W1/**` | 45 |
| `src/System Application/Test/**` | 12 |
| `src/DemoTool`, `src/Layers/{BE,CZ,IN,MX,SE}`, `src/System Application/{App,Test Library}` | 8 |

Each now declares the value already conventional for its area:

- `src/System Application/**` → `https://go.microsoft.com/fwlink/?linkid=724011` — 241 manifests there already use this lowercase form
- everywhere else → `https://go.microsoft.com/fwlink/?LinkId=724011` — 786 manifests already use this form

## Three broken URLs repaired

While scanning I found three values that were present, so they never tripped the rule, but could not resolve:

- `src/Apps/W1/BasicExperience/app/app.json` and `.../test/app.json` — `https://go.microsoft.com/fwlink/?LinkId=` , truncated with no link id at all
- `src/System Application/Test/Rest Client/app.json` — `https://go.microsoft.com/fwlink/?LinkId=72401`, a typo missing the trailing digit

## Verification

- All **877** manifests in the repository now declare a well-formed `url` matching `https://go.microsoft.com/fwlink/?LinkId=<digits>`.
- The edits were applied by a script that re-parses each file afterwards and asserts that **only** the `url` property changed, so no manifest was reformatted or otherwise disturbed. The diff is 70 insertions / 25 deletions across 69 files — one line per manifest, plus one trailing comma where `url` was appended after the last property.
- `Invoke-MiSnapApp`, the same check the `Verify App Changes` job runs, passes locally: `Validating propagation for 69 file(s)... SUCCESS: No missing files`. The country-layer `DemoTool` manifests are fixed in the same changelist as their W1 counterpart, so nothing is left to propagate.

## Deliberately out of scope

- Empty *optional* manifest URLs — 255 `logo`, 133 `help`, 15 `EULA`, 15 `privacyStatement`. No rule currently flags these.
- Three `help` values with stray leading/trailing whitespace (`src/Apps/GB/PostingDateCheckOnPosting`, `src/Apps/W1/EDocumentConnectors/{Microsoft365,Pagero}`). Different property, different rule.
- `AL0523` remains disabled — it is reported without a source location, so it cannot be suppressed with a pragma, and clearing it needs a breaking rename on `Posted Deposit Line`.

Related to [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773)



