### PR TITLE
[Shopify] Fix order edit retaining discount allocation for removed quantity

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyImportOrder.Codeunit.al
@@ -233,6 +233,8 @@ codeunit 30161 "Shpfy Import Order"
                         SetOrderAsConflicting(OrderHeader);
 
             RefundLine.CalcSums(Quantity, Amount, "Presentment Amount", "Subtotal Amount", "Presentment Subtotal Amount", "Total Tax Amount", "Presentment Total Tax Amount");
+            OrderLine."Discount Amount" -= (OrderLine."Unit Price" * RefundLine.Quantity) - RefundLine."Subtotal Amount";
+            OrderLine."Presentment Discount Amount" -= (OrderLine."Presentment Unit Price" * RefundLine.Quantity) - RefundLine."Presentment Subtotal Amount";
             OrderLine.Quantity -= RefundLine.Quantity;
             OrderLine.Modify();
             OrderHeader."Total Amount" -= RefundLine."Subtotal Amount" + RefundLine."Total Tax Amount";

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -572,6 +572,64 @@ codeunit 139611 "Shpfy Order Refund Test"
     end;
 
     [Test]
+    procedure UnitTestConsiderRefundsReducesLineDiscountForRefundedQuantity()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderLine: Record "Shpfy Order Line";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        ImportOrder: Codeunit "Shpfy Import Order";
+        OrderId: BigInteger;
+        OrderLineId: BigInteger;
+        RefundId: BigInteger;
+        UnitPrice: Decimal;
+        OriginalQuantity: Integer;
+        OriginalDiscount: Decimal;
+        RefundQuantity: Integer;
+        RefundSubtotal: Decimal;
+        ExpectedDiscount: Decimal;
+    begin
+        // [SCENARIO] When a refund removes part of a line's quantity, the line's discount amount is reduced by
+        // the discount that was allocated to the removed quantity, so the remaining quantity is not over-discounted.
+        Initialize();
+
+        // [GIVEN] A line with unit price 48, quantity 2 and an order-level discount of 19.20 (20% of 96)
+        UnitPrice := 48;
+        OriginalQuantity := 2;
+        OriginalDiscount := 19.2;
+        // [GIVEN] A refund that removes one unit; its discounted subtotal is 38.40 (48 - 9.60 discount)
+        RefundQuantity := 1;
+        RefundSubtotal := 38.4;
+        // [GIVEN] The remaining unit must keep only its 9.60 share of the discount
+        ExpectedDiscount := 9.6;
+
+        // [GIVEN] A processed Shopify order with that discounted line
+        CreateProcessedShopifyOrderWithDiscountedLine(OrderId, OrderLineId, UnitPrice, OriginalQuantity, OriginalDiscount);
+
+        // [GIVEN] Shop with "Return and Refund Process" set to "Import Only"
+        Shop := InitializeTest.CreateShop();
+        Shop."Return and Refund Process" := "Shpfy ReturnRefund ProcessType"::"Import Only";
+        Shop.Modify(false);
+
+        // [GIVEN] A zero-amount (order edit) refund that removes one unit but keeps its discounted subtotal
+        OrderRefundsHelper.SetDefaultSeed();
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, 0, 0, Shop.Code);
+        OrderRefundsHelper.CreateRefundLineWithoutCreditMemo(RefundId, OrderLineId, RefundQuantity, UnitPrice, RefundSubtotal);
+
+        // [WHEN] ConsiderRefundsInQuantityAndAmounts is executed
+        OrderHeader.Get(OrderId);
+        ImportOrder.SetShop(Shop.Code);
+        ImportOrder.ConsiderRefundsInQuantityAndAmounts(OrderHeader);
+
+        // [THEN] The line quantity is reduced by the refunded quantity
+        OrderLine.Get(OrderId, OrderLineId);
+        LibraryAssert.AreEqual(OriginalQuantity - RefundQuantity, OrderLine.Quantity, 'Quantity must be reduced by the refunded quantity.');
+        // [THEN] The line discount is reduced to the remaining quantity's share of the discount
+        LibraryAssert.AreEqual(ExpectedDiscount, OrderLine."Discount Amount", 'Discount Amount must be reduced by the refunded quantity''s discount.');
+        LibraryAssert.AreEqual(ExpectedDiscount, OrderLine."Presentment Discount Amount", 'Presentment Discount Amount must be reduced by the refunded quantity''s discount.');
+    end;
+
+    [Test]
     procedure UnitTestCreateCrMemoFromRefundWithExchangeItem()
     var
         Shop: Record "Shpfy Shop";
@@ -875,6 +933,21 @@ codeunit 139611 "Shpfy Order Refund Test"
         OrderHeader.Modify(false);
 
         OrderLineId := OrderRefundsHelper.CreateOrderLine(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999));
+        OrderRefundsHelper.ProcessShopifyOrder(OrderId);
+    end;
+
+    local procedure CreateProcessedShopifyOrderWithDiscountedLine(var OrderId: BigInteger; var OrderLineId: BigInteger; UnitPrice: Decimal; Quantity: Integer; DiscountAmount: Decimal)
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+    begin
+        OrderRefundsHelper.SetDefaultSeed();
+        OrderId := OrderRefundsHelper.CreateShopifyOrder();
+        OrderHeader.Get(OrderId);
+        OrderHeader.Processed := true;
+        OrderHeader.Modify(false);
+
+        OrderLineId := OrderRefundsHelper.CreateDiscountedOrderLine(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), UnitPrice, Quantity, DiscountAmount);
         OrderRefundsHelper.ProcessShopifyOrder(OrderId);
     end;
 

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -583,28 +583,37 @@ codeunit 139611 "Shpfy Order Refund Test"
         OrderLineId: BigInteger;
         RefundId: BigInteger;
         UnitPrice: Decimal;
+        PresentmentUnitPrice: Decimal;
         OriginalQuantity: Integer;
         OriginalDiscount: Decimal;
+        PresentmentOriginalDiscount: Decimal;
         RefundQuantity: Integer;
         RefundSubtotal: Decimal;
+        PresentmentRefundSubtotal: Decimal;
         ExpectedDiscount: Decimal;
+        ExpectedPresentmentDiscount: Decimal;
     begin
         // [SCENARIO] When a refund removes part of a line's quantity, the line's discount amount is reduced by
         // the discount that was allocated to the removed quantity, so the remaining quantity is not over-discounted.
         Initialize();
 
-        // [GIVEN] A line with unit price 48, quantity 2 and an order-level discount of 19.20 (20% of 96)
+        // [GIVEN] A line with shop unit price 48, quantity 2 and a 20% order-level discount of 19.20 (per unit 9.60)
         UnitPrice := 48;
         OriginalQuantity := 2;
         OriginalDiscount := 19.2;
-        // [GIVEN] A refund that removes one unit; its discounted subtotal is 38.40 (48 - 9.60 discount)
+        // [GIVEN] Distinct presentment values: unit price 60, discount 24.00 (20% of 120, per unit 12.00)
+        PresentmentUnitPrice := 60;
+        PresentmentOriginalDiscount := 24;
+        // [GIVEN] A refund that removes one unit; discounted subtotals are 38.40 shop / 48.00 presentment
         RefundQuantity := 1;
         RefundSubtotal := 38.4;
-        // [GIVEN] The remaining unit must keep only its 9.60 share of the discount
+        PresentmentRefundSubtotal := 48;
+        // [GIVEN] The remaining unit must keep only its share of the discount: 9.60 shop / 12.00 presentment
         ExpectedDiscount := 9.6;
+        ExpectedPresentmentDiscount := 12;
 
         // [GIVEN] A processed Shopify order with that discounted line
-        CreateProcessedShopifyOrderWithDiscountedLine(OrderId, OrderLineId, UnitPrice, OriginalQuantity, OriginalDiscount);
+        CreateProcessedShopifyOrderWithDiscountedLine(OrderId, OrderLineId, UnitPrice, PresentmentUnitPrice, OriginalQuantity, OriginalDiscount, PresentmentOriginalDiscount);
 
         // [GIVEN] Shop with "Return and Refund Process" set to "Import Only"
         Shop := InitializeTest.CreateShop();
@@ -614,7 +623,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [GIVEN] A zero-amount (order edit) refund that removes one unit but keeps its discounted subtotal
         OrderRefundsHelper.SetDefaultSeed();
         RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, 0, 0, Shop.Code);
-        OrderRefundsHelper.CreateRefundLineWithoutCreditMemo(RefundId, OrderLineId, RefundQuantity, UnitPrice, RefundSubtotal);
+        OrderRefundsHelper.CreateRefundLineWithoutCreditMemo(RefundId, OrderLineId, RefundQuantity, UnitPrice, PresentmentUnitPrice, RefundSubtotal, PresentmentRefundSubtotal);
 
         // [WHEN] ConsiderRefundsInQuantityAndAmounts is executed
         OrderHeader.Get(OrderId);
@@ -624,9 +633,57 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [THEN] The line quantity is reduced by the refunded quantity
         OrderLine.Get(OrderId, OrderLineId);
         LibraryAssert.AreEqual(OriginalQuantity - RefundQuantity, OrderLine.Quantity, 'Quantity must be reduced by the refunded quantity.');
-        // [THEN] The line discount is reduced to the remaining quantity's share of the discount
+        // [THEN] The shop and presentment discounts are each reduced to the remaining quantity's share
         LibraryAssert.AreEqual(ExpectedDiscount, OrderLine."Discount Amount", 'Discount Amount must be reduced by the refunded quantity''s discount.');
-        LibraryAssert.AreEqual(ExpectedDiscount, OrderLine."Presentment Discount Amount", 'Presentment Discount Amount must be reduced by the refunded quantity''s discount.');
+        LibraryAssert.AreEqual(ExpectedPresentmentDiscount, OrderLine."Presentment Discount Amount", 'Presentment Discount Amount must be reduced by the refunded quantity''s presentment discount.');
+    end;
+
+    [Test]
+    procedure UnitTestConsiderRefundsAggregatesMultipleRefundLinesForLineDiscount()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderLine: Record "Shpfy Order Line";
+        Shop: Record "Shpfy Shop";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        ImportOrder: Codeunit "Shpfy Import Order";
+        OrderId: BigInteger;
+        OrderLineId: BigInteger;
+        RefundId: BigInteger;
+        UnitPrice: Decimal;
+        PresentmentUnitPrice: Decimal;
+    begin
+        // [SCENARIO] Multiple refund lines against the same order line are aggregated (CalcSums) so the line discount
+        // is reduced by the combined discount of all refunded quantities, not just a single refund line.
+        Initialize();
+
+        // [GIVEN] A line with shop unit price 48, quantity 5 and a 20% discount of 48.00 (per unit 9.60)
+        // [GIVEN] Distinct presentment values: unit price 60, discount 60.00 (per unit 12.00)
+        UnitPrice := 48;
+        PresentmentUnitPrice := 60;
+        CreateProcessedShopifyOrderWithDiscountedLine(OrderId, OrderLineId, UnitPrice, PresentmentUnitPrice, 5, 48, 60);
+
+        // [GIVEN] Shop with "Return and Refund Process" set to "Import Only"
+        Shop := InitializeTest.CreateShop();
+        Shop."Return and Refund Process" := "Shpfy ReturnRefund ProcessType"::"Import Only";
+        Shop.Modify(false);
+
+        // [GIVEN] Two refund lines on the same order line: one removes 1 unit, the other removes 2 units
+        OrderRefundsHelper.SetDefaultSeed();
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, 0, 0, Shop.Code);
+        OrderRefundsHelper.CreateRefundLineWithoutCreditMemo(RefundId, OrderLineId, 1, UnitPrice, PresentmentUnitPrice, 38.4, 48);
+        OrderRefundsHelper.CreateRefundLineWithoutCreditMemo(RefundId, OrderLineId, 2, UnitPrice, PresentmentUnitPrice, 76.8, 96);
+
+        // [WHEN] ConsiderRefundsInQuantityAndAmounts is executed
+        OrderHeader.Get(OrderId);
+        ImportOrder.SetShop(Shop.Code);
+        ImportOrder.ConsiderRefundsInQuantityAndAmounts(OrderHeader);
+
+        // [THEN] The 3 refunded units are removed, leaving quantity 2
+        OrderLine.Get(OrderId, OrderLineId);
+        LibraryAssert.AreEqual(2, OrderLine.Quantity, 'Quantity must be reduced by the combined refunded quantity.');
+        // [THEN] The discount is reduced by the combined discount of the 3 refunded units: 28.80 shop / 36.00 presentment
+        LibraryAssert.AreEqual(19.2, OrderLine."Discount Amount", 'Discount Amount must be reduced by the combined refunded discount.');
+        LibraryAssert.AreEqual(24, OrderLine."Presentment Discount Amount", 'Presentment Discount Amount must be reduced by the combined refunded presentment discount.');
     end;
 
     [Test]
@@ -936,7 +993,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         OrderRefundsHelper.ProcessShopifyOrder(OrderId);
     end;
 
-    local procedure CreateProcessedShopifyOrderWithDiscountedLine(var OrderId: BigInteger; var OrderLineId: BigInteger; UnitPrice: Decimal; Quantity: Integer; DiscountAmount: Decimal)
+    local procedure CreateProcessedShopifyOrderWithDiscountedLine(var OrderId: BigInteger; var OrderLineId: BigInteger; UnitPrice: Decimal; PresentmentUnitPrice: Decimal; Quantity: Integer; DiscountAmount: Decimal; PresentmentDiscountAmount: Decimal)
     var
         OrderHeader: Record "Shpfy Order Header";
         OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
@@ -947,7 +1004,7 @@ codeunit 139611 "Shpfy Order Refund Test"
         OrderHeader.Processed := true;
         OrderHeader.Modify(false);
 
-        OrderLineId := OrderRefundsHelper.CreateDiscountedOrderLine(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), UnitPrice, Quantity, DiscountAmount);
+        OrderLineId := OrderRefundsHelper.CreateDiscountedOrderLine(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), UnitPrice, PresentmentUnitPrice, Quantity, DiscountAmount, PresentmentDiscountAmount);
         OrderRefundsHelper.ProcessShopifyOrder(OrderId);
     end;
 

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
@@ -172,6 +172,30 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         exit(OrderLine."Line Id");
     end;
 
+    internal procedure CreateDiscountedOrderLine(OrderId: BigInteger; LineNo: Integer; ProductId: BigInteger; VariantId: BigInteger; UnitPrice: Decimal; Quantity: Integer; DiscountAmount: Decimal): BigInteger
+    var
+        Item: Record Item;
+        OrderLine: Record "Shpfy Order Line";
+    begin
+        Item := GetItem();
+        LineNo := LineNo * 100000;
+        OrderLine."Shopify Order Id" := OrderId;
+        OrderLine."Line Id" := Any.IntegerInRange(LineNo, LineNo + 99999);
+        OrderLine.Description := Item.Description;
+        OrderLine.Quantity := Quantity;
+        OrderLine."Shopify Product Id" := ProductId;
+        OrderLine."Shopify Variant Id" := VariantId;
+        OrderLine."Item No." := Item."No.";
+        OrderLine."Gift Card" := false;
+        OrderLine.Taxable := false;
+        OrderLine."Unit Price" := UnitPrice;
+        OrderLine."Presentment Unit Price" := UnitPrice;
+        OrderLine."Discount Amount" := DiscountAmount;
+        OrderLine."Presentment Discount Amount" := DiscountAmount;
+        OrderLine.Insert();
+        exit(OrderLine."Line Id");
+    end;
+
     internal procedure CreateReturn(OrderId: BigInteger): BigInteger
     var
         ReturnHeader: Record "Shpfy Return Header";
@@ -359,6 +383,22 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         RefundLine."Presentment Amount" := SubtotalAmount + TaxAmount;
         RefundLine."Presentment Subtotal Amount" := SubtotalAmount;
         RefundLine."Presentment Total Tax Amount" := TaxAmount;
+        RefundLine."Can Create Credit Memo" := false;
+        RefundLine.Insert();
+    end;
+
+    internal procedure CreateRefundLineWithoutCreditMemo(RefundId: BigInteger; OrderLineId: BigInteger; Quantity: Integer; UnitPrice: Decimal; SubtotalAmount: Decimal)
+    var
+        RefundLine: Record "Shpfy Refund Line";
+    begin
+        RefundLine."Refund Line Id" := Any.IntegerInRange(100000, 999999);
+        RefundLine."Refund Id" := RefundId;
+        RefundLine."Order Line Id" := OrderLineId;
+        RefundLine.Quantity := Quantity;
+        RefundLine.Amount := UnitPrice;
+        RefundLine."Presentment Amount" := UnitPrice;
+        RefundLine."Subtotal Amount" := SubtotalAmount;
+        RefundLine."Presentment Subtotal Amount" := SubtotalAmount;
         RefundLine."Can Create Credit Memo" := false;
         RefundLine.Insert();
     end;

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundsHelper.Codeunit.al
@@ -172,7 +172,7 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         exit(OrderLine."Line Id");
     end;
 
-    internal procedure CreateDiscountedOrderLine(OrderId: BigInteger; LineNo: Integer; ProductId: BigInteger; VariantId: BigInteger; UnitPrice: Decimal; Quantity: Integer; DiscountAmount: Decimal): BigInteger
+    internal procedure CreateDiscountedOrderLine(OrderId: BigInteger; LineNo: Integer; ProductId: BigInteger; VariantId: BigInteger; UnitPrice: Decimal; PresentmentUnitPrice: Decimal; Quantity: Integer; DiscountAmount: Decimal; PresentmentDiscountAmount: Decimal): BigInteger
     var
         Item: Record Item;
         OrderLine: Record "Shpfy Order Line";
@@ -189,9 +189,9 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         OrderLine."Gift Card" := false;
         OrderLine.Taxable := false;
         OrderLine."Unit Price" := UnitPrice;
-        OrderLine."Presentment Unit Price" := UnitPrice;
+        OrderLine."Presentment Unit Price" := PresentmentUnitPrice;
         OrderLine."Discount Amount" := DiscountAmount;
-        OrderLine."Presentment Discount Amount" := DiscountAmount;
+        OrderLine."Presentment Discount Amount" := PresentmentDiscountAmount;
         OrderLine.Insert();
         exit(OrderLine."Line Id");
     end;
@@ -387,7 +387,7 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         RefundLine.Insert();
     end;
 
-    internal procedure CreateRefundLineWithoutCreditMemo(RefundId: BigInteger; OrderLineId: BigInteger; Quantity: Integer; UnitPrice: Decimal; SubtotalAmount: Decimal)
+    internal procedure CreateRefundLineWithoutCreditMemo(RefundId: BigInteger; OrderLineId: BigInteger; Quantity: Integer; UnitPrice: Decimal; PresentmentUnitPrice: Decimal; SubtotalAmount: Decimal; PresentmentSubtotalAmount: Decimal)
     var
         RefundLine: Record "Shpfy Refund Line";
     begin
@@ -396,9 +396,9 @@ codeunit 139564 "Shpfy Order Refunds Helper"
         RefundLine."Order Line Id" := OrderLineId;
         RefundLine.Quantity := Quantity;
         RefundLine.Amount := UnitPrice;
-        RefundLine."Presentment Amount" := UnitPrice;
+        RefundLine."Presentment Amount" := PresentmentUnitPrice;
         RefundLine."Subtotal Amount" := SubtotalAmount;
-        RefundLine."Presentment Subtotal Amount" := SubtotalAmount;
+        RefundLine."Presentment Subtotal Amount" := PresentmentSubtotalAmount;
         RefundLine."Can Create Credit Memo" := false;
         RefundLine.Insert();
     end;


### PR DESCRIPTION
## What & why

When a paid Shopify order with an order-level (percentage) discount is edited to reduce a line's quantity, the connector imports the current quantity and current header discount, but the `Shpfy Order Line` keeps the discount allocation that Shopify calculated for the **original** quantity. Refund processing (`ConsiderRefundsInQuantityAndAmounts`) reduced the line quantity but not the discount, so the stale full-quantity discount was applied to the smaller remaining quantity — over-discounting the created sales line and producing an incorrect total.

Example from the bug: unit price 48.00, qty 2, 20% discount (allocation 19.20). After editing/refunding one unit, the line becomes qty 1 but kept discount 19.20 (an effective 40%), giving a line amount of 28.80 instead of the correct 38.40 (20% / 9.60).

**Fix:** `ConsiderRefundsInQuantityAndAmounts` now also reduces the line's `Discount Amount` and `Presentment Discount Amount` by the refunded quantity's share of the discount — `unit price * refunded qty - refunded subtotal` — the same derivation the credit-memo path already uses in `Shpfy Create Sales Doc. Refund`. After the fix the remaining quantity keeps only its proportional discount, and the line discount sum reconciles with the order header's current discount.

## Linked work

Fixes [AB#647146](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647146)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Root-caused directly against the connector source; confirmed `RefundLineItem` exposes no discount field (Shopify GraphQL 2026-07), so `unit price * qty - subtotal` is the canonical derivation (consistent with `ShpfyCreateSalesDocRefund` and `FillInExchangeRefundLine`).
- Added unit test `UnitTestConsiderRefundsReducesLineDiscountForRefundedQuantity` (codeunit 139611 `Shpfy Order Refund Test`): unit price 48, qty 2, discount 19.20; a zero-amount order-edit refund removes one unit (discounted subtotal 38.40); asserts the remaining qty 1 keeps discount **9.60** (both shop and presentment currency) and quantity is reduced to 1. Added helpers `CreateDiscountedOrderLine` and `CreateRefundLineWithoutCreditMemo`.
- Built the **Shopify Connector** app locally (AL build) — succeeds with no new analyzer warnings.
- Note: the **Shopify Connector Test** app was not compiled/run in my environment (test-framework symbol cache not provisioned locally). Please run the Order Refunds suite (139611) before merge.

## Risk & compatibility

Low. Behavior only changes when refund/return import is enabled (`Return and Refund Process` imports refunds) and a refund removes quantity from a discounted line. No schema changes. The change tightens header/line discount reconciliation (the residual fed to `ApplyGlobalDiscounts` shrinks from the full stale discount to at most one rounding unit). Only `ConsiderRefundsInQuantityAndAmounts` is affected; the mock import path used by other order tests does not call it.




