### PR TITLE
Slice 611704: Change Tax Transaction Value ID to BigInteger with AutoIncrement

### DIFF
--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxPostingBufferMgmt.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxPostingBufferMgmt.Codeunit.al
@@ -317,7 +317,7 @@ codeunit 20343 "Tax Posting Buffer Mgmt."
         InvoiceQty: Decimal)
     var
         TaxTransactionValue: Record "Tax Transaction Value";
-        NextID: Integer;
+        NextID: BigInteger;
     begin
         TempTransactionValue.Reset();
         NextID := TempTransactionValue.Count();

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TransactionValue/table/TaxTransactionValue.Table.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TransactionValue/table/TaxTransactionValue.Table.al
@@ -101,12 +101,16 @@ table 20261 "Tax Transaction Value"
             DataClassification = EndUserIdentifiableInformation;
             Caption = 'Visible on Interface';
         }
-        field(18; "ID"; Integer)
+#pragma warning disable AS0146
+#pragma warning disable AS0041
+        field(18; "ID"; BigInteger)
         {
             DataClassification = SystemMetadata;
             Caption = 'ID';
             AutoIncrement = true;
         }
+#pragma warning restore AS0041
+#pragma warning restore AS0146
         field(19; "Tax Type"; Code[20])
         {
             DataClassification = EndUserIdentifiableInformation;


### PR DESCRIPTION
[AB#611704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611704)
[Slice 611704](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/611704): [Repair Item][IN] Change "Tax Transaction Value".ID to be BigInteger

**Issue:**
The primary key field `ID` of table Tax Transaction Value (20261) was `Integer` with `AutoIncrement`. On a production environment (IN localization, ~525 GB database) the SQL IDENTITY sequence exceeded the integer limit (2,147,483,647), causing the error: "Arithmetic overflow error converting IDENTITY to data type int." The actual row count (~285M) was well below the limit, but Posting Preview and failed/rolled-back transactions kept consuming AutoIncrement IDs without committing rows, exhausting the sequence far beyond the actual data.

**Cause:**
SQL Server IDENTITY (AutoIncrement) is non-transactional — every insert attempt permanently increments the counter, even when the transaction is rolled back (Posting Preview, validation errors). The `Integer` type has a maximum of only 2,147,483,647, which was reached over time.

**Solution:**
Changed field `ID` from `Integer` to `BigInteger` while keeping `AutoIncrement = true`. The SQL column becomes `BIGINT IDENTITY`, extending the range to 9.2 × 10¹⁸, which is practically inexhaustible for this workload. All existing insert paths continue to work unchanged (`Insert()` / `Insert(true)`), with no behavioral change other than the wider identity range. Updated the temp-table `NextID` variable in TaxPostingBufferMgmt from `Integer` to `BigInteger` to match the new field type. Breaking-change analyzer warnings (AS0041/AS0146) for the primary-key type change are suppressed via pragmas. Note: this product fix prevents future exhaustion; an already-exhausted database needs separate data remediation, and the `INT IDENTITY → BIGINT IDENTITY` schema conversion should be validated on a representative large database copy for sync duration, free space, and downtime.
