### PR TITLE
[Bug Fix] #250: Honor ImportFSSolution TryFunction result in FS setup wizard

### DIFF
--- a/src/Apps/W1/FieldServiceIntegration/app/src/Pages/FSConnectionSetupWizard.Page.al
+++ b/src/Apps/W1/FieldServiceIntegration/app/src/Pages/FSConnectionSetupWizard.Page.al
@@ -642,7 +642,8 @@ page 6613 "FS Connection Setup Wizard"
                     if not Rec.PromptForCredentials(AdminEmail, AdminPassword) then
                         exit(false);
             end;
-            FSIntegrationMgt.ImportFSSolution(Rec."Server Address", Rec."User Name", AdminEmail, AdminPassword, AccessToken, AdminADDomain, Rec."Proxy Version", true, ImportSolutionFailed);
+            if not FSIntegrationMgt.ImportFSSolution(Rec."Server Address", Rec."User Name", AdminEmail, AdminPassword, AccessToken, AdminADDomain, Rec."Proxy Version", true, ImportSolutionFailed) then
+                Error(GetLastErrorText());
         end;
         if PasswordSet then
             FSConnectionSetup.UpdateFromWizard(Rec, Password)


### PR DESCRIPTION
## Bug Reference Work item microsoft/BCAppsBugFix#250 — Fixes microsoft/BCAppsBugFix#250  ## Summary `FinalizeSetup` in the Field Service connection setup wizard invoked `FSIntegrationMgt.ImportFSSolution` — a `[TryFunction]` — as a plain statement, silently discarding the success/failure Boolean. A failed FS solution import therefore did not stop the wizard, and `UpdateFromWizard` / `EnableFSConnectionFromWizard` could still run. The call is now guarded so a failed import aborts finalization and surfaces the underlying error to the user.  ## Root Cause `FSIntegrationMgt.ImportFSSolution` is decorated with `[TryFunction]` (codeunit `FS Integration Mgt.`). Calling it as a statement discards the Boolean the TryFunction yields, so an import error was ignored and the wizard proceeded to update and enable the Field Service connection with a failed solution import, returning `true` from `FinalizeSetup`.  ## Changes Made - `src/Apps/W1/FieldServiceIntegration/app/src/Pages/FSConnectionSetupWizard.Page.al`: wrapped the `ImportFSSolution` call in a failure guard inside `FinalizeSetup`. On a failed import the caught error is re-surfaced via `Error(GetLastErrorText())`, which aborts finalization before `FSConnectionSetup.UpdateFromWizard` and `FSConnectionSetup.EnableFSConnectionFromWizard` execute. This both honors the TryFunction result and tells the user why setup failed, instead of silently swallowing the error.  ## Implementation Process  - Fix iterations: Not applicable - tests not required - Compilation: ✅ All projects compile successfully - Publish: ✅ Modified app published successfully - Validation: Tests not required by the approved plan  ## Validation Evidence  ### No-Test Validation Evidence  - **Tests required by plan**: No - **Rationale**: The failure path being fixed is only reachable when `ImportFSSolution` actually performs a live Dataverse/CRM solution import (via `DotNet CrmHelper`) that fails, and the wizard steps leading to it require an interactive/live connection. The CRONUS test container has no controllable Dataverse endpoint, so an automated AL test cannot deterministically drive `ImportFSSolution` to a controlled failure and observe the wizard aborting. This is a genuine end-to-end dependency on an external system the test environment cannot control. - **Compilation**: ✅ FieldServiceIntegration app compiled successfully - **Publish**: ✅ Modified app published successfully to the BC container - **Manual/external validation approach**: Code review confirming the new failure guard sits before `UpdateFromWizard` and `EnableFSConnectionFromWizard` in `FinalizeSetup`, matching the issue's expected control flow.  ## Validation Coverage  - [x] Automated tests: Not applicable per approved Test Strategy - [x] Build and publish validation completed - [ ] Manual/external validation: Review guard placement in `FinalizeSetup`; exercise the wizard against an endpoint that makes the FS solution import fail and confirm the connection is not updated/enabled. - [ ] Regression testing: Confirm a successful import still completes the wizard flow unchanged.  ## Miapp Propagation  - **Layers propagated to**: None - the fix touched no propagated path (the changed page exists only in the W1 layer) - **Files changed by propagation**: 0 - **VerifyMiappSync**: ✅ No files still need to be integrated  ## Review Notes The fix follows the standard BC TryFunction pattern: `if not <TryFunction>() then Error(GetLastErrorText());`. This was hardened from a plain `exit(false)` during automated AL review so the caught import error is surfaced to the user rather than swallowed. Both variants prevent the wizard from continuing on a failed import; the `Error` variant additionally reports the cause.  🤖 Generated by the bc-fix-bug skill 

---
Promoted from microsoft/BCAppsBugFix#256: https://github.com/microsoft/BCAppsBugFix/pull/256
