### PR TITLE
[Subscription Billing] Sales-Explode BOM fails for foreign-currency

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -818,7 +818,7 @@ table 8068 "Sales Subscription Line"
 
     local procedure GetDate(): Date
     begin
-        SalesLine.Get(Rec."Document Type", Rec."Document No.", Rec."Document Line No.");
+        GetSalesLine(SalesLine);
         exit(SalesLine.GetDate());
     end;
 

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -1846,6 +1846,33 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
+    [HandlerFunctions('StrMenuHandler')]
+    procedure TestTransferSalesServiceCommitmentsOnExplodeBOMInForeignCurrency()
+    var
+        Item2: Record Item;
+    begin
+        // [SCENARIO] Exploding a BOM on a sales line for a customer invoicing in a foreign currency must not
+        // fail with "'Sales Line' does not exist", because "Sales Subscription Line".GetDate() must reuse the
+        // cached sales line instead of a hard Get() on a sales line that has not been inserted yet.
+        Initialize();
+        LibraryAssembly.CreateItem(Item2, Item."Costing Method"::Standard, Item."Replenishment System"::Assembly, '', '');
+        CreateComponentItemWithSalesServiceCommitments(Item2."No.");
+
+        ContractTestLibrary.CreateCustomer(Customer, LibraryERM.CreateCurrencyWithRandomExchRates());
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
+        LibrarySales.CreateSalesLineWithShipmentDate(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item2."No.", WorkDate(), LibraryRandom.RandInt(100));
+        Codeunit.Run(Codeunit::"Sales-Explode BOM", SalesLine);
+
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.SetRange(Type, Enum::"Sales Line Type"::Item);
+        SalesLine.SetRange("No.", Item."No.");
+        SalesLine.FindLast();
+        SalesLine.CalcFields("Subscription Lines");
+        SalesLine.TestField("Subscription Lines");
+    end;
+
+    [Test]
     procedure UnitPriceOnSalesLineForServiceCommitmentItemShouldRemainAfterPosting()
     var
         SalesWithSubscription: Record Item;


### PR DESCRIPTION
## What & why
Bugfix for a Sales Document when you explode the BOM of an Item when a BOM Component has subscription package lines.

## Linked work


Fixes #10441

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
I fixed this test-driven.

## Risk & compatibility
Bugfix with test.
