### PR TITLE
Restore AL0424 to Warning in the base ruleset

### DIFF
--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -19,6 +19,11 @@
       "action": "Warning"
     },
     {
+      "id": "AL0424",
+      "action": "Warning",
+      "justification": "Bug 472148. The multilanguage syntax is being deprecated. Please update to the new syntax."
+    },
+    {
       "id": "AL0432",
       "action": "None",
       "justification": "Use pragma to remove obsolete warning."


### PR DESCRIPTION
## What & why

Adds `AL0424` back to `src/rulesets/base.ruleset.json` with `"action": "Warning"`.

PR #10300 ("Consolidate minor release ruleset and fix strict mode branch detection") repointed **325** projects in `build/projects.json` onto `src/rulesets/base.ruleset.json`:

| Previous `ruleSetPath` (NAV repo) | Projects | Now |
| --- | --- | --- |
| `App\Rulesets\app.ruleset.json` | 266 | `App\BCApps\src\rulesets\base.ruleset.json` |
| `App\Rulesets\basetest.ruleset.json` | 55 | same |
| `App\Rulesets\ruleset.json` | 2 | same |
| `App\Rulesets\application.ruleset.json` | 1 | same |
| `App\Rulesets\base.ruleset.json` | 1 | same |

`AL0424` is not listed in this ruleset, so it inherits `"generalAction": "Error"`. Both NAV rulesets it replaced set it to `Warning` explicitly, so the effective severity silently changed from Warning to Error for those projects.

**Why BCApps CI stayed green.** `AL0424` only fires when the app uses translation files. The affected apps (e.g. `src/Layers/W1/Tests/Rapid Start`) have no `features` entry in `app.json`, so the rule is dormant in this repo regardless of its configured severity. The NAV build compiles every app with `-features:lcgtranslationfile` for the localization pipeline, which activates the rule — so the promotion only manifests there.

That combination broke the NAV build across ~22 countries on legacy `CaptionML` code that predates the label syntax:

```
App\Views\W1\Tests\Rapid Start\EnumRs.Enum.al(7,21): error AL0424: The multilanguage syntax
should not be used because the app uses translation files ...
```

The justification text is copied verbatim from the NAV ruleset this replaced, so the override is restored rather than newly invented.

## Linked work

No GitHub issue — this is a regression fix for an unreleased change (#10300) found while validating a BCApps uptake into the internal NAV repo. Happy to file one if the process requires it.

Regression introduced by: #10300 (commit 4e04c2c)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings. — *not built locally; validated in a full NAV build instead, see below*
- [ ] I ran the change in Business Central and confirmed it behaves as expected. — *n/a, compile-time analyzer configuration only*
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Validated through the NAV DME build, which is the only pipeline that exercises this rule (it compiles with `-features:lcgtranslationfile`; BCApps CI does not):

- **Before** — NAV build `2672731`, uptake `6670f6a1..a31d921d`: **37 failed** records. Every `BuildApplicationTests_*`, `BuildAppExtensions_*` and `BuildTranslatedAppExtensions_*` task failed across ~22 countries. Compile line showed `-ruleset:"...\App\BCApps\src\rulesets\base.ruleset.json"` and `error AL0424` ×4.
- **After** — NAV build `2672965`, identical uptake plus only this commit: **succeeded**. Zero `error AL` diagnostics in any task. All `BuildApplicationTests_*` / `BuildAppExtensions_*` tasks passed. The 4 remaining task failures are unrelated (one CZ advance-payments test, three infrastructure) and did not fail the build.

Directly comparable prior run for the same project, before #10300 landed — NAV build `2666822`, which used `basetest.ruleset.json` and reported the **same 4 diagnostics as `warning AL0424`**, confirming this restores the previous behaviour rather than suppressing something new.

No tests added: this is a ruleset severity change with no runtime behaviour. The `.al` sources involved are unchanged (byte-identical across `6670f6a1..a31d921d`).

## Risk & compatibility

- Lowers severity of one diagnostic; cannot introduce build failures.
- No effect on BCApps CI, where the rule is inert (no `TranslationFile` feature).
- No product, schema, permission or telemetry impact.
- **Follow-up worth considering:** only 55 of the 325 consolidated projects were on `basetest.ruleset.json`; **266** were on `app.ruleset.json`, whose full override list is also gone. `AL0424` is simply the first rule to surface because it happened to be hit by existing code. Other overrides from those NAV rulesets may still be silently promoted to Error and would appear in later uptakes. It may be worth reconciling the two override lists rather than fixing rules one at a time.
- Note the two files are different despite sharing a name: NAV's `App/Rulesets/base.ruleset.json` includes `../BCApps/src/rulesets/ruleset.json` and adds 96 rules (including this `AL0424` downgrade), while this repo's `src/rulesets/base.ruleset.json` has 94 and no `AL0424` entry. That collision is a plausible reason the change went unnoticed in review.

Related to [AB#647437](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647437)


