### PR TITLE
[Bug Fix] #251: Handle GetUserName TryFunction failure during OAuth validation

### DIFF
--- a/src/Apps/W1/Email - SMTP Connector/app/src/Authentication/OAuth2SMTPAuthentication.Codeunit.al
+++ b/src/Apps/W1/Email - SMTP Connector/app/src/Authentication/OAuth2SMTPAuthentication.Codeunit.al
@@ -41,7 +41,8 @@ codeunit 4516 "OAuth2 SMTP Authentication"
         AccessToken := AzureAdMgt.GetAccessTokenAsSecretText(AzureADMgt.GetO365Resource(), AzureADMgt.GetO365ResourceName(), true);
         if AccessToken.IsEmpty() then
             Error(CouldNotAuthenticateErr);
-        GetUserName(AccessToken, UserName);
+        if not GetUserName(AccessToken, UserName) then
+            Error(CouldNotAuthenticateErr);
     end;
 
     /// <summary>
@@ -101,8 +102,10 @@ codeunit 4516 "OAuth2 SMTP Authentication"
     begin
         AccessToken := AzureAdMgt.GetAccessTokenAsSecretText(AzureADMgt.GetO365Resource(), AzureADMgt.GetO365ResourceName(), true);
         if not AccessToken.IsEmpty() then begin
-            GetUserName(AccessToken, UserName);
-            Message(AuthenticationSuccessfulMsg, UserName);
+            if GetUserName(AccessToken, UserName) then
+                Message(AuthenticationSuccessfulMsg, UserName)
+            else
+                Message(AuthenticationFailedMsg);
         end else
             Message(AuthenticationFailedMsg);
     end;

--- a/src/Apps/W1/Email - SMTP Connector/test/src/SMTPAccountAuthTests.Codeunit.al
+++ b/src/Apps/W1/Email - SMTP Connector/test/src/SMTPAccountAuthTests.Codeunit.al
@@ -211,6 +211,37 @@ codeunit 139762 "SMTP Account Auth Tests"
         // [THEN] The message handler verifies that message is about failed authentication.
     end;
 
+    [Test]
+    [HandlerFunctions('VerifyAuthenticationFailMessageHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure CheckAuthenticationWithUnparseableTokenShowsFailMsgTest()
+    var
+        OAuth2SMTPAuthentication: Codeunit "OAuth2 SMTP Authentication";
+        SMTPAccountAuthTests: Codeunit "SMTP Account Auth Tests";
+        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
+        UnparseableToken: Text;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO] When a nonempty but unparseable access token is in the cache,
+        // CheckOAuth2Authentication should show AuthenticationFailedMsg ("Could not authenticate.")
+        // instead of propagating the parse error from GetUserName.
+        // (Reproduces bug: GetUserName is called as a bare TryFunction statement, so its error is not trapped.)
+
+        // [GIVEN] Environment is on-prem and an unparseable token is in the cache.
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+        SetAuthFlowProvider(Codeunit::"SMTP Account Auth Tests");
+
+        // The token has no dot-separated sections, so AccessTokenSections.Get(2) inside GetUserName raises.
+        UnparseableToken := 'notavalidtoken';
+        SMTPAccountAuthTests.SetTokenCache(UnparseableToken);
+        BindSubscription(SMTPAccountAuthTests);
+
+        // [WHEN] CheckOAuth2Authentication is called.
+        OAuth2SMTPAuthentication.CheckOAuth2Authentication();
+
+        // [THEN] The message handler verifies that the failure message was shown (not a raw parse error).
+    end;
+
 
     #region SMTP Account page tests
     [Test]


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#251 — Fixes microsoft/BCAppsBugFix#251 (`[[AB#646834](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646834)]`)

## Summary
`CheckOAuth2Authentication` called the `[TryFunction] GetUserName` as a bare statement, ignoring its Boolean return value. In AL, a TryFunction called without consuming its result loses its error-trapping semantics, so a parse failure (malformed token payload, bad Base64, missing `unique_name` claim, or too few dot-separated sections) propagated to the user as a raw runtime error instead of the intended `AuthenticationFailedMsg`. The fix consumes the Boolean result and shows the authentication-failed message on failure. The AL review agent surfaced the same anti-pattern in `GetOAuth2Credentials`, which was fixed the same way.

## Root Cause
In `codeunit 4516 "OAuth2 SMTP Authentication"`, `CheckOAuth2Authentication` invoked `GetUserName(AccessToken, UserName)` as a standalone statement. Because the `[TryFunction]` return value was discarded, its exception handling was disabled and any parsing error inside `GetUserName` was raised to the user rather than being caught and turned into `AuthenticationFailedMsg`.

## Changes Made
- `src/Apps/W1/Email - SMTP Connector/app/src/Authentication/OAuth2SMTPAuthentication.Codeunit.al`:
  - `CheckOAuth2Authentication`: consume the `GetUserName` Boolean — show `AuthenticationSuccessfulMsg` only when it returns `true`, otherwise show the existing `AuthenticationFailedMsg`.
  - `GetOAuth2Credentials` (found by AL review, same anti-pattern): consume the `GetUserName` Boolean and raise `CouldNotAuthenticateErr` when parsing fails, so the email-send path does not proceed with an empty user name.
- `src/Apps/W1/Email - SMTP Connector/test/src/SMTPAccountAuthTests.Codeunit.al`:
  - Added regression test `CheckAuthenticationWithUnparseableTokenShowsFailMsgTest` in codeunit 139762 "SMTP Account Auth Tests": sets a nonempty but unparseable token via the existing token-cache mock, calls `CheckOAuth2Authentication`, and asserts `AuthenticationFailedMsg` is shown.

## Implementation Process

- Fix iterations: 1 of 5
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app and test app published successfully
- Validation: ✅ Automated tests passing

## Validation Evidence

### Automated Test Evidence

#### Pre-Fix Test Results (Baseline)
Tests run before implementing the fix (expected to fail):

```
❌ CheckAuthenticationWithUnparseableTokenShowsFailMsgTest: FAILED
   Error: An invalid argument was passed to a 'List' data type method.
   (raw parse error propagated from GetUserName instead of showing AuthenticationFailedMsg)
```

#### Post-Fix Test Results (Final)
Tests run after implementing the fix (expected to pass):

```
✅ CheckAuthenticationWithUnparseableTokenShowsFailMsgTest: PASSED (new test for bug scenario)
✅ CheckAuthenticationFailTest: PASSED
✅ CheckAuthenticationSuccessTest: PASSED
✅ GetOAuth2CredentialsTest: PASSED
✅ GetUserNameTest: PASSED
... plus all remaining tests in codeunit 139762 "SMTP Account Auth Tests"
```

**Total Tests Run:** 49
**All Tests Passing:** ✅ Yes (49 passed, 0 failed, 0 skipped)

#### Iteration Summary

- **Iteration 1**: Consumed the `GetUserName` TryFunction result in `CheckOAuth2Authentication`; rebuilt and republished the app and test app; ✅ all 49 tests passing.

## Validation Coverage

- [x] Existing tests pass
- [x] New tests added for bug scenario
- [x] Regression test for work item microsoft/BCAppsBugFix#251
- [x] Automated tests: All passing
- [x] Build and publish validation completed

## Miapp Propagation

- **Layers propagated to**: None - the fix touched no propagated path
- **Files changed by propagation**: 0
- **VerifyMiappSync**: ✅ No files still need to be integrated

## Review Notes
The core fix consumes the `[TryFunction]` return in `CheckOAuth2Authentication`. The AL review agent additionally flagged and fixed the identical unchecked-TryFunction pattern in `GetOAuth2Credentials`, so both the authentication-check and the email-send credential paths now handle an unparseable token gracefully.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#260: https://github.com/microsoft/BCAppsBugFix/pull/260

Fixes [AB#646834](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646834)

