### PR TITLE
[28.x] [Quality Management] Enhance bin selection logic for transfer workflows and add related tests

### DIFF
--- a/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyInspectionUtility.Codeunit.al
@@ -2610,6 +2610,16 @@ codeunit 139940 "Qlty. Inspection Utility"
     end;
 
     /// <summary>
+    /// Wrapper for QltyWorkflowResponse.GetWellKnownInTransit
+    /// </summary>
+    internal procedure GetWellKnownInTransit(): Text
+    var
+        QltyWorkflowResponse: Codeunit "Qlty. Workflow Response";
+    begin
+        exit(QltyWorkflowResponse.GetWellKnownInTransit());
+    end;
+
+    /// <summary>
     /// Wrapper for QltyWorkflowResponse.GetStepConfigurationValue
     /// </summary>
     internal procedure GetStepConfigurationValue(WorkflowStepArgument: Record "Workflow Step Argument"; CurrentKey: Text): Text

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/Transfer/QltyDispTransfer.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/Transfer/QltyDispTransfer.Codeunit.al
@@ -108,7 +108,8 @@ codeunit 20444 "Qlty. Disp. Transfer" implements "Qlty. Disposition"
         TransferHeader."Qlty. Inspection No." := QltyInspectionHeader."No.";
         TransferHeader."Qlty. Re-inspection No." := QltyInspectionHeader."Re-inspection No.";
         TransferHeader.Insert(true);
-        TransferHeader.Validate("Direct Transfer", DirectTransfer);
+        if DirectTransfer then
+            TransferHeader.Validate("Direct Transfer", true);
     end;
 
     local procedure CreateTransferLineWithOutboundTracking(var QltyInspectionHeader: Record "Qlty. Inspection Header"; var TempQuantityToActQltyDispositionBuffer: Record "Qlty. Disposition Buffer" temporary; var TransferHeader: Record "Transfer Header") Created: Boolean

--- a/src/Apps/W1/Quality Management/app/src/Dispositions/Transfer/QltyDispTransfer.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Dispositions/Transfer/QltyDispTransfer.Codeunit.al
@@ -122,12 +122,16 @@ codeunit 20444 "Qlty. Disp. Transfer" implements "Qlty. Disposition"
         TransferLine.Validate("Item No.", QltyInspectionHeader."Source Item No.");
         if QltyInspectionHeader."Source Variant Code" <> '' then
             TransferLine.Validate("Variant Code", QltyInspectionHeader."Source Variant Code");
+
+        Location.SetLoadFields("Bin Mandatory", "Directed Put-away and Pick");
         if TempQuantityToActQltyDispositionBuffer."Bin Filter" <> '' then
             if Location.Get(TempQuantityToActQltyDispositionBuffer.GetFromLocationCode()) then
                 if Location."Bin Mandatory" and not Location."Directed Put-away and Pick" then
                     TransferLine.Validate("Transfer-from Bin Code", TempQuantityToActQltyDispositionBuffer.GetFromBinCode());
         if TempQuantityToActQltyDispositionBuffer."New Bin Code" <> '' then
-            TransferLine.Validate("Transfer-To Bin Code", TempQuantityToActQltyDispositionBuffer."New Bin Code");
+            if Location.Get(TempQuantityToActQltyDispositionBuffer."New Location Code") then
+                if Location."Bin Mandatory" and not Location."Directed Put-away and Pick" then
+                    TransferLine.Validate("Transfer-To Bin Code", TempQuantityToActQltyDispositionBuffer."New Bin Code");
 
         TransferLine.Validate(Quantity, TempQuantityToActQltyDispositionBuffer."Qty. To Handle (Base)");
         TransferLine.Validate("Qty. to Ship", TempQuantityToActQltyDispositionBuffer."Qty. To Handle (Base)");

--- a/src/Apps/W1/Quality Management/app/src/Workflow/QltyWorkflowRespOptions.PageExt.al
+++ b/src/Apps/W1/Quality Management/app/src/Workflow/QltyWorkflowRespOptions.PageExt.al
@@ -388,10 +388,12 @@ pageextension 20403 "Qlty. Workflow Resp. Options" extends "Workflow Response Op
                             QltyWorkflowResponse.SetStepConfigurationValue(Rec, QltyWorkflowResponse.GetWellKnownKeyLocation(), QltyLocationCode);
                             QltyShowBinCode := true;
                             if DestinationLocation.Get(QltyLocationCode) then begin
-                                QltyShowBinCode := DestinationLocation."Bin Mandatory";
+                                QltyShowBinCode := DestinationLocation."Bin Mandatory" and not DestinationLocation."Directed Put-away and Pick";
                                 if QltyBinCode <> '' then
-                                    if not DestinationBin.Get(QltyLocationCode, QltyBinCode) then
+                                    if not QltyShowBinCode or not DestinationBin.Get(QltyLocationCode, QltyBinCode) then begin
                                         QltyBinCode := '';
+                                        QltyWorkflowResponse.SetStepConfigurationValue(Rec, QltyWorkflowResponse.GetWellKnownKeyBin(), QltyBinCode);
+                                    end;
                             end;
                         end;
                     }
@@ -1044,6 +1046,6 @@ pageextension 20403 "Qlty. Workflow Resp. Options" extends "Workflow Response Op
 
         QltyShowBinCode := true;
         if Location.Get(QltyLocationCode) then;
-        QltyShowBinCode := Location."Bin Mandatory";
+        QltyShowBinCode := Location."Bin Mandatory" and not Location."Directed Put-away and Pick";
     end;
 }

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
@@ -507,6 +507,7 @@ codeunit 139969 "Qlty. Tests - Workflows"
         QltyManagementSetup: Record "Qlty. Management Setup";
         Location: Record Location;
         DestinationLocation: Record Location;
+        InTransitLocation: Record Location;
         ToLoadQltyInspectionResult: Record "Qlty. Inspection Result";
         Bin: Record Bin;
         DestinationBin: Record Bin;
@@ -543,6 +544,7 @@ codeunit 139969 "Qlty. Tests - Workflows"
 
         if DirectedPutAwayAndPick then begin
             LibraryWarehouse.CreateFullWMSLocation(DestinationLocation, 1);
+            LibraryWarehouse.CreateInTransitLocation(InTransitLocation);
             DestinationBin.SetRange("Location Code", DestinationLocation.Code);
             DestinationBin.FindFirst();
         end else begin
@@ -570,7 +572,9 @@ codeunit 139969 "Qlty. Tests - Workflows"
         QltyInspectionUtility.SetStepConfigurationValueAsQuantityBehaviorEnum(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownMoveAll(), MoveBehavior::"Failed Quantity");
         QltyInspectionUtility.SetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownKeyLocation(), DestinationLocation.Code);
         QltyInspectionUtility.SetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownKeyBin(), DestinationBin.Code);
-        QltyInspectionUtility.SetStepConfigurationValueAsBoolean(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownDirectTransfer(), true);
+        QltyInspectionUtility.SetStepConfigurationValueAsBoolean(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownDirectTransfer(), not DirectedPutAwayAndPick);
+        if DirectedPutAwayAndPick then
+            QltyInspectionUtility.SetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownInTransit(), InTransitLocation.Code);
         Workflow.Enabled := true;
         Workflow.Modify();
 
@@ -582,10 +586,12 @@ codeunit 139969 "Qlty. Tests - Workflows"
         QltyInspectionHeader.Validate("Result Code", ToLoadQltyInspectionResult.Code);
         QltyInspectionHeader.Modify(true);
 
-        // [THEN] A direct transfer order is created with the failed quantity
+        // [THEN] A transfer order is created with the failed quantity
         TransferHeader.SetRange("Transfer-from Code", Location.Code);
         TransferHeader.SetRange("Transfer-to Code", DestinationLocation.Code);
-        TransferHeader.SetRange("Direct Transfer", true);
+        TransferHeader.SetRange("Direct Transfer", not DirectedPutAwayAndPick);
+        if DirectedPutAwayAndPick then
+            TransferHeader.SetRange("In-Transit Code", InTransitLocation.Code);
 
         LibraryAssert.AreEqual(1, TransferHeader.Count(), 'Should be one transfer header created.');
 

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsWorkflows.Codeunit.al
@@ -424,6 +424,85 @@ codeunit 139969 "Qlty. Tests - Workflows"
 
     [Test]
     procedure CreateTransfer_OnInspectionChange()
+    begin
+        CreateTransferOnInspectionChange(false);
+    end;
+
+    [Test]
+    procedure CreateTransferToDirectedLocation_OnInspectionChange()
+    begin
+        CreateTransferOnInspectionChange(true);
+    end;
+
+    [Test]
+    procedure ChangeTransferDestinationLocation_ClearsPersistedBin()
+    var
+        Location: Record Location;
+        NewLocation: Record Location;
+        Bin: Record Bin;
+        NewBin: Record Bin;
+        Workflow: Record Workflow;
+        ResponseWorkflowStep: Record "Workflow Step";
+        WorkflowStepArgument: Record "Workflow Step Argument";
+        LibraryUtility: Codeunit "Library - Utility";
+        WorkflowResponseOptions: TestPage "Workflow Response Options";
+    begin
+        // [SCENARIO] Changing a transfer destination clears a bin that does not exist at the new location
+        Initialize();
+
+        // [GIVEN] A workflow response configured with a destination location and bin
+        LibraryWarehouse.CreateLocationWMS(Location, true, false, false, false, false);
+        LibraryWarehouse.CreateBin(Bin, Location.Code, LibraryUtility.GenerateGUID(), '', '');
+        LibraryWarehouse.CreateLocationWMS(NewLocation, true, false, false, false, false);
+        LibraryWarehouse.CreateBin(NewBin, NewLocation.Code, LibraryUtility.GenerateGUID(), '', '');
+        CreateWorkflowWithSingleResponse(Workflow, QltyInspectionUtility.GetInspectionHasChangedEvent(), QltyInspectionUtility.GetWorkflowResponseCreateTransfer(), false);
+        CreateWorkflowResponseArgument(Workflow, CopyStr(QltyInspectionUtility.GetWorkflowResponseCreateTransfer(), 1, 128), ResponseWorkflowStep, WorkflowStepArgument);
+        QltyInspectionUtility.SetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownKeyLocation(), Location.Code);
+        QltyInspectionUtility.SetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownKeyBin(), Bin.Code);
+
+        // [WHEN] The destination location is changed to one that does not contain the configured bin
+        WorkflowResponseOptions.OpenEdit();
+        WorkflowResponseOptions.GoToRecord(WorkflowStepArgument);
+        WorkflowResponseOptions.Qlty_LocationCode.SetValue(NewLocation.Code);
+
+        // [THEN] The bin is cleared from both the page and the persisted workflow configuration
+        LibraryAssert.AreEqual('', WorkflowResponseOptions.Qlty_BinCode.Value(), 'Should clear the destination bin on the page.');
+        WorkflowResponseOptions.Close();
+        LibraryAssert.AreEqual('', QltyInspectionUtility.GetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownKeyBin()), 'Should clear the persisted destination bin.');
+
+        DeleteWorkflows();
+    end;
+
+    [Test]
+    procedure DirectedTransferDestination_DisablesBinSelection()
+    var
+        DestinationLocation: Record Location;
+        Workflow: Record Workflow;
+        ResponseWorkflowStep: Record "Workflow Step";
+        WorkflowStepArgument: Record "Workflow Step Argument";
+        WorkflowResponseOptions: TestPage "Workflow Response Options";
+    begin
+        // [SCENARIO] A directed put-away and pick transfer destination does not allow bin selection
+        Initialize();
+
+        // [GIVEN] A workflow response configured with a directed put-away and pick destination
+        LibraryWarehouse.CreateFullWMSLocation(DestinationLocation, 1);
+        CreateWorkflowWithSingleResponse(Workflow, QltyInspectionUtility.GetInspectionHasChangedEvent(), QltyInspectionUtility.GetWorkflowResponseCreateTransfer(), false);
+        CreateWorkflowResponseArgument(Workflow, CopyStr(QltyInspectionUtility.GetWorkflowResponseCreateTransfer(), 1, 128), ResponseWorkflowStep, WorkflowStepArgument);
+        QltyInspectionUtility.SetStepConfigurationValue(WorkflowStepArgument, QltyInspectionUtility.GetWellKnownKeyLocation(), DestinationLocation.Code);
+
+        // [WHEN] The workflow response options are opened
+        WorkflowResponseOptions.OpenEdit();
+        WorkflowResponseOptions.GoToRecord(WorkflowStepArgument);
+
+        // [THEN] Destination bin selection is disabled
+        LibraryAssert.IsFalse(WorkflowResponseOptions.Qlty_BinCode.Enabled(), 'Should disable bin selection for directed put-away and pick locations.');
+        WorkflowResponseOptions.Close();
+
+        DeleteWorkflows();
+    end;
+
+    local procedure CreateTransferOnInspectionChange(DirectedPutAwayAndPick: Boolean)
     var
         QltyManagementSetup: Record "Qlty. Management Setup";
         Location: Record Location;
@@ -462,8 +541,14 @@ codeunit 139969 "Qlty. Tests - Workflows"
 
         LibraryWarehouse.CreateNumberOfBins(Location.Code, '', '', 3, false);
 
-        LibraryWarehouse.CreateLocationWMS(DestinationLocation, true, false, false, false, false);
-        LibraryWarehouse.CreateBin(DestinationBin, DestinationLocation.Code, LibraryUtility.GenerateGUID(), '', '');
+        if DirectedPutAwayAndPick then begin
+            LibraryWarehouse.CreateFullWMSLocation(DestinationLocation, 1);
+            DestinationBin.SetRange("Location Code", DestinationLocation.Code);
+            DestinationBin.FindFirst();
+        end else begin
+            LibraryWarehouse.CreateLocationWMS(DestinationLocation, true, false, false, false, false);
+            LibraryWarehouse.CreateBin(DestinationBin, DestinationLocation.Code, LibraryUtility.GenerateGUID(), '', '');
+        end;
 
         // [GIVEN] A purchase order received with inspection created
         LibraryInventory.CreateItem(Item);
@@ -512,7 +597,10 @@ codeunit 139969 "Qlty. Tests - Workflows"
         TransferLine.FindFirst();
         LibraryAssert.AreEqual(QltyInspectionHeader."Fail Quantity", TransferLine.Quantity, 'Should have requested quantity.');
         LibraryAssert.AreEqual(Bin.Code, TransferLine."Transfer-from Bin Code", 'Should have transfer-from bin code.');
-        LibraryAssert.AreEqual(DestinationBin.Code, TransferLine."Transfer-To Bin Code", 'Should have transfer-to bin code.');
+        if DirectedPutAwayAndPick then
+            LibraryAssert.AreEqual('', TransferLine."Transfer-To Bin Code", 'Should not have a transfer-to bin code for a directed put-away and pick location.')
+        else
+            LibraryAssert.AreEqual(DestinationBin.Code, TransferLine."Transfer-To Bin Code", 'Should have transfer-to bin code.');
 
         QltyInspectionGenRule.Delete();
         DeleteWorkflows();


### PR DESCRIPTION
## What & why

Fixes:
1. Do not apply a destination bin for directed put-away and pick locations
2. Clear an invalid bin from the persisted workflow configuration

## Linked work

Fixes [AB#630606](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630606)






