### PR TITLE
[28.4] Support registration numbers in E-Documents

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/EDocument.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocument.Table.al
@@ -283,6 +283,10 @@ table 6121 "E-Document"
             Caption = 'Structured Data Process';
             ToolTip = 'Specifies the implementation to use for processing the draft received.';
         }
+        field(45; "Receiving Company Reg. No."; Text[20])
+        {
+            Caption = 'Receiving Company Registration No.';
+        }
         #endregion
 
         #region Clearance Model

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocCompanyInformation.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocCompanyInformation.PageExt.al
@@ -16,6 +16,14 @@ pageextension 6165 "E-Doc. Company Information" extends "Company Information"
 {
     layout
     {
+        addafter("Use GLN in Electronic Document")
+        {
+            field("Use Reg. No. in E-Document"; Rec."Use Reg. No. in E-Document")
+            {
+                ApplicationArea = Basic, Suite;
+                ToolTip = 'Specifies whether the company registration number is used to identify the company in electronic documents when the GLN and VAT registration number are blank.';
+            }
+        }
         addafter(GLN)
         {
             group(ElectronicDocumentServiceGroup)

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocCompanyInformation.TableExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocCompanyInformation.TableExt.al
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+
+namespace Microsoft.eServices.EDocument.Extensions;
+
+using Microsoft.Foundation.Company;
+
+tableextension 6173 "E-Doc. Company Information" extends "Company Information"
+{
+    fields
+    {
+        field(6101; "Use Reg. No. in E-Document"; Boolean)
+        {
+            Caption = 'Use Registration No. in Electronic Document';
+            DataClassification = CustomerContent;
+        }
+    }
+}

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocVendorPage.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocVendorPage.PageExt.al
@@ -3,6 +3,14 @@ pageextension 6161 "E-Doc. Vendor Page" extends "Vendor Card"
 {
     layout
     {
+        addafter("Registration Number")
+        {
+            field("Use Reg. No. in E-Document"; Rec."Use Reg. No. in E-Document")
+            {
+                ApplicationArea = Basic, Suite;
+                ToolTip = 'Specifies whether the vendor registration number is used to identify the vendor in electronic documents when the GLN and VAT registration number are blank.';
+            }
+        }
         addlast(Receiving)
         {
             field("Receive E-Document To"; Rec."Receive E-Document To")

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocumentVendor.TableExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocumentVendor.TableExt.al
@@ -9,5 +9,16 @@ tableextension 6165 "E-Document Vendor" extends Vendor
             InitValue = "Purchase Order";
             ValuesAllowed = "Purchase Order", "Purchase Invoice";
         }
+        field(6102; "Use Reg. No. in E-Document"; Boolean)
+        {
+            Caption = 'Use Registration No. in Electronic Document';
+            DataClassification = CustomerContent;
+        }
+    }
+    keys
+    {
+        key(EDocRegistrationNumber; "Registration Number")
+        {
+        }
     }
 }

--- a/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Helpers/EDocumentImportHelper.Codeunit.al
@@ -283,6 +283,19 @@ codeunit 6109 "E-Document Import Helper"
     begin
         CompanyInformation.Get();
 
+        if (EDocument."Receiving Company Reg. No." <> '') and
+           CompanyInformation."Use Reg. No. in E-Document" and
+           (CompanyInformation.GLN = '') and
+           (CompanyInformation."VAT Registration No." = '') and
+           (EDocument."Receiving Company GLN" = '') and
+           (EDocument."Receiving Company VAT Reg. No." = '')
+        then begin
+            if CompanyInformation."Registration No." <> EDocument."Receiving Company Reg. No." then
+                EDocErrorHelper.LogErrorMessage(
+                    EDocument, CompanyInformation, CompanyInformation.FieldNo("Registration No."), InvalidCompanyInfoRegistrationNoErr);
+            exit;
+        end;
+
         if (EDocument."Receiving Company GLN" = '') and (EDocument."Receiving Company VAT Reg. No." = '') then begin
             ValidateReceivingCompanyInfoByNameAndAddress(EDocument);
             exit;
@@ -431,6 +444,19 @@ codeunit 6109 "E-Document Import Helper"
     /// <param name="VATRegistrationNo">Vendor's VAT registration number.</param>
     /// <returns>Vendor number if exists or empty string.</returns>
     procedure FindVendor(VendorNoText: Code[20]; GLN: Code[13]; VATRegistrationNo: Text[20]): Code[20]
+    begin
+        exit(FindVendor(VendorNoText, GLN, VATRegistrationNo, ''));
+    end;
+
+    /// <summary>
+    /// Use it to find a vendor by number, GLN, VAT registration number or registration number.
+    /// </summary>
+    /// <param name="VendorNoText">Vendor's number.</param>
+    /// <param name="GLN">Vendor's GLN.</param>
+    /// <param name="VATRegistrationNo">Vendor's VAT registration number.</param>
+    /// <param name="RegistrationNo">Vendor's registration number.</param>
+    /// <returns>Vendor number if exists or empty string.</returns>
+    procedure FindVendor(VendorNoText: Code[20]; GLN: Code[13]; VATRegistrationNo: Text[20]; RegistrationNo: Text[20]): Code[20]
     var
         EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
         VendorNo: Code[20];
@@ -450,6 +476,12 @@ codeunit 6109 "E-Document Import Helper"
         VendorNo := FindVendorByVATRegistrationNo(VATRegistrationNo);
         if VendorNo <> '' then begin
             EDocImpSessionTelemetry.SetText('Vendor Match Method', 'VAT Id');
+            exit(VendorNo);
+        end;
+
+        VendorNo := FindVendorByRegistrationNo(RegistrationNo);
+        if VendorNo <> '' then begin
+            EDocImpSessionTelemetry.SetText('Vendor Match Method', 'Registration No.');
             exit(VendorNo);
         end;
     end;
@@ -520,6 +552,34 @@ codeunit 6109 "E-Document Import Helper"
         if VATRegistrationNo = '' then
             exit('');
         VendorNo := Vendor.FindVendorByVATRegistrationNo(VATRegistrationNo);
+        exit(VendorNo);
+    end;
+
+    /// <summary>
+    /// Use it to find a vendor by registration number.
+    /// </summary>
+    /// <param name="RegistrationNo">Vendor's registration number.</param>
+    /// <returns>Vendor number if exists or empty string.</returns>
+    procedure FindVendorByRegistrationNo(RegistrationNo: Text[20]): Code[20]
+    var
+        Vendor: Record Vendor;
+        VendorNo: Code[20];
+    begin
+        if RegistrationNo = '' then
+            exit('');
+
+        Vendor.SetCurrentKey("Registration Number");
+        Vendor.SetRange("Registration Number", RegistrationNo);
+        Vendor.SetRange("Use Reg. No. in E-Document", true);
+        Vendor.SetRange(GLN, '');
+        Vendor.SetRange("VAT Registration No.", '');
+        if not Vendor.FindSet() then
+            exit('');
+
+        VendorNo := Vendor."No.";
+        if Vendor.Next() <> 0 then
+            Error(MultipleVendorsWithRegistrationNoErr);
+
         exit(VendorNo);
     end;
 
@@ -1080,6 +1140,8 @@ codeunit 6109 "E-Document Import Helper"
         MissingCompanyInfoSetupErr: Label 'You must fill either GLN or VAT Registration No. in the Company Information window.';
         InvalidCompanyInfoGLNErr: Label 'The customer''s GLN %1 on the electronic document does not match the GLN in the Company Information window.', Comment = '%1 = GLN (13 digit number)';
         InvalidCompanyInfoVATRegNoErr: Label 'The customer''s VAT registration number %1 on the electronic document does not match the VAT Registration No. in the Company Information window.', Comment = '%1 VAT Registration Number (format could be AB###### or ###### or AB##-##-###)';
+        InvalidCompanyInfoRegistrationNoErr: Label 'The receiving company registration number does not match Company Information.';
+        MultipleVendorsWithRegistrationNoErr: Label 'Multiple vendors match the registration number on the electronic document. Make the registration number unique for vendors that use it in electronic documents.';
         InvalidCompanyInfoNameErr: Label 'The customer name ''%1'' on the electronic document does not match the name in the Company Information window.', Comment = '%1 = customer name';
         InvalidCompanyInfoAddressErr: Label 'The customer''s address ''%1'' on the electronic document does not match the Address in the Company Information window.', Comment = '%1 = customer address, street name';
         UnableToApplyDiscountErr: Label 'The invoice discount of %1 cannot be applied. Invoice discount must be allowed on at least one invoice line and invoice total must not be 0.', Comment = '%1 - a decimal number';

--- a/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
@@ -9,6 +9,7 @@ using Microsoft.eServices.EDocument.Integration;
 using Microsoft.eServices.EDocument.Service.Participant;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Vendor;
 
 codeunit 139799 "E-Doc. Helper Test"
 {
@@ -20,6 +21,8 @@ codeunit 139799 "E-Doc. Helper Test"
         Assert: Codeunit "Assert";
         LibraryEDoc: Codeunit "Library - E-Document";
         LibraryLowerPermission: Codeunit "Library - Lower Permissions";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        MultipleVendorsWithRegistrationNoErr: Label 'Multiple vendors match the registration number on the electronic document.';
 
     trigger OnRun()
     begin
@@ -53,6 +56,69 @@ codeunit 139799 "E-Doc. Helper Test"
     begin
         VendorNo := EDocumentImportHelper.FindVendor('', '', '');
         Assert.IsTrue(VendorNo = '', 'Vendor No. should be empty');
+    end;
+
+    [Test]
+    procedure FindVendorByRegistrationNo()
+    var
+        Vendor: Record Vendor;
+        EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        LibraryUtility: Codeunit "Library - Utility";
+        RegistrationNo: Text[20];
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 646793] A vendor can be resolved by Registration No. when other identifiers are unavailable.
+        RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor."Use Reg. No. in E-Document" := true;
+        Vendor."Registration Number" := RegistrationNo;
+        Vendor.Modify();
+
+        Assert.AreEqual(Vendor."No.", EDocumentImportHelper.FindVendor('', '', '', RegistrationNo), 'Vendor should be matched by Registration No.');
+    end;
+
+    [Test]
+    procedure DoesNotFindVendorByRegistrationNoWithoutSetup()
+    var
+        Vendor: Record Vendor;
+        EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        LibraryUtility: Codeunit "Library - Utility";
+        RegistrationNo: Text[20];
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 646793] Registration No. matching requires explicit vendor setup.
+        RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor."Registration Number" := RegistrationNo;
+        Vendor.Modify();
+
+        Assert.AreEqual('', EDocumentImportHelper.FindVendor('', '', '', RegistrationNo), 'Vendor should not be matched by Registration No. without setup.');
+    end;
+
+    [Test]
+    procedure ErrorsWhenMultipleVendorsMatchByRegistrationNo()
+    var
+        Vendor: array[2] of Record Vendor;
+        EDocumentImportHelper: Codeunit "E-Document Import Helper";
+        LibraryUtility: Codeunit "Library - Utility";
+        RegistrationNo: Text[20];
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 646793] Vendor matching fails when a registration number identifies multiple vendors.
+        RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
+        LibraryPurchase.CreateVendor(Vendor[1]);
+        Vendor[1]."Use Reg. No. in E-Document" := true;
+        Vendor[1]."Registration Number" := RegistrationNo;
+        Vendor[1].Modify();
+        LibraryPurchase.CreateVendor(Vendor[2]);
+        Vendor[2]."Use Reg. No. in E-Document" := true;
+        Vendor[2]."Registration Number" := RegistrationNo;
+        Vendor[2].Modify();
+
+        asserterror EDocumentImportHelper.FindVendor('', '', '', RegistrationNo);
+
+        Assert.ExpectedError(MultipleVendorsWithRegistrationNoErr);
+        Assert.ExpectedErrorCode('Dialog');
     end;
 
     [Test]
@@ -132,4 +198,5 @@ codeunit 139799 "E-Doc. Helper Test"
         // Cleanup
         EDocument.Delete();
     end;
+
 }


### PR DESCRIPTION
## Summary

- add opt-in use of company and vendor registration numbers in E-Documents
- use the registration number as the final vendor-matching fallback when vendor number, GLN, and VAT registration number are unavailable
- validate imported receiving-company registration numbers against Company Information
- add focused tests for registration-number matching, disabled setup, and duplicate matches

## Backport scope

Backports the W1 E-Document changes from #10349 and matches the backport in #10464.

The DE-specific `EDocumentDE` and `PEPPOLDE` changes from the source PR are not included because those modules are not present in 28.4.

## Validation

- E-Document app AL diagnostics: no errors or warnings
- E-Document test AL diagnostics: no errors or warnings
- `git diff --check` passes
- committed patch ID matches the W1 E-Document subset of #10349

[AB#647383](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647383)
