### PR TITLE
[Bug Fix] #189: Payables Agent MLLM total no longer set to the tax rate

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al
@@ -67,6 +67,8 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
         NestedObj2: JsonObject;
         NestedObj3: JsonObject;
         CurrencyText: Text;
+        TaxInclusiveAmount: Decimal;
+        TaxInclusiveProvided: Boolean;
     begin
         GetString(HeaderObj, 'id', MaxStrLen(TempHeader."Sales Invoice No."), TempHeader."Sales Invoice No.");
         GetDate(HeaderObj, 'issue_date', TempHeader."Document Date");
@@ -123,8 +125,16 @@ codeunit 6232 "E-Doc. MLLM Schema Helper"
         if GetNestedObject(HeaderObj, 'legal_monetary_total', NestedObj) then begin
             GetDecimal(NestedObj, 'tax_exclusive_amount', TempHeader."Sub Total");
             GetDecimal(NestedObj, 'allowance_total_amount', TempHeader."Total Discount");
+            TaxInclusiveProvided := GetDecimal(NestedObj, 'tax_inclusive_amount', TaxInclusiveAmount);
             GetDecimal(NestedObj, 'payable_amount', TempHeader.Total);
-            GetDecimal(NestedObj, 'payable_amount', TempHeader."Amount Due");
+            // Guard: for a positive invoice, the total including tax cannot be less than the tax-exclusive sub total.
+            // When the model emits the tax rate into payable_amount, correct it using tax_inclusive_amount or sub total + VAT.
+            if (TempHeader."Sub Total" > 0) and (TempHeader.Total < TempHeader."Sub Total") then
+                if TaxInclusiveProvided and (TaxInclusiveAmount >= TempHeader."Sub Total") then
+                    TempHeader.Total := TaxInclusiveAmount
+                else
+                    TempHeader.Total := TempHeader."Sub Total" + TempHeader."Total VAT";
+            TempHeader."Amount Due" := TempHeader.Total;
         end;
     end;
 

--- a/src/Apps/W1/EDocument/Test/.resources/mllm/mllm-header-tax-rate-as-total.json
+++ b/src/Apps/W1/EDocument/Test/.resources/mllm/mllm-header-tax-rate-as-total.json
@@ -1,0 +1,12 @@
+{
+    "id": "MLLM-INV-TAX-RATE",
+    "issue_date": "2024-03-15",
+    "tax_total": {
+        "tax_amount": 62.5
+    },
+    "legal_monetary_total": {
+        "tax_exclusive_amount": 250.0,
+        "tax_inclusive_amount": 312.5,
+        "payable_amount": 25.0
+    }
+}

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al
@@ -267,6 +267,29 @@ codeunit 135647 "EDoc MLLM Tests"
 #pragma warning restore AL0432
 #endif
 
+    [Test]
+    procedure MapHeader_TotalNotTaxRate()
+    var
+        TempHeader: Record "E-Document Purchase Header" temporary;
+        EDocMLLMSchemaHelper: Codeunit "E-Doc. MLLM Schema Helper";
+        HeaderObj: JsonObject;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO] When payable_amount equals the tax rate (25), the corrected total should be 312.5
+        // This reproduces the bug where the model emits the tax rate into payable_amount
+        LibraryLowerPermission.SetOutsideO365Scope();
+        EnsureGLSetup();
+
+        HeaderObj.ReadFrom(NavApp.GetResourceAsText('mllm/mllm-header-tax-rate-as-total.json'));
+
+        EDocMLLMSchemaHelper.MapHeaderFromJson(HeaderObj, TempHeader);
+
+        // Before the fix: TempHeader.Total = 25 (the tax rate, not the true total)
+        // After the fix: TempHeader.Total = 312.5 (tax_inclusive_amount)
+        Assert.AreEqual(312.5, TempHeader.Total, 'Total must be the tax-inclusive amount (312.5), not the tax rate (25)');
+        Assert.AreEqual(312.5, TempHeader."Amount Due", 'Amount Due must match the corrected Total');
+    end;
+
     local procedure EnsureGLSetup()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#189 — [[AB#644802](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644802)] Payables Agent sets the total to be the tax rate in the attached invoice

Fixes microsoft/BCAppsBugFix#189

## Summary
The Payables Agent MLLM extraction path could set the invoice header **Total** (and **Amount Due**) to the document's **tax rate** instead of the real document total. This fix adds a plausibility guard that reconciles the extracted total against the reliably-extracted tax-exclusive sub total and tax amount, correcting the value when the model misplaces the tax rate into `payable_amount`.

## Root Cause
In codeunit 6232 `E-Doc. MLLM Schema Helper`.`MapHeaderFromJson`, the header total was copied verbatim from `legal_monetary_total.payable_amount` into `TempHeader.Total` / `TempHeader."Amount Due"` with no validation. The GPT-4.1-mini MLLM occasionally emits the document tax rate/percentage into `payable_amount`, so the extracted total became the tax rate. The reliable `legal_monetary_total.tax_inclusive_amount` UBL field was never read, and there was no reconciliation against the correctly-extracted tax-exclusive sub total and tax amount.

## Changes Made
- `src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocMLLMSchemaHelper.Codeunit.al`: In the `legal_monetary_total` block of `MapHeaderFromJson`, also read `tax_inclusive_amount` and apply a plausibility guard. For a positive invoice (`Sub Total > 0`), when the mapped `Total < Sub Total` (the tax-rate-as-total symptom), `Total` is corrected to `tax_inclusive_amount` when provided and `>= Sub Total`, otherwise to `Sub Total + Total VAT`; `Amount Due` is set from the corrected `Total`.
- `src/Apps/W1/EDocument/Test/src/Processing/EDocMLLMTests.Codeunit.al`: Added regression test `MapHeader_TotalNotTaxRate`.
- `src/Apps/W1/EDocument/Test/.resources/mllm/mllm-header-tax-rate-as-total.json`: Test resource reproducing the tax-rate-as-total scenario.

## Implementation Process

- Fix iterations: 1 of 5
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app and test app published successfully
- Validation: ✅ Automated tests passing

## Validation Evidence

### Automated Test Evidence

#### Pre-Fix Test Results (Baseline)
Tests run before implementing the fix (expected to fail):

```
❌ MapHeader_TotalNotTaxRate: FAILED
   Error: Assert.AreEqual failed. Expected:<312.5> (Decimal). Actual:<25> (Decimal). Total must be the tax-inclusive amount (312.5), not the tax rate (25).
```

#### Post-Fix Test Results (Final)
Tests run after implementing the fix (expected to pass):

```
✅ MapHeader_FullInvoice: PASSED
✅ MapHeader_MissingOptionalFields: PASSED
✅ MapHeader_EmptyObject: PASSED
✅ MapLines_MultipleLines: PASSED
✅ MapLines_ZeroQuantity: PASSED
✅ MapLines_MissingQuantity: PASSED
✅ MapLines_EmptyArray: PASSED
✅ PreferredImpl_ReturnsMLLM: PASSED
✅ PreferredImpl_EventOverride_TakesPrecedence: PASSED
✅ MapHeader_TotalNotTaxRate: PASSED (new test for bug scenario)
```

**Total Tests Run:** 10
**All Tests Passing:** ✅ Yes

#### Iteration Summary

- **Iteration 1**: Added `TaxInclusiveAmount` local, read `tax_inclusive_amount`, applied the plausibility guard when `payable_amount < sub_total`. ✅ All tests passing

## Validation Coverage

- [x] Existing tests pass
- [x] New tests added for bug scenario
- [x] Regression test for work item microsoft/BCAppsBugFix#189
- [x] Automated tests: All passing
- [x] Build and publish validation completed

## Review Notes
The guard only triggers for positive invoices (`Sub Total > 0`) when the mapped total falls below the tax-exclusive sub total, so valid invoices (including the existing `MapHeader_FullInvoice` case where `payable_amount` >= sub total) are unaffected.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#218: https://github.com/microsoft/BCAppsBugFix/pull/218

Fixes [AB#644802](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644802)


