### PR TITLE
[Master] - Bug 647272: [Expense Agent] Unwanted caption in expense report FactBox

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportFactBox.Page.al
@@ -8,7 +8,7 @@ page 7098 "Expense Report FactBox"
 {
     PageType = CardPart;
     SourceTable = "Expense Report Header";
-    Caption = 'Expense Report FactBox';
+    Caption = 'Expense Report';
 
     layout
     {

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReportFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReportFactBox.Page.al
@@ -8,7 +8,7 @@ page 7094 "Posted Expense Report FactBox"
 {
     PageType = CardPart;
     SourceTable = "Posted Expense Report Header";
-    Caption = 'Posted Expense Report FactBox';
+    Caption = 'Posted Expense Report';
     Editable = false;
 
     layout


### PR DESCRIPTION
[AB#647272](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647272)

## Summary
- Change the Expense Report FactBox caption to `Expense Report`.
- Change the Posted Expense Report FactBox caption to `Posted Expense Report`.

## Reference audit
- Verified all six Expense Report FactBox hosts and the Posted Expense Report host inherit the owning page caption; none overrides `Caption`.
- Verified the permission-set references require no change.
- Checked the other Expense Agent FactBox pages; their captions are already user-facing.

## Validation
- Built the Expense Agent app with CodeCop, AppSourceCop, and UICop: no errors or warnings.


