### PR TITLE
[Bug Fix] #213: Order Planning by Project duplicates already-received demand after PO date change

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Requisition/GetUnplannedDemand.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Requisition/GetUnplannedDemand.Codeunit.al
@@ -361,7 +361,7 @@ codeunit 5520 "Get Unplanned Demand"
                 if UnplannedDemand."Demand Type" = UnplannedDemand."Demand Type"::Job then begin
                     GetJobTask(UnplannedDemand, JobPlanningLine);
                     NeededQtyBase := UnplannedDemand."Needed Qty. (Base)";
-                    ReducedJobQtyReceivedNotInvoiced := ReduceJobRealtedQtyReceivedNotInvoiced(UnplannedDemand."Demand Order No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.", TempUnplannedDemand."Item No.", TempUnplannedDemand."Variant Code", TempUnplannedDemand."Location Code", TempUnplannedDemand."Demand Date");
+                    ReducedJobQtyReceivedNotInvoiced := ReduceJobRealtedQtyReceivedNotInvoiced(UnplannedDemand."Demand Order No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.", TempUnplannedDemand."Item No.", TempUnplannedDemand."Variant Code", TempUnplannedDemand."Location Code");
                     UnplannedDemand."Needed Qty. (Base)" -= ReducedJobQtyReceivedNotInvoiced;
                     TotalNeedQuantityBase += NeededQtyBase;
 
@@ -428,7 +428,7 @@ codeunit 5520 "Get Unplanned Demand"
         JobPlanningLine.CalcFields("Reserved Qty. (Base)");
     end;
 
-    local procedure ReduceJobRealtedQtyReceivedNotInvoiced(JobNo: Code[20]; JobTaskNo: Code[20]; JobPlanningLineNo: Integer; ItemNo: Text[250]; VariantFilter: Text[250]; LocationFilter: Text[250]; DemandDate: Date): Decimal
+    local procedure ReduceJobRealtedQtyReceivedNotInvoiced(JobNo: Code[20]; JobTaskNo: Code[20]; JobPlanningLineNo: Integer; ItemNo: Text[250]; VariantFilter: Text[250]; LocationFilter: Text[250]): Decimal
     var
         Item: Record Item;
     begin
@@ -438,7 +438,6 @@ codeunit 5520 "Get Unplanned Demand"
         Item.Get(ItemNo);
         Item.SetRange("Variant Filter", VariantFilter);
         Item.SetRange("Location Filter", LocationFilter);
-        Item.SetRange("Date Filter", 0D, DemandDate);
         Item.SetRange("Drop Shipment Filter", false);
         exit(QtyOnPurchReceiptNotInvoiced(Item, JobNo, JobTaskNo, JobPlanningLineNo));
     end;
@@ -459,7 +458,6 @@ codeunit 5520 "Get Unplanned Demand"
         PurchaseLine.SetFilter("Variant Code", Item.GetFilter("Variant Filter"));
         PurchaseLine.SetFilter("Location Code", Item.GetFilter("Location Filter"));
         PurchaseLine.SetFilter("Drop Shipment", Item.GetFilter("Drop Shipment Filter"));
-        PurchaseLine.SetFilter("Expected Receipt Date", Item.GetFilter("Date Filter"));
         PurchaseLine.SetFilter("Shortcut Dimension 1 Code", Item.GetFilter("Global Dimension 1 Filter"));
         PurchaseLine.SetFilter("Shortcut Dimension 2 Code", Item.GetFilter("Global Dimension 2 Filter"));
         PurchaseLine.SetFilter("Unit of Measure Code", Item.GetFilter("Unit of Measure Filter"));

--- a/src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningI.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningI.Codeunit.al
@@ -1179,6 +1179,86 @@ codeunit 137046 "SCM Order Planning - I"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerPODateChange')]
+    procedure JobDemandNoSupplySuggestionAfterReceiptWhenPODateChangedPastDemandDate()
+    var
+        Item: Record Item;
+        Vendor: Record Vendor;
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        RequisitionLine: Record "Requisition Line";
+        LibraryJob: Codeunit "Library - Job";
+        PlanningDate: Date;
+        LaterDate: Date;
+        Qty: Decimal;
+    begin
+        // [FEATURE] [AI test 0.3]
+        // [SCENARIO 608151] Order Planning for Job demand does not create duplicate supply suggestion
+        // for items already received (but not invoiced) after PO Order/Posting Date is changed past demand date.
+        Initialize();
+
+        // [GIVEN] Item with Replenishment System = Purchase and a Vendor
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateItem(Item, Item."Replenishment System"::Purchase, '', '', Vendor."No.");
+
+        // [GIVEN] Job with Apply Usage Link = TRUE
+        LibraryJob.CreateJob(Job);
+        Job.Validate("Apply Usage Link", true);
+        Job.Modify(true);
+
+        // [GIVEN] Job Task of type Posting
+        LibraryJob.CreateJobTask(Job, JobTask);
+
+        // [GIVEN] Budget Job Planning Line for item with Quantity = 2
+        Qty := 2;
+        PlanningDate := WorkDate();
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::Budget, JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, Qty);
+        JobPlanningLine.Modify(true);
+
+        // [GIVEN] Calculate Order Planning for Job Demand and carry out to make Purchase Order
+        LibraryPlanning.CalculateOrderPlanJob(RequisitionLine);
+        // Set Supply From explicitly on the supply line (planning engine doesn't auto-set it for job demand in isolation)
+        RequisitionLine.SetRange("Demand Order No.", Job."No.");
+        RequisitionLine.SetRange(Type, RequisitionLine.Type::Item);
+        RequisitionLine.SetRange("No.", Item."No.");
+        RequisitionLine.FindFirst();
+        RequisitionLine.Validate("Supply From", Vendor."No.");
+        RequisitionLine.Modify(true);
+        LibraryPlanning.CarryOutActionMsgPlanWksh(RequisitionLine);
+
+        // [GIVEN] Retrieve the created Purchase Order
+        PurchaseLine.SetRange("Job No.", Job."No.");
+        PurchaseLine.SetRange("No.", Item."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+
+        // [GIVEN] Change Order Date and Posting Date on Purchase Order to a date AFTER the planning date
+        LaterDate := CalcDate('<+10D>', PlanningDate);
+        PurchaseHeader.Validate("Order Date", LaterDate);
+        PurchaseHeader.Validate("Posting Date", LaterDate);
+        PurchaseHeader.Modify(true);
+
+        // [GIVEN] Post Receipt only (not invoice) - the item is received but not invoiced
+        PurchaseHeader.Validate("Vendor Invoice No.", LibraryUtility.GenerateGUID());
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [WHEN] Delete existing requisition lines and re-run Order Planning for Job Demand
+        RequisitionLine.DeleteAll();
+        LibraryPlanning.CalculateOrderPlanJob(RequisitionLine);
+
+        // [THEN] No new Requisition Line is suggested for that item/job (receipt already fulfills demand)
+        RequisitionLine.SetRange("No.", Item."No.");
+        RequisitionLine.SetRange("Demand Order No.", Job."No.");
+        Assert.RecordIsEmpty(RequisitionLine);
+    end;
+
+    [Test]
     procedure SalesDemandFilterOnOrderPlanningShowsOnlySalesDemandRows()
     var
         TempSalesReceivablesSetup: Record "Sales & Receivables Setup" temporary;
@@ -2236,6 +2316,12 @@ codeunit 137046 "SCM Order Planning - I"
 
     [ConfirmHandler]
     procedure ConfirmHandlerYes(ConfirmMessage: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerPODateChange(Question: Text[1024]; var Reply: Boolean)
     begin
         Reply := true;
     end;


### PR DESCRIPTION
## Bug Reference Work item microsoft/BCAppsBugFix#213 ([AB#608151](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/608151))  Fixes microsoft/BCAppsBugFix#213  ## Summary Order Planning by Project (Job demand) no longer creates a duplicate supply suggestion for quantity that has already been received (but not yet invoiced) on a Purchase Order whose Order Date / Posting Date were changed to a date after the demand date.  ## Root Cause In `GetUnplannedDemand.Codeunit.al`, `CalcNeededDemands` reduces Job demand by the received-but-not-invoiced quantity on the linked Purchase Order via `ReduceJobRealtedQtyReceivedNotInvoiced`. That procedure set `Item.SetRange("Date Filter", 0D, DemandDate)`, and `QtyOnPurchReceiptNotInvoiced` applied it as `PurchaseLine.SetFilter("Expected Receipt Date", Item.GetFilter("Date Filter"))`. It therefore counted received-not-invoiced quantity only when the Purchase Line's `Expected Receipt Date` was on or before the demand date. When the user moves the Purchase Order's Order/Posting Date to a date after the planning demand date, the Purchase Line's `Expected Receipt Date` recalculates past that window, the already-received quantity is excluded, and the worksheet re-suggests the already-fulfilled demand. Received-but-not-invoiced quantity is physical supply that has already fulfilled the demand and must be counted regardless of the expected receipt date.  ## Changes Made - `src/Layers/W1/BaseApp/Inventory/Requisition/GetUnplannedDemand.Codeunit.al`: removed the `DemandDate` parameter and the `Item.SetRange("Date Filter", 0D, DemandDate)` call from `ReduceJobRealtedQtyReceivedNotInvoiced`, removed the `PurchaseLine.SetFilter("Expected Receipt Date", ...)` filter from `QtyOnPurchReceiptNotInvoiced`, and updated the single call site in `CalcNeededDemands`. Received-but-not-invoiced quantity is now counted for the job / job task / job planning line / item / variant / location regardless of the PO's Expected Receipt Date. All other filters are unchanged. - `src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningI.Codeunit.al`: added regression test `JobDemandNoSupplySuggestionAfterReceiptWhenPODateChangedPastDemandDate` reproducing the reported scenario.  ## Implementation Process  - Fix iterations: 1 of 5 - Compilation: ✅ All projects compile successfully - Publish: ✅ Modified app published successfully - Validation: ✅ Automated tests passing  ## Validation Evidence  ### Automated Test Evidence  #### Pre-Fix Test Results (Baseline) Tests run before implementing the fix (expected to fail):  ``` ❌ JobDemandNoSupplySuggestionAfterReceiptWhenPODateChangedPastDemandDate: FAILED    Error: Assert.TableIsEmpty failed. Table <Requisition Line> with filter    <No.: GL00000001, Demand Order No.: ZZZJ001, User ID: ADMIN> must not contain records. ```  #### Post-Fix Test Results (Final) Tests run after implementing the fix (expected to pass):  ``` ✅ OnRun: PASSED ✅ JobDemandNoSupplySuggestionAfterReceiptWhenPODateChangedPastDemandDate: PASSED (new test for bug scenario) ```  **Total Tests Run:** 3 **All Tests Passing:** ✅ Yes  #### Iteration Summary  - **Iteration 1**: Removed the `DemandDate` parameter, the `Date Filter`, and the `Expected Receipt Date` filter so received-but-not-invoiced quantity is counted regardless of PO date. ✅ All tests passing.  ## Validation Coverage  - [x] New test added for bug scenario - [x] Regression test for work item microsoft/BCAppsBugFix#213 - [x] Automated tests: All passing - [x] Build and publish validation completed  ## Review Notes The fix is a `local` procedure change scoped tightly to Job No., Job Task No., Job Planning Line No., Item No., Variant, and Location; no public API or signature visible outside the codeunit changed. Independent critique returned Accept and the AL review engine returned zero Critical/High/Medium findings.  🤖 Generated by the bc-fix-bug skill 

---
Promoted from microsoft/BCAppsBugFix#234: https://github.com/microsoft/BCAppsBugFix/pull/234

Fixes [AB#608151](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/608151)




