### PR TITLE
[Bug Fix] #177: IRS 1099 orphan fields on Purchase Order/Cr. Memo pages

### DIFF
--- a/src/Apps/US/IRSForms/app/src/Extensions/IRS1099PurchCrMemo.PageExt.al
+++ b/src/Apps/US/IRSForms/app/src/Extensions/IRS1099PurchCrMemo.PageExt.al
@@ -10,7 +10,7 @@ pageextension 10059 "IRS 1099 Purch. Cr. Memo" extends "Purchase Credit Memo"
 {
     layout
     {
-        addafter("Invoice Details")
+        addlast("Invoice Details")
         {
             field("IRS 1099 Reporting Period"; Rec."IRS 1099 Reporting Period")
             {

--- a/src/Apps/US/IRSForms/app/src/Extensions/IRS1099PurchOrder.PageExt.al
+++ b/src/Apps/US/IRSForms/app/src/Extensions/IRS1099PurchOrder.PageExt.al
@@ -10,7 +10,7 @@ pageextension 10058 "IRS 1099 Purch. Order" extends "Purchase Order"
 {
     layout
     {
-        addafter("Invoice Details")
+        addlast("Invoice Details")
         {
             field("IRS 1099 Reporting Period"; Rec."IRS 1099 Reporting Period")
             {


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#177 (Fixes [AB#624220](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624220))

## Summary
The three IRS 1099 fields on the Purchase Order (and Purchase Credit Memo) pages rendered as "orphan" fields outside any FastTab. This changes the layout anchor so the fields are placed inside the "Invoice Details" FastTab, consistent with the rest of the page and with the equivalent Purchase Invoice extension.

## Root Cause
`pageextension 10058 "IRS 1099 Purch. Order"` anchored its fields with `addafter("Invoice Details")`. On the base "Purchase Order" page, `"Invoice Details"` is a top-level `group` (FastTab) directly inside `area(content)`, so `addafter` inserted the fields as siblings of the FastTab at the content-area level - outside any group. The same defect existed on the Purchase Credit Memo extension (`pageextension` for "IRS 1099 Purch. Cr. Memo").

## Changes Made
- `src/Apps/US/IRSForms/app/src/Extensions/IRS1099PurchOrder.PageExt.al`: changed `addafter("Invoice Details")` to `addlast("Invoice Details")` so the three IRS 1099 fields render as the last controls inside the "Invoice Details" FastTab.
- `src/Apps/US/IRSForms/app/src/Extensions/IRS1099PurchCrMemo.PageExt.al`: same `addafter("Invoice Details")` to `addlast("Invoice Details")` fix for the identical orphan-field defect on the Purchase Credit Memo page (found during independent review).

## Implementation Process

- Fix iterations: Not applicable - tests not required
- Compilation: All projects compile successfully
- Publish: Modified app published successfully
- Validation: Tests not required by the approved plan

## Validation Evidence

### No-Test Validation Evidence

- **Tests required by plan**: No
- **Rationale**: The defect is the FastTab/group container membership of page controls. The AL TestPage framework addresses fields by name regardless of their containing group, so it cannot observe or assert whether a field renders inside or outside a FastTab. No red-to-green AL regression test can meaningfully reproduce or validate this layout-anchoring scenario.
- **Compilation**: All modified projects compiled successfully
- **Publish**: Modified app published successfully
- **Manual/external validation approach**: Full build of the modified IRSForms project and publish of the built app to the BC container; structural verification that the three IRS 1099 fields now appear inside the "Invoice Details" group rather than at the content-area level.

## Validation Coverage

- [x] Automated tests: Not applicable per approved Test Strategy
- [x] Build and publish validation completed
- [ ] Manual/external validation: Open a Purchase Order / Purchase Credit Memo and confirm the three IRS 1099 fields appear inside the "Invoice Details" FastTab, including when FastTabs are collapsed.
- [ ] Regression testing: Confirm no other IRS 1099 page extensions rely on the previous content-area placement.

## Review Notes
The change is a pure page-layout anchor change (`addafter` to `addlast`); no behavioral/data logic was modified.

Fixes microsoft/BCAppsBugFix#177

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#179: https://github.com/microsoft/BCAppsBugFix/pull/179

Fixes [AB#624220](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/624220)

