### PR TITLE
[MCP] Change System Tool factbox caption to 'Active System Tools'

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPSystemToolList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPSystemToolList.Page.al
@@ -7,7 +7,7 @@ namespace System.MCP;
 
 page 8365 "MCP System Tool List"
 {
-    Caption = 'System Tools';
+    Caption = 'Active System Tools';
     ApplicationArea = All;
     PageType = ListPart;
     SourceTable = "MCP System Tool";


### PR DESCRIPTION
## What & why

Renames the caption of the **MCP System Tool List** factbox (page `8365`) from **"System Tools"** to **"Active System Tools"**.

This factbox appears on the MCP Configuration Card and lists the tools contributed by the *active* server features for the configuration. The previous title "System Tools" was ambiguous; "Active System Tools" better reflects that only tools from active features are shown.

## Linked work

Fixes [AB#647280](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647280)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- This is a display-only change: a single `Caption` string literal on ListPart page 8365. It cannot alter logic or behavior.
- Verified the diff contains only the one-line caption change (`System Tools` → `Active System Tools`).
- No tests added: no test asserts on this caption text, and BC caption translations (XLIFF) are build-generated, so no other source changes are required.

## Risk & compatibility

None — UI caption text only. No data, permission, API, or behavioral impact.




