### PR TITLE
[Bug][Subscription Billing] Price Update Template filters on Subscription Lines are overwritten by the proposal's own default filters

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Contract Price Update/Codeunits/PriceUpdateManagement.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Contract Price Update/Codeunits/PriceUpdateManagement.Codeunit.al
@@ -142,6 +142,9 @@ codeunit 8009 "Price Update Management"
 
     local procedure ApplyDefaultFiltering(var ServiceCommitment: Record "Subscription Line"; PriceUpdateTemplate: Record "Price Update Template"; IncludeServiceCommitmentUpToDate: Date)
     begin
+        // The mandatory defaults are set in a separate filter group so that they intersect with the filters
+        // stored on the Price Update Template instead of replacing them field by field.
+        ServiceCommitment.FilterGroup(2);
         ServiceCommitment.SetRange(Partner, PriceUpdateTemplate.Partner);
         ServiceCommitment.SetRange("Exclude from Price Update", false);
         ServiceCommitment.SetRange("Invoicing via", Enum::"Invoicing Via"::Contract);
@@ -149,18 +152,21 @@ codeunit 8009 "Price Update Management"
         ServiceCommitment.SetRange("Planned Sub. Line exists", false);
         ServiceCommitment.SetRange("Usage Based Billing", false);
         ServiceCommitment.SetRange(Closed, false);
+        ServiceCommitment.FilterGroup(0);
     end;
 
-    local procedure InitTempServiceCommitmentTable(ServiceCommitment: Record "Subscription Line"; var TempServiceCommitment: Record "Subscription Line" temporary)
+    // ServiceCommitment must be passed by reference: an AL record parameter passed by value does not
+    // carry the caller's filters, so the temporary table would be seeded from the whole table instead of
+    // from the filtering ApplyDefaultFiltering applied. Proven by
+    // TestSubscriptionLineFilterCannotWidenDefaultFilteringOnNextPriceUpdate.
+    local procedure InitTempServiceCommitmentTable(var ServiceCommitment: Record "Subscription Line"; var TempServiceCommitment: Record "Subscription Line" temporary)
     begin
         TempServiceCommitment.Reset();
         TempServiceCommitment.DeleteAll(false);
         if ServiceCommitment.FindSet() then
             repeat
-                if not ServiceCommitment.Closed then begin
-                    TempServiceCommitment := ServiceCommitment;
-                    TempServiceCommitment.Insert(false);
-                end;
+                TempServiceCommitment := ServiceCommitment;
+                TempServiceCommitment.Insert(false);
             until ServiceCommitment.Next() = 0;
     end;
 
@@ -245,6 +251,9 @@ codeunit 8009 "Price Update Management"
 
     local procedure MarkServiceCommitmentsFromTempTable(var ServiceCommitment: Record "Subscription Line"; var TempServiceCommitment: Record "Subscription Line" temporary)
     begin
+        // Reset() also clears the mandatory defaults that ApplyDefaultFiltering sets in filter group 2.
+        // Keep it: the record is handed back to the callers and to the integration event below, and must
+        // not carry filters that GetFilters() does not show them.
         ServiceCommitment.Reset();
         if TempServiceCommitment.FindSet() then
             repeat

--- a/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
@@ -409,6 +409,93 @@ codeunit 139690 "Contract Price Proposal Test"
     end;
 
     [Test]
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure TestSubscriptionLineFilterOnNextPriceUpdateIsNotOverwrittenByDefaultFiltering()
+    var
+        NextPriceUpdateFilterText: Text;
+        OtherNextPriceUpdate: Date;
+        TargetNextPriceUpdate: Date;
+    begin
+        // [SCENARIO] A Subscription Line Filter on a field that the proposal's mandatory default filtering also uses
+        // [SCENARIO] must be honoured instead of being replaced by the default filter.
+        Initialize();
+        ContractTestLibrary.DeleteAllContractRecords();
+
+        // [GIVEN] Four Subscription Lines, two of them with Next Price Update = TargetNextPriceUpdate, the other two with a different date
+        TargetNextPriceUpdate := CalcDate('<1M>', WorkDate());
+        OtherNextPriceUpdate := CalcDate('<2M>', WorkDate());
+        CreateCustomerContractLinesWithNextPriceUpdate(4, TargetNextPriceUpdate, OtherNextPriceUpdate);
+
+        // [GIVEN] A Price Update Template whose Subscription Line Filter restricts Next Price Update to TargetNextPriceUpdate
+        NextPriceUpdateFilterText := ComposeNextPriceUpdateFilter(TargetNextPriceUpdate);
+
+        // [WHEN] The proposal is created with Include Contract Lines up to Date after both dates
+        // [THEN] Only the two Subscription Lines matching the template filter end up in the proposal
+        CreatePriceUpdateTemplateWithFilterAndUpdateCreateProposal('', NextPriceUpdateFilterText, '', 2);
+        VerifyProposalContainsOnlySubscriptionLinesWithNextPriceUpdate(TargetNextPriceUpdate);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure TestSubscriptionLineFilterCannotWidenDefaultFilteringOnNextPriceUpdate()
+    var
+        NextPriceUpdateFilterText: Text;
+        NextPriceUpdateAfterInclusionDate: Date;
+        NextPriceUpdateWithinInclusionDate: Date;
+    begin
+        // [SCENARIO] A Subscription Line Filter must not be able to pull in lines that the mandatory default filtering excludes.
+        Initialize();
+        ContractTestLibrary.DeleteAllContractRecords();
+
+        // [GIVEN] Four customer Subscription Lines, two within the Include Contract Lines up to Date of <12M> and two beyond it
+        NextPriceUpdateWithinInclusionDate := CalcDate('<1M>', WorkDate());
+        NextPriceUpdateAfterInclusionDate := CalcDate('<24M>', WorkDate());
+        CreateCustomerContractLinesWithNextPriceUpdate(4, NextPriceUpdateWithinInclusionDate, NextPriceUpdateAfterInclusionDate);
+
+        // [GIVEN] A vendor Subscription Line that satisfies every mandatory default except the Partner of the template
+        CreateVendorContractLineWithNextPriceUpdate(NextPriceUpdateWithinInclusionDate);
+
+        // [WHEN] The proposal is created from a customer template without a Subscription Line Filter
+        // [THEN] Only the two customer lines within the Include Contract Lines up to Date are proposed
+        CreatePriceUpdateTemplateWithFilterAndUpdateCreateProposal('', '', '', 2);
+        VerifyProposalContainsOnlySubscriptionLinesWithNextPriceUpdate(NextPriceUpdateWithinInclusionDate);
+        VerifyProposalContainsOnlySubscriptionLinesOfTemplatePartner();
+
+        // [WHEN] The proposal is created with a Subscription Line Filter asking for the lines beyond that date
+        NextPriceUpdateFilterText := ComposeNextPriceUpdateFilter(NextPriceUpdateAfterInclusionDate);
+
+        // [THEN] The intersection is empty - the template filter cannot widen the mandatory default
+        CreatePriceUpdateTemplateWithFilterAndUpdateCreateProposal('', NextPriceUpdateFilterText, '', 0);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure TestSubscriptionLineFilterCannotWidenDefaultFilteringOnExcludeFromPriceUpdate()
+    var
+        DummyServiceCommitment: Record "Subscription Line";
+        ExcludeFromPriceUpdateFilterText: Text;
+    begin
+        // [SCENARIO] Excluded Subscription Lines stay out of the proposal even if the Subscription Line Filter asks for them.
+        Initialize();
+        ContractTestLibrary.DeleteAllContractRecords();
+
+        // [GIVEN] Four Subscription Lines, two of them flagged as Exclude from Price Update
+        CreateCustomerContractLinesWithExcludeFromPriceUpdate(4);
+
+        // [WHEN] The proposal is created without a Subscription Line Filter
+        // [THEN] Only the two lines that are not excluded are proposed
+        CreatePriceUpdateTemplateWithFilterAndUpdateCreateProposal('', '', '', 2);
+        VerifyProposalContainsOnlyNotExcludedSubscriptionLines();
+
+        // [WHEN] The proposal is created with a Subscription Line Filter asking for the excluded lines
+        DummyServiceCommitment.SetRange("Exclude from Price Update", true);
+        ExcludeFromPriceUpdateFilterText := DummyServiceCommitment.GetView(false);
+
+        // [THEN] The intersection is empty - the template filter cannot widen the mandatory default
+        CreatePriceUpdateTemplateWithFilterAndUpdateCreateProposal('', ExcludeFromPriceUpdateFilterText, '', 0);
+    end;
+
+    [Test]
     procedure TestIfContractPriceUpdateLinesAreDeletedAfterPerformPriceUpdate()
     begin
         Initialize();
@@ -812,6 +899,111 @@ codeunit 139690 "Contract Price Proposal Test"
         // Check
         ContractPriceUpdateLine.SetRange("Price Update Template Code", PriceUpdateTemplateCustomer.Code);
         Assert.AreEqual(ExpectedValue, ContractPriceUpdateLine.Count(), 'Filtering failed.');
+    end;
+
+    local procedure CreateCustomerContractLinesWithNextPriceUpdate(NoOfContracts: Integer; NextPriceUpdateForEvenContract: Date; NextPriceUpdateForOddContract: Date)
+    var
+        CurrentServiceCommitment: Record "Subscription Line";
+        i: Integer;
+    begin
+        for i := 1 to NoOfContracts do begin
+            CreateCustomerContractWithOneSubscriptionLine(CurrentServiceCommitment);
+            if i mod 2 = 0 then
+                CurrentServiceCommitment."Next Price Update" := NextPriceUpdateForEvenContract
+            else
+                CurrentServiceCommitment."Next Price Update" := NextPriceUpdateForOddContract;
+            CurrentServiceCommitment.Modify(false);
+        end;
+    end;
+
+    local procedure CreateCustomerContractLinesWithExcludeFromPriceUpdate(NoOfContracts: Integer)
+    var
+        CurrentServiceCommitment: Record "Subscription Line";
+        i: Integer;
+    begin
+        for i := 1 to NoOfContracts do begin
+            CreateCustomerContractWithOneSubscriptionLine(CurrentServiceCommitment);
+            CurrentServiceCommitment."Exclude from Price Update" := (i mod 2 = 0);
+            CurrentServiceCommitment.Modify(false);
+        end;
+    end;
+
+    local procedure CreateVendorContractLineWithNextPriceUpdate(NextPriceUpdate: Date)
+    var
+        VendorContract: Record "Vendor Subscription Contract";
+        CurrentServiceCommitment: Record "Subscription Line";
+    begin
+        Clear(ServiceObject);
+        Clear(Vendor);
+        ContractTestLibrary.CreateVendor(Vendor);
+        ContractTestLibrary.CreateVendorContractAndCreateContractLinesForItems(VendorContract, ServiceObject, Vendor."No.");
+        CurrentServiceCommitment.Reset();
+        CurrentServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        Assert.AreEqual(1, CurrentServiceCommitment.Count(), 'Expected exactly one vendor Subscription Line per Subscription Contract in this setup.');
+        CurrentServiceCommitment.FindFirst();
+        CurrentServiceCommitment.TestField(Partner, "Service Partner"::Vendor);
+        CurrentServiceCommitment."Next Price Update" := NextPriceUpdate;
+        CurrentServiceCommitment.Modify(false);
+    end;
+
+    local procedure CreateCustomerContractWithOneSubscriptionLine(var CurrentServiceCommitment: Record "Subscription Line")
+    var
+        CustomerContract: Record "Customer Subscription Contract";
+    begin
+        Clear(ServiceObject);
+        Clear(Customer);
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+        CurrentServiceCommitment.Reset();
+        CurrentServiceCommitment.SetRange("Subscription Header No.", ServiceObject."No.");
+        Assert.AreEqual(1, CurrentServiceCommitment.Count(), 'Expected exactly one Subscription Line per Subscription Contract in this setup.');
+        CurrentServiceCommitment.FindFirst();
+    end;
+
+    local procedure ComposeNextPriceUpdateFilter(NextPriceUpdate: Date): Text
+    var
+        DummyServiceCommitment: Record "Subscription Line";
+    begin
+        DummyServiceCommitment.SetRange("Next Price Update", NextPriceUpdate);
+        exit(DummyServiceCommitment.GetView(false));
+    end;
+
+    local procedure VerifyProposalContainsOnlySubscriptionLinesWithNextPriceUpdate(ExpectedNextPriceUpdate: Date)
+    var
+        CurrentServiceCommitment: Record "Subscription Line";
+    begin
+        ContractPriceUpdateLine.Reset();
+        ContractPriceUpdateLine.SetRange("Price Update Template Code", PriceUpdateTemplateCustomer.Code);
+        ContractPriceUpdateLine.FindSet();
+        repeat
+            CurrentServiceCommitment.Get(ContractPriceUpdateLine."Subscription Line Entry No.");
+            Assert.AreEqual(ExpectedNextPriceUpdate, CurrentServiceCommitment."Next Price Update", 'A Subscription Line outside the Subscription Line Filter was proposed.');
+        until ContractPriceUpdateLine.Next() = 0;
+    end;
+
+    local procedure VerifyProposalContainsOnlySubscriptionLinesOfTemplatePartner()
+    var
+        CurrentServiceCommitment: Record "Subscription Line";
+    begin
+        ContractPriceUpdateLine.Reset();
+        ContractPriceUpdateLine.SetRange("Price Update Template Code", PriceUpdateTemplateCustomer.Code);
+        ContractPriceUpdateLine.FindSet();
+        repeat
+            CurrentServiceCommitment.Get(ContractPriceUpdateLine."Subscription Line Entry No.");
+            Assert.AreEqual(PriceUpdateTemplateCustomer.Partner, CurrentServiceCommitment.Partner, 'A Subscription Line of a different Partner than the Price Update Template was proposed.');
+        until ContractPriceUpdateLine.Next() = 0;
+    end;
+
+    local procedure VerifyProposalContainsOnlyNotExcludedSubscriptionLines()
+    var
+        CurrentServiceCommitment: Record "Subscription Line";
+    begin
+        ContractPriceUpdateLine.Reset();
+        ContractPriceUpdateLine.SetRange("Price Update Template Code", PriceUpdateTemplateCustomer.Code);
+        ContractPriceUpdateLine.FindSet();
+        repeat
+            CurrentServiceCommitment.Get(ContractPriceUpdateLine."Subscription Line Entry No.");
+            Assert.AreEqual(false, CurrentServiceCommitment."Exclude from Price Update", 'A Subscription Line excluded from Price Update was proposed.');
+        until ContractPriceUpdateLine.Next() = 0;
     end;
 
     local procedure ComposePriceUpdateTemplateFilters(var ServiceCommitmentFilterText: Text; var ServiceObjectFilterText: Text; var BadServiceObjectFilterText: Text; var ContractFilterText: Text; SerialNo: Guid; ContractTypeCode: Code[10])


### PR DESCRIPTION
## What & why

A `Price Update Template` whose **Subscription Line Filter** restricts the lines to update — for example to a single `Next Price Update` date — produced a price update proposal that ignored that filter, so Subscription Lines the user had deliberately filtered out were repriced and ended up on contracts and invoices with prices the user never asked for. `ApplyDefaultFiltering` in codeunit `8009 "Price Update Management"` set its seven mandatory filters into the same filter group that the template's `SetView` writes to, so each mandatory default silently replaced the template's filter on the same field. The mandatory defaults are now applied in `FilterGroup(2)`, so they intersect with the template's filters instead of overwriting them.

Writing the tests surfaced a second defect in the same code path that is not in the issue: `InitTempServiceCommitmentTable` took the Subscription Line record **by value**, and an AL record parameter passed by value does not carry the caller's filters. The candidate set was therefore every non-closed Subscription Line in the database, and the mandatory defaults were never applied at all whenever the template carried no Subscription Line filter of its own — a vendor line could land in a customer proposal, and lines beyond *Include Contract Lines up to Date* were proposed. The parameter is now `var`. The `if not ServiceCommitment.Closed` guard inside that loop became dead code (`Closed` is one of the mandatory defaults) and was removed.

```al
// The mandatory defaults are set in a separate filter group so that they intersect with the filters
// stored on the Price Update Template instead of replacing them field by field.
ServiceCommitment.FilterGroup(2);
ServiceCommitment.SetRange(Partner, PriceUpdateTemplate.Partner);
...
ServiceCommitment.SetRange(Closed, false);
ServiceCommitment.FilterGroup(0);
```

Comments were added at the filter-group block, at the `var` parameter, and at the `Reset()` in `MarkServiceCommitmentsFromTempTable` — the latter documents that the `Reset()` must stay, because that record is handed back to the callers and to the integration event and must not carry filters that `GetFilters()` does not show them.

## Linked work

Fixes #10358

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Built `Subscription Billing` App and Test with `alc.exe` including the repo's analyzer set — both `RESULT: OK`, `.app` artifacts emitted and verified, no new warnings from the two changed files.
- Published App and Test to container `sb10358` and ran the tests there. All test runs below were executed on that container, not reasoned about.
- Three new tests in codeunit `139690 "Contract Price Proposal Test"`:
  - `TestSubscriptionLineFilterOnNextPriceUpdateIsNotOverwrittenByDefaultFiltering` — the reported repro: four Subscription Lines, a template filtering `Next Price Update` to one of two dates, expect exactly the two matching lines.
  - `TestSubscriptionLineFilterCannotWidenDefaultFilteringOnNextPriceUpdate` — a template filter must not pull in lines past *Include Contract Lines up to Date*, and a vendor line must not reach a customer proposal.
  - `TestSubscriptionLineFilterCannotWidenDefaultFilteringOnExcludeFromPriceUpdate` — lines flagged `Exclude from Price Update` stay out even when the template filter explicitly asks for them.
- **TDD red before the fix**: all three tests failed against the unmodified source, each with `Assert.AreEqual failed. Expected:<2>. Actual:<4>. Filtering failed.` — i.e. the whole unfiltered candidate set, the intended reason.
- The three new tests were also run in the full context of codeunit `139690` after the change, and pass there.
- Sibling codeunit `139691`: 4 passed, 0 failed.
- Mutation loop executed on `sb10358` — each mutant was edited into the source, rebuilt, republished and re-run:

  | Mutant | Result |
  | --- | --- |
  | Revert `FilterGroup(2)` — defaults back in group 0 | Killed by all three new tests |
  | Revert the `var` on `InitTempServiceCommitmentTable` | Killed by tests 2 and 3 |
  | Drop the `"Exclude from Price Update"` default | Killed by test 3 |
  | Widen the `"Next Price Update"` default | Killed by test 2 |
  | Widen the `Partner` default so vendor lines leak into a customer proposal | Killed (expected 2, got 3) |
  | Apply the defaults in filter group 0 *before* `SetView` | **Survived** |

  The surviving mutant is genuinely equivalent: the later intersection with the temporary table re-imposes the mandatory defaults, so the observable proposal is identical. The filter-group form was kept anyway — it is what the issue proposed, and it makes `ApplyDefaultFiltering` correct on its own rather than correct only in combination with its caller.
- No `Label`, `Caption` or `ToolTip` is added by this change, so it produces no new trans-units and there is no XLIFF work.

## Risk & compatibility

- **Behavioural change, intended**: proposals generated from a `Price Update Template` that carries a Subscription Line Filter will now contain a different — usually smaller — set of `Contract Price Update Lines` than before, because the filter is finally honoured. Templates without a Subscription Line Filter are also affected by the `var` fix: lines that failed a mandatory default (wrong `Partner`, `Exclude from Price Update`, `Next Price Update` beyond the inclusion date, closed, usage-based, planned line) are no longer proposed. Both are the documented intent of the feature.
- Existing `Contract Price Update Lines` and already performed price updates are untouched; only newly created proposals differ. No table, field or schema change, no upgrade code needed.
- No public signature changes: `ApplyDefaultFiltering` and `InitTempServiceCommitmentTable` are both `local`. The integration event raised after `MarkServiceCommitmentsFromTempTable` is unchanged, and the `Reset()` before it is deliberately preserved so subscribers keep receiving an unfiltered record.
- No permissions or telemetry impact.

