### PR TITLE
[Agent Archiving] Fix broken reference links to archived agents and their tasks

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocuments.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/Inbound/InboundEDocuments.Page.al
@@ -94,13 +94,18 @@ page 6105 "Inbound E-Documents"
 
                     trigger OnDrillDown()
                     var
-                        Task: Record "Agent Task";
+                        AgentTaskCU: Codeunit "Agent Task";
                         TaskPane: Codeunit "Task Pane";
                     begin
                         if AgentTask.ID = 0 then
                             exit;
-                        Task.Get(AgentTask.ID);
-                        TaskPane.ShowTask(Task);
+
+                        // An archived agent is not resolvable in the task pane, so its tasks are shown
+                        // as log entries instead, which keeps them reachable for auditing.
+                        if AgentTask."Agent Substate" = AgentTask."Agent Substate"::Archived then
+                            AgentTaskCU.OpenAgentTaskLogEntries(AgentTask.ID)
+                        else
+                            TaskPane.ShowTask(AgentTask.ID);
                     end;
                 }
 #if not CLEAN28

--- a/src/Apps/W1/PayablesAgent/app/Extensions/PAPurchaseInvoiceList.PageExt.al
+++ b/src/Apps/W1/PayablesAgent/app/Extensions/PAPurchaseInvoiceList.PageExt.al
@@ -95,6 +95,14 @@ pageextension 3309 "PA Purchase Invoice List" extends "Purchase Invoices"
         if not PayablesAgentSetup.GetAgent(Agent) then
             exit;
 
+        // An archived agent is not resolvable in the task pane, so the agent card is opened instead,
+        // which keeps the agent reachable for auditing.
+        if Agent.Substate = Agent.Substate::Archived then begin
+            Agent.SetRecFilter();
+            Page.Run(Page::"Agent Card", Agent);
+            exit;
+        end;
+
         TaskPane.ShowAgent(Agent."User Security ID");
     end;
 

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.Agents;
 
+using System.Agents.TaskPane;
 using System.Agents.Troubleshooting;
 using System.Environment;
 using System.Integration;
@@ -57,6 +58,27 @@ codeunit 4300 "Agent Task Impl."
     begin
         AgentTaskLogEntry.SetRange("Task ID", AgentTask.ID);
         Page.Run(Page::"Agent Task Log Entry List", AgentTaskLogEntry);
+    end;
+
+    procedure ShowTask(AgentTaskID: BigInteger)
+    var
+        AgentTask: Record "Agent Task";
+    begin
+        AgentTask.Get(AgentTaskID);
+        ShowTask(AgentTask);
+    end;
+
+    procedure ShowTask(var AgentTask: Record "Agent Task")
+    var
+        TaskPane: Codeunit "Task Pane";
+    begin
+        // Route archived agents' tasks to the task log entries card, which keeps it reachable for auditing.
+        if AgentTask."Agent Substate" = AgentTask."Agent Substate"::Archived then begin
+            ShowTaskLogEntries(AgentTask);
+            exit;
+        end;
+
+        TaskPane.ShowTask(AgentTask);
     end;
 
     procedure CreateTask(AgentUserSecurityID: Guid; TaskTitle: Text[150]; ExternalID: Text[2048]; BillingContext: Enum "Agent Task Billing Context"; ModelId: Code[30]; var NewAgentTask: Record "Agent Task")

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskImpl.Codeunit.al
@@ -60,14 +60,6 @@ codeunit 4300 "Agent Task Impl."
         Page.Run(Page::"Agent Task Log Entry List", AgentTaskLogEntry);
     end;
 
-    procedure ShowTask(AgentTaskID: BigInteger)
-    var
-        AgentTask: Record "Agent Task";
-    begin
-        AgentTask.Get(AgentTaskID);
-        ShowTask(AgentTask);
-    end;
-
     procedure ShowTask(var AgentTask: Record "Agent Task")
     var
         TaskPane: Codeunit "Task Pane";

--- a/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentTaskList.Page.al
@@ -5,8 +5,6 @@
 
 namespace System.Agents;
 
-using System.Agents.TaskPane;
-
 page 4300 "Agent Task List"
 {
     PageType = List;
@@ -37,9 +35,9 @@ page 4300 "Agent Task List"
 
                     trigger OnDrillDown()
                     var
-                        TaskPane: Codeunit "Task Pane";
+                        AgentTaskImpl: Codeunit "Agent Task Impl.";
                     begin
-                        TaskPane.ShowTask(Rec);
+                        AgentTaskImpl.ShowTask(Rec);
                     end;
                 }
                 field(Title; Rec.Title)
@@ -92,9 +90,9 @@ page 4300 "Agent Task List"
 
                     trigger OnDrillDown()
                     var
-                        TaskPane: Codeunit "Task Pane";
+                        AgentImpl: Codeunit "Agent Impl.";
                     begin
-                        TaskPane.ShowAgent(Rec."Agent User Security ID");
+                        AgentImpl.ShowAgent(Rec."Agent User Security ID");
                     end;
                 }
                 field(AgentSubstate; Rec."Agent Substate")

--- a/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Setup/AgentImpl.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace System.Agents;
 
+using System.Agents.TaskPane;
 using System.AI;
 using System.Environment;
 using System.Environment.Configuration;
@@ -80,6 +81,21 @@ codeunit 4301 "Agent Impl."
         GetAgent(Agent, AgentUserSecurityID);
 
         exit(Agent.Substate = Agent.Substate::Archived);
+    end;
+
+    procedure ShowAgent(AgentUserSecurityID: Guid)
+    var
+        Agent: Record Agent;
+        TaskPane: Codeunit "Task Pane";
+    begin
+        // Route archived agents to the agent card, which keeps the agent reachable for auditing.
+        if Agent.Get(AgentUserSecurityID) and (Agent.Substate = Agent.Substate::Archived) then begin
+            Agent.SetRecFilter();
+            Page.Run(Page::"Agent Card", Agent);
+            exit;
+        end;
+
+        TaskPane.ShowAgent(AgentUserSecurityID);
     end;
 
     // Agent-record changes are frozen by the platform VDP; this guards the other tables.

--- a/src/System Application/App/Agent/Troubleshooting/AgentTaskContextPart.Page.al
+++ b/src/System Application/App/Agent/Troubleshooting/AgentTaskContextPart.Page.al
@@ -6,7 +6,6 @@
 namespace System.Agents.Troubleshooting;
 
 using System.Agents;
-using System.Agents.TaskPane;
 
 #pragma warning disable AS0007 // Aligning namespaces.
 page 4343 "Agent Task Context Part"
@@ -31,9 +30,9 @@ page 4343 "Agent Task Context Part"
 
                 trigger OnDrillDown()
                 var
-                    TaskPane: Codeunit "Task Pane";
+                    AgentImpl: Codeunit "Agent Impl.";
                 begin
-                    TaskPane.ShowAgent(Rec."Agent User Security ID");
+                    AgentImpl.ShowAgent(Rec."Agent User Security ID");
                 end;
             }
             field(TaskID; Rec.ID)
@@ -45,9 +44,9 @@ page 4343 "Agent Task Context Part"
 
                 trigger OnDrillDown()
                 var
-                    TaskPane: Codeunit "Task Pane";
+                    AgentTaskImpl: Codeunit "Agent Task Impl.";
                 begin
-                    TaskPane.ShowTask(Rec);
+                    AgentTaskImpl.ShowTask(Rec);
                 end;
             }
             field(TaskTitle; Rec.Title)

--- a/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
+++ b/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
@@ -5,6 +5,7 @@
 namespace System.Test.Agents;
 
 using System.Agents;
+using System.Agents.Troubleshooting;
 using System.Environment.Configuration;
 using System.Reflection;
 using System.Security.AccessControl;
@@ -1616,6 +1617,64 @@ codeunit 133961 "Agent Test"
         Assert.IsFalse(Agent.IsArchived(AgentId), 'An active agent should not be archived; it must be deactivated first');
     end;
 
+    [Test]
+    [HandlerFunctions('AgentCardPageHandler')]
+    procedure ArchivedAgentLinkOpensAgentCard()
+    var
+        AgentRecord: Record Agent;
+        Any: Codeunit Any;
+        AgentImpl: Codeunit "Agent Impl.";
+        AgentId: Guid;
+        DisplayName: Text[80];
+    begin
+        Initialize();
+
+        // [SCENARIO] A reference link to an archived agent opens the agent card, because the client cannot
+        // resolve an archived agent and the task pane would fail to open
+
+        // [GIVEN] An archived agent
+        DisplayName := CopyStr(Any.AlphanumericText(80), 1, 80);
+        AgentId := CreateDeactivatedAgent(AgentRecord, DisplayName);
+        Agent.Archive(AgentId);
+
+        // [WHEN] The agent reference link is followed
+        AgentImpl.ShowAgent(AgentId);
+
+        // [THEN] The agent card is opened for that agent
+        Assert.AreEqual(DisplayName, LibraryVariableStorage.DequeueText(), 'The agent card should be opened for the archived agent.');
+    end;
+
+    [Test]
+    [HandlerFunctions('AgentTaskLogEntryListPageHandler')]
+    procedure ArchivedAgentTaskLinkOpensTaskLogEntries()
+    var
+        AgentRecord: Record Agent;
+        AgentTaskRecord: Record "Agent Task";
+        AgentTaskBuilder: Codeunit "Agent Task Builder";
+        AgentTaskImpl: Codeunit "Agent Task Impl.";
+        Any: Codeunit Any;
+        AgentId: Guid;
+    begin
+        Initialize();
+
+        // [SCENARIO] A reference link to the task of an archived agent opens the task log entries, because the
+        // client cannot resolve the archived agent and the task pane would fail to open
+
+        // [GIVEN] An agent with a task, that is then archived
+        AgentId := CreateActiveAgent(AgentRecord, CopyStr(Any.AlphanumericText(80), 1, 80));
+        AgentTaskBuilder.Initialize(AgentId, 'Task of an agent that gets archived');
+        AgentTaskRecord := AgentTaskBuilder.Create(false, false); // Allow for tasks without message.
+
+        Agent.Deactivate(AgentId);
+        Agent.Archive(AgentId);
+
+        // [WHEN] The task reference link is followed
+        AgentTaskImpl.ShowTask(AgentTaskRecord.ID);
+
+        // [THEN] The log entries of that task are opened
+        Assert.AreEqual(Format(AgentTaskRecord.ID), LibraryVariableStorage.DequeueText(), 'The log entries should be opened for the task of the archived agent.');
+    end;
+
     [ModalPageHandler]
     procedure AgentArchiveConfirmationModalHandler(var AgentArchiveConfirmation: TestPage "Agent Archive Confirmation")
     var
@@ -1636,6 +1695,21 @@ codeunit 133961 "Agent Test"
     begin
         Assert.AreEqual('This agent is archived and can no longer be modified. Its tasks and logs remain available for auditing.', ArchivedNotification.Message(), 'Unexpected notification was raised on the archived agent card.');
         exit(true);
+    end;
+
+    [PageHandler]
+    procedure AgentCardPageHandler(var AgentCard: TestPage "Agent Card")
+    begin
+        LibraryVariableStorage.Enqueue(AgentCard.DisplayName.Value());
+        AgentCard.Close();
+    end;
+
+    [PageHandler]
+    procedure AgentTaskLogEntryListPageHandler(var AgentTaskLogEntryList: TestPage "Agent Task Log Entry List")
+    begin
+        // The page can be empty when the task has no log entries yet, so assert on the filter rather than a row.
+        LibraryVariableStorage.Enqueue(AgentTaskLogEntryList.Filter.GetFilter("Task ID"));
+        AgentTaskLogEntryList.Close();
     end;
 
     local procedure CreateDeactivatedAgent(var AgentRecord: Record Agent; DisplayName: Text[80]) AgentId: Guid

--- a/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
+++ b/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
@@ -1618,7 +1618,7 @@ codeunit 133961 "Agent Test"
     end;
 
     [Test]
-    [HandlerFunctions('AgentCardPageHandler')]
+    [HandlerFunctions('SendArchivedAgentNotificationHandler,AgentCardPageHandler')]
     procedure ArchivedAgentLinkOpensAgentCard()
     var
         AgentRecord: Record Agent;
@@ -1642,6 +1642,7 @@ codeunit 133961 "Agent Test"
 
         // [THEN] The agent card is opened for that agent
         Assert.AreEqual(DisplayName, LibraryVariableStorage.DequeueText(), 'The agent card should be opened for the archived agent.');
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     [Test]
@@ -1673,6 +1674,7 @@ codeunit 133961 "Agent Test"
 
         // [THEN] The log entries of that task are opened
         Assert.AreEqual(Format(AgentTaskRecord.ID), LibraryVariableStorage.DequeueText(), 'The log entries should be opened for the task of the archived agent.');
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     [ModalPageHandler]

--- a/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
+++ b/src/System Application/Test/Agent/src/SDK/AgentTest.Codeunit.al
@@ -1670,7 +1670,8 @@ codeunit 133961 "Agent Test"
         Agent.Archive(AgentId);
 
         // [WHEN] The task reference link is followed
-        AgentTaskImpl.ShowTask(AgentTaskRecord.ID);
+        AgentTaskRecord.Get(AgentTaskRecord.ID);
+        AgentTaskImpl.ShowTask(AgentTaskRecord);
 
         // [THEN] The log entries of that task are opened
         Assert.AreEqual(Format(AgentTaskRecord.ID), LibraryVariableStorage.DequeueText(), 'The log entries should be opened for the task of the archived agent.');


### PR DESCRIPTION
## What & why

Reference links to an **archived** agent or to an archived agent's task are broken. Clicking the agent task reference on Inbound E-Documents, or the agent/task drill-downs on the agent task pages, either reports that the agent/task could not be found or silently lands on an unrelated agent's task list.

Cause: the client resolves agents through a visibility lookup that also gates access, so an archived agent is not resolvable there and the task pane cannot open it. The task pane then falls back to the first visible agent.

Archived agents must stay reachable for auditing, so the links now route to a surface that can show them.

| Link | When the agent is archived |
| --- | --- |
| Agent reference | Opens the **Agent Card** |
| Agent task reference | Opens the **Agent Task Log Entries** |

Non-archived agents are unaffected — every path still goes to the task pane exactly as before.

## Changes

Two internal helpers pick the surface, and the affected call sites use them:

- `Agent Impl.ShowAgent` and `Agent Task Impl.ShowTask` (both codeunits are `Access = Internal`)
- Call sites: Agent Task List (4300), Agent Task Context Part (4343), Inbound E-Documents, PA Purchase Invoice List

**No new public API.** The two apps outside the System Application inline the same check using API that already ships today (`Agent.Substate`, `AgentTask."Agent Substate"`, `Agent Task.OpenAgentTaskLogEntries`, page `Agent Card`), so this stays easy to revoke once the substate is carried to the client properly.

## Linked work

[AB#620767](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620767)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior.

Two tests in `Agent Test` cover the archived routing: an archived agent's reference opens the agent card, and an archived agent's task reference opens that task's log entries.

Verified on a local NST for the Agent Task List and Agent Task Context Part links.

## Risk & compatibility

- Behaviour changes only when `Substate = Archived`; every other path is unchanged.
- If the agent or task record cannot be read, the code falls through to the task pane, i.e. previous behaviour.
- No schema, permission, telemetry or upgrade impact.



