### PR TITLE
[Bug Fix] #210: Post item charge to Value Entry when receipt and charge invoice are posted separately

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1475,7 +1475,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2138,6 +2142,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/BE/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1447,7 +1447,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2109,6 +2113,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/CA/Tests/ERM/O365PurchItemChargeTests.Codeunit.al
+++ b/src/Layers/CA/Tests/ERM/O365PurchItemChargeTests.Codeunit.al
@@ -365,6 +365,74 @@ codeunit 135300 "O365 Purch Item Charge Tests"
         VerifyItemChargeAssignmentLines(PurchHeaderInvoice, ItemCharge."No.", 5, 6);
     end;
 
+    [Test]
+    procedure ItemChargeValueEntryCreatedWhenChargeInvoicedSeparately()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        ItemCharge: Record "Item Charge";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLineItem: Record "Purchase Line";
+        PurchaseLineCharge: Record "Purchase Line";
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+        ItemChargeAssgntPurch: Codeunit "Item Charge Assgnt. (Purch.)";
+        ValueEntry: Record "Value Entry";
+        NextLineNo: Integer;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO 613348] Value Entry is created for item charge when receipt and charge invoice are posted separately on same purchase order
+        Initialize();
+
+        // [GIVEN] Vendor "V", Item "I", Item Charge "C" and a purchase order "PO"
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemCharge(ItemCharge);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+
+        // [GIVEN] Purchase order "PO" has item line "L1" (Qty = 1) and item charge line "L2" (Qty = 1)
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineItem, PurchaseHeader, PurchaseLineItem.Type::Item, Item."No.", 1);
+        PurchaseLineItem.Validate("Direct Unit Cost", 100);
+        PurchaseLineItem.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineCharge, PurchaseHeader, PurchaseLineCharge.Type::"Charge (Item)", ItemCharge."No.", 1);
+        PurchaseLineCharge.Validate("Direct Unit Cost", 50);
+        PurchaseLineCharge.Modify(true);
+
+        // [GIVEN] Item charge "L2" assigned (Qty. to Assign = 1) to item line "L1" on the same order
+        NextLineNo := 0;
+        ItemChargeAssignmentPurch."Document Type" := PurchaseLineCharge."Document Type";
+        ItemChargeAssignmentPurch."Document No." := PurchaseLineCharge."Document No.";
+        ItemChargeAssignmentPurch."Document Line No." := PurchaseLineCharge."Line No.";
+        ItemChargeAssignmentPurch."Item Charge No." := PurchaseLineCharge."No.";
+        ItemChargeAssgntPurch.InsertItemChargeAssignmentWithValues(
+            ItemChargeAssignmentPurch,
+            "Purchase Applies-to Document Type"::Order,
+            PurchaseLineItem."Document No.",
+            PurchaseLineItem."Line No.",
+            PurchaseLineItem."No.",
+            PurchaseLineItem.Description,
+            1,
+            PurchaseLineCharge."Direct Unit Cost",
+            NextLineNo);
+
+        // [WHEN] Post receipt only for purchase order "PO" (Receive = true, Invoice = false)
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [WHEN] Set item line "L1" Qty. to Invoice = 0 so only charge line "L2" is invoiced
+        PurchaseLineItem.Find();
+        PurchaseLineItem.Validate("Qty. to Invoice", 0);
+        PurchaseLineItem.Modify(true);
+
+        // [WHEN] Post the invoice for purchase order "PO" (charge line "L2" invoiced, item line "L1" skipped)
+        PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, PurchaseHeader."No.");
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
+
+        // [THEN] Value Entry "VE" exists for item charge "C" applied to item "I"
+        ValueEntry.SetRange("Entry Type", ValueEntry."Entry Type"::"Direct Cost");
+        ValueEntry.SetRange("Item No.", Item."No.");
+        ValueEntry.SetRange("Item Charge No.", ItemCharge."No.");
+        Assert.RecordIsNotEmpty(ValueEntry);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/CH/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1451,7 +1451,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2113,6 +2117,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/ES/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1523,7 +1523,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2196,6 +2200,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/FI/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1450,7 +1450,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2112,6 +2116,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/GB/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/GB/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1477,7 +1477,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2139,6 +2143,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/IT/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1566,7 +1566,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2228,6 +2232,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/NA/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1540,7 +1540,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2211,6 +2215,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/RU/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1581,7 +1581,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2248,6 +2252,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/US/Tests/ERM/O365PurchItemChargeTests.Codeunit.al
+++ b/src/Layers/US/Tests/ERM/O365PurchItemChargeTests.Codeunit.al
@@ -365,6 +365,74 @@ codeunit 135300 "O365 Purch Item Charge Tests"
         VerifyItemChargeAssignmentLines(PurchHeaderInvoice, ItemCharge."No.", 5, 6);
     end;
 
+    [Test]
+    procedure ItemChargeValueEntryCreatedWhenChargeInvoicedSeparately()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        ItemCharge: Record "Item Charge";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLineItem: Record "Purchase Line";
+        PurchaseLineCharge: Record "Purchase Line";
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+        ItemChargeAssgntPurch: Codeunit "Item Charge Assgnt. (Purch.)";
+        ValueEntry: Record "Value Entry";
+        NextLineNo: Integer;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO 613348] Value Entry is created for item charge when receipt and charge invoice are posted separately on same purchase order
+        Initialize();
+
+        // [GIVEN] Vendor "V", Item "I", Item Charge "C" and a purchase order "PO"
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemCharge(ItemCharge);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+
+        // [GIVEN] Purchase order "PO" has item line "L1" (Qty = 1) and item charge line "L2" (Qty = 1)
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineItem, PurchaseHeader, PurchaseLineItem.Type::Item, Item."No.", 1);
+        PurchaseLineItem.Validate("Direct Unit Cost", 100);
+        PurchaseLineItem.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineCharge, PurchaseHeader, PurchaseLineCharge.Type::"Charge (Item)", ItemCharge."No.", 1);
+        PurchaseLineCharge.Validate("Direct Unit Cost", 50);
+        PurchaseLineCharge.Modify(true);
+
+        // [GIVEN] Item charge "L2" assigned (Qty. to Assign = 1) to item line "L1" on the same order
+        NextLineNo := 0;
+        ItemChargeAssignmentPurch."Document Type" := PurchaseLineCharge."Document Type";
+        ItemChargeAssignmentPurch."Document No." := PurchaseLineCharge."Document No.";
+        ItemChargeAssignmentPurch."Document Line No." := PurchaseLineCharge."Line No.";
+        ItemChargeAssignmentPurch."Item Charge No." := PurchaseLineCharge."No.";
+        ItemChargeAssgntPurch.InsertItemChargeAssignmentWithValues(
+            ItemChargeAssignmentPurch,
+            "Purchase Applies-to Document Type"::Order,
+            PurchaseLineItem."Document No.",
+            PurchaseLineItem."Line No.",
+            PurchaseLineItem."No.",
+            PurchaseLineItem.Description,
+            1,
+            PurchaseLineCharge."Direct Unit Cost",
+            NextLineNo);
+
+        // [WHEN] Post receipt only for purchase order "PO" (Receive = true, Invoice = false)
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [WHEN] Set item line "L1" Qty. to Invoice = 0 so only charge line "L2" is invoiced
+        PurchaseLineItem.Find();
+        PurchaseLineItem.Validate("Qty. to Invoice", 0);
+        PurchaseLineItem.Modify(true);
+
+        // [WHEN] Post the invoice for purchase order "PO" (charge line "L2" invoiced, item line "L1" skipped)
+        PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, PurchaseHeader."No.");
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
+
+        // [THEN] Value Entry "VE" exists for item charge "C" applied to item "I"
+        ValueEntry.SetRange("Entry Type", ValueEntry."Entry Type"::"Direct Cost");
+        ValueEntry.SetRange("Item No.", Item."No.");
+        ValueEntry.SetRange("Item Charge No.", ItemCharge."No.");
+        Assert.RecordIsNotEmpty(ValueEntry);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";

--- a/src/Layers/W1/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -1444,7 +1444,11 @@ codeunit 90 "Purch.-Post"
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice,
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Return Order",
                   TempItemChargeAssgntPurch."Applies-to Doc. Type"::"Credit Memo":
-                        CheckItemCharge(TempItemChargeAssgntPurch);
+                        begin
+                            CheckItemCharge(TempItemChargeAssgntPurch);
+                            if PostItemChargeFromReceivedOrderLine(PurchHeader, PurchaseLineBackup) then
+                                TempItemChargeAssgntPurch.Mark(true);
+                        end;
                 end;
 
                 OnPostItemChargeLineOnAfterPostItemCharge(TempItemChargeAssgntPurch, PurchHeader, PurchaseLineBackup, PurchLine);
@@ -2106,6 +2110,63 @@ codeunit 90 "Purch.-Post"
               TempItemChargeAssgntPurch."Amount to Assign" * Sign,
               TempItemChargeAssgntPurch."Qty. to Assign",
               PurchRcptLine."Indirect Cost %");
+    end;
+
+    local procedure PostItemChargeFromReceivedOrderLine(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line"): Boolean
+    var
+        PurchLineForCharge: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempItemLedgEntry: Record "Item Ledger Entry" temporary;
+        DistributeCharge: Boolean;
+    begin
+        if TempItemChargeAssgntPurch.Mark() then
+            exit(false);
+
+        if not (TempItemChargeAssgntPurch."Applies-to Doc. Type" in
+            [TempItemChargeAssgntPurch."Applies-to Doc. Type"::Order,
+             TempItemChargeAssgntPurch."Applies-to Doc. Type"::Invoice])
+        then
+            exit(false);
+
+        if not PurchLineForCharge.Get(
+            TempItemChargeAssgntPurch."Applies-to Doc. Type",
+            TempItemChargeAssgntPurch."Applies-to Doc. No.",
+            TempItemChargeAssgntPurch."Applies-to Doc. Line No.")
+        then
+            exit(false);
+
+        if PurchLineForCharge."Qty. Rcd. Not Invoiced (Base)" = 0 then
+            exit(false);
+
+        PurchRcptLine.SetRange("Order No.", TempItemChargeAssgntPurch."Applies-to Doc. No.");
+        PurchRcptLine.SetRange("Order Line No.", TempItemChargeAssgntPurch."Applies-to Doc. Line No.");
+        if not PurchRcptLine.FindFirst() then
+            exit(false);
+
+        if PurchRcptLine."Item Rcpt. Entry No." <> 0 then
+            DistributeCharge :=
+                CostCalcMgt.SplitItemLedgerEntriesExist(
+                    TempItemLedgEntry, PurchRcptLine."Quantity (Base)", PurchRcptLine."Item Rcpt. Entry No.")
+        else begin
+            DistributeCharge := true;
+            ItemTrackingMgt.CollectItemEntryRelation(TempItemLedgEntry,
+                DATABASE::"Purch. Rcpt. Line", 0, PurchRcptLine."Document No.",
+                '', 0, PurchRcptLine."Line No.", PurchRcptLine."Quantity (Base)");
+        end;
+
+        if DistributeCharge then
+            PostDistributeItemCharge(
+                PurchHeader, PurchLine, TempItemLedgEntry, PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Qty. to Assign", TempItemChargeAssgntPurch."Amount to Assign",
+                1, PurchRcptLine."Indirect Cost %")
+        else
+            PostItemCharge(PurchHeader, PurchLine,
+                PurchRcptLine."Item Rcpt. Entry No.", PurchRcptLine."Quantity (Base)",
+                TempItemChargeAssgntPurch."Amount to Assign",
+                TempItemChargeAssgntPurch."Qty. to Assign",
+                PurchRcptLine."Indirect Cost %");
+
+        exit(true);
     end;
 
     local procedure PostItemChargePerRetShpt(PurchHeader: Record "Purchase Header"; var PurchLine: Record "Purchase Line")

--- a/src/Layers/W1/Tests/ERM/O365PurchItemChargeTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/O365PurchItemChargeTests.Codeunit.al
@@ -390,6 +390,74 @@ codeunit 135300 "O365 Purch Item Charge Tests"
         VerifyItemChargeAssignmentLines(PurchHeaderInvoice, ItemCharge."No.", 5, 6);
     end;
 
+    [Test]
+    procedure ItemChargeValueEntryCreatedWhenChargeInvoicedSeparately()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        ItemCharge: Record "Item Charge";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLineItem: Record "Purchase Line";
+        PurchaseLineCharge: Record "Purchase Line";
+        ItemChargeAssignmentPurch: Record "Item Charge Assignment (Purch)";
+        ItemChargeAssgntPurch: Codeunit "Item Charge Assgnt. (Purch.)";
+        ValueEntry: Record "Value Entry";
+        NextLineNo: Integer;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO 613348] Value Entry is created for item charge when receipt and charge invoice are posted separately on same purchase order
+        Initialize();
+
+        // [GIVEN] Vendor "V", Item "I", Item Charge "C" and a purchase order "PO"
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemCharge(ItemCharge);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+
+        // [GIVEN] Purchase order "PO" has item line "L1" (Qty = 1) and item charge line "L2" (Qty = 1)
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineItem, PurchaseHeader, PurchaseLineItem.Type::Item, Item."No.", 1);
+        PurchaseLineItem.Validate("Direct Unit Cost", 100);
+        PurchaseLineItem.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineCharge, PurchaseHeader, PurchaseLineCharge.Type::"Charge (Item)", ItemCharge."No.", 1);
+        PurchaseLineCharge.Validate("Direct Unit Cost", 50);
+        PurchaseLineCharge.Modify(true);
+
+        // [GIVEN] Item charge "L2" assigned (Qty. to Assign = 1) to item line "L1" on the same order
+        NextLineNo := 0;
+        ItemChargeAssignmentPurch."Document Type" := PurchaseLineCharge."Document Type";
+        ItemChargeAssignmentPurch."Document No." := PurchaseLineCharge."Document No.";
+        ItemChargeAssignmentPurch."Document Line No." := PurchaseLineCharge."Line No.";
+        ItemChargeAssignmentPurch."Item Charge No." := PurchaseLineCharge."No.";
+        ItemChargeAssgntPurch.InsertItemChargeAssignmentWithValues(
+            ItemChargeAssignmentPurch,
+            "Purchase Applies-to Document Type"::Order,
+            PurchaseLineItem."Document No.",
+            PurchaseLineItem."Line No.",
+            PurchaseLineItem."No.",
+            PurchaseLineItem.Description,
+            1,
+            PurchaseLineCharge."Direct Unit Cost",
+            NextLineNo);
+
+        // [WHEN] Post receipt only for purchase order "PO" (Receive = true, Invoice = false)
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [WHEN] Set item line "L1" Qty. to Invoice = 0 so only charge line "L2" is invoiced
+        PurchaseLineItem.Find();
+        PurchaseLineItem.Validate("Qty. to Invoice", 0);
+        PurchaseLineItem.Modify(true);
+
+        // [WHEN] Post the invoice for purchase order "PO" (charge line "L2" invoiced, item line "L1" skipped)
+        PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, PurchaseHeader."No.");
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, false, true);
+
+        // [THEN] Value Entry "VE" exists for item charge "C" applied to item "I"
+        ValueEntry.SetRange("Entry Type", ValueEntry."Entry Type"::"Direct Cost");
+        ValueEntry.SetRange("Item No.", Item."No.");
+        ValueEntry.SetRange("Item Charge No.", ItemCharge."No.");
+        Assert.RecordIsNotEmpty(ValueEntry);
+    end;
+
     local procedure Initialize()
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#210 — Fixes microsoft/BCAppsBugFix#210

## Summary
When a purchase order has an item line and an item-charge line assigned to that item line, and the **receipt** and the **item-charge invoice** are posted in **separate** steps (receipt first, then the charge invoice with the item line's `Qty. to Invoice = 0`), the item charge cost was never transferred to a Value Entry. This left `Qty. Assigned` at `0` while `Quantity Invoiced` was `1`, so the purchase order could never be deleted ("Qty. Assigned must be equal to '1' in Purchase Line..."). The fix makes the standalone item-charge invoice post the charge to a Value Entry against the already-posted receipt's item ledger entry.

## Root Cause
In `Codeunit 90 "Purch.-Post"` an item charge assigned to an item line of the same order was only transferred to a Value Entry as a side-effect of posting that item line's item journal line during an Invoice run — `PostItemJnlLine` calls `PostItemJnlLineItemCharges` (→ `PostItemChargePerOrder`) only when `(PurchLine.Type = Item) and PurchHeader.Invoice`. When the receipt is posted first (Invoice = false) and the charge is invoiced separately with the assigned item line's `Qty. to Invoice = 0`, the item line's `PostItemJnlLine` never runs, so no Value Entry is created. Posting the charge line runs `PostItemChargeLine`, but for an `Applies-to Doc. Type::Order`/`Invoice` assignment it only called `CheckItemCharge` (validation, no posting). The charge line therefore became `Quantity Invoiced = 1` while `Qty. Assigned` stayed `0`, and `PurchaseLine.DeleteChargeChargeAssgnt` (`TestField("Qty. Assigned","Quantity Invoiced")`) blocked deletion. Posting the receipt and charge invoice together worked because the item line was received in the same run, so the charge Value Entry was created.

## Changes Made
- `src/Layers/W1/BaseApp/Purchases/Posting/PurchPost.Codeunit.al`: Extended the `Order`/`Invoice`/`Return Order`/`Credit Memo` case in `PostItemChargeLine` to also call a new local procedure `PostItemChargeFromReceivedOrderLine`. When the assigned item line was already received (`"Qty. Rcd. Not Invoiced (Base)" <> 0`), it locates the corresponding `Purch. Rcpt. Line` and posts the charge via the existing receipt distribution helpers (`PostDistributeItemCharge` / `PostItemCharge`) — the same path as `PostItemChargePerRcpt` — creating the Value Entry and correctly updating `Qty. Assigned`. Guarded with `if TempItemChargeAssgntPurch.Mark() then exit(false)` so a charge already handled by the combined receipt+invoice flow is never double-posted. Minimal and additive; the combined-posting path, return/credit-memo semantics, and existing `CheckItemCharge` validations are unchanged.
- Regression test added to `src/Layers/W1/Tests/ERM/O365PurchItemChargeTests.Codeunit.al` (codeunit 135300).

## Implementation Process

- Fix iterations: 1 of 5
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app published successfully
- Validation: ✅ Automated tests passing

## Validation Evidence

### Automated Test Evidence

#### Pre-Fix Test Results (Baseline)
Tests run before implementing the fix (expected to fail):

```
❌ ItemChargeValueEntryCreatedWhenChargeInvoicedSeparately: FAILED
   Error: Assert.TableIsNotEmpty failed. Table <Value Entry> with filter <Item No.: GL00000001, Item Charge No.: GU00000002, Entry Type: Direct Cost> must contain records.
```

#### Post-Fix Test Results (Final)
Tests run after implementing the fix (expected to pass):

```
✅ OnRun: PASSED
✅ SetupItemChargeTest: PASSED
✅ CreateCorrectiveCreditMemoWithItemChargeTest: PASSED
✅ CreateCorrectiveCreditMemoWithItemChargesTest: PASSED
✅ CreateCorrectiveCreditMemoFromLargeInvoiceWithItemChargeTest: PASSED
✅ CreateCorrectiveCreditMemoWithItemChargeAndCurrencyTest: PASSED
✅ CreateCorrectiveCreditMemoWithoutItemChargeTest: PASSED
✅ CancelInvoiceWithChargeItemAssignedToMultipleShipmentLines: PASSED
✅ TestRemovePostedReceiptWithChargeItemAssigned: PASSED
✅ VariantCodeIsMandatoryDoesntDisruptItemChargePosting: PASSED
✅ VerifyQtyOnItemChargeAssignmentLinesForPurchInvoiceLinesFromPurchRcptsFromPurchOrder: PASSED
✅ ItemChargeValueEntryCreatedWhenChargeInvoicedSeparately: PASSED (new test for bug scenario)
```

**Total Tests Run:** 12
**All Tests Passing:** ✅ Yes

#### Iteration Summary

- **Iteration 1**: ✅ Added `PostItemChargeFromReceivedOrderLine` and extended the `PostItemChargeLine` Order/Invoice case; all tests passing.

## Validation Coverage

- [x] Existing tests pass
- [x] New tests added for bug scenario
- [x] Regression test for work item microsoft/BCAppsBugFix#210
- [x] Automated tests: All passing
- [x] Build and publish validation completed

## Miapp Propagation

- **Layers propagated to**: APAC, BE, CA, CH, ES, FI, GB, IT, NA, RU, US
- **Files changed by propagation**: 11
- **VerifyMiappSync**: ✅ No files still need to be integrated

## Review Notes
Focus on `PostItemChargeFromReceivedOrderLine` and the receipt-line resolution: the charge is posted against the posted `Purch. Rcpt. Line` for the assigned order line, reusing the existing distribution helpers. The double-post guard relies on the `TempItemChargeAssgntPurch.Mark()` flag set by the combined receipt+invoice flow.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#266: https://github.com/microsoft/BCAppsBugFix/pull/266
