### PR TITLE
Add integration event before inserting the outgoing IC sales line buffer

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/ICDataExchangeAPI.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/ICDataExchangeAPI.Codeunit.al
@@ -475,6 +475,7 @@ codeunit 561 "IC Data Exchange API" implements "IC Data Exchange"
             TempICPartnerICInboxSalesLine.FindSet();
             repeat
                 BufferICInboxSalesLine.TransferFields(TempICPartnerICInboxSalesLine);
+                OnPostICSalesLineToICPartnerInboxOnBeforeBufferICInboxSalesLineInsert(BufferICInboxSalesLine, TempICPartnerICInboxSalesLine, ICPartner);
                 BufferICInboxSalesLine.Insert();
             until TempICPartnerICInboxSalesLine.Next() = 0;
         end;
@@ -1469,6 +1470,11 @@ codeunit 561 "IC Data Exchange API" implements "IC Data Exchange"
     /// <param name="RegisteredPartner">Registered partner information</param>
     [IntegrationEvent(false, false)]
     local procedure OnPostICSalesHeaderToICPartnerInboxOnBeforeBufferICInboxSalesHeaderInsert(var BufferICInboxSalesHeader: Record "Buffer IC Inbox Sales Header"; TempICPartnerICInboxSalesHeader: Record "IC Inbox Sales Header" temporary; ICPartner: Record "IC Partner"; RegisteredPartner: Record "IC Partner" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnPostICSalesLineToICPartnerInboxOnBeforeBufferICInboxSalesLineInsert(var BufferICInboxSalesLine: Record "Buffer IC Inbox Sales Line"; TempICPartnerICInboxSalesLine: Record "IC Inbox Sales Line" temporary; ICPartner: Record "IC Partner")
     begin
     end;
 


### PR DESCRIPTION
## What & why

The outgoing intercompany flow already raises before insert events for the sales header and purchase header buffers, but not for the sales line. This adds OnPostICSalesLineToICPartnerInboxOnBeforeBufferICInboxSalesLineInsert after TransferFields and before the buffer insert, so extensions can enrich each outgoing sales line before it reaches the API payload. It fires per line and mirrors the existing sibling events.

Fixes [AB#642176](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642176)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Subscribed to the event and posted IC sales lines to a partner inbox. It fired once per line before insert, with buffers still created as before. No test added since this is an additive event matching the existing header events.

## Risk & compatibility

Additive and non breaking. Adds one event following the existing sales header and purchase header pattern, no change to existing logic, data, or signatures.
