### PR TITLE
[Shopify] Pace raw-text GraphQL calls to prevent excessive throttling

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyCommunicationMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyCommunicationMgt.Codeunit.al
@@ -119,7 +119,7 @@ codeunit 30103 "Shpfy Communication Mgt."
     /// <returns>Return value of type JsonToken.</returns>
     internal procedure ExecuteGraphQL(GraphQLQuery: Text): JsonToken
     begin
-        exit(ExecuteGraphQL(GraphQLQuery, 0));
+        exit(ExecuteGraphQL(GraphQLQuery, 10));
     end;
 
     /// <summary> 


### PR DESCRIPTION
## Summary

The Shopify connector's GraphQL rate limiter did not pace requests issued through the single-argument `ExecuteGraphQL(GraphQLQuery: Text)` overload, because that overload hard-coded `ExpectedCost = 0`. With `ExpectedCost = 0`, `Shpfy GraphQL Rate Limit.WaitForRequestAvailable` / `CalcWaitTime` always compute a wait of `0`, so those calls were sent with no pacing — and the `while … THROTTLED` retry loop, which re-uses the same `ExpectedCost`, also re-fired with no back-off.

On shops with a small GraphQL cost bucket (for example Shopify development stores, ~40 max / 2 restore per second) this drove near-total throttling: raw-text mutations (customer/company/product/variant create & update, draft orders, fulfillment; Shopify cost ~10) drained the bucket and spun the retry loop. Data was still returned correctly by the retry logic (no data loss), but sync throughput was severely degraded.

## Fix

Pass a guesstimated average GraphQL cost (`10`, the Shopify mutation base cost) instead of `0` from the raw-text `ExecuteGraphQL(Text)` overload. Because the throttled-retry loop re-uses `ExpectedCost`, a non-zero value restores both pre-request and inter-retry pacing without any change to the retry loop. The enum / `# cost:` resource path already threads the annotated cost and is unaffected.

Fixes [AB#647306](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647306)



