### PR TITLE
[Bug][Subscription Billing] Contract Renewal Quote total ignores the Billing Base Period and shows the base-period amount instead of the renewal-term amount

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Sales Service Commitments/Tables/SalesSubscriptionLine.Table.al
@@ -612,12 +612,7 @@ table 8068 "Sales Subscription Line"
     var
         SalesServiceCommitment: Record "Sales Subscription Line";
         SalesTaxCalculate: Codeunit "Sales Tax Calculate";
-        BasePeriodCount: Integer;
-        RhythmPeriodCount: Integer;
     begin
-        BasePeriodCount := 1;
-        RhythmPeriodCount := 1;
-
         if SalesHeader."Currency Code" = '' then
             Currency.InitRoundingPrecision()
         else
@@ -630,7 +625,7 @@ table 8068 "Sales Subscription Line"
         SalesServiceCommitment.SetRange("Invoicing via", SalesServiceCommitment."Invoicing via"::Contract);
         if SalesServiceCommitment.FindSet() then
             repeat
-                CreateTempSalesServiceCommitmentBuffForSalesServiceCommitment(SalesServiceCommitment, TempSalesServiceCommitmentBuff, UniqueRhythmDictionary, BasePeriodCount, RhythmPeriodCount);
+                CreateTempSalesServiceCommitmentBuffForSalesServiceCommitment(SalesServiceCommitment, TempSalesServiceCommitmentBuff, UniqueRhythmDictionary);
             until SalesServiceCommitment.Next() = 0;
 
         if TempSalesServiceCommitmentBuff.Find('-') then
@@ -693,9 +688,7 @@ table 8068 "Sales Subscription Line"
 
     local procedure CreateTempSalesServiceCommitmentBuffForSalesServiceCommitment(SalesServiceCommitment: Record "Sales Subscription Line";
                                                                  var TempSalesServiceCommitmentBuff: Record "Sales Service Commitment Buff." temporary;
-                                                                 var UniqueRhythmDictionary: Dictionary of [Code[20], Text];
-                                                                 var BasePeriodCount: Integer;
-                                                                 var RhythmPeriodCount: Integer)
+                                                                 var UniqueRhythmDictionary: Dictionary of [Code[20], Text])
     var
         SalesLineVAT: Record "Sales Line";
         ContractRenewalMgt: Codeunit "Sub. Contract Renewal Mgt.";
@@ -703,6 +696,8 @@ table 8068 "Sales Subscription Line"
         RhythmIdentifier: Code[20];
         ContractRenewalPriceCalculationRatio: Decimal;
         VatPercent: Decimal;
+        BasePeriodCount: Integer;
+        RhythmPeriodCount: Integer;
         DateFormulaType: Enum "Date Formula Type";
         ContractRenewalLbl: Label 'Contract Renewal';
         RhythmTextLbl: Label '%1 %2', Comment = '%1 = Billing Rhythm Period Count,%2 = Billing Rhythm Text';
@@ -713,15 +708,17 @@ table 8068 "Sales Subscription Line"
             exit;
 
         GetSalesLine(SalesServiceCommitment, SalesLineVAT);
-        // Get Rhythm and Base period count
+        // Get Rhythm and Base period count. The Amount is stated per Billing Base Period and has to be converted to the Billing Rhythm.
+        // An empty or complex Billing Base Period or Billing Rhythm leaves the count at 1, so the Amount is then taken as it is.
+        BasePeriodCount := 1;
+        RhythmPeriodCount := 1;
+        DateFormulaType := DateFormulaManagement.FindDateFormulaTypeForComparison(SalesServiceCommitment."Billing Rhythm", RhythmPeriodCount);
+        DateFormulaManagement.FindDateFormulaTypeForComparison(SalesServiceCommitment."Billing Base Period", BasePeriodCount);
         if SalesLineVAT.IsContractRenewal() then begin
             ContractRenewalPriceCalculationRatio := DateFormulaManagement.CalculateRenewalTermRatioByBillingRhythm(SalesServiceCommitment."Agreed Sub. Line Start Date", SalesServiceCommitment."Initial Term", SalesServiceCommitment."Billing Rhythm");
             RhythmIdentifier := ContractRenewalMgt.GetContractRenewalIdentifierLabel();
             RhythmText := ContractRenewalLbl;
         end else begin
-            DateFormulaType := DateFormulaManagement.FindDateFormulaTypeForComparison(SalesServiceCommitment."Billing Rhythm", RhythmPeriodCount);
-            DateFormulaManagement.FindDateFormulaTypeForComparison(SalesServiceCommitment."Billing Base Period", BasePeriodCount);
-
             if (DateFormulaType = DateFormulaType::Quarter) or (DateFormulaType = DateFormulaType::Year) then
                 DateFormulaType := DateFormulaType::Month;
             RhythmIdentifier := Format(RhythmPeriodCount) + Format(DateFormulaType);
@@ -762,7 +759,7 @@ table 8068 "Sales Subscription Line"
             TempSalesServiceCommitmentBuff.Reset();
             TempSalesServiceCommitmentBuff.Quantity += SalesLineVAT."Quantity (Base)";
             if SalesLineVAT.IsContractRenewal() then
-                TempSalesServiceCommitmentBuff."Line Amount" += SalesServiceCommitment.Amount * ContractRenewalPriceCalculationRatio
+                TempSalesServiceCommitmentBuff."Line Amount" += SalesServiceCommitment.Amount / BasePeriodCount * RhythmPeriodCount * ContractRenewalPriceCalculationRatio
             else
                 TempSalesServiceCommitmentBuff."Line Amount" += SalesServiceCommitment.Amount / BasePeriodCount * RhythmPeriodCount;
             TempSalesServiceCommitmentBuff.Modify(false);

--- a/src/Apps/W1/Subscription Billing/Test/Contract Renewal/ContractRenewalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Renewal/ContractRenewalTest.Codeunit.al
@@ -381,6 +381,104 @@ codeunit 139692 "Contract Renewal Test"
         TestContractRenewalPeriodCalculation(NewRenewalTerm);
     end;
 
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler,SelectContractRenewalHandler')]
+    [Test]
+    procedure CheckVatCalculationForContractRenewalWithBillingBasePeriodDifferentFromBillingRhythm()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesServiceCommitment: Record "Sales Subscription Line";
+        TempSalesServiceCommitmentBuff: Record "Sales Service Commitment Buff." temporary;
+        DateFormulaManagement: Codeunit "Date Formula Management";
+        UniqueRhythmDictionary: Dictionary of [Code[20], Text];
+    begin
+        // [SCENARIO] The Subscription totals of a Contract Renewal Quote show the amount for the whole renewal term.
+        // [SCENARIO] The Amount per Billing Base Period is converted to the Billing Rhythm first and only then scaled by the renewal term.
+        Initialize();
+
+        // [GIVEN] A Contract Renewal Quote over a Renewal Term of <12M> for a Subscription Line priced at 100 per month (Billing Base Period <1M>) but billed yearly (Billing Rhythm <12M>)
+        CreateContractRenewalQuoteForBillingPeriods('<1M>', '<12M>', '<12M>', SalesHeader, SalesServiceCommitment);
+
+        // [GIVEN] Exactly one Billing Rhythm fits into the Renewal Term, so the renewal ratio does not scale the amount at all
+        Assert.AreEqual(
+            1, DateFormulaManagement.CalculateRenewalTermRatioByBillingRhythm(SalesServiceCommitment."Agreed Sub. Line Start Date", SalesServiceCommitment."Initial Term", SalesServiceCommitment."Billing Rhythm"),
+            'A Renewal Term of <12M> billed in a Billing Rhythm of <12M> should result in a renewal ratio of exactly 1.');
+
+        // [WHEN] VAT amount lines are calculated for the Contract Renewal Quote
+        SalesServiceCommitment.CalcVATAmountLines(SalesHeader, TempSalesServiceCommitmentBuff, UniqueRhythmDictionary);
+
+        // [THEN] The totals show the amount for the whole 12 month renewal term (100 per month * 12), not the monthly amount
+        Assert.RecordCount(TempSalesServiceCommitmentBuff, 1);
+        TempSalesServiceCommitmentBuff.CalcSums("Line Amount");
+        Assert.AreEqual(1200, TempSalesServiceCommitmentBuff."Line Amount", 'Contract Renewal Sales Quote VAT Line Amount must be scaled from the Billing Base Period to the Billing Rhythm.');
+    end;
+
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler,SelectContractRenewalHandler')]
+    [Test]
+    procedure CheckVatCalculationForContractRenewalWithoutBillingBasePeriod()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesServiceCommitment: Record "Sales Subscription Line";
+        TempSalesServiceCommitmentBuff: Record "Sales Service Commitment Buff." temporary;
+        UniqueRhythmDictionary: Dictionary of [Code[20], Text];
+    begin
+        // [SCENARIO] A Contract Renewal Quote whose Subscription Line has no Billing Base Period still shows a total.
+        // [SCENARIO] Create Sub. Contract Renewal only transfers the Billing Base Period when it is set, so it can reach the Sales Quote empty.
+        // [SCENARIO] The Contract Renewal branch has to fall back the same way the regular branch does, which counts a missing Billing Base Period as 1.
+        // [SCENARIO] What is pinned here is that consistency between the two branches, not the amount the billing engine charges for such a line.
+        Initialize();
+
+        // [GIVEN] A Contract Renewal Quote over a Renewal Term of <12M> for a Subscription Line priced at 100 per year (Billing Base Period <12M>) and billed yearly (Billing Rhythm <12M>)
+        CreateContractRenewalQuoteForBillingPeriods('<12M>', '<12M>', '<12M>', SalesHeader, SalesServiceCommitment);
+
+        // [GIVEN] The Subscription Line of the quote has no Billing Base Period
+        Clear(SalesServiceCommitment."Billing Base Period");
+        SalesServiceCommitment.Modify(false);
+
+        // [WHEN] VAT amount lines are calculated for the Contract Renewal Quote
+        SalesServiceCommitment.CalcVATAmountLines(SalesHeader, TempSalesServiceCommitmentBuff, UniqueRhythmDictionary);
+
+        // [THEN] The Amount is scaled to the Billing Rhythm with a Billing Base Period count of 1, the same fallback a regular Sales Quote applies
+        Assert.RecordCount(TempSalesServiceCommitmentBuff, 1);
+        TempSalesServiceCommitmentBuff.CalcSums("Line Amount");
+        Assert.AreEqual(1200, TempSalesServiceCommitmentBuff."Line Amount", 'Contract Renewal Sales Quote VAT Line Amount must fall back to a Billing Base Period count of 1.');
+    end;
+
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler,SelectContractRenewalHandler')]
+    [Test]
+    procedure CheckVatCalculationForContractRenewalWithComplexBillingRhythm()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesServiceCommitment: Record "Sales Subscription Line";
+        TempSalesServiceCommitmentBuff: Record "Sales Service Commitment Buff." temporary;
+        DateFormulaManagement: Codeunit "Date Formula Management";
+        ComplexBillingRhythm: DateFormula;
+        ExpectedLineAmount: Decimal;
+        UniqueRhythmDictionary: Dictionary of [Code[20], Text];
+    begin
+        // [SCENARIO] A Billing Rhythm that is not a plain period (<1M+1D>) has no period count, so the Amount has to be taken as it is instead of being multiplied by zero.
+        Initialize();
+
+        // [GIVEN] A Contract Renewal Quote over a Renewal Term of <12M> for a Subscription Line priced at 100
+        CreateContractRenewalQuoteForBillingPeriods('<1M>', '<1M>', '<12M>', SalesHeader, SalesServiceCommitment);
+
+        // [GIVEN] The Subscription Line of the quote is billed in a complex Billing Rhythm and has no Billing Base Period to compare it against
+        Clear(SalesServiceCommitment."Billing Base Period");
+        Evaluate(ComplexBillingRhythm, '<1M+1D>');
+        SalesServiceCommitment."Billing Rhythm" := ComplexBillingRhythm;
+        SalesServiceCommitment.Modify(false);
+
+        ExpectedLineAmount := 100 * DateFormulaManagement.CalculateRenewalTermRatioByBillingRhythm(SalesServiceCommitment."Agreed Sub. Line Start Date", SalesServiceCommitment."Initial Term", ComplexBillingRhythm);
+        Assert.IsTrue(ExpectedLineAmount > 0, 'The renewal ratio for a complex Billing Rhythm should be greater than zero.');
+
+        // [WHEN] VAT amount lines are calculated for the Contract Renewal Quote
+        SalesServiceCommitment.CalcVATAmountLines(SalesHeader, TempSalesServiceCommitmentBuff, UniqueRhythmDictionary);
+
+        // [THEN] The total is the Amount scaled by the renewal term ratio only, and not zero
+        Assert.RecordCount(TempSalesServiceCommitmentBuff, 1);
+        TempSalesServiceCommitmentBuff.CalcSums("Line Amount");
+        Assert.AreEqual(ExpectedLineAmount, TempSalesServiceCommitmentBuff."Line Amount", 'Contract Renewal Sales Quote VAT Line Amount must fall back to a Billing Rhythm count of 1.');
+    end;
+
     [Test]
     [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler,ConfirmHandler,ContractRenewalSelectionHandler')]
     procedure CheckServCommSelectionPageAcceptChanges()
@@ -925,6 +1023,43 @@ codeunit 139692 "Contract Renewal Test"
         ContractTestLibrary.SetGeneralPostingSetup(Customer."Gen. Bus. Posting Group", Item."Gen. Prod. Posting Group", false, Enum::"Service Partner"::Customer);
     end;
 
+    local procedure CreateContractRenewalQuoteForBillingPeriods(BillingBasePeriodText: Text; BillingRhythmText: Text; RenewalTermText: Text; var SalesHeader: Record "Sales Header"; var SalesServiceCommitment: Record "Sales Subscription Line")
+    var
+        ServiceCommitment: Record "Subscription Line";
+        BillingBasePeriod: DateFormula;
+        BillingRhythm: DateFormula;
+        NewRenewalTerm: DateFormula;
+    begin
+        // Creates a Contract Renewal Quote for a Customer Subscription Contract with a single Subscription Line
+        // that uses the given Billing Base Period and Billing Rhythm, and prices the resulting Sales Subscription Line at 100 per Billing Base Period
+        Evaluate(BillingBasePeriod, BillingBasePeriodText);
+        Evaluate(BillingRhythm, BillingRhythmText);
+        Evaluate(NewRenewalTerm, RenewalTermText);
+
+        CreateBaseData(false, false, 1, 0);
+
+        ServiceCommitment.Reset();
+        ServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        ServiceCommitment.FindFirst();
+        ContractTestLibrary.ValidateBillingBasePeriodAndBillingRhythmOnServiceCommitment(ServiceCommitment, BillingBasePeriodText, BillingRhythmText);
+        ServiceCommitment.Modify(false);
+
+        UpdateContractLinesWithNewRenewalTerm(NewRenewalTerm);
+        Clear(ContractRenewalMgt);
+        SalesHeader.Get(SalesHeader."Document Type"::Quote, CreateSalesQuoteFromContract()); // SelectContractRenewalHandler
+
+        SalesServiceCommitment.FilterOnDocument(SalesHeader."Document Type", SalesHeader."No.");
+        SalesServiceCommitment.SetRange(Partner, Enum::"Service Partner"::Customer);
+        SalesServiceCommitment.SetRange("Invoicing via", SalesServiceCommitment."Invoicing via"::Contract);
+        Assert.RecordCount(SalesServiceCommitment, 1);
+        SalesServiceCommitment.FindFirst();
+        SalesServiceCommitment.TestField("Billing Base Period", BillingBasePeriod);
+        SalesServiceCommitment.TestField("Billing Rhythm", BillingRhythm);
+        SalesServiceCommitment.TestField("Initial Term", NewRenewalTerm);
+        SalesServiceCommitment.Amount := 100;
+        SalesServiceCommitment.Modify(false);
+    end;
+
     local procedure CreateContractRenewalLinesFromContract()
     var
         CustomerContract2: Record "Customer Subscription Contract";
@@ -1080,11 +1215,18 @@ codeunit 139692 "Contract Renewal Test"
         SalesServiceCommitment: Record "Sales Subscription Line";
         TempSalesServiceCommitmentBuff: Record "Sales Service Commitment Buff." temporary;
         DateFormulaManagement: Codeunit "Date Formula Management";
+        BillingBasePeriodOneYear: DateFormula;
+        BillingRhythmOneMonth: DateFormula;
         SalesQuoteNo: Code[20];
         ExpectedCalculatedLineAmount: Decimal;
         PriceRatio: Decimal;
         UniqueRhythmDictionary: Dictionary of [Code[20], Text];
     begin
+        // The base data prices every Subscription Line per year and bills it monthly, so one Billing Rhythm is a twelfth of the Billing Base Period.
+        // That factor is stated here as a literal instead of being read back through Date Formula Management, so the expectation cannot follow the implementation into a wrong conversion.
+        Evaluate(BillingBasePeriodOneYear, '<1Y>');
+        Evaluate(BillingRhythmOneMonth, '<1M>');
+
         UpdateContractLinesWithNewRenewalTerm(NewRenewalTerm);
 
         Clear(ContractRenewalMgt);
@@ -1097,9 +1239,11 @@ codeunit 139692 "Contract Renewal Test"
             SalesServiceCommitment.FilterOnSalesLine(SalesLine);
             SalesServiceCommitment.FindFirst();
             SalesServiceCommitment.TestField("Initial Term", NewRenewalTerm);
-            SalesServiceCommitment.TestField("Billing Rhythm");
+            SalesServiceCommitment.TestField("Billing Base Period", BillingBasePeriodOneYear);
+            SalesServiceCommitment.TestField("Billing Rhythm", BillingRhythmOneMonth);
             PriceRatio := DateFormulaManagement.CalculateRenewalTermRatioByBillingRhythm(SalesServiceCommitment."Agreed Sub. Line Start Date", SalesServiceCommitment."Initial Term", SalesServiceCommitment."Billing Rhythm");
-            ExpectedCalculatedLineAmount += SalesServiceCommitment.Amount * PriceRatio;
+            // The Amount is stated per Billing Base Period; it has to be converted to the Billing Rhythm before the renewal term ratio is applied
+            ExpectedCalculatedLineAmount += SalesServiceCommitment.Amount / 12 * PriceRatio;
         until SalesLine.Next() = 0;
 
         SalesServiceCommitment.CalcVATAmountLines(SalesHeader, TempSalesServiceCommitmentBuff, UniqueRhythmDictionary);


### PR DESCRIPTION
## What & why

The subscription totals block on a printed Contract Renewal Quote showed the amount per Billing Base Period instead of the amount for the renewal term the customer is actually being asked to sign. With Billing Base Period `1M`, Billing Rhythm `12M` and a Renewal Term of `12M`, a Subscription Line priced at 100 per month printed a total of 100 instead of 1,200.

`"Sales Subscription Line".CalcVATAmountLines` delegates to the local procedure `CreateTempSalesServiceCommitmentBuffForSalesServiceCommitment`, which converted `Amount` from the Billing Base Period to the Billing Rhythm **only in the regular branch**. The contract-renewal branch multiplied by `CalculateRenewalTermRatioByBillingRhythm` alone — that ratio expresses how many Billing Rhythms fit into the renewal term, not how the base period relates to the rhythm. When the two happen to coincide the ratio is exactly 1, which is why the defect stayed invisible in the common `1M`/`1M` case where both factors are 1.

This change moves the two `FindDateFormulaTypeForComparison` lookups above the branch so both paths share one conversion, and applies `/ BasePeriodCount * RhythmPeriodCount` in the contract-renewal branch as well:

```al
if SalesLineVAT.IsContractRenewal() then
    TempSalesServiceCommitmentBuff."Line Amount" += SalesServiceCommitment.Amount / BasePeriodCount * RhythmPeriodCount * ContractRenewalPriceCalculationRatio
else
    TempSalesServiceCommitmentBuff."Line Amount" += SalesServiceCommitment.Amount / BasePeriodCount * RhythmPeriodCount;
```

It also turns `BasePeriodCount` and `RhythmPeriodCount` from `var` parameters threaded in from `CalcVATAmountLines` into locals of the procedure, re-initialised to 1 per line. As `var` parameters they were initialised once per document, and `FindDateFormulaType` leaves `PeriodCount` untouched for empty, complex and current-period formulas — so one line's period count leaked into the next.

## Linked work

Fixes #10356

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Container `sb10356`. The Subscription Billing App, Test and Demo Data apps were built with `alc.exe` and published to that container, where the tests below were executed and the renewal quote total was also checked manually.

**Build** — clean, with CodeCop, UICop and PerTenantExtensionCop plus `base.ruleset.json`. No analyzer warnings from the changed files.

**TDD (red first)** — with the fix reverted, the new test `CheckVatCalculationForContractRenewalWithBillingBasePeriodDifferentFromBillingRhythm` failed with:

```
Expected:<1200> Actual:<100>
```

which is exactly the number reported in the issue.

**Green** — codeunit `139692 "Contract Renewal Test"`, run with `al_run_tests` against `sb10356`. The four relevant tests: **5 passed, 0 failed**.

- `CheckVatCalculationForContractRenewalWithBillingBasePeriodDifferentFromBillingRhythm` (new) — the reported `1M` base period / `12M` rhythm / `12M` renewal term scenario.
- `CheckVatCalculationForContractRenewalWithoutBillingBasePeriod` (new) — empty Billing Base Period falls back to a count of 1, the same way the regular branch does.
- `CheckVatCalculationForContractRenewalWithComplexBillingRhythm` (new) — a `<1M+1D>` rhythm has no period count, so the amount is taken as it is rather than multiplied by zero.
- `CheckVatCalculationForContractRenewalServiceCommitmentRhythmInReports` (existing) — its oracle in the helper `TestContractRenewalPeriodCalculation` was asserting the defect, because the base data uses Billing Base Period `1Y` with Billing Rhythm `1M`. The expectation now states the conversion factor as a literal guarded by `TestField("Billing Base Period", ...)` / `TestField("Billing Rhythm", ...)` instead of deriving it through Date Formula Management, so the assertion can no longer follow the implementation into a wrong conversion.


**Codeunit 139915 "Sales Service Commitment Test"** — covers the non-renewal branch of the same procedure, which this change also touches: 66 passed, 0 failed.

**Mutation testing** — executed, not reasoned: for each mutant the source was edited, rebuilt, republished and the tests re-run, then reverted. 7 mutants, all killed.

| # | Mutant | Killed by | Observed |
|---|---|---|---|
| 1 | Drop `* RhythmPeriodCount` | new `...WithBillingBasePeriodDifferentFromBillingRhythm` | 100 instead of 1200 |
| 2 | Drop `/ BasePeriodCount` | `...ServiceCommitmentRhythmInReports` (multi-term) | 181.28 instead of 15.11 |
| 3 | Drop `* ContractRenewalPriceCalculationRatio` | `...ServiceCommitmentRhythmInReports` (multi-term) | 46.83 |
| 4 | Swap the base and rhythm lookups | all three new tests | 8.33 |
| 5 | Drop `BasePeriodCount := 1` | `...WithoutBillingBasePeriod` | divide by zero |
| 6 | Drop `RhythmPeriodCount := 1` | `...WithComplexBillingRhythm` | total silently 0 |
| 7 | Remove `DateFormulaType::Year: PeriodCountForComparison * 12` from `DateFormulaManagement.FindDateFormulaTypeForComparison` | corrected oracle in `TestContractRenewalPeriodCalculation` | `Expected:<15.11> Actual:<181.28>` |

Mutants 5 and 6 survived the first round; `...WithoutBillingBasePeriod` and `...WithComplexBillingRhythm` were written specifically to kill them. Mutant 7 reproduces the original defect through the date-formula helper — the **old** oracle stayed green on it, which is what demonstrates that the oracle correction has teeth.

This change adds no new `Label`, `Caption` or `ToolTip`, so it introduces no translatable strings and there is nothing to add to the XLIFF files.

## Risk & compatibility

- **Behavioural change, by design.** Contract Renewal Quotes whose Subscription Lines have a Billing Base Period that differs from the Billing Rhythm now show a different (correct) subscription total. Quotes where base period and rhythm match are unaffected — both factors are 1 there.
- **No stored data changes.** The totals are computed into a temporary `"Sales Service Commitment Buff."` when the document is printed or statistics are opened, so existing open Contract Renewal Quotes will display the corrected total on their next print without any upgrade step. No table schema change, no permission, telemetry or upgrade impact.
- The regular (non-renewal) branch is unchanged in arithmetic; only the two `FindDateFormulaTypeForComparison` lookups moved above the branch and the two period counts became locals. The fixed leak of `BasePeriodCount` / `RhythmPeriodCount` between lines can also change a **regular** multi-line quote whose lines use different rhythms — previously the second line could inherit the first line's counts when its own formula is empty, complex or current-period.
- The signature change is on the `local procedure CreateTempSalesServiceCommitmentBuffForSalesServiceCommitment`; the public `CalcVATAmountLines` signature is untouched, so nothing external can be broken by it.
- **Deliberately out of scope:** the issue's secondary observation that the `Subscriptions*` detail rows print `SalesSubscriptionLine.Price` into "Unit Price" with no period indication. Fixing that means adding a column to three report layout `.docx` files, and the issue's "Expected behavior" section covers only the totals block. Left for a follow-up.

