### PR TITLE
[Expense Agent] Add activity log retention policy

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Codeunits/ExpenseActivityLogMgt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Codeunits/ExpenseActivityLogMgt.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.ExpenseAgent;
 
+using System.DataAdministration;
 using System.Security.AccessControl;
 
 codeunit 6926 "Expense Activity Log Mgt."
@@ -11,6 +12,9 @@ codeunit 6926 "Expense Activity Log Mgt."
     Access = Internal;
     Permissions = tabledata "Expense Activity Log Entry" = rimd,
                   tabledata User = r;
+
+    var
+        NoRetentionFiltersErr: Label 'No filters were set on table %1, %2. Please contact your Microsoft Partner for assistance.', Comment = '%1 = table number, %2 = table name';
 
     /// <summary>
     /// Appends an activity entry for an in-flight expense report.
@@ -128,6 +132,33 @@ codeunit 6926 "Expense Activity Log Mgt."
         ExpenseActivityLogEntry.SetRange("Source Table ID", SourceTableID);
         ExpenseActivityLogEntry.SetRange("Source Record System ID", SourceRecordSystemID);
         exit(not ExpenseActivityLogEntry.IsEmpty());
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Apply Retention Policy", OnApplyRetentionPolicyIndirectPermissionRequired, '', true, true)]
+    local procedure DeleteEntriesWithIndirectPermissions(var RecRef: RecordRef; var Handled: Boolean)
+    var
+        RetentionPolicyLog: Codeunit "Retention Policy Log";
+    begin
+        if Handled then
+            exit;
+
+        if RecRef.Number <> Database::"Expense Activity Log Entry" then
+            exit;
+
+        if (RecRef.GetFilters() = '') or (not RecRef.MarkedOnly()) then
+            RetentionPolicyLog.LogError(
+                RetentionPolicyLogCategory(),
+                StrSubstNo(NoRetentionFiltersErr, RecRef.Number, RecRef.Name));
+
+        RecRef.DeleteAll(true);
+        Handled := true;
+    end;
+
+    local procedure RetentionPolicyLogCategory(): Enum "Retention Policy Log Category"
+    var
+        RetentionPolicyLogCategory: Enum "Retention Policy Log Category";
+    begin
+        exit(RetentionPolicyLogCategory::"Retention Policy - Apply");
     end;
 
     local procedure InitializeExpenseReportEntry(

--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Tables/ExpenseActivityLogEntry.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Tables/ExpenseActivityLogEntry.Table.al
@@ -223,6 +223,9 @@ table 7100 "Expense Activity Log Entry"
         key(Occurred; "Occurred At", "Entry No.")
         {
         }
+        key(Retention; "Source Table ID", "Occurred At", "Entry No.")
+        {
+        }
     }
 
     trigger OnModify()

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/InstallExpenseAgentSetup.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/InstallExpenseAgentSetup.Codeunit.al
@@ -9,7 +9,6 @@ using System.AI;
 using System.DataAdministration;
 using System.Environment;
 using System.Environment.Configuration;
-using System.Upgrade;
 
 codeunit 6992 "Install Expense Agent Setup"
 {
@@ -61,17 +60,8 @@ codeunit 6992 "Install Expense Agent Setup"
     end;
 
     internal procedure RegisterActivityLogRetentionPolicy(): Boolean
-    var
-        UpgradeTag: Codeunit "Upgrade Tag";
     begin
-        if UpgradeTag.HasUpgradeTag(GetActivityLogRetentionPolicyUpgradeTag()) then
-            exit(true);
-
-        if not AddActivityLogToAllowedTables() then
-            exit(false);
-
-        UpgradeTag.SetUpgradeTag(GetActivityLogRetentionPolicyUpgradeTag());
-        exit(true);
+        exit(AddActivityLogToAllowedTables());
     end;
 
     local procedure AddActivityLogToAllowedTables(): Boolean

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/InstallExpenseAgentSetup.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/InstallExpenseAgentSetup.Codeunit.al
@@ -6,8 +6,10 @@ namespace Microsoft.ExpenseAgent;
 
 using Microsoft.Foundation.Company;
 using System.AI;
+using System.DataAdministration;
 using System.Environment;
 using System.Environment.Configuration;
+using System.Upgrade;
 
 codeunit 6992 "Install Expense Agent Setup"
 {
@@ -21,6 +23,7 @@ codeunit 6992 "Install Expense Agent Setup"
         ExpenseAgentSetup: Record "Expense Agent Setup";
     begin
         ExpenseAgentSetup.InitRecord();
+        RegisterActivityLogRetentionPolicy();
     end;
 
     trigger OnInstallAppPerDatabase()
@@ -34,6 +37,7 @@ codeunit 6992 "Install Expense Agent Setup"
         ExpenseAgentSetup: Record "Expense Agent Setup";
     begin
         ExpenseAgentSetup.InitRecord();
+        RegisterActivityLogRetentionPolicy();
     end;
 
     [EventSubscriber(ObjectType::Page, Page::"Copilot AI Capabilities", 'OnRegisterCopilotCapability', '', false, false)]
@@ -54,6 +58,59 @@ codeunit 6992 "Install Expense Agent Setup"
                 Enum::"Copilot Availability"::Preview,
                 Enum::"Copilot Billing Type"::"Microsoft Billed",
                 LearnMoreUrlTxt);
+    end;
+
+    internal procedure RegisterActivityLogRetentionPolicy(): Boolean
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if UpgradeTag.HasUpgradeTag(GetActivityLogRetentionPolicyUpgradeTag()) then
+            exit(true);
+
+        if not AddActivityLogToAllowedTables() then
+            exit(false);
+
+        UpgradeTag.SetUpgradeTag(GetActivityLogRetentionPolicyUpgradeTag());
+        exit(true);
+    end;
+
+    local procedure AddActivityLogToAllowedTables(): Boolean
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        RetenPolAllowedTables: Codeunit "Reten. Pol. Allowed Tables";
+        RecRef: RecordRef;
+        TableFilters: JsonArray;
+    begin
+        ExpenseActivityLogEntry.SetRange("Source Table ID", Database::"Expense Report Header");
+        RecRef.GetTable(ExpenseActivityLogEntry);
+        RetenPolAllowedTables.AddTableFilterToJsonArray(
+            TableFilters,
+            Enum::"Retention Period Enum"::"Never Delete",
+            ExpenseActivityLogEntry.FieldNo("Occurred At"),
+            true,
+            true,
+            RecRef);
+
+        ExpenseActivityLogEntry.Reset();
+        ExpenseActivityLogEntry.SetRange("Source Table ID", Database::"Posted Expense Report Header");
+        RecRef.GetTable(ExpenseActivityLogEntry);
+        RetenPolAllowedTables.AddTableFilterToJsonArray(
+            TableFilters,
+            Enum::"Retention Period Enum"::"Never Delete",
+            ExpenseActivityLogEntry.FieldNo("Occurred At"),
+            true,
+            false,
+            RecRef);
+
+        exit(RetenPolAllowedTables.AddAllowedTable(
+            Database::"Expense Activity Log Entry",
+            ExpenseActivityLogEntry.FieldNo("Occurred At"),
+            TableFilters));
+    end;
+
+    internal procedure GetActivityLogRetentionPolicyUpgradeTag(): Code[250]
+    begin
+        exit('MS-646820-ExpenseActivityLogRetentionPolicy-20260819');
     end;
 
     [EventSubscriber(ObjectType::Report, Report::"Copy Company", 'OnAfterCreatedNewCompanyByCopyCompany', '', false, false)]

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/UpgradeExpenseAgentSetup.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/UpgradeExpenseAgentSetup.Codeunit.al
@@ -34,8 +34,16 @@ codeunit 6978 "Upgrade Expense Agent Setup"
 
     trigger OnUpgradePerCompany()
     begin
+        UpgradeRegisterActivityLogRetentionPolicy();
         UpgradeClearStaleCopyCompanyState();
         UpgradeEnableCommunicationDefault();
+    end;
+
+    local procedure UpgradeRegisterActivityLogRetentionPolicy()
+    var
+        InstallExpenseAgentSetup: Codeunit "Install Expense Agent Setup";
+    begin
+        InstallExpenseAgentSetup.RegisterActivityLogRetentionPolicy();
     end;
 
     local procedure UpgradeClearStaleCopyCompanyState()
@@ -117,7 +125,10 @@ codeunit 6978 "Upgrade Expense Agent Setup"
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerCompanyUpgradeTags, '', false, false)]
     local procedure RegisterPerCompanyUpgradeTags(var PerCompanyUpgradeTags: List of [Code[250]])
+    var
+        InstallExpenseAgentSetup: Codeunit "Install Expense Agent Setup";
     begin
+        PerCompanyUpgradeTags.Add(InstallExpenseAgentSetup.GetActivityLogRetentionPolicyUpgradeTag());
         PerCompanyUpgradeTags.Add(GetClearStaleCopyCompanyStateUpgradeTag());
         PerCompanyUpgradeTags.Add(GetEnableCommunicationDefaultUpgradeTag());
     end;

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/UpgradeExpenseAgentSetup.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/UpgradeExpenseAgentSetup.Codeunit.al
@@ -42,8 +42,13 @@ codeunit 6978 "Upgrade Expense Agent Setup"
     local procedure UpgradeRegisterActivityLogRetentionPolicy()
     var
         InstallExpenseAgentSetup: Codeunit "Install Expense Agent Setup";
+        UpgradeTag: Codeunit "Upgrade Tag";
     begin
-        InstallExpenseAgentSetup.RegisterActivityLogRetentionPolicy();
+        if UpgradeTag.HasUpgradeTag(InstallExpenseAgentSetup.GetActivityLogRetentionPolicyUpgradeTag()) then
+            exit;
+
+        if InstallExpenseAgentSetup.RegisterActivityLogRetentionPolicy() then
+            UpgradeTag.SetUpgradeTag(InstallExpenseAgentSetup.GetActivityLogRetentionPolicyUpgradeTag());
     end;
 
     local procedure UpgradeClearStaleCopyCompanyState()

--- a/src/Apps/W1/ExpenseAgent/test/src/ActivityLog/ExpenseActivityLogTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ActivityLog/ExpenseActivityLogTest.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Test.ExpenseAgent;
 
 using Microsoft.ExpenseAgent;
+using System.DataAdministration;
 using System.Security.AccessControl;
 using System.Security.User;
 
@@ -584,6 +585,46 @@ codeunit 148342 "Expense Activity Log Test"
         Assert.RecordIsEmpty(ExpenseActivityLogEntry);
     end;
 
+    [Test]
+    procedure ActivityLogRetentionPolicyHasSourceSpecificRules()
+    var
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        InstallExpenseAgentSetup: Codeunit "Install Expense Agent Setup";
+        FirstRegistrationSucceeded: Boolean;
+        SecondRegistrationSucceeded: Boolean;
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO 646820] Activity history has protected active retention and configurable posted retention.
+        Initialize();
+
+        // [GIVEN] No retention policy setup "RP" exists for activity history.
+        DeleteActivityLogRetentionPolicySetup();
+
+        // [WHEN] Registration runs repeatedly and retention policy "RP" is created.
+        FirstRegistrationSucceeded := InstallExpenseAgentSetup.RegisterActivityLogRetentionPolicy();
+        SecondRegistrationSucceeded := InstallExpenseAgentSetup.RegisterActivityLogRetentionPolicy();
+        RetentionPolicySetup.Init();
+        RetentionPolicySetup.Validate("Table Id", Database::"Expense Activity Log Entry");
+        RetentionPolicySetup.Insert(true);
+
+        // [THEN] Policy "RP" uses Occurred At and has the approved active and posted rules.
+        VerifyActivityLogRetentionPolicyRegistration(
+            RetentionPolicySetup,
+            FirstRegistrationSucceeded,
+            SecondRegistrationSucceeded);
+    end;
+
+    local procedure Initialize()
+    begin
+        LibraryTestInitialize.OnTestInitialize(Codeunit::"Expense Activity Log Test");
+        if IsInitialized then
+            exit;
+
+        LibraryExpense.SetupNumberSeriesInExpenseMgmt();
+        IsInitialized := true;
+        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Expense Activity Log Test");
+    end;
+
     local procedure CreateApprovalScenario(
         var
             SubmitterExpenseUser: Record "Expense User";
@@ -643,15 +684,97 @@ codeunit 148342 "Expense Activity Log Test"
         UserSetup.Modify();
     end;
 
-    local procedure Initialize()
+    local procedure DeleteActivityLogRetentionPolicySetup()
+    var
+        RetentionPolicySetup: Record "Retention Policy Setup";
     begin
-        LibraryTestInitialize.OnTestInitialize(Codeunit::"Expense Activity Log Test");
-        if IsInitialized then
-            exit;
+        if RetentionPolicySetup.Get(Database::"Expense Activity Log Entry") then
+            RetentionPolicySetup.Delete(true);
+    end;
 
-        LibraryExpense.SetupNumberSeriesInExpenseMgmt();
-        IsInitialized := true;
-        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Expense Activity Log Test");
+    local procedure VerifyActivityLogRetentionPolicyLines()
+    var
+        RetentionPolicySetupLine: Record "Retention Policy Setup Line";
+        ActiveRuleFound: Boolean;
+        PostedRuleFound: Boolean;
+        SourceTableId: Integer;
+    begin
+        RetentionPolicySetupLine.SetRange("Table ID", Database::"Expense Activity Log Entry");
+        Assert.RecordCount(RetentionPolicySetupLine, 2);
+        RetentionPolicySetupLine.FindSet();
+        repeat
+            SourceTableId := GetRetentionPolicyLineSourceTableId(RetentionPolicySetupLine);
+            case SourceTableId of
+                Database::"Expense Report Header":
+                    begin
+                        VerifyRetentionPolicyLine(RetentionPolicySetupLine, true);
+                        ActiveRuleFound := true;
+                    end;
+                Database::"Posted Expense Report Header":
+                    begin
+                        VerifyRetentionPolicyLine(RetentionPolicySetupLine, false);
+                        PostedRuleFound := true;
+                    end;
+                else
+                    Error('Unexpected source table %1 in the activity retention policy.', SourceTableId);
+            end;
+        until RetentionPolicySetupLine.Next() = 0;
+
+        Assert.IsTrue(ActiveRuleFound, 'The active expense report retention rule must exist.');
+        Assert.IsTrue(PostedRuleFound, 'The posted expense report retention rule must exist.');
+    end;
+
+    local procedure VerifyActivityLogRetentionPolicyRegistration(
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        FirstRegistrationSucceeded: Boolean;
+        SecondRegistrationSucceeded: Boolean)
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        RetenPolAllowedTables: Codeunit "Reten. Pol. Allowed Tables";
+    begin
+        Assert.IsTrue(FirstRegistrationSucceeded, 'The first activity retention registration must succeed.');
+        Assert.IsTrue(SecondRegistrationSucceeded, 'Repeated activity retention registration must be idempotent.');
+        Assert.IsTrue(
+            RetenPolAllowedTables.IsAllowedTable(Database::"Expense Activity Log Entry"),
+            'The activity log table must be allowed for retention policies.');
+        Assert.AreEqual(
+            ExpenseActivityLogEntry.FieldNo("Occurred At"),
+            RetenPolAllowedTables.GetDefaultDateFieldNo(Database::"Expense Activity Log Entry"),
+            'Occurred At must determine the age of activity entries.');
+        Assert.IsFalse(
+            RetentionPolicySetup."Apply to all records",
+            'Source-specific retention rules must disable Apply to all records.');
+        VerifyActivityLogRetentionPolicyLines();
+    end;
+
+    local procedure VerifyRetentionPolicyLine(
+        RetentionPolicySetupLine: Record "Retention Policy Setup Line";
+        ExpectedLocked: Boolean)
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        RetentionPeriod: Record "Retention Period";
+    begin
+        RetentionPeriod.Get(RetentionPolicySetupLine."Retention Period");
+        Assert.AreEqual(Enum::"Retention Period Enum"::"Never Delete", RetentionPeriod."Retention Period", 'Activity retention must default to Never Delete.');
+        Assert.AreEqual(ExpenseActivityLogEntry.FieldNo("Occurred At"), RetentionPolicySetupLine."Date Field No.", 'Activity retention lines must use Occurred At.');
+        Assert.IsTrue(RetentionPolicySetupLine.Enabled, 'Activity retention lines must be enabled.');
+        Assert.AreEqual(ExpectedLocked, RetentionPolicySetupLine.IsLocked(), 'The activity retention line lock state is incorrect.');
+    end;
+
+    local procedure GetRetentionPolicyLineSourceTableId(
+        RetentionPolicySetupLine: Record "Retention Policy Setup Line") SourceTableId: Integer
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        FieldRef: FieldRef;
+        RecordRef: RecordRef;
+    begin
+        RecordRef.Open(Database::"Expense Activity Log Entry");
+        RecordRef.SetView(RetentionPolicySetupLine.GetTableFilterView());
+        FieldRef := RecordRef.Field(ExpenseActivityLogEntry.FieldNo("Source Table ID"));
+        Assert.IsTrue(
+            Evaluate(SourceTableId, FieldRef.GetFilter()),
+            'The source table filter must be a single table ID.');
+        RecordRef.Close();
     end;
 
 }

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpensePermissionsTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpensePermissionsTest.Codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.Test.ExpenseAgent;
 using Microsoft.ExpenseAgent;
 using Microsoft.HumanResources.Employee;
 using Microsoft.HumanResources.Setup;
+using System.DataAdministration;
 
 codeunit 148338 "Expense Permissions Test"
 {
@@ -26,6 +27,7 @@ codeunit 148338 "Expense Permissions Test"
         AutomationPermissionSetTok: Label 'Exp. Auto Test', Locked = true;
         D365BasicPermissionSetTok: Label 'D365 BASIC', Locked = true;
         ExpenseAgentPermissionSetTok: Label 'Expense Agent', Locked = true;
+        RetentionPolicyAdminPermissionSetTok: Label 'Retention Pol. Admin', Locked = true;
         CannotDeleteEmployeeWithExpenseErr: Label 'You cannot delete Employee %1 because they have active expense.', Comment = '%1 = Employee No.';
         CannotDeleteEmployeeWithExpenseReportErr: Label 'You cannot delete Employee %1 because they have active expense report.', Comment = '%1 = Employee No.';
         CannotDeleteEmployeeWithPostedExpenseReportErr: Label 'You cannot delete Employee %1 because they have posted expense report.', Comment = '%1 = Employee No.';
@@ -190,6 +192,76 @@ codeunit 148338 "Expense Permissions Test"
         RestoreFullPermissions();
     end;
 
+    [Test]
+    procedure RetentionPolicyDeletesExpiredPostedActivityWithIndirectPermission()
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseUser: Record "Expense User";
+        PostedExpenseReportHeader: Record "Posted Expense Report Header";
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        ApplyRetentionPolicy: Codeunit "Apply Retention Policy";
+        ActiveEntryNo: BigInteger;
+        ExpiredPostedEntryNo: BigInteger;
+        RecentPostedEntryNo: BigInteger;
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO 646820] Retention deletes only expired posted activity through indirect permission.
+        Initialize();
+
+        // [GIVEN] Policy "RP" retains posted activity for one week and entries "A1", "A2", and "A3" have different ages.
+        CreateEnabledActivityLogRetentionPolicy(RetentionPolicySetup);
+        LibraryExpense.CreateExpenseUser(ExpenseUser);
+        LibraryExpense.CreateExpenseReport(ExpenseReportHeader, ExpenseUser."No.", '', '');
+        CreatePostedExpenseReportForDeletionGuard(PostedExpenseReportHeader, ExpenseUser."No.");
+        ActiveEntryNo :=
+            CreateActivityLogEntry(
+                Database::"Expense Report Header",
+                ExpenseReportHeader.SystemId,
+                ExpenseReportHeader.SystemId,
+                CreateDateTime(CalcDate('<-2W>', Today()), 120000T));
+        ExpiredPostedEntryNo :=
+            CreateActivityLogEntry(
+                Database::"Posted Expense Report Header",
+                PostedExpenseReportHeader.SystemId,
+                ExpenseReportHeader.SystemId,
+                CreateDateTime(CalcDate('<-2W>', Today()), 120000T));
+        RecentPostedEntryNo :=
+            CreateActivityLogEntry(
+                Database::"Posted Expense Report Header",
+                PostedExpenseReportHeader.SystemId,
+                ExpenseReportHeader.SystemId,
+                CreateDateTime(CalcDate('<-4D>', Today()), 120000T));
+
+        // [WHEN] A retention administrator with only indirect activity delete permission applies policy "RP".
+        LibraryLowerPermissions.SetExactPermissionSet(D365BasicPermissionSetTok);
+        LibraryLowerPermissions.AddPermissionSet(RetentionPolicyAdminPermissionSetTok);
+        Assert.IsFalse(ExpenseActivityLogEntry.DeletePermission(), 'The retention caller must not have direct activity delete permission.');
+        ApplyRetentionPolicy.ApplyRetentionPolicy(RetentionPolicySetup, false);
+        RestoreFullPermissions();
+
+        // [THEN] Only expired posted entry "A2" is deleted.
+        VerifyRetentionPolicyApplicationResult(ActiveEntryNo, ExpiredPostedEntryNo, RecentPostedEntryNo);
+    end;
+
+    local procedure Initialize()
+    begin
+        LibraryTestInitialize.OnTestInitialize(Codeunit::"Expense Permissions Test");
+        RestoreFullPermissions();
+        LibraryExpense.CleanTransactionalData();
+        LibraryExpense.CleanUpBeforeTesting();
+        if IsInitialized then
+            exit;
+
+        LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Expense Permissions Test");
+        EnsureSetupRecordsExist();
+        LibraryExpense.SetupNumberSeriesInExpenseMgmt();
+        LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(false);
+        IsInitialized := true;
+        Commit();
+        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Expense Permissions Test");
+    end;
+
     local procedure VerifyCompanyEmailSynchronization(PermissionSetId: Code[20])
     var
         Employee: Record Employee;
@@ -243,22 +315,87 @@ codeunit 148338 "Expense Permissions Test"
         PostedExpenseReportHeader.Insert(false);
     end;
 
-    local procedure Initialize()
+    local procedure CreateEnabledActivityLogRetentionPolicy(var RetentionPolicySetup: Record "Retention Policy Setup")
+    var
+        RetentionPolicySetupLine: Record "Retention Policy Setup Line";
+        RetentionPolicySetupMgt: Codeunit "Retention Policy Setup";
     begin
-        LibraryTestInitialize.OnTestInitialize(Codeunit::"Expense Permissions Test");
-        RestoreFullPermissions();
-        LibraryExpense.CleanTransactionalData();
-        LibraryExpense.CleanUpBeforeTesting();
-        if IsInitialized then
-            exit;
+        if RetentionPolicySetup.Get(Database::"Expense Activity Log Entry") then
+            RetentionPolicySetup.Delete(true);
 
-        LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Expense Permissions Test");
-        EnsureSetupRecordsExist();
-        LibraryExpense.SetupNumberSeriesInExpenseMgmt();
-        LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(false);
-        IsInitialized := true;
-        Commit();
-        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Expense Permissions Test");
+        RetentionPolicySetup.Init();
+        RetentionPolicySetup.Validate("Table ID", Database::"Expense Activity Log Entry");
+        RetentionPolicySetup.Insert(true);
+
+        GetActivityLogRetentionPolicyLine(RetentionPolicySetupLine, Database::"Posted Expense Report Header");
+        RetentionPolicySetupLine.Validate(
+            "Retention Period",
+            RetentionPolicySetupMgt.FindOrCreateRetentionPeriod(Enum::"Retention Period Enum"::"1 Week"));
+        RetentionPolicySetupLine.Modify(true);
+
+        RetentionPolicySetup.Validate(Enabled, true);
+        RetentionPolicySetup.Modify(true);
+    end;
+
+    local procedure CreateActivityLogEntry(
+        SourceTableId: Integer;
+        SourceRecordSystemId: Guid;
+        SubjectSystemId: Guid;
+        OccurredAt: DateTime): BigInteger
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+    begin
+        ExpenseActivityLogEntry.Init();
+        ExpenseActivityLogEntry."Source Table ID" := SourceTableId;
+        ExpenseActivityLogEntry."Source Record System ID" := SourceRecordSystemId;
+        ExpenseActivityLogEntry."Subject Table ID" := Database::"Expense Report Header";
+        ExpenseActivityLogEntry."Subject System ID" := SubjectSystemId;
+        ExpenseActivityLogEntry."Event Type" := Enum::"Expense Activity Event Type"::Created;
+        ExpenseActivityLogEntry."Occurred At" := OccurredAt;
+        ExpenseActivityLogEntry.Insert();
+        exit(ExpenseActivityLogEntry."Entry No.");
+    end;
+
+    local procedure GetActivityLogRetentionPolicyLine(
+        var RetentionPolicySetupLine: Record "Retention Policy Setup Line";
+        SourceTableId: Integer)
+    begin
+        RetentionPolicySetupLine.SetRange("Table ID", Database::"Expense Activity Log Entry");
+        RetentionPolicySetupLine.FindSet();
+        repeat
+            if GetRetentionPolicyLineSourceTableId(RetentionPolicySetupLine) = SourceTableId then
+                exit;
+        until RetentionPolicySetupLine.Next() = 0;
+
+        Error('The activity retention policy line for source table %1 was not found.', SourceTableId);
+    end;
+
+    local procedure GetRetentionPolicyLineSourceTableId(
+        RetentionPolicySetupLine: Record "Retention Policy Setup Line") SourceTableId: Integer
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        FieldRef: FieldRef;
+        RecordRef: RecordRef;
+    begin
+        RecordRef.Open(Database::"Expense Activity Log Entry");
+        RecordRef.SetView(RetentionPolicySetupLine.GetTableFilterView());
+        FieldRef := RecordRef.Field(ExpenseActivityLogEntry.FieldNo("Source Table ID"));
+        Assert.IsTrue(
+            Evaluate(SourceTableId, FieldRef.GetFilter()),
+            'The source table filter must be a single table ID.');
+        RecordRef.Close();
+    end;
+
+    local procedure VerifyRetentionPolicyApplicationResult(
+        ActiveEntryNo: BigInteger;
+        ExpiredPostedEntryNo: BigInteger;
+        RecentPostedEntryNo: BigInteger)
+    var
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+    begin
+        Assert.IsTrue(ExpenseActivityLogEntry.Get(ActiveEntryNo), 'Expired active activity must be protected by Never Delete.');
+        Assert.IsFalse(ExpenseActivityLogEntry.Get(ExpiredPostedEntryNo), 'Expired posted activity must be deleted.');
+        Assert.IsTrue(ExpenseActivityLogEntry.Get(RecentPostedEntryNo), 'Recent posted activity must remain.');
     end;
 
     local procedure VerifyPermissionSetCanInsertActivity(PermissionSetId: Code[20])

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpensePermissionsTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpensePermissionsTest.Codeunit.al
@@ -236,7 +236,7 @@ codeunit 148338 "Expense Permissions Test"
         // [WHEN] A retention administrator with only indirect activity delete permission applies policy "RP".
         LibraryLowerPermissions.SetExactPermissionSet(D365BasicPermissionSetTok);
         LibraryLowerPermissions.AddPermissionSet(RetentionPolicyAdminPermissionSetTok);
-        Assert.IsFalse(ExpenseActivityLogEntry.DeletePermission(), 'The retention caller must not have direct activity delete permission.');
+        Assert.IsFalse(ExpenseActivityLogEntry.WritePermission(), 'The retention caller must not have direct activity write permission.');
         ApplyRetentionPolicy.ApplyRetentionPolicy(RetentionPolicySetup, false);
         RestoreFullPermissions();
 


### PR DESCRIPTION
## Summary

Add Business Central retention-policy uptake for Expense Agent activity history.

- Register `Expense Activity Log Entry` during per-company installation, upgrade, and company initialization.
- Protect active-report activity with an enabled, locked `Never Delete` filter.
- Make posted-report activity customer-configurable with an enabled, unlocked `Never Delete` default.
- Use `Occurred At` as the retention date and add a source/date key for retention filtering.
- Handle retention deletion through the existing activity-log management codeunit when the execution user has indirect delete permission.
- Preserve the existing explicit source-document deletion cascades.

`OnRefreshAllowedTables` is intentionally not subscribed; lifecycle registration is sufficient for initial uptake and newly created companies.

## Permissions

No permission-set or entitlement changes are included. Installation and upgrade use the existing inherently executable setup codeunits. `SUPER` users can use the retention framework's direct deletion path, while indirect deletion is handled through `Expense Activity Log Mgt.`. PR #10346 separately supplies indirect activity-table permissions to normal Expense Management and Expense Agent roles.

## Validation

- [x] `git diff --check`
- [x] Reviewed install/upgrade tag idempotency and retention deletion safeguards
- [x] App compilation, publication, and runtime validation will be performed manually

Fixes [AB#646820](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646820)


<img width="2041" height="1117" alt="image" src="https://github.com/user-attachments/assets/e8e3dd97-6669-4b47-a579-b58e830f1567" />








