### PR TITLE
Bug 645043: [Expense Agent] Hide Expense User with missing Employee Posting Group from Expense Users API

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseUsersAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseUsersAPI.Page.al
@@ -129,15 +129,16 @@ page 6918 "Expense Users API"
     var
         OriginalFilterGroup: Integer;
     begin
-        // Expense Users without a linked Employee No. cannot post expenses
-        // (validation fails at submission), so don't surface them to the agent
-        // gateway. The gateway treats an absent user as "not in this environment"
-        // and blocks sign-in there. Apply the constraint in FilterGroup 2 so it
-        // AND-combines with any caller-supplied $filter on Employee No., rather
-        // than replacing it in the default FilterGroup 0.
+        // Expense Users whose linked Employee is missing (blank Employee No.) or has
+        // no Employee Posting Group cannot post expenses (validation fails at
+        // submission), so don't surface them to the agent gateway. The gateway treats
+        // an absent user as "not in this environment" and blocks sign-in there. Apply
+        // the constraints in FilterGroup 2 so they AND-combine with any caller-supplied
+        // $filter, rather than replacing it in the default FilterGroup 0.
         OriginalFilterGroup := Rec.FilterGroup();
         Rec.FilterGroup(2);
         Rec.SetFilter("Employee No.", '<>%1', '');
+        Rec.SetFilter("Employee Posting Group", '<>%1', '');
         Rec.FilterGroup(OriginalFilterGroup);
     end;
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Tables/ExpenseUser.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Tables/ExpenseUser.Table.al
@@ -133,6 +133,14 @@ table 6923 "Expense User"
             FieldClass = FlowField;
             CalcFormula = lookup(Employee."Resource No." where("No." = field("Employee No.")));
         }
+        field(41; "Employee Posting Group"; Code[20])
+        {
+            Caption = 'Employee Posting Group';
+            ToolTip = 'Specifies the posting group of the related employee.';
+            Editable = false;
+            FieldClass = FlowField;
+            CalcFormula = lookup(Employee."Employee Posting Group" where("No." = field("Employee No.")));
+        }
         field(21; "User Id For Approvals"; Code[50])
         {
             Caption = 'User Id For Approvals';

--- a/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseUsersAPITest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseUsersAPITest.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Test.ExpenseAgent;
 
 using Microsoft.ExpenseAgent;
+using Microsoft.HumanResources.Employee;
 
 codeunit 148315 "Expense Users API Test"
 {
@@ -77,6 +78,61 @@ codeunit 148315 "Expense Users API Test"
         // [THEN] the unlinked user is absent from the list
         Assert.AreEqual(0, StrPos(ResponseText, UnlinkedUserIdTxt),
             'Unlinked Expense User should not appear in the list response');
+    end;
+
+    [Test]
+    procedure ExpenseUserWithoutEmployeePostingGroupIsHiddenFromAPI()
+    var
+        ValidExpenseUser: Record "Expense User";
+        NoPostingGroupExpenseUser: Record "Expense User";
+        Employee: Record Employee;
+        TargetURL: Text;
+        ResponseText: Text;
+        ValidUserIdTxt: Text;
+        NoPostingGroupUserIdTxt: Text;
+    begin
+        // [SCENARIO 645043] An Expense User whose linked Employee has no Employee
+        // Posting Group cannot post expenses, so it must not surface through the
+        // agent-facing Expense Users API - same treatment as an unlinked user.
+        Initialize();
+
+        // [GIVEN] an Expense User whose Employee has an Employee Posting Group
+        LibraryExpense.CreateExpenseUser(ValidExpenseUser);
+
+        // [GIVEN] an Expense User whose Employee has a blank Employee Posting Group
+        LibraryExpense.CreateExpenseUser(NoPostingGroupExpenseUser);
+        Employee.Get(NoPostingGroupExpenseUser."Employee No.");
+        Employee."Employee Posting Group" := '';
+        Employee.Modify();
+        Commit();
+
+        ValidUserIdTxt := LowerCase(LibraryGraphMgt.StripBrackets(Format(ValidExpenseUser.SystemId)));
+        NoPostingGroupUserIdTxt := LowerCase(LibraryGraphMgt.StripBrackets(Format(NoPostingGroupExpenseUser.SystemId)));
+
+        // [WHEN] the valid user is fetched by id
+        // [THEN] the request succeeds (200)
+        TargetURL := LibraryGraphMgt.CreateTargetURL(
+            Format(ValidExpenseUser.SystemId), Page::"Expense Users API", ServiceNameTok);
+        LibraryGraphMgt.GetFromWebServiceAndCheckResponseCode(ResponseText, TargetURL, 200);
+
+        // [WHEN] the user without a posting group is fetched by id
+        // [THEN] the API responds 404 because the visibility filter hides it
+        TargetURL := LibraryGraphMgt.CreateTargetURL(
+            Format(NoPostingGroupExpenseUser.SystemId), Page::"Expense Users API", ServiceNameTok);
+        asserterror LibraryGraphMgt.GetFromWebServiceAndCheckResponseCode(ResponseText, TargetURL, 404);
+
+        // [WHEN] the full collection is fetched through the API
+        TargetURL := LibraryGraphMgt.CreateTargetURL('', Page::"Expense Users API", ServiceNameTok);
+        LibraryGraphMgt.GetFromWebServiceAndCheckResponseCode(ResponseText, TargetURL, 200);
+        ResponseText := LowerCase(ResponseText);
+
+        // [THEN] the user with a posting group appears in the list
+        Assert.AreNotEqual(0, StrPos(ResponseText, ValidUserIdTxt),
+            'Expense User with an Employee Posting Group should appear in the list response');
+
+        // [THEN] the user without a posting group is absent from the list
+        Assert.AreEqual(0, StrPos(ResponseText, NoPostingGroupUserIdTxt),
+            'Expense User without an Employee Posting Group should not appear in the list response');
     end;
 
     local procedure Initialize()

--- a/src/Apps/W1/ExpenseAgent/test/src/LibraryExpense.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/LibraryExpense.Codeunit.al
@@ -28,11 +28,20 @@ codeunit 148300 "Library - Expense"
         NameTxt: Label 'Name';
 
     internal procedure CreateExpenseUser(var ExpenseUser: Record "Expense User")
+    var
+        Employee: Record Employee;
     begin
         ExpenseUser.Init();
         ExpenseUser.Validate("No.", LibraryUtility.GenerateRandomCode(ExpenseUser.FieldNo("No."), Database::"Expense User"));
         ExpenseUser.Validate("Employee No.", LibraryHumanResource.CreateEmployeeNo());
         ExpenseUser.Insert(true);
+
+        // Ensure the linked employee has a posting group so the user can post expenses.
+        Employee.Get(ExpenseUser."Employee No.");
+        if Employee."Employee Posting Group" = '' then begin
+            Employee.Validate("Employee Posting Group", LibraryHumanResource.FindEmployeePostingGroup());
+            Employee.Modify(true);
+        end;
     end;
 
     procedure CreateEmployee(EmployeeNo: Code[20]): Code[20]


### PR DESCRIPTION

## Problem
An Expense User whose linked Employee has a blank **Employee Posting Group** is still returned by the agent-facing `expenseUsers` API, so the user can sign in to the Expense web app but gets stuck at submission with "System configuration error: Employee Posting Group is missing." (GitHub Enterprise issue bic/BC-ExpenseAgent#1990).

## Fix
- Added a FlowField `Employee Posting Group` (lookup of the linked Employee) to the **Expense User** table.
- **Expense Users API** `OnOpenPage` now also filters out users whose Employee has a blank Employee Posting Group, in FilterGroup 2 (AND-combined with caller filters) - the same treatment as the existing blank `Employee No.` filter (precedent PR 246985). These users are hidden from the gateway, which blocks sign-in with a clear message instead of failing later at submission.

## Tests
- New `ExpenseUserWithoutEmployeePostingGroupIsHiddenFromAPI`: a user whose Employee has no posting group returns 404 / is absent from the list; a valid user returns 200 / appears.
- `LibraryExpense.CreateExpenseUser` now guarantees the created employee has a posting group so created users are valid/postable (keeps the existing unlinked-user test green under the new filter).

Scope: NAV/AL only - no gateway or TypeSpec change needed.

