### PR TITLE
[Extensibility Request] issue 30423: expose previous service header

### DIFF
--- a/src/Layers/W1/BaseApp/Service/Document/ServiceHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Service/Document/ServiceHeader.Table.al
@@ -467,7 +467,7 @@ table 5900 "Service Header"
                     Validate("Service Zone Code");
 
                 IsHandled := false;
-                OnValidateShipToCodeOnBeforeDeleteLines(Rec, IsHandled);
+                OnValidateShipToCodeOnBeforeDeleteLines(Rec, IsHandled, xRec);
                 if not IsHandled then
                     if ("Ship-to Code" <> xRec."Ship-to Code") and
                        ("Customer No." = xRec."Customer No.") and
@@ -6059,7 +6059,7 @@ table 5900 "Service Header"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnValidateShipToCodeOnBeforeDeleteLines(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean)
+    local procedure OnValidateShipToCodeOnBeforeDeleteLines(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; xServiceHeader: Record "Service Header")
     begin
     end;
 


### PR DESCRIPTION
## Summary
Service Header event subscribers need access to the previous record values to determine whether custom fields changed while deciding whether to handle line deletion. This PR passes the previous Service Header state through the existing extensibility event without changing the existing parameter order.

Source issue repository: microsoft/AlAppExtensions; issue number: 30423

## Changes Made
- `Service Header.OnValidateShipToCodeOnBeforeDeleteLines` - appends the previous `Service Header` record to the event and supplies `xRec` from the `Ship-to Code` validation flow

Fixes [AB#647077](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647077)




