### PR TITLE
[Extensibility Request] issue 30421: allow custom travel cost lookup

### DIFF
--- a/src/Layers/W1/BaseApp/Service/Document/ServOrderManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Document/ServOrderManagement.Codeunit.al
@@ -246,6 +246,7 @@ codeunit 5900 ServOrderManagement
         ServInvLine2: Record "Service Line";
         ServCost: Record "Service Cost";
         NextLine: Integer;
+        IsHandled: Boolean;
     begin
         ServHeader.Get(ServInvLine."Document Type", ServInvLine."Document No.");
 
@@ -261,15 +262,19 @@ codeunit 5900 ServOrderManagement
         case CostType of
             0: // Travel Fee
                 begin
-                    ServHeader.TestField("Service Zone Code");
-                    ServCost.Reset();
-                    ServCost.SetCurrentKey("Service Zone Code");
-                    ServCost.SetRange("Service Zone Code", ServHeader."Service Zone Code");
-                    ServCost.SetRange("Cost Type", ServCost."Cost Type"::Travel);
-                    if not ServCost.FindFirst() then
-                        Error(
-                          Text009,
-                          ServCost.TableCaption(), ServCost.FieldCaption("Service Zone Code"), ServHeader."Service Zone Code");
+                    IsHandled := false;
+                    OnInsertServCostOnCostTypeZeroOnBeforeTestServiceZoneCode(ServHeader, ServCost, IsHandled);
+                    if not IsHandled then begin
+                        ServHeader.TestField("Service Zone Code");
+                        ServCost.Reset();
+                        ServCost.SetCurrentKey("Service Zone Code");
+                        ServCost.SetRange("Service Zone Code", ServHeader."Service Zone Code");
+                        ServCost.SetRange("Cost Type", ServCost."Cost Type"::Travel);
+                        if not ServCost.FindFirst() then
+                            Error(
+                              Text009,
+                              ServCost.TableCaption(), ServCost.FieldCaption("Service Zone Code"), ServHeader."Service Zone Code");
+                    end;
 
                     ServInvLine2.Init();
                     if LinktoServItemLine then begin
@@ -902,6 +907,11 @@ codeunit 5900 ServOrderManagement
 
     [IntegrationEvent(false, false)]
     local procedure OnInsertServCostOnCostTypeOneOnAfterServCostGet(var ServHeader: Record "Service Header"; var ServCost: Record "Service Cost")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnInsertServCostOnCostTypeZeroOnBeforeTestServiceZoneCode(ServiceHeader: Record "Service Header"; var ServiceCost: Record "Service Cost"; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Service extensions need to determine travel fees without relying on Service Zone Codes while still allowing the standard behavior for existing implementations. This PR adds a handled event before the standard travel-cost validation and lookup so subscribers can provide the appropriate Service Cost record and continue creating the service line.

Source issue repository: microsoft/AlAppExtensions; issue number: 30421

## Changes Made
- `ServOrderManagement.InsertServCost` - added a handled event that allows subscribers to replace Service Zone Code validation and travel-cost lookup while preserving the standard path when unhandled

Fixes [AB#647292](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647292)



