### PR TITLE
Remove Microsoft Managed background GuiCheck in Azure OpenAI

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -35,7 +35,6 @@ codeunit 7772 "Azure OpenAI Impl" implements "AI Service Name"
         EmbeddingsFailedWithCodeErr: Label 'Embeddings failed to be generated.';
         ChatCompletionsFailedWithCodeErr: Label 'Chat completions failed to be generated.';
         AuthenticationNotConfiguredErr: Label 'The authentication was not configured.';
-        CapabilityBackgroundErr: Label 'Microsoft Copilot Capabilities are not allowed in the background.';
         CapabilityODataErr: Label 'Microsoft Copilot Capabilities are not allowed in API and OData Web Services sessions.';
         MessagesMustContainJsonWordWhenResponseFormatIsJsonErr: Label 'The messages must contain the word ''json'' in some form, to use ''response format'' of type ''json_object''.';
 #if not CLEAN29
@@ -607,9 +606,6 @@ codeunit 7772 "Azure OpenAI Impl" implements "AI Service Name"
 
         if ClientTypeManagement.GetCurrentClientType() in [ClientType::Api, ClientType::OData, ClientType::ODataV4, ClientType::SOAP, ClientType::Management] then
             Error(CapabilityODataErr);
-
-        if (not GuiAllowed()) and (AOAIAuthorization.GetResourceUtilization() = Enum::"AOAI Resource Utilization"::"Microsoft Managed") then
-            Error(CapabilityBackgroundErr);
     end;
 
     local procedure CheckAuthorizationEnabled(AOAIAuthorization: Codeunit "AOAI Authorization"; CallerModuleInfo: ModuleInfo)


### PR DESCRIPTION
## What & why

`AzureOpenAIImpl.GuiCheck` blocked Microsoft Managed Copilot capabilities from running whenever `GuiAllowed()` was false, erroring with "Microsoft Copilot Capabilities are not allowed in the background." That restriction is no longer valid, so the guard is removed along with its now-unused `CapabilityBackgroundErr` label.

The rest of `GuiCheck` is untouched: it still exits early for Self-Managed resource utilization and still errors on Api, OData, ODataV4, SOAP, and Management client types via `CapabilityODataErr`.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>". -->

Fixes [AB#647407](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647407)

> Note: no issue number was available in this session. Please fill in the approved issue (and `AB#<number>` if applicable) before merge.

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Change is a 4-line deletion: the `GuiAllowed()` guard in `GuiCheck` plus the `CapabilityBackgroundErr` label declaration.
- Searched the System Application app and test projects for `CapabilityBackgroundErr` and for the "not allowed in the background" message; no other references exist, so nothing else breaks and no test asserted the removed behavior.
- No new tests added: this removes a restriction rather than adding behavior, and the remaining OData/client-type path is unchanged.
- Local build and in-product verification still need to be done by the PR author before merge.

## Risk & compatibility

- Behavior change: Microsoft Managed Copilot capabilities can now be invoked from non-GUI sessions (for example job queue or background sessions) instead of failing with an error. Callers that relied on that error as a safety net will no longer get it.
- The `CapabilityBackgroundErr` label is removed. It was a local label in an internal implementation codeunit, so this is not a breaking API or translation-surface change for extensions, though the string will drop out of translation files on the next regeneration.
- No upgrade, permission, or telemetry impact.


