### PR TITLE
[SOA] Ignore extended-text lines when editing sales quotes

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Validation/SOASessionFilter.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Validation/SOASessionFilter.Codeunit.al
@@ -37,6 +37,14 @@ codeunit 4306 "SOA Session Filter"
         Rec.FilterGroup(0);
     end;
 
+    [EventSubscriber(ObjectType::Page, Page::"Sales Quote Subform", 'OnOpenPageEvent', '', false, false)]
+    local procedure SetFiltersOnOpenSalesQuoteSubform(var Rec: Record "Sales Line")
+    begin
+        Rec.FilterGroup(10);
+        Rec.SetRange(Type, Rec.Type::Item);
+        Rec.FilterGroup(0);
+    end;
+
     [EventSubscriber(ObjectType::Table, Database::"Sales Header", 'OnAfterModifyEvent', '', false, false)]
     local procedure VerifySameCustomer(var Rec: Record "Sales Header")
     var


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

The Sales Order Agent could get stuck repeatedly trying to add an item after automatic extended text was inserted into a sales quote.

The agent’s Sales Quote Subform now displays only item lines. Extended-text lines remain stored on the quote but are excluded from the agent’s working view, preventing item lookups from running on text lines.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#647282](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647282)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Low risk and backward compatible.
 - The filter applies only during Sales Order Agent sessions.
 - Normal user sessions remain unchanged.
 - Extended text is neither modified nor deleted.
 - Existing sales quotes and printed documents retain their extended text.
 - The app compiles successfully with all configured analyzers.
