### PR TITLE
[Master]-ACY amount on Value Entries is recalculated from LCY when the document currency equals the Additional Reporting Currency, causing a mismatch with G/L Entries]

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -3683,12 +3683,31 @@ codeunit 22 "Item Jnl.-Post Line"
             end;
         end;
 
-        if GLSetup."Additional Reporting Currency" <> '' then begin
-            if ItemJnlLine."Source Currency Code" = '' then begin
-                if ItemJnlLine."Vendor Exchange Rate (ACY)" <> 0 then begin
-                    DirCostACY := Round(DirCost * ItemJnlLine."Vendor Exchange Rate (ACY)");
-                    OvhdCostACY := Round(OvhdCost * ItemJnlLine."Vendor Exchange Rate (ACY)");
-                    ItemJnlLine."Unit Cost (ACY)" := Round(ItemJnlLine."Unit Cost" * ItemJnlLine."Vendor Exchange Rate (ACY)");
+        if GLSetup."Additional Reporting Currency" <> '' then
+            if ShouldUseDocumentAmountForACY() then begin
+                if Expected then
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
+                else
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                OvhdCostACY := 0;
+                PurchVarACY := 0;
+            end else begin
+                if ItemJnlLine."Source Currency Code" = '' then begin
+                    if ItemJnlLine."Vendor Exchange Rate (ACY)" <> 0 then begin
+                        DirCostACY := Round(DirCost * ItemJnlLine."Vendor Exchange Rate (ACY)");
+                        OvhdCostACY := Round(OvhdCost * ItemJnlLine."Vendor Exchange Rate (ACY)");
+                        ItemJnlLine."Unit Cost (ACY)" := Round(ItemJnlLine."Unit Cost" * ItemJnlLine."Vendor Exchange Rate (ACY)");
+                    end else begin
+                        DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
+                        OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
+                        ItemJnlLine."Unit Cost (ACY)" :=
+                          Round(
+                            CurrExchRate.ExchangeAmtLCYToFCY(
+                              ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
+                              CurrExchRate.ExchangeRate(
+                                ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
+                            Currency."Unit-Amount Rounding Precision");
+                    end;
                 end else begin
                     DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
                     OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
@@ -3700,22 +3719,22 @@ codeunit 22 "Item Jnl.-Post Line"
                             ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
                         Currency."Unit-Amount Rounding Precision");
                 end;
-            end else begin
-                DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
-                OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
-                ItemJnlLine."Unit Cost (ACY)" :=
-                  Round(
-                    CurrExchRate.ExchangeAmtLCYToFCY(
-                      ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
-                      CurrExchRate.ExchangeRate(
-                        ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
-                    Currency."Unit-Amount Rounding Precision");
+                PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
             end;
-            PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
-        end;
         CalcUnitCost := (DirCost <> 0) and (ItemJnlLine."Unit Cost" = 0);
 
         OnAfterCalcPosShares(ItemJnlLine, DirCost, OvhdCost, PurchVar, DirCostACY, OvhdCostACY, PurchVarACY, CalcUnitCost, CalcPurchVar, Expected, GlobalItemLedgEntry);
+    end;
+
+    local procedure ShouldUseDocumentAmountForACY(): Boolean
+    begin
+        exit(
+          (ItemJnlLine."Source Currency Code" = GLSetup."Additional Reporting Currency") and
+          (Item."Costing Method" <> Item."Costing Method"::Standard) and
+          (ItemJnlLine."Item Charge No." = '') and
+          (ItemJnlLine."Discount Amount" = 0) and
+          (ItemJnlLine."Indirect Cost %" = 0) and
+          (ItemJnlLine."Overhead Rate" = 0));
     end;
 
     local procedure CalcPurchCorrShares(var OverheadAmount: Decimal; var OverheadAmountACY: Decimal; var VarianceAmount: Decimal; var VarianceAmountACY: Decimal)

--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -103,6 +103,7 @@ codeunit 22 "Item Jnl.-Post Line"
         QtyPerUnitOfMeasure: Decimal;
         RoundingResidualAmount: Decimal;
         RoundingResidualAmountACY: Decimal;
+        RoundingResidualAmountInvdACY: Decimal;
         InvtSetupRead: Boolean;
         GLSetupRead: Boolean;
         SKUExists: Boolean;
@@ -306,9 +307,12 @@ codeunit 22 "Item Jnl.-Post Line"
 
         RoundingResidualAmount := 0;
         RoundingResidualAmountACY := 0;
+        RoundingResidualAmountInvdACY := 0;
         RoundingResidualAmount := ItemJnlLine.Quantity *
           (ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure, GLSetup."Unit-Amount Rounding Precision"));
         RoundingResidualAmountACY := ItemJnlLine.Quantity *
+          (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
+        RoundingResidualAmountInvdACY := ItemJnlLine."Invoiced Quantity" *
           (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
 
         ItemJnlLine."Unit Amount" := Round(
@@ -3688,7 +3692,7 @@ codeunit 22 "Item Jnl.-Post Line"
                 if Expected then
                     DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
                 else
-                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" + RoundingResidualAmountInvdACY;
                 OvhdCostACY := 0;
                 PurchVarACY := 0;
             end else begin

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -103,6 +103,7 @@ codeunit 22 "Item Jnl.-Post Line"
         QtyPerUnitOfMeasure: Decimal;
         RoundingResidualAmount: Decimal;
         RoundingResidualAmountACY: Decimal;
+        RoundingResidualAmountInvdACY: Decimal;
         InvtSetupRead: Boolean;
         GLSetupRead: Boolean;
         SKUExists: Boolean;
@@ -306,9 +307,12 @@ codeunit 22 "Item Jnl.-Post Line"
 
         RoundingResidualAmount := 0;
         RoundingResidualAmountACY := 0;
+        RoundingResidualAmountInvdACY := 0;
         RoundingResidualAmount := ItemJnlLine.Quantity *
           (ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure, GLSetup."Unit-Amount Rounding Precision"));
         RoundingResidualAmountACY := ItemJnlLine.Quantity *
+          (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
+        RoundingResidualAmountInvdACY := ItemJnlLine."Invoiced Quantity" *
           (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
 
         ItemJnlLine."Unit Amount" := Round(
@@ -3678,7 +3682,7 @@ codeunit 22 "Item Jnl.-Post Line"
                 if Expected then
                     DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
                 else
-                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" + RoundingResidualAmountInvdACY;
                 OvhdCostACY := 0;
                 PurchVarACY := 0;
             end else begin

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -3673,21 +3673,40 @@ codeunit 22 "Item Jnl.-Post Line"
             end;
         end;
 
-        if GLSetup."Additional Reporting Currency" <> '' then begin
-            DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
-            OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
-            ItemJnlLine."Unit Cost (ACY)" :=
-              Round(
-                CurrExchRate.ExchangeAmtLCYToFCY(
-                  ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
-                  CurrExchRate.ExchangeRate(
-                    ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
-                Currency."Unit-Amount Rounding Precision");
-            PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
-        end;
+        if GLSetup."Additional Reporting Currency" <> '' then
+            if ShouldUseDocumentAmountForACY() then begin
+                if Expected then
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
+                else
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                OvhdCostACY := 0;
+                PurchVarACY := 0;
+            end else begin
+                DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
+                OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
+                ItemJnlLine."Unit Cost (ACY)" :=
+                  Round(
+                    CurrExchRate.ExchangeAmtLCYToFCY(
+                      ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
+                      CurrExchRate.ExchangeRate(
+                        ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
+                    Currency."Unit-Amount Rounding Precision");
+                PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
+            end;
         CalcUnitCost := (DirCost <> 0) and (ItemJnlLine."Unit Cost" = 0);
 
         OnAfterCalcPosShares(ItemJnlLine, DirCost, OvhdCost, PurchVar, DirCostACY, OvhdCostACY, PurchVarACY, CalcUnitCost, CalcPurchVar, Expected, GlobalItemLedgEntry);
+    end;
+
+    local procedure ShouldUseDocumentAmountForACY(): Boolean
+    begin
+        exit(
+          (ItemJnlLine."Source Currency Code" = GLSetup."Additional Reporting Currency") and
+          (Item."Costing Method" <> Item."Costing Method"::Standard) and
+          (ItemJnlLine."Item Charge No." = '') and
+          (ItemJnlLine."Discount Amount" = 0) and
+          (ItemJnlLine."Indirect Cost %" = 0) and
+          (ItemJnlLine."Overhead Rate" = 0));
     end;
 
     local procedure CalcPurchCorrShares(var OverheadAmount: Decimal; var OverheadAmountACY: Decimal; var VarianceAmount: Decimal; var VarianceAmountACY: Decimal)

--- a/src/Layers/CZ/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
+++ b/src/Layers/CZ/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
@@ -237,6 +237,69 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
           InventoryPostingSetup."Inventory Account", DocumentNo, ValueEntry."Cost Amount (Actual) (ACY)");
     end;
 
+    [Test]
+    procedure PurchaseInACYWithNonBaseUoMKeepsUnitCostRoundingResidualOnBothLegs()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        AddReportingCurrencyCode: Code[10];
+        ReceiptDocumentNo: Code[20];
+        InvoiceDocumentNo: Code[20];
+        ExpectedCostAmountACY: Decimal;
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        QtyPerUnitOfMeasure: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [Expected Cost] [Unit of Measure] [AI test 0.4]
+        // [SCENARIO] When the purchase currency equals the Additional Reporting Currency and the purchase unit of measure holds more than one base unit, the per-base-unit ACY unit cost must be rounded, which drops a residual. Both the expected (receipt) and the actual (invoice) Value Entry ACY amounts must still equal the exact document ACY amount, so neither leg drifts by the dropped residual.
+        Initialize();
+
+        // [GIVEN] Automatic cost posting and expected cost posting are both enabled, so the receipt posts an expected ACY cost that is later reversed and replaced by the actual ACY cost on invoicing.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(true);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency with a coarse 0.01 Unit-Amount Rounding Precision, so rounding the per-base-unit ACY cost drops a residual larger than the 0.01 Amount Rounding Precision and a dropped residual is visible on the Value Entry. The exchange rate only affects LCY conversion, not the ACY amount, so it can be random.
+        ExchangeRate := LibraryRandom.RandIntInRange(2, 10);
+        AddReportingCurrencyCode := CreateAddReportingCurrencyWithUnitAmountPrecision(ExchangeRate, 0.01);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase unit of measure holding a random multiple of 3 base units, so 1/(base-unit count) stays a non-terminating decimal (a factor of 3 never clears against the 2s and 5s of the rounding precision).
+        QtyPerUnitOfMeasure := 3 * LibraryRandom.RandIntInRange(1, 5);
+        LibraryInventory.CreateItemUnitOfMeasureCode(ItemUnitOfMeasure, Item."No.", QtyPerUnitOfMeasure);
+
+        // [GIVEN] A purchase order for a random number of that unit of measure at a random unit cost that is never divisible by the base-unit count, so the per-base-unit ACY cost is a repeating decimal that rounds and drops a residual on each base unit.
+        Quantity := LibraryRandom.RandIntInRange(2, 10);
+        DirectUnitCost := QtyPerUnitOfMeasure * LibraryRandom.RandIntInRange(2, 10) + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Quantity);
+        PurchaseLine.Validate("Unit of Measure Code", ItemUnitOfMeasure.Code);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase order is received but not invoiced, so only the expected cost is posted.
+        ReceiptDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] The Value Entry "Cost Amount (Expected) (ACY)" equals the exact document ACY amount, with the residual folded back in.
+        ExpectedCostAmountACY := DirectUnitCost * Quantity;
+        VerifyValueEntryExpectedCostAmountACY(Item."No.", ReceiptDocumentNo, ExpectedCostAmountACY);
+
+        // [WHEN] The same purchase order is invoiced separately.
+        PurchaseHeader.Find();
+        InvoiceDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
+
+        // [THEN] The Value Entry "Cost Amount (Actual) (ACY)" also equals the exact document ACY amount, so the actual leg reconstructs the residual exactly as the expected leg does instead of dropping it.
+        VerifyValueEntryCostAmountACY(Item."No.", InvoiceDocumentNo, ExpectedCostAmountACY);
+    end;
+
     [Normal]
     local procedure Initialize()
     var
@@ -452,6 +515,19 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         LibraryERM.CreateExchangeRate(Currency.Code, WorkDate(), ExchangeRate, ExchangeRate);
         Currency.Validate("Amount Rounding Precision", 0.01);
         Currency.Validate("Unit-Amount Rounding Precision", 0.00001);
+        Currency.Modify(true);
+        LibraryERM.SetAddReportingCurrency(Currency.Code);
+        exit(Currency.Code);
+    end;
+
+    local procedure CreateAddReportingCurrencyWithUnitAmountPrecision(ExchangeRate: Decimal; UnitAmountRoundingPrecision: Decimal): Code[10]
+    var
+        Currency: Record Currency;
+    begin
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        LibraryERM.CreateExchangeRate(Currency.Code, WorkDate(), ExchangeRate, ExchangeRate);
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Validate("Unit-Amount Rounding Precision", UnitAmountRoundingPrecision);
         Currency.Modify(true);
         LibraryERM.SetAddReportingCurrency(Currency.Code);
         exit(Currency.Code);

--- a/src/Layers/CZ/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
+++ b/src/Layers/CZ/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         LibraryERM: Codeunit "Library - ERM";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        Assert: Codeunit Assert;
         isInitialized: Boolean;
 
     [Test]
@@ -66,6 +67,176 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         VerifyInvtWIPAmntGLEntry(CurrencyExchangeRate, Currency."Amount Rounding Precision", PurchaseLine."No.");
     end;
 
+    [Test]
+    procedure PurchaseInACYUsesDocumentAmountForValueEntryACY()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        AddReportingCurrencyCode: Code[10];
+        DocumentNo: Code[20];
+        ExpectedCostAmountACY: Decimal;
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [AI test 0.4]
+        // [SCENARIO] Value Entry ACY cost uses the document Additional Reporting Currency amount directly instead of reconverting it from LCY when the purchase currency equals the Additional Reporting Currency, so it reconciles with the G/L Entry Additional-Currency Amount.
+        Initialize();
+
+        // [GIVEN] Automatic cost posting to the inventory account is enabled and expected cost posting is disabled.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(false);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency. Exchange rate 3 is used because 1/3 is non-terminating, so a naive ACY -> LCY -> ACY round-trip drops a cent.
+        ExchangeRate := LibraryRandom.RandIntInRange(3, 3);
+        AddReportingCurrencyCode := CreateAddReportingCurrency(ExchangeRate);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase invoice whose Quantity and Direct Unit Cost are each one above a multiple of the exchange rate, so the ACY line amount is never divisible by it and ACY -> LCY rounding always leaves a remainder.
+        Quantity := LibraryRandom.RandInt(5) * ExchangeRate + 1;
+        DirectUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Quantity);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase invoice is posted.
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The Value Entry "Cost Amount (Actual) (ACY)" equals the exact document ACY amount, not the value obtained by reconverting the rounded LCY amount back to "C".
+        ExpectedCostAmountACY := DirectUnitCost * Quantity;
+        VerifyValueEntryCostAmountACY(Item."No.", DocumentNo, ExpectedCostAmountACY);
+
+        // [THEN] The Inventory Account G/L Entry "Additional-Currency Amount" matches the Value Entry ACY amount, so Value Entries and G/L Entries reconcile.
+        FindInventoryAccount(InventoryPostingSetup, Item);
+        VerifyGLEntryAddnlCurrencyAmount(InventoryPostingSetup."Inventory Account", DocumentNo, ExpectedCostAmountACY);
+    end;
+
+    [Test]
+    procedure PurchaseReceiptInACYUsesDocumentAmountForExpectedValueEntryACY()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        AddReportingCurrencyCode: Code[10];
+        DocumentNo: Code[20];
+        ExpectedCostAmountACY: Decimal;
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [Expected Cost] [AI test 0.4]
+        // [SCENARIO] Value Entry expected ACY cost uses the document Additional Reporting Currency amount directly instead of reconverting it from LCY when a purchase receipt is posted with expected cost posting enabled and the purchase currency equals the Additional Reporting Currency, so it reconciles with the interim G/L Entry Additional-Currency Amount before invoicing.
+        Initialize();
+
+        // [GIVEN] Automatic cost posting and expected cost posting to the interim inventory account are both enabled.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(true);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency. Exchange rate 3 is used because 1/3 is non-terminating, so a naive ACY -> LCY -> ACY round-trip drops a cent.
+        ExchangeRate := LibraryRandom.RandIntInRange(3, 3);
+        AddReportingCurrencyCode := CreateAddReportingCurrency(ExchangeRate);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase order whose Quantity and Direct Unit Cost are each one above a multiple of the exchange rate, so the ACY line amount is never divisible by it and ACY -> LCY rounding always leaves a remainder.
+        Quantity := LibraryRandom.RandInt(5) * ExchangeRate + 1;
+        DirectUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Quantity);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase order is received but not invoiced, so only the expected cost is posted.
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] The Value Entry "Cost Amount (Expected) (ACY)" equals the exact document ACY amount, not the value obtained by reconverting the rounded LCY amount back to "C".
+        ExpectedCostAmountACY := DirectUnitCost * Quantity;
+        VerifyValueEntryExpectedCostAmountACY(Item."No.", DocumentNo, ExpectedCostAmountACY);
+
+        // [THEN] The interim Inventory Account G/L Entry "Additional-Currency Amount" matches the Value Entry expected ACY amount, so Value Entries and G/L Entries reconcile before invoicing.
+        FindInventoryAccount(InventoryPostingSetup, Item);
+        VerifyGLEntryAddnlCurrencyAmount(InventoryPostingSetup."Inventory Account (Interim)", DocumentNo, ExpectedCostAmountACY);
+    end;
+
+    [Test]
+    procedure ItemChargeInACYReconcilesValueEntryAndGLEntryACY()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        ItemPurchaseLine: Record "Purchase Line";
+        ChargePurchaseLine: Record "Purchase Line";
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        ValueEntry: Record "Value Entry";
+        AddReportingCurrencyCode: Code[10];
+        DocumentNo: Code[20];
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        ChargeUnitCost: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [Item Charge]
+        // [SCENARIO] An item charge is excluded from the document-amount ACY shortcut (guard requires an empty Item Charge No.), so its Value Entry ACY is still derived from LCY. This verifies that item charges purchased in the Additional Reporting Currency continue to reconcile: the summed Value Entry "Cost Amount (Actual) (ACY)" equals the summed Inventory Account G/L Entry "Additional-Currency Amount".
+        Initialize();
+
+        // [GIVEN] Automatic cost posting to the inventory account is enabled and expected cost posting is disabled.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(false);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency. Exchange rate 3 is used because 1/3 is non-terminating, so a naive ACY -> LCY -> ACY round-trip drops a cent.
+        ExchangeRate := LibraryRandom.RandIntInRange(3, 3);
+        AddReportingCurrencyCode := CreateAddReportingCurrency(ExchangeRate);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase order in "C" with an item line and an item charge line assigned to that item line, each amount one above a multiple of the exchange rate so ACY -> LCY rounding always leaves a remainder.
+        Quantity := LibraryRandom.RandInt(5) * ExchangeRate + 1;
+        DirectUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        ChargeUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(ItemPurchaseLine, PurchaseHeader, ItemPurchaseLine.Type::Item, Item."No.", Quantity);
+        ItemPurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        ItemPurchaseLine.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+          ChargePurchaseLine, PurchaseHeader, ChargePurchaseLine.Type::"Charge (Item)", LibraryInventory.CreateItemChargeNo(), 1);
+        ChargePurchaseLine.Validate("Direct Unit Cost", ChargeUnitCost);
+        ChargePurchaseLine.Modify(true);
+        LibraryInventory.CreateItemChargeAssignPurchase(
+          ItemChargeAssignmentPurch, ChargePurchaseLine, PurchaseHeader."Document Type", PurchaseHeader."No.",
+          ItemPurchaseLine."Line No.", Item."No.");
+
+        // [WHEN] The purchase order is received and invoiced.
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The summed Value Entry "Cost Amount (Actual) (ACY)" (item plus charge) reconciles with the summed Inventory Account G/L Entry "Additional-Currency Amount", so excluding item charges from the shortcut does not break reconciliation.
+        FindInventoryAccount(InventoryPostingSetup, Item);
+        ValueEntry.SetRange("Item No.", Item."No.");
+        ValueEntry.SetRange("Document No.", DocumentNo);
+        ValueEntry.CalcSums("Cost Amount (Actual) (ACY)");
+        VerifyGLEntryAddnlCurrencyAmount(
+          InventoryPostingSetup."Inventory Account", DocumentNo, ValueEntry."Cost Amount (Actual) (ACY)");
+    end;
+
     [Normal]
     local procedure Initialize()
     var
@@ -82,6 +253,7 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         // Setup Demonstration data.
         LibraryERMCountryData.CreateVATData();
         LibraryERMCountryData.UpdateGeneralPostingSetup();
+        LibraryERMCountryData.UpdateGeneralLedgerSetup();
         LibraryERMCountryData.UpdateInventoryPostingSetup(); // NAVCZ
         LibrarySetupStorage.Save(DATABASE::"Inventory Setup");
         isInitialized := true;
@@ -270,6 +442,72 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
           Round(CurrencyExchangeRate."Exchange Rate Amount" / CurrencyExchangeRate."Relational Exch. Rate Amount" *
             GLEntry.Amount,
             CurrencyAmntRoundingPrecision));
+    end;
+
+    local procedure CreateAddReportingCurrency(ExchangeRate: Decimal): Code[10]
+    var
+        Currency: Record Currency;
+    begin
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        LibraryERM.CreateExchangeRate(Currency.Code, WorkDate(), ExchangeRate, ExchangeRate);
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Validate("Unit-Amount Rounding Precision", 0.00001);
+        Currency.Modify(true);
+        LibraryERM.SetAddReportingCurrency(Currency.Code);
+        exit(Currency.Code);
+    end;
+
+    local procedure CreateAverageCostItem(var Item: Record Item)
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Costing Method", Item."Costing Method"::Average);
+        Item.Modify(true);
+    end;
+
+    local procedure FindInventoryAccount(var InventoryPostingSetup: Record "Inventory Posting Setup"; Item: Record Item)
+    begin
+        InventoryPostingSetup.SetRange("Invt. Posting Group Code", Item."Inventory Posting Group");
+        InventoryPostingSetup.FindFirst();
+    end;
+
+    local procedure VerifyValueEntryCostAmountACY(ItemNo: Code[20]; DocumentNo: Code[20]; ExpectedCostAmountACY: Decimal)
+    var
+        ValueEntry: Record "Value Entry";
+    begin
+        ValueEntry.SetRange("Item No.", ItemNo);
+        ValueEntry.SetRange("Document No.", DocumentNo);
+        ValueEntry.CalcSums("Cost Amount (Actual) (ACY)");
+        Assert.AreEqual(
+          ExpectedCostAmountACY, ValueEntry."Cost Amount (Actual) (ACY)",
+          ValueEntry.FieldCaption("Cost Amount (Actual) (ACY)"));
+    end;
+
+    local procedure VerifyValueEntryExpectedCostAmountACY(ItemNo: Code[20]; DocumentNo: Code[20]; ExpectedCostAmountACY: Decimal)
+    var
+        ValueEntry: Record "Value Entry";
+    begin
+        ValueEntry.SetRange("Item No.", ItemNo);
+        ValueEntry.SetRange("Document No.", DocumentNo);
+        ValueEntry.CalcSums("Cost Amount (Expected) (ACY)");
+        Assert.AreEqual(
+          ExpectedCostAmountACY, ValueEntry."Cost Amount (Expected) (ACY)",
+          ValueEntry.FieldCaption("Cost Amount (Expected) (ACY)"));
+    end;
+
+    local procedure VerifyGLEntryAddnlCurrencyAmount(GLAccountNo: Code[20]; DocumentNo: Code[20]; ExpectedAddnlCurrencyAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+        ActualAddnlCurrencyAmount: Decimal;
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.FindSet();
+        repeat
+            ActualAddnlCurrencyAmount += GLEntry."Additional-Currency Amount";
+        until GLEntry.Next() = 0;
+        Assert.AreEqual(
+          ExpectedAddnlCurrencyAmount, ActualAddnlCurrencyAmount,
+          GLEntry.FieldCaption("Additional-Currency Amount"));
     end;
 
     [ConfirmHandler]

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -3682,21 +3682,40 @@ codeunit 22 "Item Jnl.-Post Line"
             end;
         end;
 
-        if GLSetup."Additional Reporting Currency" <> '' then begin
-            DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
-            OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
-            ItemJnlLine."Unit Cost (ACY)" :=
-              Round(
-                CurrExchRate.ExchangeAmtLCYToFCY(
-                  ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
-                  CurrExchRate.ExchangeRate(
-                    ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
-                Currency."Unit-Amount Rounding Precision");
-            PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
-        end;
+        if GLSetup."Additional Reporting Currency" <> '' then
+            if ShouldUseDocumentAmountForACY() then begin
+                if Expected then
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
+                else
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                OvhdCostACY := 0;
+                PurchVarACY := 0;
+            end else begin
+                DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
+                OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
+                ItemJnlLine."Unit Cost (ACY)" :=
+                  Round(
+                    CurrExchRate.ExchangeAmtLCYToFCY(
+                      ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
+                      CurrExchRate.ExchangeRate(
+                        ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
+                    Currency."Unit-Amount Rounding Precision");
+                PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
+            end;
         CalcUnitCost := (DirCost <> 0) and (ItemJnlLine."Unit Cost" = 0);
 
         OnAfterCalcPosShares(ItemJnlLine, DirCost, OvhdCost, PurchVar, DirCostACY, OvhdCostACY, PurchVarACY, CalcUnitCost, CalcPurchVar, Expected, GlobalItemLedgEntry);
+    end;
+
+    local procedure ShouldUseDocumentAmountForACY(): Boolean
+    begin
+        exit(
+          (ItemJnlLine."Source Currency Code" = GLSetup."Additional Reporting Currency") and
+          (Item."Costing Method" <> Item."Costing Method"::Standard) and
+          (ItemJnlLine."Item Charge No." = '') and
+          (ItemJnlLine."Discount Amount" = 0) and
+          (ItemJnlLine."Indirect Cost %" = 0) and
+          (ItemJnlLine."Overhead Rate" = 0));
     end;
 
     local procedure CalcPurchCorrShares(var OverheadAmount: Decimal; var OverheadAmountACY: Decimal; var VarianceAmount: Decimal; var VarianceAmountACY: Decimal)

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -103,6 +103,7 @@ codeunit 22 "Item Jnl.-Post Line"
         QtyPerUnitOfMeasure: Decimal;
         RoundingResidualAmount: Decimal;
         RoundingResidualAmountACY: Decimal;
+        RoundingResidualAmountInvdACY: Decimal;
         InvtSetupRead: Boolean;
         GLSetupRead: Boolean;
         SKUExists: Boolean;
@@ -306,9 +307,12 @@ codeunit 22 "Item Jnl.-Post Line"
 
         RoundingResidualAmount := 0;
         RoundingResidualAmountACY := 0;
+        RoundingResidualAmountInvdACY := 0;
         RoundingResidualAmount := ItemJnlLine.Quantity *
           (ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure, GLSetup."Unit-Amount Rounding Precision"));
         RoundingResidualAmountACY := ItemJnlLine.Quantity *
+          (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
+        RoundingResidualAmountInvdACY := ItemJnlLine."Invoiced Quantity" *
           (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
 
         ItemJnlLine."Unit Amount" := Round(
@@ -3687,7 +3691,7 @@ codeunit 22 "Item Jnl.-Post Line"
                 if Expected then
                     DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
                 else
-                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" + RoundingResidualAmountInvdACY;
                 OvhdCostACY := 0;
                 PurchVarACY := 0;
             end else begin

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -106,6 +106,7 @@ codeunit 22 "Item Jnl.-Post Line"
         QtyPerUnitOfMeasure: Decimal;
         RoundingResidualAmount: Decimal;
         RoundingResidualAmountACY: Decimal;
+        RoundingResidualAmountInvdACY: Decimal;
         InvtSetupRead: Boolean;
         GLSetupRead: Boolean;
         SKUExists: Boolean;
@@ -309,9 +310,12 @@ codeunit 22 "Item Jnl.-Post Line"
 
         RoundingResidualAmount := 0;
         RoundingResidualAmountACY := 0;
+        RoundingResidualAmountInvdACY := 0;
         RoundingResidualAmount := ItemJnlLine.Quantity *
           (ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure, GLSetup."Unit-Amount Rounding Precision"));
         RoundingResidualAmountACY := ItemJnlLine.Quantity *
+          (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
+        RoundingResidualAmountInvdACY := ItemJnlLine."Invoiced Quantity" *
           (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
 
         ItemJnlLine."Unit Amount" := Round(
@@ -3705,7 +3709,7 @@ codeunit 22 "Item Jnl.-Post Line"
                 if Expected then
                     DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
                 else
-                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" + RoundingResidualAmountInvdACY;
                 OvhdCostACY := 0;
                 PurchVarACY := 0;
             end else begin

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -3700,21 +3700,40 @@ codeunit 22 "Item Jnl.-Post Line"
             end;
         end;
 
-        if GLSetup."Additional Reporting Currency" <> '' then begin
-            DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
-            OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
-            ItemJnlLine."Unit Cost (ACY)" :=
-              Round(
-                CurrExchRate.ExchangeAmtLCYToFCY(
-                  ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
-                  CurrExchRate.ExchangeRate(
-                    ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
-                Currency."Unit-Amount Rounding Precision");
-            PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
-        end;
+        if GLSetup."Additional Reporting Currency" <> '' then
+            if ShouldUseDocumentAmountForACY() then begin
+                if Expected then
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
+                else
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                OvhdCostACY := 0;
+                PurchVarACY := 0;
+            end else begin
+                DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
+                OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
+                ItemJnlLine."Unit Cost (ACY)" :=
+                  Round(
+                    CurrExchRate.ExchangeAmtLCYToFCY(
+                      ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
+                      CurrExchRate.ExchangeRate(
+                        ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
+                    Currency."Unit-Amount Rounding Precision");
+                PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
+            end;
         CalcUnitCost := (DirCost <> 0) and (ItemJnlLine."Unit Cost" = 0);
 
         OnAfterCalcPosShares(ItemJnlLine, DirCost, OvhdCost, PurchVar, DirCostACY, OvhdCostACY, PurchVarACY, CalcUnitCost, CalcPurchVar, Expected, GlobalItemLedgEntry);
+    end;
+
+    local procedure ShouldUseDocumentAmountForACY(): Boolean
+    begin
+        exit(
+          (ItemJnlLine."Source Currency Code" = GLSetup."Additional Reporting Currency") and
+          (Item."Costing Method" <> Item."Costing Method"::Standard) and
+          (ItemJnlLine."Item Charge No." = '') and
+          (ItemJnlLine."Discount Amount" = 0) and
+          (ItemJnlLine."Indirect Cost %" = 0) and
+          (ItemJnlLine."Overhead Rate" = 0));
     end;
 
     local procedure CalcPurchCorrShares(var OverheadAmount: Decimal; var OverheadAmountACY: Decimal; var VarianceAmount: Decimal; var VarianceAmountACY: Decimal)

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -3712,21 +3712,40 @@ codeunit 22 "Item Jnl.-Post Line"
             end;
         end;
 
-        if GLSetup."Additional Reporting Currency" <> '' then begin
-            DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
-            OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
-            ItemJnlLine."Unit Cost (ACY)" :=
-              Round(
-                CurrExchRate.ExchangeAmtLCYToFCY(
-                  ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
-                  CurrExchRate.ExchangeRate(
-                    ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
-                Currency."Unit-Amount Rounding Precision");
-            PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
-        end;
+        if GLSetup."Additional Reporting Currency" <> '' then
+            if ShouldUseDocumentAmountForACY() then begin
+                if Expected then
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
+                else
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                OvhdCostACY := 0;
+                PurchVarACY := 0;
+            end else begin
+                DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
+                OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
+                ItemJnlLine."Unit Cost (ACY)" :=
+                  Round(
+                    CurrExchRate.ExchangeAmtLCYToFCY(
+                      ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
+                      CurrExchRate.ExchangeRate(
+                        ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
+                    Currency."Unit-Amount Rounding Precision");
+                PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
+            end;
         CalcUnitCost := (DirCost <> 0) and (ItemJnlLine."Unit Cost" = 0);
 
         OnAfterCalcPosShares(ItemJnlLine, DirCost, OvhdCost, PurchVar, DirCostACY, OvhdCostACY, PurchVarACY, CalcUnitCost, CalcPurchVar, Expected, GlobalItemLedgEntry);
+    end;
+
+    local procedure ShouldUseDocumentAmountForACY(): Boolean
+    begin
+        exit(
+          (ItemJnlLine."Source Currency Code" = GLSetup."Additional Reporting Currency") and
+          (Item."Costing Method" <> Item."Costing Method"::Standard) and
+          (ItemJnlLine."Item Charge No." = '') and
+          (ItemJnlLine."Discount Amount" = 0) and
+          (ItemJnlLine."Indirect Cost %" = 0) and
+          (ItemJnlLine."Overhead Rate" = 0));
     end;
 
     local procedure CalcPurchCorrShares(var OverheadAmount: Decimal; var OverheadAmountACY: Decimal; var VarianceAmount: Decimal; var VarianceAmountACY: Decimal)

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -109,6 +109,7 @@ codeunit 22 "Item Jnl.-Post Line"
         QtyPerUnitOfMeasure: Decimal;
         RoundingResidualAmount: Decimal;
         RoundingResidualAmountACY: Decimal;
+        RoundingResidualAmountInvdACY: Decimal;
         InvtSetupRead: Boolean;
         GLSetupRead: Boolean;
         SKUExists: Boolean;
@@ -316,9 +317,12 @@ codeunit 22 "Item Jnl.-Post Line"
 
         RoundingResidualAmount := 0;
         RoundingResidualAmountACY := 0;
+        RoundingResidualAmountInvdACY := 0;
         RoundingResidualAmount := ItemJnlLine.Quantity *
           (ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure, GLSetup."Unit-Amount Rounding Precision"));
         RoundingResidualAmountACY := ItemJnlLine.Quantity *
+          (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
+        RoundingResidualAmountInvdACY := ItemJnlLine."Invoiced Quantity" *
           (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
 
         ItemJnlLine."Unit Amount" := Round(
@@ -3717,7 +3721,7 @@ codeunit 22 "Item Jnl.-Post Line"
                 if Expected then
                     DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
                 else
-                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" + RoundingResidualAmountInvdACY;
                 OvhdCostACY := 0;
                 PurchVarACY := 0;
             end else begin

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -3669,21 +3669,40 @@ codeunit 22 "Item Jnl.-Post Line"
             end;
         end;
 
-        if GLSetup."Additional Reporting Currency" <> '' then begin
-            DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
-            OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
-            ItemJnlLine."Unit Cost (ACY)" :=
-              Round(
-                CurrExchRate.ExchangeAmtLCYToFCY(
-                  ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
-                  CurrExchRate.ExchangeRate(
-                    ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
-                Currency."Unit-Amount Rounding Precision");
-            PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
-        end;
+        if GLSetup."Additional Reporting Currency" <> '' then
+            if ShouldUseDocumentAmountForACY() then begin
+                if Expected then
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
+                else
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                OvhdCostACY := 0;
+                PurchVarACY := 0;
+            end else begin
+                DirCostACY := ACYMgt.CalcACYAmt(DirCost, ItemJnlLine."Posting Date", false);
+                OvhdCostACY := ACYMgt.CalcACYAmt(OvhdCost, ItemJnlLine."Posting Date", false);
+                ItemJnlLine."Unit Cost (ACY)" :=
+                  Round(
+                    CurrExchRate.ExchangeAmtLCYToFCY(
+                      ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency", ItemJnlLine."Unit Cost",
+                      CurrExchRate.ExchangeRate(
+                        ItemJnlLine."Posting Date", GLSetup."Additional Reporting Currency")),
+                    Currency."Unit-Amount Rounding Precision");
+                PurchVarACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" - DirCostACY - OvhdCostACY;
+            end;
         CalcUnitCost := (DirCost <> 0) and (ItemJnlLine."Unit Cost" = 0);
 
         OnAfterCalcPosShares(ItemJnlLine, DirCost, OvhdCost, PurchVar, DirCostACY, OvhdCostACY, PurchVarACY, CalcUnitCost, CalcPurchVar, Expected, GlobalItemLedgEntry);
+    end;
+
+    local procedure ShouldUseDocumentAmountForACY(): Boolean
+    begin
+        exit(
+          (ItemJnlLine."Source Currency Code" = GLSetup."Additional Reporting Currency") and
+          (Item."Costing Method" <> Item."Costing Method"::Standard) and
+          (ItemJnlLine."Item Charge No." = '') and
+          (ItemJnlLine."Discount Amount" = 0) and
+          (ItemJnlLine."Indirect Cost %" = 0) and
+          (ItemJnlLine."Overhead Rate" = 0));
     end;
 
     local procedure CalcPurchCorrShares(var OverheadAmount: Decimal; var OverheadAmountACY: Decimal; var VarianceAmount: Decimal; var VarianceAmountACY: Decimal)

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -103,6 +103,7 @@ codeunit 22 "Item Jnl.-Post Line"
         QtyPerUnitOfMeasure: Decimal;
         RoundingResidualAmount: Decimal;
         RoundingResidualAmountACY: Decimal;
+        RoundingResidualAmountInvdACY: Decimal;
         InvtSetupRead: Boolean;
         GLSetupRead: Boolean;
         SKUExists: Boolean;
@@ -306,9 +307,12 @@ codeunit 22 "Item Jnl.-Post Line"
 
         RoundingResidualAmount := 0;
         RoundingResidualAmountACY := 0;
+        RoundingResidualAmountInvdACY := 0;
         RoundingResidualAmount := ItemJnlLine.Quantity *
           (ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost" / QtyPerUnitOfMeasure, GLSetup."Unit-Amount Rounding Precision"));
         RoundingResidualAmountACY := ItemJnlLine.Quantity *
+          (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
+        RoundingResidualAmountInvdACY := ItemJnlLine."Invoiced Quantity" *
           (ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure - Round(ItemJnlLine."Unit Cost (ACY)" / QtyPerUnitOfMeasure, Currency."Unit-Amount Rounding Precision"));
 
         ItemJnlLine."Unit Amount" := Round(
@@ -3674,7 +3678,7 @@ codeunit 22 "Item Jnl.-Post Line"
                 if Expected then
                     DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine.Quantity + RoundingResidualAmountACY
                 else
-                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity";
+                    DirCostACY := ItemJnlLine."Unit Cost (ACY)" * ItemJnlLine."Invoiced Quantity" + RoundingResidualAmountInvdACY;
                 OvhdCostACY := 0;
                 PurchVarACY := 0;
             end else begin

--- a/src/Layers/W1/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
@@ -18,6 +18,7 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         LibraryERM: Codeunit "Library - ERM";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        Assert: Codeunit Assert;
         isInitialized: Boolean;
 
     [Test]
@@ -66,6 +67,176 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         VerifyInvtWIPAmntGLEntry(CurrencyExchangeRate, Currency."Amount Rounding Precision", PurchaseLine."No.");
     end;
 
+    [Test]
+    procedure PurchaseInACYUsesDocumentAmountForValueEntryACY()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        AddReportingCurrencyCode: Code[10];
+        DocumentNo: Code[20];
+        ExpectedCostAmountACY: Decimal;
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [AI test 0.4]
+        // [SCENARIO] Value Entry ACY cost uses the document Additional Reporting Currency amount directly instead of reconverting it from LCY when the purchase currency equals the Additional Reporting Currency, so it reconciles with the G/L Entry Additional-Currency Amount.
+        Initialize();
+
+        // [GIVEN] Automatic cost posting to the inventory account is enabled and expected cost posting is disabled.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(false);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency. Exchange rate 3 is used because 1/3 is non-terminating, so a naive ACY -> LCY -> ACY round-trip drops a cent.
+        ExchangeRate := LibraryRandom.RandIntInRange(3, 3);
+        AddReportingCurrencyCode := CreateAddReportingCurrency(ExchangeRate);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase invoice whose Quantity and Direct Unit Cost are each one above a multiple of the exchange rate, so the ACY line amount is never divisible by it and ACY -> LCY rounding always leaves a remainder.
+        Quantity := LibraryRandom.RandInt(5) * ExchangeRate + 1;
+        DirectUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Quantity);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase invoice is posted.
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The Value Entry "Cost Amount (Actual) (ACY)" equals the exact document ACY amount, not the value obtained by reconverting the rounded LCY amount back to "C".
+        ExpectedCostAmountACY := DirectUnitCost * Quantity;
+        VerifyValueEntryCostAmountACY(Item."No.", DocumentNo, ExpectedCostAmountACY);
+
+        // [THEN] The Inventory Account G/L Entry "Additional-Currency Amount" matches the Value Entry ACY amount, so Value Entries and G/L Entries reconcile.
+        FindInventoryAccount(InventoryPostingSetup, Item);
+        VerifyGLEntryAddnlCurrencyAmount(InventoryPostingSetup."Inventory Account", DocumentNo, ExpectedCostAmountACY);
+    end;
+
+    [Test]
+    procedure PurchaseReceiptInACYUsesDocumentAmountForExpectedValueEntryACY()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        AddReportingCurrencyCode: Code[10];
+        DocumentNo: Code[20];
+        ExpectedCostAmountACY: Decimal;
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [Expected Cost] [AI test 0.4]
+        // [SCENARIO] Value Entry expected ACY cost uses the document Additional Reporting Currency amount directly instead of reconverting it from LCY when a purchase receipt is posted with expected cost posting enabled and the purchase currency equals the Additional Reporting Currency, so it reconciles with the interim G/L Entry Additional-Currency Amount before invoicing.
+        Initialize();
+
+        // [GIVEN] Automatic cost posting and expected cost posting to the interim inventory account are both enabled.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(true);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency. Exchange rate 3 is used because 1/3 is non-terminating, so a naive ACY -> LCY -> ACY round-trip drops a cent.
+        ExchangeRate := LibraryRandom.RandIntInRange(3, 3);
+        AddReportingCurrencyCode := CreateAddReportingCurrency(ExchangeRate);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase order whose Quantity and Direct Unit Cost are each one above a multiple of the exchange rate, so the ACY line amount is never divisible by it and ACY -> LCY rounding always leaves a remainder.
+        Quantity := LibraryRandom.RandInt(5) * ExchangeRate + 1;
+        DirectUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Quantity);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase order is received but not invoiced, so only the expected cost is posted.
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] The Value Entry "Cost Amount (Expected) (ACY)" equals the exact document ACY amount, not the value obtained by reconverting the rounded LCY amount back to "C".
+        ExpectedCostAmountACY := DirectUnitCost * Quantity;
+        VerifyValueEntryExpectedCostAmountACY(Item."No.", DocumentNo, ExpectedCostAmountACY);
+
+        // [THEN] The interim Inventory Account G/L Entry "Additional-Currency Amount" matches the Value Entry expected ACY amount, so Value Entries and G/L Entries reconcile before invoicing.
+        FindInventoryAccount(InventoryPostingSetup, Item);
+        VerifyGLEntryAddnlCurrencyAmount(InventoryPostingSetup."Inventory Account (Interim)", DocumentNo, ExpectedCostAmountACY);
+    end;
+
+    [Test]
+    procedure ItemChargeInACYReconcilesValueEntryAndGLEntryACY()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        ItemPurchaseLine: Record "Purchase Line";
+        ChargePurchaseLine: Record "Purchase Line";
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+        ValueEntry: Record "Value Entry";
+        AddReportingCurrencyCode: Code[10];
+        DocumentNo: Code[20];
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        ChargeUnitCost: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [Item Charge]
+        // [SCENARIO] An item charge is excluded from the document-amount ACY shortcut (guard requires an empty Item Charge No.), so its Value Entry ACY is still derived from LCY. This verifies that item charges purchased in the Additional Reporting Currency continue to reconcile: the summed Value Entry "Cost Amount (Actual) (ACY)" equals the summed Inventory Account G/L Entry "Additional-Currency Amount".
+        Initialize();
+
+        // [GIVEN] Automatic cost posting to the inventory account is enabled and expected cost posting is disabled.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(false);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency. Exchange rate 3 is used because 1/3 is non-terminating, so a naive ACY -> LCY -> ACY round-trip drops a cent.
+        ExchangeRate := LibraryRandom.RandIntInRange(3, 3);
+        AddReportingCurrencyCode := CreateAddReportingCurrency(ExchangeRate);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase order in "C" with an item line and an item charge line assigned to that item line, each amount one above a multiple of the exchange rate so ACY -> LCY rounding always leaves a remainder.
+        Quantity := LibraryRandom.RandInt(5) * ExchangeRate + 1;
+        DirectUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        ChargeUnitCost := LibraryRandom.RandInt(20) * ExchangeRate + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(ItemPurchaseLine, PurchaseHeader, ItemPurchaseLine.Type::Item, Item."No.", Quantity);
+        ItemPurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        ItemPurchaseLine.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(
+          ChargePurchaseLine, PurchaseHeader, ChargePurchaseLine.Type::"Charge (Item)", LibraryInventory.CreateItemChargeNo(), 1);
+        ChargePurchaseLine.Validate("Direct Unit Cost", ChargeUnitCost);
+        ChargePurchaseLine.Modify(true);
+        LibraryInventory.CreateItemChargeAssignPurchase(
+          ItemChargeAssignmentPurch, ChargePurchaseLine, PurchaseHeader."Document Type", PurchaseHeader."No.",
+          ItemPurchaseLine."Line No.", Item."No.");
+
+        // [WHEN] The purchase order is received and invoiced.
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] The summed Value Entry "Cost Amount (Actual) (ACY)" (item plus charge) reconciles with the summed Inventory Account G/L Entry "Additional-Currency Amount", so excluding item charges from the shortcut does not break reconciliation.
+        FindInventoryAccount(InventoryPostingSetup, Item);
+        ValueEntry.SetRange("Item No.", Item."No.");
+        ValueEntry.SetRange("Document No.", DocumentNo);
+        ValueEntry.CalcSums("Cost Amount (Actual) (ACY)");
+        VerifyGLEntryAddnlCurrencyAmount(
+          InventoryPostingSetup."Inventory Account", DocumentNo, ValueEntry."Cost Amount (Actual) (ACY)");
+    end;
+
     [Normal]
     local procedure Initialize()
     var
@@ -82,6 +253,7 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         // Setup Demonstration data.
         LibraryERMCountryData.CreateVATData();
         LibraryERMCountryData.UpdateGeneralPostingSetup();
+        LibraryERMCountryData.UpdateGeneralLedgerSetup();
         LibrarySetupStorage.Save(DATABASE::"Inventory Setup");
         isInitialized := true;
         Commit();
@@ -269,6 +441,72 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
           Round(CurrencyExchangeRate."Exchange Rate Amount" / CurrencyExchangeRate."Relational Exch. Rate Amount" *
             GLEntry.Amount,
             CurrencyAmntRoundingPrecision));
+    end;
+
+    local procedure CreateAddReportingCurrency(ExchangeRate: Decimal): Code[10]
+    var
+        Currency: Record Currency;
+    begin
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        LibraryERM.CreateExchangeRate(Currency.Code, WorkDate(), ExchangeRate, ExchangeRate);
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Validate("Unit-Amount Rounding Precision", 0.00001);
+        Currency.Modify(true);
+        LibraryERM.SetAddReportingCurrency(Currency.Code);
+        exit(Currency.Code);
+    end;
+
+    local procedure CreateAverageCostItem(var Item: Record Item)
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Costing Method", Item."Costing Method"::Average);
+        Item.Modify(true);
+    end;
+
+    local procedure FindInventoryAccount(var InventoryPostingSetup: Record "Inventory Posting Setup"; Item: Record Item)
+    begin
+        InventoryPostingSetup.SetRange("Invt. Posting Group Code", Item."Inventory Posting Group");
+        InventoryPostingSetup.FindFirst();
+    end;
+
+    local procedure VerifyValueEntryCostAmountACY(ItemNo: Code[20]; DocumentNo: Code[20]; ExpectedCostAmountACY: Decimal)
+    var
+        ValueEntry: Record "Value Entry";
+    begin
+        ValueEntry.SetRange("Item No.", ItemNo);
+        ValueEntry.SetRange("Document No.", DocumentNo);
+        ValueEntry.CalcSums("Cost Amount (Actual) (ACY)");
+        Assert.AreEqual(
+          ExpectedCostAmountACY, ValueEntry."Cost Amount (Actual) (ACY)",
+          ValueEntry.FieldCaption("Cost Amount (Actual) (ACY)"));
+    end;
+
+    local procedure VerifyValueEntryExpectedCostAmountACY(ItemNo: Code[20]; DocumentNo: Code[20]; ExpectedCostAmountACY: Decimal)
+    var
+        ValueEntry: Record "Value Entry";
+    begin
+        ValueEntry.SetRange("Item No.", ItemNo);
+        ValueEntry.SetRange("Document No.", DocumentNo);
+        ValueEntry.CalcSums("Cost Amount (Expected) (ACY)");
+        Assert.AreEqual(
+          ExpectedCostAmountACY, ValueEntry."Cost Amount (Expected) (ACY)",
+          ValueEntry.FieldCaption("Cost Amount (Expected) (ACY)"));
+    end;
+
+    local procedure VerifyGLEntryAddnlCurrencyAmount(GLAccountNo: Code[20]; DocumentNo: Code[20]; ExpectedAddnlCurrencyAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+        ActualAddnlCurrencyAmount: Decimal;
+    begin
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.FindSet();
+        repeat
+            ActualAddnlCurrencyAmount += GLEntry."Additional-Currency Amount";
+        until GLEntry.Next() = 0;
+        Assert.AreEqual(
+          ExpectedAddnlCurrencyAmount, ActualAddnlCurrencyAmount,
+          GLEntry.FieldCaption("Additional-Currency Amount"));
     end;
 
     [ConfirmHandler]

--- a/src/Layers/W1/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Costing/SCMWIPCostingAddnlCurrency.Codeunit.al
@@ -237,6 +237,69 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
           InventoryPostingSetup."Inventory Account", DocumentNo, ValueEntry."Cost Amount (Actual) (ACY)");
     end;
 
+    [Test]
+    procedure PurchaseInACYWithNonBaseUoMKeepsUnitCostRoundingResidualOnBothLegs()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        AddReportingCurrencyCode: Code[10];
+        ReceiptDocumentNo: Code[20];
+        InvoiceDocumentNo: Code[20];
+        ExpectedCostAmountACY: Decimal;
+        Quantity: Decimal;
+        DirectUnitCost: Decimal;
+        QtyPerUnitOfMeasure: Decimal;
+        ExchangeRate: Decimal;
+    begin
+        // [FEATURE] [ACY] [Purchase] [Expected Cost] [Unit of Measure] [AI test 0.4]
+        // [SCENARIO] When the purchase currency equals the Additional Reporting Currency and the purchase unit of measure holds more than one base unit, the per-base-unit ACY unit cost must be rounded, which drops a residual. Both the expected (receipt) and the actual (invoice) Value Entry ACY amounts must still equal the exact document ACY amount, so neither leg drifts by the dropped residual.
+        Initialize();
+
+        // [GIVEN] Automatic cost posting and expected cost posting are both enabled, so the receipt posts an expected ACY cost that is later reversed and replaced by the actual ACY cost on invoicing.
+        LibraryInventory.SetAutomaticCostPosting(true);
+        LibraryInventory.SetExpectedCostPosting(true);
+
+        // [GIVEN] Currency "C" is the Additional Reporting Currency with a coarse 0.01 Unit-Amount Rounding Precision, so rounding the per-base-unit ACY cost drops a residual larger than the 0.01 Amount Rounding Precision and a dropped residual is visible on the Value Entry. The exchange rate only affects LCY conversion, not the ACY amount, so it can be random.
+        ExchangeRate := LibraryRandom.RandIntInRange(2, 10);
+        AddReportingCurrencyCode := CreateAddReportingCurrencyWithUnitAmountPrecision(ExchangeRate, 0.01);
+
+        // [GIVEN] An Average costing Item and a Vendor invoicing in the Additional Reporting Currency "C".
+        CreateAverageCostItem(Item);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Currency Code", AddReportingCurrencyCode);
+        Vendor.Modify(true);
+
+        // [GIVEN] A purchase unit of measure holding a random multiple of 3 base units, so 1/(base-unit count) stays a non-terminating decimal (a factor of 3 never clears against the 2s and 5s of the rounding precision).
+        QtyPerUnitOfMeasure := 3 * LibraryRandom.RandIntInRange(1, 5);
+        LibraryInventory.CreateItemUnitOfMeasureCode(ItemUnitOfMeasure, Item."No.", QtyPerUnitOfMeasure);
+
+        // [GIVEN] A purchase order for a random number of that unit of measure at a random unit cost that is never divisible by the base-unit count, so the per-base-unit ACY cost is a repeating decimal that rounds and drops a residual on each base unit.
+        Quantity := LibraryRandom.RandIntInRange(2, 10);
+        DirectUnitCost := QtyPerUnitOfMeasure * LibraryRandom.RandIntInRange(2, 10) + 1;
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", Quantity);
+        PurchaseLine.Validate("Unit of Measure Code", ItemUnitOfMeasure.Code);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase order is received but not invoiced, so only the expected cost is posted.
+        ReceiptDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] The Value Entry "Cost Amount (Expected) (ACY)" equals the exact document ACY amount, with the residual folded back in.
+        ExpectedCostAmountACY := DirectUnitCost * Quantity;
+        VerifyValueEntryExpectedCostAmountACY(Item."No.", ReceiptDocumentNo, ExpectedCostAmountACY);
+
+        // [WHEN] The same purchase order is invoiced separately.
+        PurchaseHeader.Find();
+        InvoiceDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
+
+        // [THEN] The Value Entry "Cost Amount (Actual) (ACY)" also equals the exact document ACY amount, so the actual leg reconstructs the residual exactly as the expected leg does instead of dropping it.
+        VerifyValueEntryCostAmountACY(Item."No.", InvoiceDocumentNo, ExpectedCostAmountACY);
+    end;
+
     [Normal]
     local procedure Initialize()
     var
@@ -451,6 +514,19 @@ codeunit 137002 "SCM WIP Costing Addnl Currency"
         LibraryERM.CreateExchangeRate(Currency.Code, WorkDate(), ExchangeRate, ExchangeRate);
         Currency.Validate("Amount Rounding Precision", 0.01);
         Currency.Validate("Unit-Amount Rounding Precision", 0.00001);
+        Currency.Modify(true);
+        LibraryERM.SetAddReportingCurrency(Currency.Code);
+        exit(Currency.Code);
+    end;
+
+    local procedure CreateAddReportingCurrencyWithUnitAmountPrecision(ExchangeRate: Decimal; UnitAmountRoundingPrecision: Decimal): Code[10]
+    var
+        Currency: Record Currency;
+    begin
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        LibraryERM.CreateExchangeRate(Currency.Code, WorkDate(), ExchangeRate, ExchangeRate);
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Validate("Unit-Amount Rounding Precision", UnitAmountRoundingPrecision);
         Currency.Modify(true);
         LibraryERM.SetAddReportingCurrency(Currency.Code);
         exit(Currency.Code);


### PR DESCRIPTION
Fixes [AB#646085](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646085)





