### PR TITLE
[IRS Forms] Performance optimization

### DIFF
--- a/src/Apps/US/IRSForms/app/src/VendorFormBox/IRS1099FormBoxCalcImpl.Codeunit.al
+++ b/src/Apps/US/IRSForms/app/src/VendorFormBox/IRS1099FormBoxCalcImpl.Codeunit.al
@@ -66,7 +66,7 @@ codeunit 10041 "IRS 1099 Form Box Calc. Impl." implements "IRS 1099 Form Box Cal
         PmtVendLedgEntry: Record "Vendor Ledger Entry";
         TempInteger: Record "Integer" temporary;
     begin
-        FilterPaymentVendorLedgerEntries(PmtVendLedgEntry, IRSReportingPeriod);
+        FilterPaymentVendorLedgerEntries(PmtVendLedgEntry, IRSReportingPeriod, VendorNo);
         if PmtVendLedgEntry.FindSet() then
             repeat
                 GetAppliedVendorEntriesFromtPmtEntry(IRS1099VendEntryBuffer, TempIRS1099Form, TempInteger, PmtVendLedgEntry, VendorNo);
@@ -92,12 +92,14 @@ codeunit 10041 "IRS 1099 Form Box Calc. Impl." implements "IRS 1099 Form Box Cal
             until PmtDtldVendLedgEntry.Next() = 0;
     end;
 
-    local procedure FilterPaymentVendorLedgerEntries(var VendLedgEntry: Record "Vendor Ledger Entry"; IRSReportingPeriod: Record "IRS Reporting Period")
+    local procedure FilterPaymentVendorLedgerEntries(var VendLedgEntry: Record "Vendor Ledger Entry"; IRSReportingPeriod: Record "IRS Reporting Period"; VendorNo: Code[20])
     begin
         VendLedgEntry.SetCurrentKey("Document Type", "Vendor No.", "Posting Date");
         VendLedgEntry.SetLoadFields("Document Type", "Vendor No.", "Posting Date", "Closed by Entry No.");
         VendLedgEntry.SetFilter("Document Type", '%1|%2', VendLedgEntry."Document Type"::Payment, VendLedgEntry."Document Type"::Refund);
         VendLedgEntry.SetRange("Posting Date", IRSReportingPeriod."Starting Date", IRSReportingPeriod."Ending Date");
+        if VendorNo <> '' then
+            VendLedgEntry.SetRange("Vendor No.", VendorNo);
     end;
 
     local procedure FilterApplicationDetailedVendorLedgerEntries(var DtldVendLedgEntry: Record "Detailed Vendor Ledg. Entry"; VendLedgEntry: Record "Vendor Ledger Entry")
@@ -111,7 +113,7 @@ codeunit 10041 "IRS 1099 Form Box Calc. Impl." implements "IRS 1099 Form Box Cal
 
     local procedure FindRelatedApplicationDetailedVendorLedgerEntries(var DtldVendLedgEntry: Record "Detailed Vendor Ledg. Entry"; VendLedgEntry: Record "Vendor Ledger Entry"; RelatedDtldVendLedgEntry: Record "Detailed Vendor Ledg. Entry")
     begin
-        DtldVendLedgEntry.SetCurrentKey("Vendor Ledger Entry No.", "Entry Type");
+        DtldVendLedgEntry.SetCurrentKey("Application No.", "Vendor No.", "Entry Type");
         DtldVendLedgEntry.SetLoadFields("Vendor Ledger Entry No.", "Entry Type", "Vendor No.", "Transaction No.", "Application No.", Amount, "Amount (LCY)");
         DtldVendLedgEntry.SetFilter("Vendor Ledger Entry No.", '<>%1', VendLedgEntry."Entry No.");
         DtldVendLedgEntry.SetRange("Entry Type", DtldVendLedgEntry."Entry Type"::Application);


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

**What**

In codeunit 10041 "IRS 1099 Form Box Calc. Impl.":

FindRelatedApplicationDetailedVendorLedgerEntries: changed SetCurrentKey from ("Vendor Ledger Entry No.", "Entry Type") to ("Application No.", "Vendor No.", "Entry Type") (existing Key10).
FilterPaymentVendorLedgerEntries: added a VendorNo parameter and applies SetRange("Vendor No.", VendorNo) when a specific vendor is requested.
No schema changes — both keys already exist on Detailed Vendor Ledg. Entry. No new keys/SIFT.

**Why**

Vendor form-box calculation walks every payment/refund in the period and, for each application, queries related application detailed ledger entries. Profiling showed a single query (FindRelatedApplicationDetailedVendorLedgerEntries) accounting for ~86% of a ~10-minute run (~167k executions). Its old current key forced an ORDER BY "Vendor Ledger Entry No.", whose only predicate was a non-sargable <> — so SQL scanned in that order and filtered the selective equality predicates (Application No., Vendor No., Entry Type) as residuals. Aligning the current key with those equality filters lets the optimizer satisfy the ordering with a selective index seek instead of a broad scan. The added vendor filter stops single-vendor recalculations from enumerating the whole period's payments. Runtime was constant regardless of form count because the cost is driven by payment/application history, not the number of forms — this addresses that root cause.


## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#647491](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647491)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->
Existing IRS1099FormCalcTests cover the affected paths (multi-application aggregation and single-vendor-among-others); calculation output is unchanged since aggregation is order-independent. Perf win to be confirmed by re-profiling / query plan

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

