### PR TITLE
Fix/miapp country regex

### DIFF
--- a/build/scripts/Miapp/MicroAppIntegrate.psm1
+++ b/build/scripts/Miapp/MicroAppIntegrate.psm1
@@ -177,7 +177,7 @@ function IntegrateBranchedObjects {
             if($Params.Country)
             {
                 # Match country code from paths like src/Layers/CZ/, src/Layers/MX/, etc.
-                $Matched = $branch -match 'src/Layers/(?<Country>.+?(?=/)'
+                $Matched = $branch -match 'src/Layers/(?<Country>.+?(?=/))'
                 if($Matched)
                 {
                     $Matched = $Matches.Country -eq $Params.Country


### PR DESCRIPTION
## What & why
Fixes #10419 

`Invoke-Miapp -Country <code>` could not run at all. The regex that extracts the country code from a layer path opened the named group `(?<Country>` but never closed it ΓÇö the lookahead `(?=/)` closes its own parenthesis ΓÇö so .NET rejected the pattern and the command threw before integrating a single file:

```
IntegrateBranchedObjects: Invalid pattern 'src/Layers/(?<Country>.+?(?=/)' at offset 30. Not enough )'s.
```

This adds the missing parenthesis in `build/scripts/Miapp/MicroAppIntegrate.psm1`. One character, one line.

The pattern is only evaluated inside `if($Params.Country)`, which is why the defect went unnoticed: without `-Country` the tool works. The equivalent function in the internal NAV repository (`Eng/Normal/Lib/GitMiapp/MicroAppIntegrate.psm1`) has the closing parenthesis, so it was lost when the path was adapted from `App/Layers/` to `src/Layers/` for this repository ΓÇö the BCApps copy has been broken since it was introduced in 748fdaa43f (#8848).

## Linked work

Fixes #10419

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

The two unticked boxes do not apply: this changes a PowerShell build script, not AL code. No app is affected, so there is nothing to compile and nothing to run in Business Central.

What I did validate:

- Reproduced the failure on `main` with `Invoke-Miapp -Country DK`, which throws the error above before any file is processed.
- Verified the pattern in isolation, before and after. Before the fix it cannot be compiled at all; after it, the country code is captured for both two-letter and longer layer names, since `.+?` is lazy up to the next `/`:

  ```powershell
  'src/Layers/DK/BaseApp/Sales/Foo.al' -match 'src/Layers/(?<Country>.+?(?=/))'   # True, Country = 'DK'
  'src/Layers/W1/BaseApp/Foo.al'       -match 'src/Layers/(?<Country>.+?(?=/))'   # True, Country = 'W1'
  'src/Layers/APAC/BaseApp/Foo.al'     -match 'src/Layers/(?<Country>.+?(?=/))'   # True, Country = 'APAC'
  ```

- Ran `Invoke-Miapp -Country DK` after the fix; the command gets past the pattern and proceeds to file integration.

No test was added: the Miapp scripts have no test coverage in this repository today (there is no test file referencing `MicroApp` or `Miapp`), so a test here would mean introducing a harness for these scripts, which is out of scope for a one-character fix. Worth doing separately if the team wants it.

## Risk & compatibility

Very low. The changed line sits in a code path that currently always throws, so no working behaviour can regress:

- **With `-Country`:** previously impossible, now works.
- **Without `-Country`:** unchanged, since the pattern is never evaluated.

No AL objects, no runtime behaviour in Business Central, no upgrade or data impact.





Fixes [AB#648903](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648903)
