### PR TITLE
Resolve purchase lines to items on exact description match

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocActivityLogSession.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocActivityLogSession.Codeunit.al
@@ -111,6 +111,11 @@ codeunit 6175 "E-Doc. Activity Log Session"
         exit('TextToAccountMapping');
     end;
 
+    procedure ItemDescriptionTok(): Text
+    begin
+        exit('ItemDescription');
+    end;
+
     procedure SellerItemIdTok(): Text
     begin
         exit('SellerItemId');

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocPreparePurchDraft.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocPreparePurchDraft.Codeunit.al
@@ -168,6 +168,7 @@ codeunit 6406 "EDoc Prepare Purch. Draft"
         Log(EDocActivityLogSession, EDocActivityLogSession.DeferralTok());
         Log(EDocActivityLogSession, EDocActivityLogSession.ItemRefTok());
         Log(EDocActivityLogSession, EDocActivityLogSession.TextToAccountMappingTok());
+        Log(EDocActivityLogSession, EDocActivityLogSession.ItemDescriptionTok());
     end;
 
     local procedure Log(EDocActivityLogSession: Codeunit "E-Doc. Activity Log Session"; ActivityLogName: Text)

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocProviders.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/PrepareDraft/EDocProviders.Codeunit.al
@@ -24,6 +24,8 @@ codeunit 6124 "E-Doc. Providers" implements IPurchaseLineProvider, IUnitOfMeasur
     var
         NoVendorInformationErr: Label 'There is no vendor information in the source document. Verify that the source document is an invoice, and if it''s not, consider deleting this E-Document.';
         PurchaseOrderNoTruncatedMsg: Label 'Purchase Order No. was truncated because it exceeded the maximum length of 20 characters.', Locked = true;
+        ItemDescriptionReasonMsg: Label 'Item was found by an exact description match.';
+        ItemDescriptionSourceMsg: Label 'Item %1', Comment = '%1 - Item No.';
 
 
     procedure GetVendor(EDocument: Record "E-Document") Vendor: Record Vendor
@@ -101,6 +103,7 @@ codeunit 6124 "E-Doc. Providers" implements IPurchaseLineProvider, IUnitOfMeasur
     procedure GetPurchaseLine(var EDocumentPurchaseLine: Record "E-Document Purchase Line")
     var
         EDocumentPurchaseHeader: Record "E-Document Purchase Header";
+        Item: Record Item;
         ItemReference: Record "Item Reference";
         EDocument: Record "E-Document";
         TextToAccountMapping: Record "Text-to-Account Mapping";
@@ -140,6 +143,16 @@ codeunit 6124 "E-Doc. Providers" implements IPurchaseLineProvider, IUnitOfMeasur
 
             SetActivityLog(EDocumentPurchaseLine.SystemId, EDocumentPurchaseLine.FieldNo("[BC] Purchase Type No."), StrSubstNo(AccountNumberReasonMsg, VendorNo), TextToAccountMapping, Page::"Text-to-Account Mapping", StrSubstNo(AccountNumberSourceMsg, TextToAccountMapping."Line No."), ActivityLog);
             EDocActivityLogSession.Set(EDocActivityLogSession.TextToAccountMappingTok(), ActivityLog);
+            exit;
+        end;
+
+        if GetPurchaseLineItemByDescription(EDocumentPurchaseLine, Item) then begin
+            EDocumentPurchaseLine."[BC] Purchase Line Type" := "Purchase Line Type"::Item;
+            EDocumentPurchaseLine.Validate("[BC] Purchase Type No.", Item."No.");
+            EDocImpSessionTelemetry.SetLineBool(EDocumentPurchaseLine.SystemId, 'ItemDescriptionMatch', true);
+
+            SetActivityLog(EDocumentPurchaseLine.SystemId, EDocumentPurchaseLine.FieldNo("[BC] Purchase Type No."), ItemDescriptionReasonMsg, Item, Page::"Item Card", StrSubstNo(ItemDescriptionSourceMsg, Item."No."), ActivityLog);
+            EDocActivityLogSession.Set(EDocActivityLogSession.ItemDescriptionTok(), ActivityLog);
             exit;
         end;
     end;
@@ -187,6 +200,32 @@ codeunit 6124 "E-Doc. Providers" implements IPurchaseLineProvider, IUnitOfMeasur
         if ItemReference.FindFirst() then
             if Item.Get(ItemReference."Item No.") then
                 exit(true);
+    end;
+
+    local procedure GetPurchaseLineItemByDescription(EDocumentPurchaseLine: Record "E-Document Purchase Line"; var Item: Record Item): Boolean
+    var
+        EDocImpSessionTelemetry: Codeunit "E-Doc. Imp. Session Telemetry";
+    begin
+        if EDocumentPurchaseLine.Description = '' then
+            exit(false);
+
+        Item.SetLoadFields("No.");
+        Item.SetRange(Description, EDocumentPurchaseLine.Description);
+        Item.SetRange(Blocked, false);
+        Item.SetRange("Purchasing Blocked", false);
+
+        if not Item.FindFirst() then begin
+            EDocImpSessionTelemetry.SetLineText(EDocumentPurchaseLine.SystemId, 'ItemDescriptionMatchResult', 'NoMatch');
+            exit(false);
+        end;
+
+        if Item.Count() = 1 then begin
+            EDocImpSessionTelemetry.SetLineText(EDocumentPurchaseLine.SystemId, 'ItemDescriptionMatchResult', 'Single');
+            exit(true);
+        end;
+
+        EDocImpSessionTelemetry.SetLineText(EDocumentPurchaseLine.SystemId, 'ItemDescriptionMatchResult', 'Multiple');
+        exit(false);
     end;
 
 }

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocProcessTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocProcessTest.Codeunit.al
@@ -240,6 +240,52 @@ codeunit 139883 "E-Doc Process Test"
     end;
 
     [Test]
+    procedure PreparingPurchaseDraftFindsItemByExactDescription()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPurchaseHeader: Record "E-Document Purchase Header";
+        EDocumentPurchaseLine: Record "E-Document Purchase Line";
+        TempEDocImportParameters: Record "E-Doc. Import Parameters";
+        Vendor2: Record Vendor;
+        Item: Record Item;
+        EDocumentProcessing: Codeunit "E-Document Processing";
+        EDocImport: Codeunit "E-Doc. Import";
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO] A draft line whose description exactly matches a single item resolves to that item
+        Initialize(Enum::"Service Integration"::"Mock");
+
+        // [GIVEN] An item "I" and a vendor "V" resolvable by VAT id
+        LibraryInventory.CreateItem(Item);
+        Item.Description := 'Exact description item';
+        Item.Modify();
+        CreateVendorWithTaxId(Vendor2, 'XXXXXXX001');
+
+        // [GIVEN] An inbound e-document from "V" with a line described exactly as "I"
+        LibraryEDoc.CreateInboundEDocument(EDocument, EDocumentService);
+        EDocumentPurchaseHeader."E-Document Entry No." := EDocument."Entry No";
+        EDocumentPurchaseHeader."Vendor VAT Id" := Vendor2."VAT Registration No.";
+        EDocumentPurchaseHeader.Insert();
+        EDocumentPurchaseLine."E-Document Entry No." := EDocument."Entry No";
+        EDocumentPurchaseLine.Description := Item.Description;
+        EDocumentPurchaseLine.Insert();
+
+        // [WHEN] The draft is prepared
+        EDocumentProcessing.ModifyEDocumentProcessingStatus(EDocument, "Import E-Doc. Proc. Status"::"Ready for draft");
+        TempEDocImportParameters."Step to Run" := "Import E-Document Steps"::"Prepare draft";
+        EDocImport.ProcessIncomingEDocument(EDocument, TempEDocImportParameters);
+
+        // [THEN] The line resolves to item "I"
+        EDocumentPurchaseLine.SetRecFilter();
+        EDocumentPurchaseLine.FindFirst();
+        Assert.AreEqual("Purchase Line Type"::Item, EDocumentPurchaseLine."[BC] Purchase Line Type", 'The purchase line type should be set to Item.');
+        Assert.AreEqual(Item."No.", EDocumentPurchaseLine."[BC] Purchase Type No.", 'The item with the exact description should be found.');
+
+        Vendor2.Delete();
+        Item.Delete();
+    end;
+
+    [Test]
     procedure PreparingPurchaseDraftFindsAccountConfiguredWithTextToAccountMapping()
     var
         EDocument: Record "E-Document";
@@ -249,6 +295,7 @@ codeunit 139883 "E-Doc Process Test"
         Vendor2: Record Vendor;
         CompanyInformation: Record "Company Information";
         GLAccount: Record "G/L Account";
+        Item: Record Item;
         TextToAccountMapping: Record "Text-to-Account Mapping";
         EDocumentProcessing: Codeunit "E-Document Processing";
         EDocImport: Codeunit "E-Doc. Import";
@@ -257,6 +304,9 @@ codeunit 139883 "E-Doc Process Test"
         LibraryEDoc.CreateInboundEDocument(EDocument, EDocumentService);
         GLAccount."No." := 'EDOC001';
         GLAccount.Insert();
+        LibraryInventory.CreateItem(Item);
+        Item.Description := 'Test description';
+        Item.Modify();
 
         CompanyInformation.GetRecordOnce();
         Vendor2."Country/Region Code" := CompanyInformation."Country/Region Code";
@@ -287,14 +337,90 @@ codeunit 139883 "E-Doc Process Test"
         EDocumentPurchaseHeader.FindFirst();
         Assert.AreEqual(Vendor2."No.", EDocumentPurchaseHeader."[BC] Vendor No.", 'The vendor should be found when the tax id is specified and it matches the one in BC.');
         Assert.AreEqual("Purchase Line Type"::"G/L Account", EDocumentPurchaseLine."[BC] Purchase Line Type", 'The purchase line type should be set to G/L Account.');
-        Assert.AreEqual(GLAccount."No.", EDocumentPurchaseLine."[BC] Purchase Type No.", 'The G/L Account configured in the Text-to-Account Mapping should be found.');
+        Assert.AreEqual(GLAccount."No.", EDocumentPurchaseLine."[BC] Purchase Type No.", 'The configured Text-to-Account Mapping should take precedence over an item description match.');
 
         Vendor2.SetRecFilter();
         Vendor2.Delete();
         GLAccount.SetRecFilter();
         GLAccount.Delete();
+        Item.Delete();
         TextToAccountMapping.SetRecFilter();
         TextToAccountMapping.Delete();
+    end;
+
+    [Test]
+    procedure PurchaseLineProviderDoesNotMatchDuplicateItemDescriptions()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPurchaseHeader: Record "E-Document Purchase Header";
+        EDocumentPurchaseLine: Record "E-Document Purchase Line";
+        Item: Record Item;
+        Item2: Record Item;
+        EDocProviders: Codeunit "E-Doc. Providers";
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO] A draft line whose description matches more than one item is left unresolved
+        Initialize(Enum::"Service Integration"::"Mock");
+
+        // [GIVEN] Two items "I1" and "I2" sharing the same description
+        LibraryInventory.CreateItem(Item);
+        Item.Description := 'Duplicate description';
+        Item.Modify();
+        LibraryInventory.CreateItem(Item2);
+        Item2.Description := Item.Description;
+        Item2.Modify();
+
+        // [GIVEN] An inbound e-document line described the same as "I1" and "I2"
+        LibraryEDoc.CreateInboundEDocument(EDocument, EDocumentService);
+        EDocumentPurchaseHeader.InsertForEDocument(EDocument);
+        EDocumentPurchaseLine."E-Document Entry No." := EDocument."Entry No";
+        EDocumentPurchaseLine.Description := Item.Description;
+        EDocumentPurchaseLine.Insert();
+
+        // [WHEN] The purchase line is resolved
+        EDocProviders.GetPurchaseLine(EDocumentPurchaseLine);
+
+        // [THEN] The line stays unresolved because the match is ambiguous
+        Assert.AreEqual("Purchase Line Type"::" ", EDocumentPurchaseLine."[BC] Purchase Line Type", 'An ambiguous item description should not resolve the purchase line.');
+        Assert.AreEqual('', EDocumentPurchaseLine."[BC] Purchase Type No.", 'An ambiguous item description should not assign an item number.');
+
+        Item.Delete();
+        Item2.Delete();
+    end;
+
+    [Test]
+    procedure PurchaseLineProviderDoesNotMatchPurchasingBlockedItem()
+    var
+        EDocument: Record "E-Document";
+        EDocumentPurchaseHeader: Record "E-Document Purchase Header";
+        EDocumentPurchaseLine: Record "E-Document Purchase Line";
+        Item: Record Item;
+        EDocProviders: Codeunit "E-Doc. Providers";
+    begin
+        // [FEATURE] [AI test 1.0]
+        // [SCENARIO] A draft line matching a purchasing-blocked item is left unresolved
+        Initialize(Enum::"Service Integration"::"Mock");
+
+        // [GIVEN] A purchasing-blocked item "I"
+        LibraryInventory.CreateItem(Item);
+        Item.Description := 'Purchasing blocked item';
+        Item."Purchasing Blocked" := true;
+        Item.Modify();
+
+        // [GIVEN] An inbound e-document line described exactly as "I"
+        LibraryEDoc.CreateInboundEDocument(EDocument, EDocumentService);
+        EDocumentPurchaseHeader.InsertForEDocument(EDocument);
+        EDocumentPurchaseLine."E-Document Entry No." := EDocument."Entry No";
+        EDocumentPurchaseLine.Description := Item.Description;
+        EDocumentPurchaseLine.Insert();
+
+        // [WHEN] The purchase line is resolved
+        EDocProviders.GetPurchaseLine(EDocumentPurchaseLine);
+
+        // [THEN] The line stays unresolved because the item cannot be purchased
+        Assert.AreEqual("Purchase Line Type"::" ", EDocumentPurchaseLine."[BC] Purchase Line Type", 'A purchasing-blocked item should not resolve the purchase line.');
+
+        Item.Delete();
     end;
 
     [Test]
@@ -1306,7 +1432,7 @@ codeunit 139883 "E-Doc Process Test"
         TempEDocImportParameters."Step to Run" := "Import E-Document Steps"::"Finish draft";
         EDocImport.ProcessIncomingEDocument(EDocument, TempEDocImportParameters);
         EDocument.Get(EDocument."Entry No");
-        
+
         // [THEN] The e-document is Processed and the resulting Sales Header is a Sales Order (OrderTypeCode is ignored)
         EDocument.CalcFields("Import Processing Status");
         Assert.AreEqual(Enum::"Import E-Doc. Proc. Status"::Processed, EDocument."Import Processing Status", 'The status should be Processed after FinishDraft regardless of OrderTypeCode.');
@@ -1441,6 +1567,17 @@ codeunit 139883 "E-Doc Process Test"
         ItemReference."Reference Type No." := Vendor."No.";
         ItemReference."Reference No." := 'TESTITMREFNO';
         ItemReference.Insert();
+    end;
+
+    local procedure CreateVendorWithTaxId(var NewVendor: Record Vendor; VatRegistrationNo: Code[20])
+    var
+        CompanyInformation: Record "Company Information";
+    begin
+        LibraryPurchase.CreateVendor(NewVendor);
+        CompanyInformation.GetRecordOnce();
+        NewVendor."Country/Region Code" := CompanyInformation."Country/Region Code";
+        NewVendor."VAT Registration No." := VatRegistrationNo;
+        NewVendor.Modify();
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

Inbound invoice lines were falling through to G/L account matching even when an item with the exact same description already existed. The line was posted to a G/L account instead of the item.

This PR adds a deterministic step that resolves the line to the item when there is exactly one eligible item with that description. It runs after item reference and text-to-account mapping, so no impact on explicit setup.

Fixes [AB#647171](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647171)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

 Imported a sample invoice with a line whose description exactly matches an existing item. Before the change it resolved to a G/L account, after the change it resolves to the item.

## Risk & compatibility

Matching only triggers when exactly one non blocked item matches and the unit of measure fits, so ambiguous cases keep the old behavior. No schema or upgrade impact.









