### PR TITLE
[Bug Fix] #192: Make Consolidate.GetGLAccounts public for external consolidation integration

### DIFF
--- a/src/Layers/BE/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
@@ -1620,7 +1620,15 @@ codeunit 432 Consolidate
         TempSubsidGLEntry.SetRange("G/L Account No.", TempSubsidGLAcc."No.");
     end;
 
-    internal procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
+    /// <summary>
+    /// Returns the current temporary subsidiary G/L account buffer populated during the consolidation run.
+    /// Pass an empty temporary G/L Account record; the buffer entries are copied into it.
+    /// </summary>
+    /// <remarks>
+    /// This procedure is public to support external integration with the consolidation process.
+    /// It is a supported, stable API surface; do not change the signature without following the obsolescence lifecycle.
+    /// </remarks>
+    procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
     begin
         if not TempSubsidGLAcc.FindSet() then
             exit;

--- a/src/Layers/ES/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
@@ -1618,7 +1618,15 @@ codeunit 432 Consolidate
         TempSubsidGLEntry.SetRange("G/L Account No.", TempSubsidGLAcc."No.");
     end;
 
-    internal procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
+    /// <summary>
+    /// Returns the current temporary subsidiary G/L account buffer populated during the consolidation run.
+    /// Pass an empty temporary G/L Account record; the buffer entries are copied into it.
+    /// </summary>
+    /// <remarks>
+    /// This procedure is public to support external integration with the consolidation process.
+    /// It is a supported, stable API surface; do not change the signature without following the obsolescence lifecycle.
+    /// </remarks>
+    procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
     begin
         if not TempSubsidGLAcc.FindSet() then
             exit;

--- a/src/Layers/NL/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
@@ -1620,7 +1620,15 @@ codeunit 432 Consolidate
         TempSubsidGLEntry.SetRange("G/L Account No.", TempSubsidGLAcc."No.");
     end;
 
-    internal procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
+    /// <summary>
+    /// Returns the current temporary subsidiary G/L account buffer populated during the consolidation run.
+    /// Pass an empty temporary G/L Account record; the buffer entries are copied into it.
+    /// </summary>
+    /// <remarks>
+    /// This procedure is public to support external integration with the consolidation process.
+    /// It is a supported, stable API surface; do not change the signature without following the obsolescence lifecycle.
+    /// </remarks>
+    procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
     begin
         if not TempSubsidGLAcc.FindSet() then
             exit;

--- a/src/Layers/W1/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al
@@ -1618,7 +1618,15 @@ codeunit 432 Consolidate
         TempSubsidGLEntry.SetRange("G/L Account No.", TempSubsidGLAcc."No.");
     end;
 
-    internal procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
+    /// <summary>
+    /// Returns the current temporary subsidiary G/L account buffer populated during the consolidation run.
+    /// Pass an empty temporary G/L Account record; the buffer entries are copied into it.
+    /// </summary>
+    /// <remarks>
+    /// This procedure is public to support external integration with the consolidation process.
+    /// It is a supported, stable API surface; do not change the signature without following the obsolescence lifecycle.
+    /// </remarks>
+    procedure GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)
     begin
         if not TempSubsidGLAcc.FindSet() then
             exit;


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#192

Fixes microsoft/BCAppsBugFix#192

## Summary
Changes the access modifier of procedure `GetGLAccounts(var TempGLAccount: Record "G/L Account" temporary)` in `codeunit 432 Consolidate` from `internal` to `public`, so external extensions (AppSource/partner apps) can retrieve the temporary subsidiary G/L account buffer prepared by the consolidation engine without duplicating the core `Consolidate` codeunit logic. This is a visibility-only change; the procedure signature and behavior are unchanged.

## Root Cause
`GetGLAccounts` was declared `internal`, restricting it to the Base Application. External apps implementing their own consolidation process could not call it and were forced to duplicate consolidation logic. Existing public procedures (`GetNumSubsidGLAcc`, `Get1stSubsidGLAcc`, `GetNxtSubsidGLAcc`) already expose the same account data one record at a time, so widening this bulk-retrieval convenience method to `public` exposes no new class of data.

## Changes Made
- `src/Layers/W1/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al`: `GetGLAccounts` changed from `internal` to `public`; added an XML `<summary>`/`<remarks>` block documenting it as a supported, stable public API for external consolidation integration. Signature and body unchanged.
- `src/Layers/BE/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al`: same change, propagated by Miapp.
- `src/Layers/ES/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al`: same change, propagated by Miapp.
- `src/Layers/NL/BaseApp/Finance/Consolidation/Consolidate.Codeunit.al`: same change, propagated by Miapp.

## Implementation Process

- Fix iterations: Not applicable - tests not required
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app published successfully
- Validation: Tests not required by the approved plan

## Validation Evidence

### No-Test Validation Evidence

- **Tests required by plan**: No
- **Rationale**: This is a purely additive visibility change (`internal` → `public`) with no behavioral change. Like an extensibility point, it has no defect state that a red-to-green AL regression test can reproduce; the only observable effect is compile-time accessibility from an external module. An AL automated test cannot meaningfully reproduce or validate this scenario.
- **Compilation**: ✅ Full AL build of the modified Base Application project succeeded.
- **Publish**: ✅ Modified Base Application published successfully to the BC container.
- **Manual/external validation approach**: Verified that only the access modifier changed (`GetGLAccounts` is now `public`) and that the procedure signature and body are unchanged; confirmed the widened accessibility compiles cleanly.

## Validation Coverage

- [x] Automated tests: Not applicable per approved Test Strategy
- [x] Build and publish validation completed
- [ ] Regression testing: Consolidation flows that call `GetGLAccounts` internally are unaffected (visibility-only change).

## Miapp Propagation

- **Layers propagated to**: BE, ES, NL
- **Files changed by propagation**: 3
- **VerifyMiappSync**: ✅ No files still need to be integrated

## Review Notes
Visibility-only change plus XML documentation. Reviewers should confirm the public API contract is acceptable; the procedure copies records out of the internal `TempSubsidGLAcc` buffer into a caller-supplied temporary record, so callers cannot mutate the internal buffer.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#263: https://github.com/microsoft/BCAppsBugFix/pull/263
