### PR TITLE
[Bug Fix] #202: Quality Management - Date/DateTime format adjustment silently changes user input

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al
@@ -694,6 +694,8 @@ codeunit 20410 "Qlty. Result Evaluation"
         TempQltyInspectionHeader: Record "Qlty. Inspection Header" temporary;
         ValueAsDateTime: DateTime;
     begin
+        if AdjustValueIfGood then;
+
         if ValueToCheck = '' then
             ValueAsDateTime := 0DT
         else
@@ -702,9 +704,6 @@ codeunit 20410 "Qlty. Result Evaluation"
         if IsAnythingExceptEmptyCondition(AcceptableValue) then
             if ValueToCheck <> '' then begin
                 IsGood := true;
-                if AdjustValueIfGood then
-                    ValueToCheck := CopyStr(Format(ValueAsDateTime, 0, 9), 1, MaxStrLen(ValueToCheck));
-
                 exit(IsGood);
             end else begin
                 IsGood := false;
@@ -714,9 +713,6 @@ codeunit 20410 "Qlty. Result Evaluation"
         if IsBlankOrEmptyCondition(AcceptableValue) then
             if ValueToCheck <> '' then begin
                 IsGood := true;
-                if AdjustValueIfGood then
-                    ValueToCheck := CopyStr(Format(ValueAsDateTime, 0, 9), 1, MaxStrLen(ValueToCheck));
-
                 exit(IsGood);
             end else begin
                 IsGood := true;
@@ -727,8 +723,6 @@ codeunit 20410 "Qlty. Result Evaluation"
         TempQltyInspectionHeader.Insert();
         TempQltyInspectionHeader.SetFilter("Finished Date", AcceptableValue);
         IsGood := not TempQltyInspectionHeader.IsEmpty();
-        if IsGood and AdjustValueIfGood then
-            ValueToCheck := CopyStr(Format(ValueAsDateTime, 0, 9), 1, MaxStrLen(ValueToCheck));
 
         exit(IsGood);
     end;
@@ -745,6 +739,8 @@ codeunit 20410 "Qlty. Result Evaluation"
         TempDateLookupBuffer: Record "Date Lookup Buffer" temporary;
         ValueAsDate: Date;
     begin
+        if AdjustValueIfGood then;
+
         if ValueToCheck = '' then
             ValueAsDate := 0D
         else
@@ -753,9 +749,6 @@ codeunit 20410 "Qlty. Result Evaluation"
         if IsAnythingExceptEmptyCondition(AcceptableValue) then
             if ValueToCheck <> '' then begin
                 IsGood := true;
-                if AdjustValueIfGood then
-                    ValueToCheck := CopyStr(Format(ValueAsDate, 0, 9), 1, MaxStrLen(ValueToCheck));
-
                 exit(IsGood);
             end else begin
                 IsGood := false;
@@ -765,9 +758,6 @@ codeunit 20410 "Qlty. Result Evaluation"
         if IsBlankOrEmptyCondition(AcceptableValue) then
             if ValueToCheck <> '' then begin
                 IsGood := true;
-                if AdjustValueIfGood then
-                    ValueToCheck := CopyStr(Format(ValueAsDate, 0, 9), 1, MaxStrLen(ValueToCheck));
-
                 exit(IsGood);
             end else begin
                 IsGood := true;
@@ -778,8 +768,6 @@ codeunit 20410 "Qlty. Result Evaluation"
         TempDateLookupBuffer.Insert();
         TempDateLookupBuffer.SetFilter("Period Start", AcceptableValue);
         IsGood := not TempDateLookupBuffer.IsEmpty();
-        if IsGood and AdjustValueIfGood then
-            ValueToCheck := CopyStr(Format(ValueAsDate, 0, 9), 1, MaxStrLen(ValueToCheck));
 
         exit(IsGood);
     end;

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al
@@ -267,7 +267,7 @@ codeunit 139963 "Qlty. Tests - Result Eval."
 
         TestValue := OriginalTestValue;
         LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '', true), 'Date basic no condition 1');
-        LibraryAssert.AreEqual(TestValue, format(Date, 0, '<Year4>-<Month,2>-<Day,2>'), 'Back and forth date - should change');
+        LibraryAssert.AreEqual(TestValue, OriginalTestValue, 'Back and forth date - no change expected');
 
         LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '1' + GetDateSeparator() + '1..2' + GetDateSeparator() + '2', false), 'Date basic date range 1');
         LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, StrSubstNo('1' + GetDateSeparator() + '1' + GetDateSeparator() + '%1..2' + GetDateSeparator() + '2' + GetDateSeparator() + '%1', YearAsString), false), 'Date basic date range 2');
@@ -277,17 +277,17 @@ codeunit 139963 "Qlty. Tests - Result Eval."
         if IsDayMonthYearLocal() then begin
             LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '28' + GetDateSeparator() + '1', false),
                 'Date basic NO CONVERT');
-            LibraryAssert.AreNotEqual('28-1' + YearAsString, TestValue, 'date basic NO CONVERT');
+            LibraryAssert.AreEqual(TestValue, OriginalTestValue, 'date basic NO CONVERT');
 
             LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '28-1', true), 'Date basic convert');
         end else begin
             LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '1' + GetDateSeparator() + '28', false), 'Date basic NO CONVERT');
-            LibraryAssert.AreNotEqual('1/28/' + YearAsString, TestValue, 'date basic NO CONVERT');
+            LibraryAssert.AreEqual(TestValue, OriginalTestValue, 'date basic NO CONVERT');
 
             LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '1/28', true), 'Date basic convert');
         end;
 
-        LibraryAssert.AreEqual(YearAsString + '-01-28', TestValue, 'date basic convert 1');
+        LibraryAssert.AreEqual(OriginalTestValue, TestValue, 'date basic convert 1');
 
         TestValue := '2023-12-31';
         Date := DMY2Date(31, 12, 2023);
@@ -372,6 +372,68 @@ codeunit 139963 "Qlty. Tests - Result Eval."
         TestValue := '';
         // [THEN] Blank datetime fails validation
         LibraryAssert.IsFalse(QltyInspectionUtility.CheckIfValueIsDateTime(TestValue, format(Date, 0, 9), true), 'blank input date with valid acceptable date' + DateFailureSuffixDetails);
+    end;
+
+    [Test]
+    procedure ValueDate_NonIsoInput_NotSilentlyRewritten()
+    var
+        QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
+        TestValue: Text[250];
+        OriginalValue: Text[250];
+        TestDate: Date;
+        YearAsString: Text;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO] When CheckIfValueIsDate is called with a non-ISO locale date string and AdjustValueIfGood=true,
+        //            the original user input must not be silently overwritten with the ISO (format 9) representation.
+
+        // [GIVEN] A valid date expressed in the regional locale format (non-ISO)
+        TestDate := DMY2Date(15, 1, 2025);
+        YearAsString := Format(Date2DMY(TestDate, 3), 0, 9);
+        if IsDayMonthYearLocal() then
+            TestValue := '15' + GetDateSeparator() + '1' + GetDateSeparator() + YearAsString
+        else
+            TestValue := '1' + GetDateSeparator() + '15' + GetDateSeparator() + YearAsString;
+        OriginalValue := TestValue;
+
+        // [WHEN] CheckIfValueIsDate is called with AdjustValueIfGood=true and a matching condition
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDate(TestValue, '', true), 'Non-ISO date should pass validation');
+
+        // [THEN] The value must equal the original user input - not silently rewritten to ISO format
+        LibraryAssert.AreEqual(OriginalValue, TestValue, 'User-entered non-ISO date must not be silently rewritten to ISO format');
+    end;
+
+    [Test]
+    procedure ValueDateTime_NonIsoInput_NotSilentlyRewritten()
+    var
+        QltyInspectionUtility: Codeunit "Qlty. Inspection Utility";
+        TestValue: Text[250];
+        OriginalValue: Text[250];
+        TestDateTime: DateTime;
+        TestDate: Date;
+        IsoValue: Text[250];
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO] When CheckIfValueIsDateTime is called with a non-ISO datetime string and AdjustValueIfGood=true,
+        //            the original user input must not be silently overwritten with the ISO (format 9) representation.
+
+        // [GIVEN] A valid datetime expressed in a locale format - build it from a known date so the non-ISO string
+        //         differs from the format-9 representation
+        TestDate := DMY2Date(15, 1, 2025);
+        TestDateTime := CreateDateTime(TestDate, 143000T);
+        IsoValue := Format(TestDateTime, 0, 9);
+        // Use the locale default format (format 0) which differs from ISO format 9 on most sessions
+        TestValue := Format(TestDateTime, 0, 1);
+        // Guard: if for some reason format 1 == format 9, skip the test to avoid a false baseline
+        if TestValue = IsoValue then
+            TestValue := '01/15/2025 14:30:00';
+        OriginalValue := TestValue;
+
+        // [WHEN] CheckIfValueIsDateTime is called with AdjustValueIfGood=true and no condition
+        LibraryAssert.IsTrue(QltyInspectionUtility.CheckIfValueIsDateTime(TestValue, '', true), 'Non-ISO datetime should pass validation');
+
+        // [THEN] The value must equal the original user input - not silently rewritten to ISO format
+        LibraryAssert.AreEqual(OriginalValue, TestValue, 'User-entered non-ISO datetime must not be silently rewritten to ISO format');
     end;
 
     [Test]


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#202

Fixes microsoft/BCAppsBugFix#202

## Summary
`CheckIfValueIsDateTime` and `CheckIfValueIsDate` in the Quality Management app silently overwrote the caller's originally entered date/datetime text with an ISO (Format `9`) representation whenever `AdjustValueIfGood = true` and validation succeeded. This fix removes that hidden mutation so a value-checking routine no longer rewrites the user's input, preserving the original format/locale and any DateTime timezone/offset information.

## Root Cause
In `src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al`, both procedures take a `var ValueToCheck: Text[250]` parameter and, in three code paths each, executed `ValueToCheck := CopyStr(Format(<value>, 0, 9), 1, MaxStrLen(ValueToCheck))`. Format `9` is a fixed XML/ISO format (`<Year4>-<Month,2>-<Day,2>`), so user-entered non-ISO input such as `01/15/2025 14:30:00` was silently rewritten to `2025-01-15T14:30:00`, discarding the original format, locale, and timezone/offset — an unexpected side effect of a "check" routine. Callers pass `AdjustValueIfGood = true`, so real user input flowed through this mutation.

## Changes Made
- `src/Apps/W1/Quality Management/app/src/Configuration/Result/QltyResultEvaluation.Codeunit.al`: Removed the six silent ISO-reformatting assignments (three in `CheckIfValueIsDateTime`, three in `CheckIfValueIsDate`) so the caller's original input is preserved. Signatures and the `AdjustValueIfGood` parameter are unchanged (callers and the Test Library wrappers depend on them); a benign `if AdjustValueIfGood then;` keeps the parameter referenced.
- `src/Apps/W1/Quality Management/test/src/QltyTestsResultEval.Codeunit.al`: Added two regression tests and updated three existing `ValueDate` assertions that had encoded the old (buggy) reformatting behavior to instead assert value preservation.

## Implementation Process

- Fix iterations: 1 of 5
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app published successfully
- Validation: ✅ Automated tests passing

## Validation Evidence

### Automated Test Evidence

#### Pre-Fix Test Results (Baseline)
Tests run before implementing the fix (expected to fail):

```
❌ ValueDate_NonIsoInput_NotSilentlyRewritten: FAILED
   Error: Expected:<1/15/2025> Actual:<2025-01-15> — input silently rewritten to ISO

❌ ValueDateTime_NonIsoInput_NotSilentlyRewritten: FAILED
   Error: Expected:<01/15/25 02:30:00 PM> Actual:<2025-01-15T14:30:00Z> — input silently rewritten to ISO
```

#### Post-Fix Test Results (Final)
Tests run after implementing the fix (expected to pass):

```
✅ ValueDate: PASSED
✅ ValueDateTime: PASSED
✅ ValueDate_NonIsoInput_NotSilentlyRewritten: PASSED (new test for bug scenario)
✅ ValueDateTime_NonIsoInput_NotSilentlyRewritten: PASSED (new test for bug scenario)
```

**Total Tests Run:** 4
**All Tests Passing:** ✅ Yes (full codeunit 139963 "Qlty. Tests - Result Eval." passed; 18 pre-existing failures in unrelated codeunits are not caused by this change)

#### Iteration Summary

- **Iteration 1**: ✅ Removed the six ISO-reformatting assignments and updated stale assertions; baseline regression tests turned green and all Quality Management result-evaluation tests passed.

## Validation Coverage

- [x] Existing tests pass
- [x] New tests added for bug scenario
- [x] Regression test for work item microsoft/BCAppsBugFix#202
- [x] Automated tests: All passing
- [x] Build and publish validation completed

## Review Notes
The `AdjustValueIfGood` parameter is retained in both signatures for caller/wrapper compatibility but no longer mutates the input. The change is minimal and additive-safe: no API signature, schema, or event changes.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#229: https://github.com/microsoft/BCAppsBugFix/pull/229
