### PR TITLE
Add integration event before inserting the cost allocation journal line

### DIFF
--- a/src/Layers/W1/BaseApp/CostAccounting/Allocation/CostAllocation.Report.al
+++ b/src/Layers/W1/BaseApp/CostAccounting/Allocation/CostAllocation.Report.al
@@ -486,6 +486,7 @@ report 1131 "Cost Allocation"
         TempCostJnlLine."Allocation ID" := AllocID;
         TempCostJnlLine."Source Code" := SourceCodeSetup."Cost Allocation";
         TempCostJnlLine."Budget Name" := CostBudgetName.Name;
+        OnWriteJournalLineOnBeforeInsertTempCostJournalLine(TempCostJnlLine, "Cost Allocation Source");
         TempCostJnlLine.Insert();
 
         if TempCostJnlLine.Amount > 0 then
@@ -530,6 +531,11 @@ report 1131 "Cost Allocation"
         AllocDate := NewAllocDate;
         AllocVariant := NewAllocVariant;
         CostBudgetName.Name := NewCostBudgetName;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnWriteJournalLineOnBeforeInsertTempCostJournalLine(var TempCostJournalLine: Record "Cost Journal Line" temporary; CostAllocationSource: Record "Cost Allocation Source")
+    begin
     end;
 }
 


### PR DESCRIPTION
## What & why

Report 1131 "Cost Allocation" had no seam for extensions to add data to a cost journal line before it is inserted. This adds the integration event OnWriteJournalLineOnBeforeInsertTempCostJournalLine right before the temporary line insert, passing the line by var and the Cost Allocation Source for context. Purely additive.

Fixes [AB#646934](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646934)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Subscribed to the event and ran a cost allocation. It fired once per line before insert, with the allocation result unchanged. No test added since this is an additive event with no behavior change.

## Risk & compatibility

Additive and non breaking. Adds one event before the insert, no change to existing logic, data, or signatures.

