### PR TITLE
[SOA] Uptake Agent Task Message Failed status for outbound replies

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAEmailMessage.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAEmailMessage.Page.al
@@ -182,20 +182,21 @@ page 4404 "SOA Email Message"
                                 {
                                     Caption = 'Status';
                                     Editable = false;
+                                    StyleExpr = StatusStyleTxt;
                                 }
                             }
 
-                            group(SendingStatusGroup)
+                            group(StatusReasonGroup)
                             {
                                 ShowCaption = false;
-                                Visible = RetrySendingVisible;
+                                Visible = StatusReasonVisible;
 
-                                field(SendingStatus; SendingStatusTxt)
+                                field(StatusReason; Rec."Status Reason")
                                 {
-                                    ApplicationArea = All;
-                                    Caption = 'Sending status';
-                                    ToolTip = 'Specifies that the reply could not be sent after all retry attempts.';
+                                    Caption = 'Status reason';
+                                    ToolTip = 'Specifies why the message has its current status.';
                                     Editable = false;
+                                    MultiLine = true;
                                     Style = Unfavorable;
                                 }
                             }
@@ -269,7 +270,7 @@ page 4404 "SOA Email Message"
                 ApplicationArea = All;
                 Caption = 'Retry sending';
                 Image = Refresh;
-                ToolTip = 'Reset the failed sending attempts so the reply is retried during the next agent run.';
+                ToolTip = 'Set the failed reply back to reviewed so it is sent again during the next agent run.';
                 Visible = RetrySendingVisible;
 
                 trigger OnAction()
@@ -279,9 +280,11 @@ page 4404 "SOA Email Message"
                     if not Confirm(RetrySendingQst) then
                         exit;
 
-                    SOAReplyRetryMgt.ResetAttempts(Rec."Task ID", Rec.ID);
+                    SOAReplyRetryMgt.RetrySending(Rec."Task ID", Rec.ID);
+                    Rec.Get(Rec."Task ID", Rec.ID);
                     Message(RetrySendingScheduledMsg);
                     UpdateControls();
+                    CurrPage.Update(false);
                 end;
             }
         }
@@ -310,17 +313,17 @@ page 4404 "SOA Email Message"
 
     local procedure UpdateControls()
     var
-        SOAReplyRetryMgt: Codeunit "SOA Reply Retry Mgt.";
         EmailAddress: Text;
     begin
         UpdatePageCaption();
         UpdateEmailFields(EmailAddress);
         UpdateContactInformation(EmailAddress);
-        RetrySendingVisible := (Rec.Type = Rec.Type::Output) and (Rec.Status = Rec.Status::Reviewed) and SOAReplyRetryMgt.IsExhausted(Rec."Task ID", Rec.ID);
-        if RetrySendingVisible then
-            SendingStatusTxt := SendingFailedTxt
+        RetrySendingVisible := (Rec.Type = Rec.Type::Output) and (Rec.Status = Rec.Status::Failed);
+        StatusReasonVisible := (Rec.Status = Rec.Status::Failed) and (Rec."Status Reason" <> '');
+        if Rec.Status = Rec.Status::Failed then
+            StatusStyleTxt := UnfavorableStyleTxt
         else
-            Clear(SendingStatusTxt);
+            Clear(StatusStyleTxt);
         CurrPage.Attachments.Page.LoadRecords(Rec);
     end;
 
@@ -478,12 +481,13 @@ page 4404 "SOA Email Message"
         AttachmentsVisible: Boolean;
         BlockedStatusVisible: Boolean;
         RetrySendingVisible: Boolean;
-        SendingStatusTxt: Text;
+        StatusReasonVisible: Boolean;
+        StatusStyleTxt: Text;
         OutgoingMessageTxt: Label 'Outgoing email';
         IncomingMessageTxt: Label 'Incoming email';
         SelectContactOrCreateLbl: Label 'Select an existing contact, or create a new one';
         ShowAttachmentLbl: Label 'Show attachments (%1)', Comment = '%1 = Attachment count';
-        SendingFailedTxt: Label 'Failed to send';
+        UnfavorableStyleTxt: Label 'Unfavorable', Locked = true;
         RetrySendingQst: Label 'Do you want to retry sending this reply?';
         RetrySendingScheduledMsg: Label 'The reply will be retried during the next agent run.';
 }

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAReplyRetryMgt.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAReplyRetryMgt.Codeunit.al
@@ -17,7 +17,35 @@ codeunit 4418 "SOA Reply Retry Mgt."
 
     var
         ReplyNotAuthorizedErr: Label 'You are not authorized to send this reply.';
+        ReplyNotFailedErr: Label 'Only a reply that failed to be sent can be retried.';
 
+    /// <summary>
+    /// Moves a failed output message back to Reviewed so that delivery is attempted again on the next agent run.
+    /// </summary>
+    internal procedure RetrySending(TaskId: BigInteger; MessageId: Guid)
+    var
+        AgentTaskMessage: Record "Agent Task Message";
+        AgentMessage: Codeunit "Agent Message";
+    begin
+        AgentTaskMessage.Get(TaskId, MessageId);
+        ValidateMessageAccess(AgentTaskMessage);
+
+        if (AgentTaskMessage.Type <> AgentTaskMessage.Type::Output) or (AgentTaskMessage.Status <> AgentTaskMessage.Status::Failed) then
+            Error(ReplyNotFailedErr);
+
+        ClearAttempts(TaskId, MessageId);
+        AgentMessage.SetStatusToReviewed(TaskId, MessageId);
+    end;
+
+    /// <summary>
+    /// Counts a failed delivery attempt for an output message.
+    /// </summary>
+    /// <remarks>
+    /// Terminal state lives on the message itself, as the Failed status. This table only counts the attempts that lead
+    /// up to it, because a single failure is not conclusive: transient mailbox errors such as a mailbox move in progress
+    /// resolve themselves, and failing such a reply terminally on the first error would lose a deliverable reply.
+    /// Rows are short lived and are removed as soon as the message is sent or moves to Failed.
+    /// </remarks>
     internal procedure RegisterFailedAttempt(TaskId: BigInteger; MessageId: Guid)
     var
         SOAReplyAttempt: Record "SOA Reply Attempt";
@@ -34,16 +62,6 @@ codeunit 4418 "SOA Reply Retry Mgt."
             SOAReplyAttempt."Attempt Count" := 1;
             SOAReplyAttempt.Insert();
         end;
-    end;
-
-    internal procedure ResetAttempts(TaskId: BigInteger; MessageId: Guid)
-    var
-        AgentTaskMessage: Record "Agent Task Message";
-    begin
-        AgentTaskMessage.Get(TaskId, MessageId);
-        ValidateMessageAccess(AgentTaskMessage);
-
-        ClearAttempts(TaskId, MessageId);
     end;
 
     internal procedure IsExhausted(TaskId: BigInteger; MessageId: Guid): Boolean
@@ -73,12 +91,10 @@ codeunit 4418 "SOA Reply Retry Mgt."
     var
         SOASetup: Record "SOA Setup";
     begin
-        ValidateMessageAccess(AgentTaskMessage, SOASetup);
-    end;
-
-    local procedure ValidateMessageAccess(AgentTaskMessage: Record "Agent Task Message"; var SOASetup: Record "SOA Setup")
-    begin
-        SOASetup.GetBasedOnAgentUserSecurityID(AgentTaskMessage."Agent User Security ID", true);
+        // A setup that cannot be resolved means authorization cannot be established, which is reported as
+        // such rather than surfacing the internal "setup not found" error to the user.
+        if not SOASetup.GetBasedOnAgentUserSecurityID(AgentTaskMessage."Agent User Security ID", false) then
+            Error(ReplyNotAuthorizedErr);
         if not SOASetup.IsAuthorizedUserSecurityID(UserSecurityId()) then
             Error(ReplyNotAuthorizedErr);
     end;

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAReplyRetryMgt.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAReplyRetryMgt.Codeunit.al
@@ -7,6 +7,7 @@
 namespace Microsoft.Agent.SalesOrderAgent;
 
 using System.Agents;
+using System.Telemetry;
 
 codeunit 4418 "SOA Reply Retry Mgt."
 {
@@ -18,6 +19,7 @@ codeunit 4418 "SOA Reply Retry Mgt."
     var
         ReplyNotAuthorizedErr: Label 'You are not authorized to send this reply.';
         ReplyNotFailedErr: Label 'Only a reply that failed to be sent can be retried.';
+        TelemetryReplySendingRetriedLbl: Label 'Failed email reply was set back to Reviewed so that sending is retried.', Locked = true;
 
     /// <summary>
     /// Moves a failed output message back to Reviewed so that delivery is attempted again on the next agent run.
@@ -26,6 +28,9 @@ codeunit 4418 "SOA Reply Retry Mgt."
     var
         AgentTaskMessage: Record "Agent Task Message";
         AgentMessage: Codeunit "Agent Message";
+        SOASetupCU: Codeunit "SOA Setup";
+        FeatureTelemetry: Codeunit "Feature Telemetry";
+        TelemetryDimensions: Dictionary of [Text, Text];
     begin
         AgentTaskMessage.Get(TaskId, MessageId);
         ValidateMessageAccess(AgentTaskMessage);
@@ -35,6 +40,10 @@ codeunit 4418 "SOA Reply Retry Mgt."
 
         ClearAttempts(TaskId, MessageId);
         AgentMessage.SetStatusToReviewed(TaskId, MessageId);
+
+        TelemetryDimensions.Add('AgentTaskID', Format(TaskId));
+        TelemetryDimensions.Add('AgentTaskMessageID', MessageId);
+        FeatureTelemetry.LogUsage('0000V6L', SOASetupCU.GetFeatureName(), TelemetryReplySendingRetriedLbl, TelemetryDimensions);
     end;
 
     /// <summary>

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASendReplies.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASendReplies.Codeunit.al
@@ -113,7 +113,6 @@ codeunit 4581 "SOA Send Replies"
         InputAgentTaskMessage: Record "Agent Task Message";
         SOASendReply: Codeunit "SOA Send Reply";
         ErrorCallStack: Text;
-        ErrorText: Text;
     begin
         if not InputAgentTaskMessage.Get(OutputAgentTaskMessage."Task ID", OutputAgentTaskMessage."Input Message ID") then begin
             AllSentSuccessfully := false;
@@ -135,11 +134,11 @@ codeunit 4581 "SOA Send Replies"
             exit;
         end;
 
-        ErrorText := GetLastErrorText(true);
+        // The error text is deliberately not put into a custom dimension. It comes from the mail stack and can
+        // incidentally carry contact or mailbox data, so only the call stack is recorded here.
         ErrorCallStack := GetLastErrorCallStack();
         AllSentSuccessfully := false;
         AddReplyResult(TempReplyResult, OutputAgentTaskMessage, TempReplyResult.Status::Failed);
-        TelemetryDimensions.Set('Error', ErrorText);
         FeatureTelemetry.LogError('0000OAB', SOASetupCU.GetFeatureName(), 'Send Email Reply', TelemetryEmailReplyFailedToSendLbl, ErrorCallStack, TelemetryDimensions);
     end;
 

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASendReplies.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASendReplies.Codeunit.al
@@ -29,18 +29,22 @@ codeunit 4581 "SOA Send Replies"
         TelemetryEmailReplyFailedToSendLbl: Label 'Email reply failed to send.', Locked = true;
         TelemetryEmailReplyExternalIdEmptyLbl: Label 'Email reply failed to be sent due to input agent task message containing empty External Id.', Locked = true;
         TelemetryFailedToGetInputAgentTaskMessageLbl: Label 'Failed to get input agent task message.', Locked = true;
+        ReplyDeliveryFailedReasonLbl: Label 'The reply could not be sent after %1 attempts. Check your email connection and account permissions, then choose Retry sending.', Comment = '%1 = number of attempts';
 
     local procedure SendEmailReplies(SOASetup: Record "SOA Setup")
     var
         OutputAgentTaskMessage: Record "Agent Task Message";
-        TempFailedReplyAttempt: Record "SOA Reply Attempt" temporary;
-        TempSuccessfulReplyAttempt: Record "SOA Reply Attempt" temporary;
-        SOAReplyRetryMgt: Codeunit "SOA Reply Retry Mgt.";
+        TempReplyResult: Record "Agent Task Message" temporary;
         TelemetryDimensions: Dictionary of [Text, Text];
     begin
         AllSentSuccessfully := true;
 
+        // Must run before the first send. Sending commits, and after a commit an error can no longer be
+        // trapped, so the status transition would abort this codeunit instead of being handled.
+        FailExhaustedReplies(SOASetup);
+
         OutputAgentTaskMessage.ReadIsolation(IsolationLevel::ReadCommitted);
+        // Messages that gave up on delivery are in the Failed status, so this filter already excludes them.
         OutputAgentTaskMessage.SetRange(Status, OutputAgentTaskMessage.Status::Reviewed);
         OutputAgentTaskMessage.SetRange(Type, OutputAgentTaskMessage.Type::Output);
         OutputAgentTaskMessage.SetRange("Agent User Security ID", SOASetup."User Security ID");
@@ -53,13 +57,46 @@ codeunit 4581 "SOA Send Replies"
             TelemetryDimensions.Add('AgentTaskID', Format(OutputAgentTaskMessage."Task ID"));
             TelemetryDimensions.Add('AgentTaskMessageID', OutputAgentTaskMessage."ID");
 
-            if SOAReplyRetryMgt.IsExhausted(OutputAgentTaskMessage."Task ID", OutputAgentTaskMessage.ID) then
-                AllSentSuccessfully := false
-            else
-                SendEmailReply(OutputAgentTaskMessage, TelemetryDimensions, TempFailedReplyAttempt, TempSuccessfulReplyAttempt);
+            SendEmailReply(OutputAgentTaskMessage, TelemetryDimensions, TempReplyResult);
         until OutputAgentTaskMessage.Next() = 0;
 
-        ApplyRetryUpdates(TempFailedReplyAttempt, TempSuccessfulReplyAttempt);
+        ApplyReplyResults(TempReplyResult);
+    end;
+
+    /// <summary>
+    /// Moves messages that already used up their retry budget to the terminal Failed status, so that they are
+    /// not attempted again. A message that uses up its budget during a run is failed at the start of the next run.
+    /// </summary>
+    local procedure FailExhaustedReplies(SOASetup: Record "SOA Setup")
+    var
+        OutputAgentTaskMessage: Record "Agent Task Message";
+        TempExhaustedReply: Record "Agent Task Message" temporary;
+        SOAReplyRetryMgt: Codeunit "SOA Reply Retry Mgt.";
+    begin
+        OutputAgentTaskMessage.ReadIsolation(IsolationLevel::ReadCommitted);
+        OutputAgentTaskMessage.SetRange(Status, OutputAgentTaskMessage.Status::Reviewed);
+        OutputAgentTaskMessage.SetRange(Type, OutputAgentTaskMessage.Type::Output);
+        OutputAgentTaskMessage.SetRange("Agent User Security ID", SOASetup."User Security ID");
+
+        if not OutputAgentTaskMessage.FindSet() then
+            exit;
+
+        // Buffered, because the transition changes the status this loop filters on.
+        repeat
+            if SOAReplyRetryMgt.IsExhausted(OutputAgentTaskMessage."Task ID", OutputAgentTaskMessage.ID) then begin
+                TempExhaustedReply.Init();
+                TempExhaustedReply."Task ID" := OutputAgentTaskMessage."Task ID";
+                TempExhaustedReply.ID := OutputAgentTaskMessage.ID;
+                TempExhaustedReply.Insert();
+            end;
+        until OutputAgentTaskMessage.Next() = 0;
+
+        if not TempExhaustedReply.FindSet() then
+            exit;
+
+        repeat
+            GiveUpOnDelivery(TempExhaustedReply, SOAReplyRetryMgt);
+        until TempExhaustedReply.Next() = 0;
     end;
 
     procedure GetAllSentSuccessfully(): Boolean
@@ -67,7 +104,7 @@ codeunit 4581 "SOA Send Replies"
         exit(AllSentSuccessfully);
     end;
 
-    local procedure SendEmailReply(OutputAgentTaskMessage: Record "Agent Task Message"; var TelemetryDimensions: Dictionary of [Text, Text]; var TempFailedReplyAttempt: Record "SOA Reply Attempt" temporary; var TempSuccessfulReplyAttempt: Record "SOA Reply Attempt" temporary)
+    local procedure SendEmailReply(OutputAgentTaskMessage: Record "Agent Task Message"; var TelemetryDimensions: Dictionary of [Text, Text]; var TempReplyResult: Record "Agent Task Message" temporary)
     var
         InputAgentTaskMessage: Record "Agent Task Message";
         SOASendReply: Codeunit "SOA Send Reply";
@@ -76,20 +113,20 @@ codeunit 4581 "SOA Send Replies"
     begin
         if not InputAgentTaskMessage.Get(OutputAgentTaskMessage."Task ID", OutputAgentTaskMessage."Input Message ID") then begin
             AllSentSuccessfully := false;
-            AddRetryUpdate(TempFailedReplyAttempt, OutputAgentTaskMessage);
+            AddReplyResult(TempReplyResult, OutputAgentTaskMessage, TempReplyResult.Status::Failed);
             FeatureTelemetry.LogError('0000NDQ', SOASetupCU.GetFeatureName(), 'Get Input Agent Task Message', TelemetryFailedToGetInputAgentTaskMessageLbl, GetLastErrorCallStack(), TelemetryDimensions);
             exit;
         end;
 
         if InputAgentTaskMessage."External ID" = '' then begin
             AllSentSuccessfully := false;
-            AddRetryUpdate(TempFailedReplyAttempt, OutputAgentTaskMessage);
+            AddReplyResult(TempReplyResult, OutputAgentTaskMessage, TempReplyResult.Status::Failed);
             FeatureTelemetry.LogError('0000NDR', SOASetupCU.GetFeatureName(), 'Send Email Reply', TelemetryEmailReplyExternalIdEmptyLbl, '', TelemetryDimensions);
             exit;
         end;
 
         if SOASendReply.Run(OutputAgentTaskMessage) then begin
-            AddRetryUpdate(TempSuccessfulReplyAttempt, OutputAgentTaskMessage);
+            AddReplyResult(TempReplyResult, OutputAgentTaskMessage, TempReplyResult.Status::Sent);
             FeatureTelemetry.LogUsage('0000NDS', SOASetupCU.GetFeatureName(), TelemetryEmailReplySentLbl, TelemetryDimensions);
             exit;
         end;
@@ -97,31 +134,60 @@ codeunit 4581 "SOA Send Replies"
         ErrorText := GetLastErrorText(true);
         ErrorCallStack := GetLastErrorCallStack();
         AllSentSuccessfully := false;
-        AddRetryUpdate(TempFailedReplyAttempt, OutputAgentTaskMessage);
+        AddReplyResult(TempReplyResult, OutputAgentTaskMessage, TempReplyResult.Status::Failed);
         TelemetryDimensions.Set('Error', ErrorText);
         FeatureTelemetry.LogError('0000OAB', SOASetupCU.GetFeatureName(), 'Send Email Reply', TelemetryEmailReplyFailedToSendLbl, ErrorCallStack, TelemetryDimensions);
     end;
 
-    local procedure AddRetryUpdate(var TempSOAReplyAttempt: Record "SOA Reply Attempt" temporary; OutputAgentTaskMessage: Record "Agent Task Message")
+    /// <summary>
+    /// Buffers the outcome of a send attempt so that the message status and the attempt counter are only written
+    /// after the loop over the reviewed messages has completed, because the loop filters on the status it would change.
+    /// </summary>
+    local procedure AddReplyResult(var TempReplyResult: Record "Agent Task Message" temporary; OutputAgentTaskMessage: Record "Agent Task Message"; ResultStatus: Option)
     begin
-        TempSOAReplyAttempt.Init();
-        TempSOAReplyAttempt."Task ID" := OutputAgentTaskMessage."Task ID";
-        TempSOAReplyAttempt."Message ID" := OutputAgentTaskMessage.ID;
-        TempSOAReplyAttempt.Insert();
+        TempReplyResult.Init();
+        TempReplyResult."Task ID" := OutputAgentTaskMessage."Task ID";
+        TempReplyResult.ID := OutputAgentTaskMessage.ID;
+        TempReplyResult.Status := ResultStatus;
+        TempReplyResult.Insert();
     end;
 
-    local procedure ApplyRetryUpdates(var TempFailedReplyAttempt: Record "SOA Reply Attempt" temporary; var TempSuccessfulReplyAttempt: Record "SOA Reply Attempt" temporary)
+    local procedure ApplyReplyResults(var TempReplyResult: Record "Agent Task Message" temporary)
     var
         SOAReplyRetryMgt: Codeunit "SOA Reply Retry Mgt.";
     begin
-        if TempFailedReplyAttempt.FindSet() then
-            repeat
-                SOAReplyRetryMgt.RegisterFailedAttempt(TempFailedReplyAttempt."Task ID", TempFailedReplyAttempt."Message ID");
-            until TempFailedReplyAttempt.Next() = 0;
+        if not TempReplyResult.FindSet() then
+            exit;
 
-        if TempSuccessfulReplyAttempt.FindSet() then
-            repeat
-                SOAReplyRetryMgt.ClearAttempts(TempSuccessfulReplyAttempt."Task ID", TempSuccessfulReplyAttempt."Message ID");
-            until TempSuccessfulReplyAttempt.Next() = 0;
+        repeat
+            if TempReplyResult.Status = TempReplyResult.Status::Sent then
+                SOAReplyRetryMgt.ClearAttempts(TempReplyResult."Task ID", TempReplyResult.ID)
+            else
+                SOAReplyRetryMgt.RegisterFailedAttempt(TempReplyResult."Task ID", TempReplyResult.ID);
+        until TempReplyResult.Next() = 0;
+    end;
+
+    /// <summary>
+    /// Moves the message to the terminal Failed status so that it is no longer picked up for delivery,
+    /// and records why delivery was given up in the status reason shown to the user.
+    /// </summary>
+    local procedure GiveUpOnDelivery(var TempExhaustedReply: Record "Agent Task Message" temporary; var SOAReplyRetryMgt: Codeunit "SOA Reply Retry Mgt.")
+    var
+        AgentTaskMessageToFail: Record "Agent Task Message";
+        SOASetReplyFailed: Codeunit "SOA Set Reply Failed";
+    begin
+        // Only carries the values into the isolated run; it is never inserted or modified here.
+        AgentTaskMessageToFail."Task ID" := TempExhaustedReply."Task ID";
+        AgentTaskMessageToFail.ID := TempExhaustedReply.ID;
+        // The status reason is shown to the user, so it tells them what to do instead of repeating a
+        // technical message that only says the send failed.
+        AgentTaskMessageToFail."Status Reason" := CopyStr(StrSubstNo(ReplyDeliveryFailedReasonLbl, SOAReplyRetryMgt.GetMaxAttempts()), 1, MaxStrLen(AgentTaskMessageToFail."Status Reason"));
+
+        // The message keeps its counter at the maximum, so the next run tries the transition again
+        // rather than restarting the retry budget or sending the reply once more.
+        if not SOASetReplyFailed.Run(AgentTaskMessageToFail) then
+            exit;
+
+        SOAReplyRetryMgt.ClearAttempts(TempExhaustedReply."Task ID", TempExhaustedReply.ID);
     end;
 }

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASendReplies.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASendReplies.Codeunit.al
@@ -29,6 +29,8 @@ codeunit 4581 "SOA Send Replies"
         TelemetryEmailReplyFailedToSendLbl: Label 'Email reply failed to send.', Locked = true;
         TelemetryEmailReplyExternalIdEmptyLbl: Label 'Email reply failed to be sent due to input agent task message containing empty External Id.', Locked = true;
         TelemetryFailedToGetInputAgentTaskMessageLbl: Label 'Failed to get input agent task message.', Locked = true;
+        TelemetryEmailReplyDeliveryGivenUpLbl: Label 'Email reply delivery given up after the retry budget was used up. The message was set to Failed.', Locked = true;
+        TelemetryFailedToSetMessageToFailedLbl: Label 'Failed to set the agent task message status to Failed.', Locked = true;
         ReplyDeliveryFailedReasonLbl: Label 'The reply could not be sent after %1 attempts. Check your email connection and account permissions, then choose Retry sending.', Comment = '%1 = number of attempts';
 
     local procedure SendEmailReplies(SOASetup: Record "SOA Setup")
@@ -44,6 +46,7 @@ codeunit 4581 "SOA Send Replies"
         FailExhaustedReplies(SOASetup);
 
         OutputAgentTaskMessage.ReadIsolation(IsolationLevel::ReadCommitted);
+        OutputAgentTaskMessage.SetLoadFields("Task ID", ID, "Input Message ID");
         // Messages that gave up on delivery are in the Failed status, so this filter already excludes them.
         OutputAgentTaskMessage.SetRange(Status, OutputAgentTaskMessage.Status::Reviewed);
         OutputAgentTaskMessage.SetRange(Type, OutputAgentTaskMessage.Type::Output);
@@ -74,6 +77,7 @@ codeunit 4581 "SOA Send Replies"
         SOAReplyRetryMgt: Codeunit "SOA Reply Retry Mgt.";
     begin
         OutputAgentTaskMessage.ReadIsolation(IsolationLevel::ReadCommitted);
+        OutputAgentTaskMessage.SetLoadFields("Task ID", ID);
         OutputAgentTaskMessage.SetRange(Status, OutputAgentTaskMessage.Status::Reviewed);
         OutputAgentTaskMessage.SetRange(Type, OutputAgentTaskMessage.Type::Output);
         OutputAgentTaskMessage.SetRange("Agent User Security ID", SOASetup."User Security ID");
@@ -175,6 +179,7 @@ codeunit 4581 "SOA Send Replies"
     var
         AgentTaskMessageToFail: Record "Agent Task Message";
         SOASetReplyFailed: Codeunit "SOA Set Reply Failed";
+        TelemetryDimensions: Dictionary of [Text, Text];
     begin
         // Only carries the values into the isolated run; it is never inserted or modified here.
         AgentTaskMessageToFail."Task ID" := TempExhaustedReply."Task ID";
@@ -183,11 +188,18 @@ codeunit 4581 "SOA Send Replies"
         // technical message that only says the send failed.
         AgentTaskMessageToFail."Status Reason" := CopyStr(StrSubstNo(ReplyDeliveryFailedReasonLbl, SOAReplyRetryMgt.GetMaxAttempts()), 1, MaxStrLen(AgentTaskMessageToFail."Status Reason"));
 
-        // The message keeps its counter at the maximum, so the next run tries the transition again
-        // rather than restarting the retry budget or sending the reply once more.
-        if not SOASetReplyFailed.Run(AgentTaskMessageToFail) then
+        TelemetryDimensions.Add('AgentTaskID', Format(TempExhaustedReply."Task ID"));
+        TelemetryDimensions.Add('AgentTaskMessageID', TempExhaustedReply.ID);
+        TelemetryDimensions.Add('Attempts', Format(SOAReplyRetryMgt.GetMaxAttempts()));
+
+        if not SOASetReplyFailed.Run(AgentTaskMessageToFail) then begin
+            // The message keeps its counter at the maximum, so the next run tries the transition again
+            // rather than restarting the retry budget or sending the reply once more.
+            FeatureTelemetry.LogError('0000V6J', SOASetupCU.GetFeatureName(), 'Set Agent Task Message To Failed', TelemetryFailedToSetMessageToFailedLbl, GetLastErrorCallStack(), TelemetryDimensions);
             exit;
+        end;
 
         SOAReplyRetryMgt.ClearAttempts(TempExhaustedReply."Task ID", TempExhaustedReply.ID);
+        FeatureTelemetry.LogUsage('0000V6K', SOASetupCU.GetFeatureName(), TelemetryEmailReplyDeliveryGivenUpLbl, TelemetryDimensions);
     end;
 }

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASetReplyFailed.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOASetReplyFailed.Codeunit.al
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+#pragma warning disable AS0007
+namespace Microsoft.Agent.SalesOrderAgent;
+
+using System.Agents;
+
+/// <summary>
+/// Sets an output message to the terminal Failed status in its own error scope.
+/// </summary>
+/// <remarks>
+/// The transition writes to the database, so it cannot run inside a try function. It is isolated with
+/// Codeunit.Run instead, so that a rejected transition, for example because the message was concurrently
+/// discarded, is trappable and does not abort the whole send run.
+/// The caller passes the target message in Rec, using the status reason it wants recorded.
+/// </remarks>
+codeunit 4408 "SOA Set Reply Failed"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+    TableNo = "Agent Task Message";
+
+    trigger OnRun()
+    var
+        AgentMessage: Codeunit "Agent Message";
+    begin
+        AgentMessage.SetStatusToFailed(Rec."Task ID", Rec.ID, Rec."Status Reason");
+    end;
+}

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAUpgrade.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAUpgrade.Codeunit.al
@@ -42,6 +42,7 @@ codeunit 4589 "SOA Upgrade"
         SetMarkEmailAsRead();
         UpgradeOwnerUserSecurityID();
         UpgradeAgentIdentity();
+        ResetReplyAttempts();
 #if not CLEAN29
         UpgradeSOAKPIToPerAgent();
 #endif
@@ -299,6 +300,22 @@ codeunit 4589 "SOA Upgrade"
     end;
 #endif
 
+    // Attempt counts recorded before the Failed status existed represented terminal state on their own, and messages
+    // that had used up their budget were skipped indefinitely while still sitting in Reviewed. Clearing the counters
+    // lets those messages be attempted again and reach the real Failed status, instead of migrating a private flag.
+    local procedure ResetReplyAttempts()
+    var
+        SOAReplyAttempt: Record "SOA Reply Attempt";
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        if UpgradeTag.HasUpgradeTag(GetResetReplyAttemptsTag()) then
+            exit;
+
+        SOAReplyAttempt.DeleteAll();
+
+        UpgradeTag.SetUpgradeTag(GetResetReplyAttemptsTag());
+    end;
+
     internal procedure GetRegisterSalesOrderAgentCapabilityTag(): Code[250]
     begin
         exit('MS-539550-SalesOrderAgentCapability-20240802');
@@ -341,6 +358,11 @@ codeunit 4589 "SOA Upgrade"
         exit('MS-635860-OwnerUserSecurityID-20260617');
     end;
 
+    internal procedure GetResetReplyAttemptsTag(): Code[250]
+    begin
+        exit('MS-647024-ResetReplyAttempts-20260819');
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Upgrade Tag", OnGetPerDatabaseUpgradeTags, '', false, false)]
     local procedure RegisterPerDatabaseUpgradeTags(var PerDatabaseUpgradeTags: List of [Code[250]])
     begin
@@ -354,6 +376,7 @@ codeunit 4589 "SOA Upgrade"
         PerCompanyUpgradeTags.Add(GetSetMarkEmailAsReadTag());
         PerCompanyUpgradeTags.Add(GetOwnerUserSecurityIDTag());
         PerCompanyUpgradeTags.Add(GetAgentIdentityTag());
+        PerCompanyUpgradeTags.Add(GetResetReplyAttemptsTag());
 #if not CLEAN29
         PerCompanyUpgradeTags.Add(GetSOAKPIPerAgentTag());
 #endif

--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
@@ -616,6 +616,10 @@ page 4400 "SOA Setup"
         SOASetupCU: Codeunit "SOA Setup";
     begin
         UpdateAgentSetupBuffer();
+        // The warning is only meaningful when the agent actually monitors a mailbox.
+        if (not Rec."Email Monitoring") or IsNullGuid(Rec."Email Account ID") then
+            exit(false);
+
         if (TempAgentSetupBuffer.State = TempAgentSetupBuffer.State::Disabled) and StateChanged() and not IsFirstConfig() then
             if not SOASetupCU.ValidateEmailConnectionStatus(Rec) then
                 exit(true);

--- a/src/System Application/App/Agent/Interaction/AgentMessage.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/AgentMessage.Codeunit.al
@@ -130,6 +130,35 @@ codeunit 4307 "Agent Message"
 #endif
 
     /// <summary>
+    /// Sets the message status to failed, to indicate that delivery of the output message failed terminally.
+    /// Only a reviewed output message, or one that already failed, can be set to failed.
+    /// </summary>
+    /// <param name="TaskID">The task ID of the message.</param>
+    /// <param name="MessageID">The unique identifier of the message.</param>
+    /// <param name="StatusReason">The reason the message could not be delivered. It is shown to the user and recorded on the agent task log entry.</param>
+    procedure SetStatusToFailed(TaskID: BigInteger; MessageID: Guid; StatusReason: Text[250])
+    var
+        AgentMessageImpl: Codeunit "Agent Message Impl.";
+    begin
+        FeatureAccessManagement.AgentManagementAllowed(true);
+        AgentMessageImpl.SetStatusToFailed(TaskID, MessageID, StatusReason);
+    end;
+
+    /// <summary>
+    /// Sets the message status back to reviewed, so that delivery of a failed output message can be attempted again.
+    /// The status reason of the previous failure is cleared.
+    /// </summary>
+    /// <param name="TaskID">The task ID of the message.</param>
+    /// <param name="MessageID">The unique identifier of the message.</param>
+    procedure SetStatusToReviewed(TaskID: BigInteger; MessageID: Guid)
+    var
+        AgentMessageImpl: Codeunit "Agent Message Impl.";
+    begin
+        FeatureAccessManagement.AgentManagementAllowed(true);
+        AgentMessageImpl.SetStatusToReviewed(TaskID, MessageID);
+    end;
+
+    /// <summary>
     /// Add an attachment to the task message.
     /// </summary>
     /// <param name="FileName">The name of the file to be attached.</param>

--- a/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
+++ b/src/System Application/App/Agent/Interaction/Internal/AgentMessageImpl.Codeunit.al
@@ -91,6 +91,34 @@ codeunit 4308 "Agent Message Impl."
         UpdateStatus(AgentTaskMessage, AgentTaskMessage.Status::Sent);
     end;
 
+    procedure SetStatusToFailed(TaskID: BigInteger; MessageID: Guid; StatusReason: Text[250])
+    var
+        AgentTaskMessage: Record "Agent Task Message";
+    begin
+        AgentTaskMessage."Task ID" := TaskID;
+        AgentTaskMessage.ID := MessageID;
+        SetStatusToFailed(AgentTaskMessage, StatusReason);
+    end;
+
+    procedure SetStatusToFailed(var AgentTaskMessage: Record "Agent Task Message"; StatusReason: Text[250])
+    begin
+        UpdateStatus(AgentTaskMessage, AgentTaskMessage.Status::Failed, StatusReason);
+    end;
+
+    procedure SetStatusToReviewed(TaskID: BigInteger; MessageID: Guid)
+    var
+        AgentTaskMessage: Record "Agent Task Message";
+    begin
+        AgentTaskMessage."Task ID" := TaskID;
+        AgentTaskMessage.ID := MessageID;
+        SetStatusToReviewed(AgentTaskMessage);
+    end;
+
+    procedure SetStatusToReviewed(var AgentTaskMessage: Record "Agent Task Message")
+    begin
+        UpdateStatus(AgentTaskMessage, AgentTaskMessage.Status::Reviewed, '');
+    end;
+
     procedure SetIgnoreAttachment(IgnoreAttachment: Boolean)
     begin
         GlobalIgnoreAttachment := IgnoreAttachment;
@@ -256,6 +284,21 @@ codeunit 4308 "Agent Message Impl."
         AgentTaskMessageToModify.Modify(true);
 
         AgentTaskMessage.Status := AgentTaskMessageToModify.Status;
+    end;
+
+    // The platform persists the status reason from the same record buffer as the status, so both fields
+    // must be written in a single Modify for the reason to be picked up for the resulting task log entry.
+    local procedure UpdateStatus(var AgentTaskMessage: Record "Agent Task Message"; Status: Option; StatusReason: Text[250])
+    var
+        AgentTaskMessageToModify: Record "Agent Task Message";
+    begin
+        AgentTaskMessageToModify.Get(AgentTaskMessage."Task ID", AgentTaskMessage.ID);
+        AgentTaskMessageToModify.Status := Status;
+        AgentTaskMessageToModify."Status Reason" := StatusReason;
+        AgentTaskMessageToModify.Modify(true);
+
+        AgentTaskMessage.Status := AgentTaskMessageToModify.Status;
+        AgentTaskMessage."Status Reason" := AgentTaskMessageToModify."Status Reason";
     end;
 
     procedure GetFileSizeDisplayText(SizeInBytes: Decimal): Text


### PR DESCRIPTION
Fixes [AB#647024](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647024)

## Summary

Agent Runtime added a terminal `Failed` status for output messages, together with the supported transitions `Reviewed -> Failed` and `Failed -> Reviewed` ([AB#642752](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642752), BC-Platform build 29.0.53743.0). Sales Order Agent now uses it, instead of modelling terminal delivery failure with application-side state only.

This replaces the workaround added for [AB#642291](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642291), where a reply that could not be delivered stayed in `Reviewed` and was therefore re-read and re-logged on every agent run.

## System Application

- `Agent Message` / `Agent Message Impl.`: added `SetStatusToFailed(TaskID; MessageID; StatusReason)` and `SetStatusToReviewed(TaskID; MessageID)`.
- Added an `UpdateStatus` overload that writes `Status` and `Status Reason` in a single `Modify`. The platform reads the status reason from the same record buffer as the status, so both must be written together for the reason to reach the resulting agent task log entry.

## Sales Order Agent

- A reply that uses up its bounded retry budget is moved to `Failed`. The existing `SetRange(Status, Status::Reviewed)` filter then excludes it, so it is no longer picked up, re-attempted, or re-logged.
- The transition runs in a pre-pass **before** the send loop. Sending commits, and in AL an error can no longer be trapped once a `COMMIT` has occurred in the transaction, so attempting the transition after sending aborted the whole run instead of being handled. A message that exhausts its budget during a run is failed at the start of the next run and is never sent again in between.
- The transition is isolated in new codeunit `SOA Set Reply Failed`, so a rejected transition does not abort the send run.
- `SOA Email Message` page: shows the real `Status` and `Status Reason` instead of a synthetic sending-status field, styles a failed message as unfavorable, and binds **Retry sending** to `Status = Failed`. The action now performs the supported `Failed -> Reviewed` transition rather than deleting rows from a private table.
- The status reason is user-facing guidance rather than a raw error, since the underlying email error resolves to a generic message: *"The reply could not be sent after 5 attempts. Check your email connection and account permissions, then choose Retry sending."*
- An agent setup that cannot be resolved is now reported as an authorization failure, instead of surfacing an internal "Sales Order Agent Setup not found." error to the user.
- Upgrade code clears attempt rows left over from the previous logic, so affected messages are attempted again and reach `Failed` naturally. No status is written during upgrade, which avoids emitting agent log and audit entries from an upgrade session.

## Why table 4589 is kept

Table `SOA Reply Attempt` is retained, as an attempt counter only. Terminal state now lives on the message itself. A single failure is not conclusive - the error mix in [AB#642291](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642291) includes transient causes such as a mailbox move in progress - so failing a reply terminally on the first error would lose a deliverable reply. The table carries no schema change in this PR.

## Testing

Verified manually against a local server (29.0.53774.0):

- A reply that repeatedly fails to send reaches `Failed` with the status reason shown on the message page.
- The failed message is not picked up again by `SOA Send Replies`, and stops producing recurring `0000OAB` telemetry.
- The run no longer aborts when the terminal transition is applied.

## Follow-ups (not in this PR)

- Telemetry for the terminal give-up and for a rejected transition is intentionally not included here and will be added separately with allocated event IDs.
- Automated tests in `App/Internal/Apps/SalesOrderAgent/test`.
- The status reason cannot yet surface the underlying send error, because `Email Outbox."Error Message"` is `Access = Internal` and the Outlook connector raises `Error(HttpErrorMessage)` with a non-constant text. Surfacing it needs a public accessor on the Email module.




