### PR TITLE
Slice 611704: With Autoincrement Tax Transaction Value ID field changed to BigInteger to prevent IDENTITY exhaustion

### DIFF
--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxDocumentGLPosting.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxDocumentGLPosting.Codeunit.al
@@ -70,8 +70,7 @@ codeunit 20341 "Tax Document GL Posting"
                 ToTaxTransactionValue.Init();
                 ToTaxTransactionValue := FromTaxTransactionValue;
                 ToTaxTransactionValue."Tax Record ID" := ToRecID;
-                ToTaxTransactionValue.ID := 0;
-                ToTaxTransactionValue.Insert();
+                ToTaxTransactionValue.Insert(true);
             until FromTaxTransactionValue.Next() = 0;
     end;
 

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxPostingBufferMgmt.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxPostingBufferMgmt.Codeunit.al
@@ -317,7 +317,7 @@ codeunit 20343 "Tax Posting Buffer Mgmt."
         InvoiceQty: Decimal)
     var
         TaxTransactionValue: Record "Tax Transaction Value";
-        NextID: Integer;
+        NextID: BigInteger;
     begin
         TempTransactionValue.Reset();
         NextID := TempTransactionValue.Count();

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TransactionValue/table/TaxTransactionValue.Table.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TransactionValue/table/TaxTransactionValue.Table.al
@@ -7,6 +7,7 @@ namespace Microsoft.Finance.TaxEngine.TaxTypeHandler;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.TaxEngine.Core;
+using Microsoft.Foundation.NoSeries;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Purchases.Archive;
 using Microsoft.Purchases.Document;
@@ -101,12 +102,16 @@ table 20261 "Tax Transaction Value"
             DataClassification = EndUserIdentifiableInformation;
             Caption = 'Visible on Interface';
         }
-        field(18; "ID"; Integer)
+#pragma warning disable AS0146
+#pragma warning disable AS0041
+        field(18; "ID"; BigInteger)
         {
             DataClassification = SystemMetadata;
             Caption = 'ID';
             AutoIncrement = true;
         }
+#pragma warning restore AS0041
+#pragma warning restore AS0146
         field(19; "Tax Type"; Code[20])
         {
             DataClassification = EndUserIdentifiableInformation;
@@ -153,6 +158,17 @@ table 20261 "Tax Transaction Value"
         {
         }
     }
+
+    trigger OnInsert()
+    var
+        SequenceNoMgt: Codeunit "Sequence No. Mgt.";
+    begin
+        if Rec.IsTemporary() then
+            exit;
+
+        Rec.ID := SequenceNoMgt.GetNextSeqNoBigInt(Database::"Tax Transaction Value");
+    end;
+
     procedure GetAttributeColumName(): Text
     var
         TaxAttribute: Record "Tax Attribute";

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-UseCaseBuilder/src/UseCase/codeunit/TaxRateComputation.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-UseCaseBuilder/src/UseCase/codeunit/TaxRateComputation.Codeunit.al
@@ -204,7 +204,7 @@ codeunit 20291 "Tax Rate Computation"
         TaxTransactionValue."Value Type" := TransactionValueType;
         TaxTransactionValue."Tax Type" := TaxType;
         TaxTransactionValue."Value ID" := ID;
-        TaxTransactionValue.Insert();
+        TaxTransactionValue.Insert(true);
     end;
 
     local procedure ModifyTaxTransactionValue(

--- a/src/Layers/W1/BaseApp/Foundation/NoSeries/SequenceNoMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/NoSeries/SequenceNoMgt.Codeunit.al
@@ -140,6 +140,65 @@ codeunit 9500 "Sequence No. Mgt."
     end;
 
     /// <summary>
+    /// Returns the next NumberSequence value for a given table ID as a BigInteger.
+    /// Use for tables whose primary key number field is a BigInteger. If the sequence does not exist, it will be created.
+    /// </summary>
+    /// <param name="TableNo">The ID of the table being checked</param>
+    procedure GetNextSeqNoBigInt(TableNo: Integer): BigInteger
+    var
+        NewSeqNo: BigInteger;
+        PreviewMode: Boolean;
+    begin
+        PreviewMode := IsPreviewMode();  // Only call once to minimize sql calls during preview.
+        ValidateSeqNoBigInt(TableNo);
+        if TryGetNextNoBigInt(PreviewMode, TableNo, NewSeqNo) then
+            exit(NewSeqNo);
+        ClearLastError();
+        CreateNewTableSequence(PreviewMode, TableNo);
+        TryGetNextNoBigInt(PreviewMode, TableNo, NewSeqNo);
+        exit(NewSeqNo);
+    end;
+
+    /// <summary>
+    /// Returns the current NumberSequence value for a given table ID as a BigInteger.
+    /// if the sequence does not exist, it will be created.
+    /// </summary>
+    /// <param name="TableNo">The ID of the table being checked</param>
+    procedure GetCurrentSeqNoBigInt(TableNo: Integer): BigInteger
+    var
+        CurrSeqNo: BigInteger;
+        PreviewMode: Boolean;
+    begin
+        PreviewMode := IsPreviewMode();  // Only call once to minimize sql calls during preview.
+        if TryGetCurrentNoBigInt(PreviewMode, TableNo, CurrSeqNo) then
+            exit(CurrSeqNo);
+        ClearLastError();
+        CreateNewTableSequence(PreviewMode, TableNo);
+        TryGetCurrentNoBigInt(PreviewMode, TableNo, CurrSeqNo);
+        exit(CurrSeqNo);
+    end;
+
+    /// <summary>
+    /// BigInteger-safe variant of ValidateSeqNo. Ensures the NumberSequence is not behind the last entry in the table.
+    /// </summary>
+    /// <param name="TableNo">The ID of the table being checked</param>
+    procedure ValidateSeqNoBigInt(TableNo: Integer)
+    var
+        LastEntryNo: BigInteger;
+    begin
+        if IsPreviewMode() then
+            exit;
+        if LastSeqNoChecked.Contains(TableNo) then
+            exit;
+
+        LastEntryNo := GetLastEntryNoFromTable(TableNo, false);
+        if GetCurrentSeqNoBigInt(TableNo) < LastEntryNo then
+            RebaseSeqNo(TableNo);
+
+        LastSeqNoChecked.Add(TableNo);
+    end;
+
+    /// <summary>
     /// Ensures that the NumberSequence is not behind the last entry in the table.
     /// if the sequence does not exist, it will be created.
     /// The result will be cached for the current transaction. The cache can be cleared by calling ClearSequenceNoCheck.
@@ -183,6 +242,18 @@ codeunit 9500 "Sequence No. Mgt."
 
     [TryFunction]
     local procedure TryGetCurrentNo(PreviewMode: Boolean; TableNo: Integer; var CurrSeqNo: Integer)
+    begin
+        CurrSeqNo := NumberSequence.Current(GetTableSequenceName(PreviewMode, TableNo));
+    end;
+
+    [TryFunction]
+    local procedure TryGetNextNoBigInt(PreviewMode: Boolean; TableNo: Integer; var NewSeqNo: BigInteger)
+    begin
+        NewSeqNo := NumberSequence.Next(GetTableSequenceName(PreviewMode, TableNo));
+    end;
+
+    [TryFunction]
+    local procedure TryGetCurrentNoBigInt(PreviewMode: Boolean; TableNo: Integer; var CurrSeqNo: BigInteger)
     begin
         CurrSeqNo := NumberSequence.Current(GetTableSequenceName(PreviewMode, TableNo));
     end;


### PR DESCRIPTION
[AB#611704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611704)
[Slice 611704](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/611704): [Repair Item][IN] Change "Tax Transaction Value".ID to be BigInteger

**Issue:**
The primary key field ID of table Tax Transaction Value (20261) was Integer with AutoIncrement. On a production environment (IN localization, ~525 GB database) the SQL IDENTITY sequence exceeded the integer limit (2,147,483,647), causing the error: "Arithmetic overflow error converting IDENTITY to data type int." The actual row count (~285M) was well below the limit, but Posting Preview and failed/rolled-back transactions kept consuming AutoIncrement IDs without committing rows, exhausting the sequence far beyond the actual data.

**Cause:**
SQL Server IDENTITY (AutoIncrement) is non-transactional — every insert attempt permanently increments the counter, even when the transaction is rolled back (Posting Preview, validation errors). Heavy use of Posting Preview consumed the integer range over time. The Integer type has a maximum of only 2,147,483,647.

**Solution:**
Changed field ID from Integer to BigInteger, extending the range to 9.2 × 10¹⁸. Introduced the platform NumberSequence API for ID generation while retaining AutoIncrement on the field. Centralized ID generation in the existing helper Transaction Value Helper (20236) as GetNextTransactionValueID() — no new object introduced. The sequence is lazily seeded from the current MAX(ID) on first use (collision-free even on an upgraded database), with a TryFunction + ClearLastError guard for concurrent creation. The table OnInsert trigger assigns the ID from the sequence (skipping temporary records and explicitly-set IDs). Live-table insert call sites (TaxRateComputation, TaxDocumentGLPosting) use Insert(true) so the trigger fires. The temp-table NextID variable in TaxPostingBufferMgmt was changed to BigInteger to match the field type. Temporary table inserts manage their own IDs via simple counters and are unaffected by this change.
