### PR TITLE
Bug 647233: [Expense Agent] User Confirmed is copied into Canceled when posting expense report lines

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/PostedExpenseReportLine.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/PostedExpenseReportLine.Table.al
@@ -424,7 +424,7 @@ table 6916 "Posted Expense Report Line"
             DataClassification = EndUserIdentifiableInformation;
             Editable = false;
         }
-        field(92; Canceled; Boolean)
+        field(93; Canceled; Boolean)
         {
             Caption = 'Canceled';
             Editable = false;


### PR DESCRIPTION
Workitem Bug 647233: [Expense Agent] User Confirmed is copied into Canceled when posting expense report lines



Issue: When an expense report is posted, the resulting posted expense report lines were incorrectly flagged as canceled. Instead of defaulting to not-canceled, each posted line's Canceled value mirrored the source line's "User Confirmed" flag, producing wrong Canceled state on freshly posted documents.

Cause: The Canceled field on the Posted Expense Report Line table was defined with field ID 92 — the same field ID used by the "User Confirmed" field on the Expense Report Line table. During posting, PostedExpenseReportLine.TransferFields(ExpenseReportLine) copies values by matching field ID, so the source "User Confirmed" value (ID 92) was written straight into the destination Canceled field (ID 92). The header path was unaffected because Expense Report Header has no field 92, so its TransferFields never collided.

Solution: Moved the Canceled field on Posted Expense Report Line from field ID 92 to 93 — an ID that is unused in Expense Report Line — so TransferFields no longer overwrites it and Canceled keeps its intended default. Only the posted line table changed (1 file); all Canceled references are by name (Rec.Canceled, SetRange(Canceled, ...)), so no call sites were affected. Built the Expense Agent app locally with CodeCop/AppSourceCop/UICop enabled — no errors and no new warnings. Note: changing a field ID on a posted table is a breaking metadata change; acceptable for this preview app but called out for reviewer awareness of any upgrade/data impact.

