### PR TITLE
[Bug Fix] #254: [APIV2][Performance] Replace FindFirst/Next with FindSet when rebuilding dimension set entries

### DIFF
--- a/src/Apps/W1/APIV2/app/src/pages/APIV2DimensionSetLines.Page.al
+++ b/src/Apps/W1/APIV2/app/src/pages/APIV2DimensionSetLines.Page.al
@@ -701,7 +701,7 @@ page 30022 "APIV2 - Dimension Set Lines"
         ErrorMsg: Text;
     begin
         Rec.Reset();
-        if Rec.FindFirst() then
+        if Rec.FindSet() then
             repeat
                 TempDimensionSetEntry.TransferFields(Rec, true);
                 TempDimensionSetEntry."Dimension Set ID" := 0;


### PR DESCRIPTION
## Bug Reference Work item microsoft/BCAppsBugFix#254  Fixes microsoft/BCAppsBugFix#254  ## Summary Replaces the single-record retrieval pattern (`Rec.FindFirst()` followed by a full `repeat ... until Rec.Next() = 0` loop) with `Rec.FindSet()` in the dimension-set rebuild loop of `APIV2DimensionSetLines.Page.al`. The loop iterates the entire filtered result set, so `FindSet()` is the correct, performance-optimized retrieval method. The loop body and exit condition are unchanged, preserving the exact dimension-set reconstruction behavior.  ## Root Cause `FindFirst()` is optimized for retrieving a single record. In `APIV2DimensionSetLines.Page.al` (~line 704) it was used to drive a `repeat`/`until Rec.Next() = 0` loop that consumes the entire filtered result set, causing unnecessary repeated database round trips and degraded APIV2 performance as the number of dimension lines grows.  ## Changes Made - `src/Apps/W1/APIV2/app/src/pages/APIV2DimensionSetLines.Page.al`: replaced `if Rec.FindFirst() then` with `if Rec.FindSet() then` in the temporary dimension-set rebuild loop. No other logic changed.  ## Implementation Process  - Fix iterations: Not applicable - tests not required - Compilation: ✅ All projects compile successfully - Publish: ✅ Modified app published successfully - Validation: Tests not required by the approved plan  ## Validation Evidence  ### No-Test Validation Evidence  - **Tests required by plan**: No - **Rationale**: This is a pure performance optimization. `FindFirst()` followed by a full `repeat/until Rec.Next()=0` iteration and `FindSet()` produce functionally identical output (the same records in the same order); only the database access pattern differs. There is no functional defect state a red AL regression test could reproduce, and AL tests cannot deterministically assert database round-trip counts. - **Compilation**: ✅ All modified projects compiled successfully - **Publish**: ✅ Modified app published successfully - **Manual/external validation approach**: Full `al_build` (all-project scope) of the APIV2 app, then `al_publish` to the BC container. Manual verification that the loop now uses `FindSet()` and the surrounding reconstruction logic is unchanged apart from the single method name.  ## Validation Coverage  - [x] Automated tests: Not applicable per approved Test Strategy - [x] Build and publish validation completed - [ ] Regression testing: APIV2 dimension set line create/update flows exercising the rebuild loop - [ ] Performance: Fewer database round trips when rebuilding dimension sets with multiple lines  ## Miapp Propagation  - **Layers propagated to**: None - the fix touched no propagated path - **Files changed by propagation**: 0 - **VerifyMiappSync**: ✅ No files still need to be integrated  ## Review Notes Single-line change; the loop body and `until Rec.Next() = 0` exit condition are byte-for-byte unchanged, so functional behavior is preserved while the retrieval pattern is corrected.  🤖 Generated by the bc-fix-bug skill 

---
Promoted from microsoft/BCAppsBugFix#255: https://github.com/microsoft/BCAppsBugFix/pull/255
