### PR TITLE
Remove permission set ref and move the Page Inspector changes to BCApps

### DIFF
--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspection.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspection.Page.al
@@ -463,7 +463,7 @@ page 9631 "Page Inspection"
         CurrPage.Fields.PAGE.SetFieldListVisibility(PageHasSourceTable);
 
         if ShowExtensions then begin
-            CurrPage.Extensions.PAGE.FilterForExtAffectingPage(Rec."Page ID", Rec."Source Table No.", Rec."Current Form ID");
+            CurrPage.Extensions.PAGE.FilterForExtAffectingPage(Rec."Page ID", Rec."Source Table No.");
             CurrPage.Extensions.PAGE.SetExtensionListVisibility(not PageIsReportRequest and not PageIsReportViewer and not PageIsSystem and not ShowNoPermissionForExtensions);
         end;
 

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
@@ -142,6 +142,12 @@ page 9633 "Page Inspection Extensions"
         ExtPageLbl: Label 'Extends page';
         ExtTableLbl: Label 'Extends table';
 
+    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; FormId: Guid)
+    begin
+        if FormId <> Guid.Empty then; // Kept to not break existing code that calls this method with 3 parameters. The FormId parameter is not used in the current implementation.
+        FilterForExtAffectingPage(PageId, TableId);
+    end;
+
     procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer)
     var
         VSCodeRequestHelper: Codeunit "Page Inspection VS Code Helper";

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
@@ -98,13 +98,13 @@ page 9633 "Page Inspection Extensions"
             // page added by extension
             AllObjWithCaption.SetRange("Object ID", CurrentPageId);
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Page);
-            if AllObjWithCaption.FindFirst() then
+            if not AllObjWithCaption.IsEmpty() then
                 TypeOfExtension := TypeOfExtension + ', ' + NewPageLbl;
 
             // table added by extension
             AllObjWithCaption.SetRange("Object ID", CurrentTableId);
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
-            if AllObjWithCaption.FindFirst() then
+            if not AllObjWithCaption.IsEmpty() then
                 TypeOfExtension := TypeOfExtension + ', ' + NewTableLbl;
 
             AllObjWithCaption.Reset();
@@ -113,13 +113,13 @@ page 9633 "Page Inspection Extensions"
             // page extended by extension
             AllObjWithCaption.SetRange("Object Subtype", StrSubstNo('%1', CurrentPageId));
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::PageExtension);
-            if AllObjWithCaption.FindFirst() then
+            if not AllObjWithCaption.IsEmpty() then
                 TypeOfExtension := TypeOfExtension + ', ' + ExtPageLbl;
 
             // table extended by extension
             AllObjWithCaption.SetRange("Object Subtype", StrSubstNo('%1', CurrentTableId));
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::TableExtension);
-            if AllObjWithCaption.FindFirst() then
+            if not AllObjWithCaption.IsEmpty() then
                 TypeOfExtension := TypeOfExtension + ', ' + ExtTableLbl;
 
             TypeOfExtension := DelChr(TypeOfExtension, '<', ',');

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
@@ -50,9 +50,9 @@ page 9633 "Page Inspection Extensions"
                 field(TypeOfExtension; TypeOfExtension)
                 {
                     ApplicationArea = All;
-                    Caption = 'Extension execution info and type.';
+                    Caption = 'Type of extension.';
                     ShowCaption = false;
-                    ToolTip = 'Specifies extension execution information and extension type.';
+                    ToolTip = 'Specifies extension type.';
                 }
             }
         }
@@ -85,16 +85,11 @@ page 9633 "Page Inspection Extensions"
     trigger OnAfterGetRecord()
     var
         AllObjWithCaption: Record AllObjWithCaption;
-        ExtensionExecutionInfo: Record "Extension Execution Info";
-        ExtensionType: Text;
-        ExtensionInfo: Text;
-        SeparatorText: Text;
     begin
         Version := StrSubstNo('%1.%2.%3', Rec."Version Major", Rec."Version Minor", Rec."Version Build");
         PublishedBy := StrSubstNo('by %1', Rec.Publisher);
 
-        ExtensionType := '';
-        ExtensionInfo := '';
+        TypeOfExtension := '';
 
         if AllObjWithCaption.ReadPermission() then begin
             AllObjWithCaption.Reset();
@@ -104,13 +99,13 @@ page 9633 "Page Inspection Extensions"
             AllObjWithCaption.SetRange("Object ID", CurrentPageId);
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Page);
             if AllObjWithCaption.FindFirst() then
-                ExtensionType := ExtensionType + ', ' + NewPageLbl;
+                TypeOfExtension := TypeOfExtension + ', ' + NewPageLbl;
 
             // table added by extension
             AllObjWithCaption.SetRange("Object ID", CurrentTableId);
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::Table);
             if AllObjWithCaption.FindFirst() then
-                ExtensionType := ExtensionType + ', ' + NewTableLbl;
+                TypeOfExtension := TypeOfExtension + ', ' + NewTableLbl;
 
             AllObjWithCaption.Reset();
             AllObjWithCaption.SetRange("App Package ID", Rec."Package ID");
@@ -119,41 +114,16 @@ page 9633 "Page Inspection Extensions"
             AllObjWithCaption.SetRange("Object Subtype", StrSubstNo('%1', CurrentPageId));
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::PageExtension);
             if AllObjWithCaption.FindFirst() then
-                ExtensionType := ExtensionType + ', ' + ExtPageLbl;
+                TypeOfExtension := TypeOfExtension + ', ' + ExtPageLbl;
 
             // table extended by extension
             AllObjWithCaption.SetRange("Object Subtype", StrSubstNo('%1', CurrentTableId));
             AllObjWithCaption.SetRange("Object Type", AllObjWithCaption."Object Type"::TableExtension);
             if AllObjWithCaption.FindFirst() then
-                ExtensionType := ExtensionType + ', ' + ExtTableLbl;
+                TypeOfExtension := TypeOfExtension + ', ' + ExtTableLbl;
 
-            ExtensionType := DelChr(ExtensionType, '<', ',');
-
-            AllObjWithCaption.Reset();
-            AllObjWithCaption.SetRange("App Package ID", Rec."Package ID");
-
-            if AllObjWithCaption.FindFirst() then
-                if ExtensionExecutionInfo.ReadPermission() then begin
-                    ExtensionExecutionInfo.Reset();
-                    ExtensionExecutionInfo.SetRange("Form ID", CurrentFormId);
-                    ExtensionExecutionInfo.SetRange("Runtime Package ID", AllObjWithCaption."App Runtime Package ID");
-
-                    if ExtensionExecutionInfo.FindFirst() then
-                        ExtensionInfo := StrSubstNo(
-                            MillisecondsAndSubscribersLbl,
-                            Format(ExtensionExecutionInfo."Execution Time"),
-                            Format(ExtensionExecutionInfo."Subscriber Execution Count"))
-                    else
-                        ExtensionInfo := NoExtensionInfoLbl;
-                end;
+            TypeOfExtension := DelChr(TypeOfExtension, '<', ',');
         end;
-
-        if (StrLen(ExtensionType) > 0) and (StrLen(ExtensionInfo) > 0) then
-            SeparatorText := '; '
-        else
-            SeparatorText := '';
-
-        TypeOfExtension := StrSubstNo(TypeOfExtensionFmtLbl, ExtensionInfo, SeparatorText, ExtensionType);
 
         SetSourceSpecification();
     end;
@@ -165,18 +135,14 @@ page 9633 "Page Inspection Extensions"
         IsExtensionListVisible: Boolean;
         IsSourceSpecificationEnabled: Boolean;
         TypeOfExtension: Text;
-        CurrentFormId: Guid;
         CurrentPageId: Integer;
         CurrentTableId: Integer;
         NewPageLbl: Label 'Adds page';
         NewTableLbl: Label 'Adds table';
         ExtPageLbl: Label 'Extends page';
         ExtTableLbl: Label 'Extends table';
-        MillisecondsAndSubscribersLbl: Label '%1ms, %2 subs.', Comment = '%1 is millisceonds, %2 is subscribers. "subs." is an abbreviation of "subscribers"';
-        NoExtensionInfoLbl: Label 'No extension info';
-        TypeOfExtensionFmtLbl: Label '%1%2%3', Locked = true;
 
-    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; FormId: Guid)
+    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer)
     var
         VSCodeRequestHelper: Codeunit "Page Inspection VS Code Helper";
     begin
@@ -185,9 +151,7 @@ page 9633 "Page Inspection Extensions"
 
         CurrentPageId := PageId;
         CurrentTableId := TableId;
-        CurrentFormId := FormId;
-
-        VSCodeRequestHelper.FilterForExtAffectingPage(PageId, TableId, FormId, Rec);
+        VSCodeRequestHelper.FilterForExtAffectingPage(PageId, TableId, Rec);
         CurrPage.Update(false);
     end;
 

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionExtensions.Page.al
@@ -144,7 +144,7 @@ page 9633 "Page Inspection Extensions"
 
     procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; FormId: Guid)
     begin
-        if FormId <> Guid.Empty then; // Kept to not break existing code that calls this method with 3 parameters. The FormId parameter is not used in the current implementation.
+        if IsNullGuid(FormId) then; // Kept to not break existing code that calls this method with 3 parameters. The FormId parameter is not used in the current implementation.
         FilterForExtAffectingPage(PageId, TableId);
     end;
 

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionVSCodeHelper.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionVSCodeHelper.Codeunit.al
@@ -36,11 +36,11 @@ codeunit 5378 "Page Inspection VS Code Helper"
     end;
 
     [Scope('OnPrem')]
-    procedure FindPublishedApplication(var NAVAppInstalledApp: Record "NAV App Installed App"; var PublishedApplication: Record "Published Application"): Boolean
+    procedure FindPublishedApplication(var InstalledApp: Record "NAV App Installed App"; var PublishedApplication: Record "Published Application"): Boolean
     begin
         if PublishedApplication.ReadPermission() then begin
             PublishedApplication.Reset();
-            PublishedApplication.SetRange("Package ID", NAVAppInstalledApp."Package ID");
+            PublishedApplication.SetRange("Package ID", InstalledApp."Package ID");
             exit(PublishedApplication.FindFirst());
         end;
 
@@ -48,7 +48,7 @@ codeunit 5378 "Page Inspection VS Code Helper"
     end;
 
     [Scope('OnPrem')]
-    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; var NAVAppInstalledApp: Record "NAV App Installed App")
+    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; var InstalledApp: Record "NAV App Installed App")
     var
         AllObjWithCaption: Record AllObjWithCaption;
         TempGuid: Guid;
@@ -94,14 +94,14 @@ codeunit 5378 "Page Inspection VS Code Helper"
 
         end;
 
-        NAVAppInstalledApp.Reset();
+        InstalledApp.Reset();
         if FilterConditions <> '' then begin
             FilterConditions := DelChr(FilterConditions, '>', '|');
-            NAVAppInstalledApp.SetFilter(NAVAppInstalledApp."Package ID", FilterConditions);
+            InstalledApp.SetFilter(InstalledApp."Package ID", FilterConditions);
         end else begin
             TempGuid := CreateGuid();
             Clear(TempGuid);
-            NAVAppInstalledApp.SetFilter(NAVAppInstalledApp."Package ID", '%1', TempGuid);
+            InstalledApp.SetFilter(InstalledApp."Package ID", '%1', TempGuid);
         end;
     end;
 }

--- a/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionVSCodeHelper.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PageInspection/PageInspectionVSCodeHelper.Codeunit.al
@@ -17,7 +17,7 @@ codeunit 5378 "Page Inspection VS Code Helper"
     begin
         // There's a performance overhead when computing dependencies, only do when necessary, 
         if UpdateDependencies then
-            FilterForExtAffectingPage(PageInfoAndFields."Page ID", PageInfoAndFields."Source Table No.", PageInfoAndFields."Current Form ID", NavAppInstalledApp);
+            FilterForExtAffectingPage(PageInfoAndFields."Page ID", PageInfoAndFields."Source Table No.", NavAppInstalledApp);
         VSCodeIntegration.NavigateToPageDefinitionInVSCode(PageInfoAndFields, NavAppInstalledApp);
     end;
 
@@ -25,7 +25,7 @@ codeunit 5378 "Page Inspection VS Code Helper"
     procedure NavigateFieldDefinitionInVSCode(var PageInfoAndFields: Record "Page Info And Fields"; UpdateDependencies: Boolean): Text
     begin
         if UpdateDependencies then
-            FilterForExtAffectingPage(PageInfoAndFields."Page ID", PageInfoAndFields."Source Table No.", PageInfoAndFields."Current Form ID", NavAppInstalledApp);
+            FilterForExtAffectingPage(PageInfoAndFields."Page ID", PageInfoAndFields."Source Table No.", NavAppInstalledApp);
         VSCodeIntegration.NavigateFieldDefinitionInVSCode(PageInfoAndFields, NavAppInstalledApp);
     end;
 
@@ -48,9 +48,8 @@ codeunit 5378 "Page Inspection VS Code Helper"
     end;
 
     [Scope('OnPrem')]
-    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; FormId: Guid; var NAVAppInstalledApp: Record "NAV App Installed App")
+    procedure FilterForExtAffectingPage(PageId: Integer; TableId: Integer; var NAVAppInstalledApp: Record "NAV App Installed App")
     var
-        ExtensionExecutionInfo: Record "Extension Execution Info";
         AllObjWithCaption: Record AllObjWithCaption;
         TempGuid: Guid;
         OrFilterFmtLbl: Label '%1|', Locked = true;
@@ -93,17 +92,6 @@ codeunit 5378 "Page Inspection VS Code Helper"
                     FilterConditions := FilterConditions + StrSubstNo(OrFilterFmtLbl, AllObjWithCaption."App Package ID");
                 until AllObjWithCaption.Next() = 0;
 
-            // Add filters for arbitrary code which has executed on the form
-            if ExtensionExecutionInfo.ReadPermission() then begin
-                ExtensionExecutionInfo.SetRange("Form ID", FormId);
-                if ExtensionExecutionInfo.Find('-') then
-                    repeat
-                        AllObjWithCaption.Reset();
-                        AllObjWithCaption.SetRange("App Runtime Package ID", ExtensionExecutionInfo."Runtime Package ID");
-                        if AllObjWithCaption.FindFirst() then
-                            FilterConditions := FilterConditions + StrSubstNo(OrFilterFmtLbl, AllObjWithCaption."App Package ID");
-                    until ExtensionExecutionInfo.Next() = 0;
-            end;
         end;
 
         NAVAppInstalledApp.Reset();

--- a/src/Layers/W1/BaseApp/Permissions/PageInspection.permissionset.al
+++ b/src/Layers/W1/BaseApp/Permissions/PageInspection.permissionset.al
@@ -5,7 +5,6 @@ permissionset 5377 "Page Inspection"
     IncludedPermissionSets = "Page Inspection - Objects";
     Permissions =
             tabledata AllObjWithCaption = R,
-            tabledata "Extension Execution Info" = R,
             tabledata "NAV App Installed App" = R,
             tabledata "Page Metadata" = R,
             tabledata "Page Info And Fields" = R;

--- a/src/Layers/W1/BaseApp/Permissions/d365basicread.permissionset.al
+++ b/src/Layers/W1/BaseApp/Permissions/d365basicread.permissionset.al
@@ -193,7 +193,6 @@ permissionset 209 "D365 Basic - Read"
                   tabledata "Direct Trans. Line" = R,
                   tabledata Drive = R,
                   tabledata "Event Subscription" = R,
-                  tabledata "Extension Execution Info" = R,
                   tabledata "Feature Key" = R,
                   tabledata Field = R,
                   tabledata File = R,

--- a/src/System Application/App/VS Code Integration/Permissions/VSCIntgrAdmin.PermissionSet.al
+++ b/src/System Application/App/VS Code Integration/Permissions/VSCIntgrAdmin.PermissionSet.al
@@ -17,7 +17,6 @@ permissionset 8335 "VSC Intgr. - Admin"
 
     Permissions = tabledata AllObjWithCaption = R,
                   tabledata "Application Object Metadata" = R, // r needed for check CanInteractWithSourceCode
-                  tabledata "Extension Execution Info" = R,
                   tabledata "Page Info And Fields" = R,
                   tabledata "Published Application" = R;
 }


### PR DESCRIPTION
## What & why
Clean up the permission sets that reference the to be obsoleted table "Extension Execution Info" and move the page inspector changes from Platform to BCApps also.

## Linked work
[AB#647234](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647234)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->







