### PR TITLE
[NL][Telebank] Payment History export crashes when combining entries

### DIFF
--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
@@ -170,7 +170,7 @@ codeunit 1222 "SEPA CT-Prepare Source"
         RemittanceNotification.Id := GetRemittanceTruncationNotificationId();
         RemittanceNotification.Message(RemittanceTruncatedMsg);
         RemittanceNotification.Scope(NotificationScope::LocalScope);
-        RemittanceNotification.AddAction(DontShowAgainTxt, Codeunit "SEPA CT-Prepare Source", 'DisableRemittanceTruncationNotification');
+        RemittanceNotification.AddAction(DontShowAgainTxt, Codeunit::"SEPA CT-Prepare Source", 'DisableRemittanceTruncationNotification');
         RemittanceNotification.Send();
     end;
 

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.Bank.DirectDebit;
 
 using Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Journal;
+using System.Environment.Configuration;
 
 /// <summary>
 /// Prepares general journal line data for SEPA credit transfer XML export by copying and organizing
@@ -58,6 +59,7 @@ codeunit 1222 "SEPA CT-Prepare Source"
         AppliedDocNoList: Text;
         DescriptionLen: Integer;
         IsHandled: Boolean;
+        RemittanceTruncated: Boolean;
     begin
         IsHandled := false;
         OnBeforeCreateTempJnlLines(FromGenJnlLine, TempGenJnlLine, IsHandled);
@@ -107,10 +109,15 @@ codeunit 1222 "SEPA CT-Prepare Source"
                     if StrLen(AppliedDocNoList) > DescriptionLen then
                         TempGenJnlLine."Message to Recipient" :=
                           CopyStr(AppliedDocNoList, DescriptionLen + 1, MaxStrLen(TempGenJnlLine."Message to Recipient"));
+                    if StrLen(AppliedDocNoList) > DescriptionLen + MaxStrLen(TempGenJnlLine."Message to Recipient") then
+                        RemittanceTruncated := true;
                 end;
 
                 TempGenJnlLine.Insert();
             until PaymentHistoryLine.Next() = 0;
+
+        if RemittanceTruncated then
+            NotifyRemittanceTruncated();
 
         OnAfterCreateTempJnlLines(FromGenJnlLine, TempGenJnlLine);
     end;
@@ -149,5 +156,53 @@ codeunit 1222 "SEPA CT-Prepare Source"
     local procedure OnCopyJnlLinesOnBeforeTempGenJnlLineInsert(var FromGenJournalLine: Record "Gen. Journal Line"; var TempGenJournalLine: Record "Gen. Journal Line" temporary; GenJournalBatch: Record "Gen. Journal Batch")
     begin
     end;
+
+    local procedure NotifyRemittanceTruncated()
+    var
+        MyNotifications: Codeunit "My Notifications";
+        RemittanceNotification: Notification;
+    begin
+        if not GuiAllowed() then
+            exit;
+        if not MyNotifications.IsEnabled(GetRemittanceTruncationNotificationId()) then
+            exit;
+
+        RemittanceNotification.Id := GetRemittanceTruncationNotificationId();
+        RemittanceNotification.Message(RemittanceTruncatedMsg);
+        RemittanceNotification.Scope(NotificationScope::LocalScope);
+        RemittanceNotification.AddAction(DontShowAgainTxt, Codeunit "SEPA CT-Prepare Source", 'DisableRemittanceTruncationNotification');
+        RemittanceNotification.Send();
+    end;
+
+    /// <summary>
+    /// Disables the remittance truncation notification for the current user.
+    /// </summary>
+    /// <param name="RemittanceNotification">The notification whose action was invoked.</param>
+    procedure DisableRemittanceTruncationNotification(RemittanceNotification: Notification)
+    var
+        MyNotifications: Codeunit "My Notifications";
+    begin
+        MyNotifications.Disable(GetRemittanceTruncationNotificationId());
+    end;
+
+    local procedure GetRemittanceTruncationNotificationId(): Guid
+    begin
+        exit(RemittanceTruncationNotificationIdTok);
+    end;
+
+    [EventSubscriber(ObjectType::Page, Page::"My Notifications", 'OnInitializingNotificationWithDefaultState', '', false, false)]
+    local procedure OnInitializingNotificationWithDefaultStateRegisterNotifications()
+    var
+        MyNotifications: Codeunit "My Notifications";
+    begin
+        MyNotifications.InsertDefault(GetRemittanceTruncationNotificationId(), RemittanceTruncationNotificationNameTxt, RemittanceTruncationNotificationDescriptionTxt, true);
+    end;
+
+    var
+        RemittanceTruncatedMsg: Label 'The list of applied documents will be shortened in the exported payment file. To avoid this, split the payment or turn off combining entries on the transaction mode.';
+        DontShowAgainTxt: Label 'Don''t show this again';
+        RemittanceTruncationNotificationNameTxt: Label 'Remittance information shortened on payment export';
+        RemittanceTruncationNotificationDescriptionTxt: Label 'Notify me when the list of applied documents is too long for the remittance information and will be shortened in the exported payment file.';
+        RemittanceTruncationNotificationIdTok: Label 'd9f2b3a7-6c41-4e8b-9a2d-7f0c1e5b84a3', Locked = true;
 }
 

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
@@ -105,7 +105,6 @@ codeunit 1222 "SEPA CT-Prepare Source"
                 if AppliedDocNoList <> '' then begin
                     TempGenJnlLine.Description := CopyStr(AppliedDocNoList, 1, DescriptionLen);
                     if StrLen(AppliedDocNoList) > DescriptionLen then
-                        // Third CopyStr argument is a length, so cap it at the field size to avoid overflowing Text[140].
                         TempGenJnlLine."Message to Recipient" :=
                           CopyStr(AppliedDocNoList, DescriptionLen + 1, MaxStrLen(TempGenJnlLine."Message to Recipient"));
                 end;

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
@@ -105,8 +105,9 @@ codeunit 1222 "SEPA CT-Prepare Source"
                 if AppliedDocNoList <> '' then begin
                     TempGenJnlLine.Description := CopyStr(AppliedDocNoList, 1, DescriptionLen);
                     if StrLen(AppliedDocNoList) > DescriptionLen then
+                        // Third CopyStr argument is a length, so cap it at the field size to avoid overflowing Text[140].
                         TempGenJnlLine."Message to Recipient" :=
-                          CopyStr(AppliedDocNoList, DescriptionLen + 1, DescriptionLen + MaxStrLen(TempGenJnlLine."Message to Recipient"));
+                          CopyStr(AppliedDocNoList, DescriptionLen + 1, MaxStrLen(TempGenJnlLine."Message to Recipient"));
                 end;
 
                 TempGenJnlLine.Insert();

--- a/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Bank/DirectDebit/SEPACTPrepareSource.Codeunit.al
@@ -159,7 +159,7 @@ codeunit 1222 "SEPA CT-Prepare Source"
 
     local procedure NotifyRemittanceTruncated()
     var
-        MyNotifications: Codeunit "My Notifications";
+        MyNotifications: Record "My Notifications";
         RemittanceNotification: Notification;
     begin
         if not GuiAllowed() then
@@ -180,7 +180,7 @@ codeunit 1222 "SEPA CT-Prepare Source"
     /// <param name="RemittanceNotification">The notification whose action was invoked.</param>
     procedure DisableRemittanceTruncationNotification(RemittanceNotification: Notification)
     var
-        MyNotifications: Codeunit "My Notifications";
+        MyNotifications: Record "My Notifications";
     begin
         MyNotifications.Disable(GetRemittanceTruncationNotificationId());
     end;
@@ -193,7 +193,7 @@ codeunit 1222 "SEPA CT-Prepare Source"
     [EventSubscriber(ObjectType::Page, Page::"My Notifications", 'OnInitializingNotificationWithDefaultState', '', false, false)]
     local procedure OnInitializingNotificationWithDefaultStateRegisterNotifications()
     var
-        MyNotifications: Codeunit "My Notifications";
+        MyNotifications: Record "My Notifications";
     begin
         MyNotifications.InsertDefault(GetRemittanceTruncationNotificationId(), RemittanceTruncationNotificationNameTxt, RemittanceTruncationNotificationDescriptionTxt, true);
     end;

--- a/src/Layers/NL/Tests/Local/UTTABTelebank.Codeunit.al
+++ b/src/Layers/NL/Tests/Local/UTTABTelebank.Codeunit.al
@@ -163,6 +163,44 @@ codeunit 144055 "UT TAB Telebank"
     [Test]
     [TransactionModel(TransactionModel::AutoRollback)]
     [Scope('OnPrem')]
+    procedure PrepareSourceTruncatesRemittanceExceedingFieldLengths()
+    var
+        PaymentHistory: Record "Payment History";
+        PaymentHistoryLine: Record "Payment History Line";
+        TempGenJnlLine: Record "Gen. Journal Line" temporary;
+        AppliedDocNoList: Text;
+        DescriptionLen: Integer;
+    begin
+        // [SCENARIO] Preparing SEPA CT source from a payment line whose combined applied document numbers
+        // exceed Description plus Message to Recipient must truncate gracefully instead of raising a length error.
+
+        // [GIVEN] A vendor payment history line with applied documents longer than Description + Message to Recipient combined
+        MockVendorPaymentHistoryWithLongAppliedDocs(PaymentHistory, PaymentHistoryLine);
+        DescriptionLen := MaxStrLen(TempGenJnlLine.Description);
+        AppliedDocNoList := PaymentHistoryLine.GetAppliedDocNoList(DescriptionLen);
+        Assert.IsTrue(
+          StrLen(AppliedDocNoList) > DescriptionLen + MaxStrLen(TempGenJnlLine."Message to Recipient"),
+          'Test data must exceed the combined Description and Message to Recipient length.');
+
+        // [WHEN] SEPA CT-Prepare Source builds the temporary journal lines
+        TempGenJnlLine.SetRange("Bal. Account No.", PaymentHistory."Our Bank");
+        TempGenJnlLine.SetRange("Document No.", PaymentHistory."Run No.");
+        Codeunit.Run(Codeunit::"SEPA CT-Prepare Source", TempGenJnlLine);
+
+        // [THEN] The list is split across Description (first part) and Message to Recipient (next part) without overflow
+        TempGenJnlLine.Reset();
+        TempGenJnlLine.FindFirst();
+        Assert.AreEqual(
+          CopyStr(AppliedDocNoList, 1, DescriptionLen), TempGenJnlLine.Description,
+          TempGenJnlLine.FieldName(Description));
+        Assert.AreEqual(
+          CopyStr(AppliedDocNoList, DescriptionLen + 1, MaxStrLen(TempGenJnlLine."Message to Recipient")),
+          TempGenJnlLine."Message to Recipient", TempGenJnlLine.FieldName("Message to Recipient"));
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
     procedure CollectAccHolderDataOnPaymentExportBuffer()
     var
         GenJnlLine: Record "Gen. Journal Line";
@@ -812,6 +850,40 @@ codeunit 144055 "UT TAB Telebank"
         DetailLine."Account Type" := PaymentHistoryLine."Account Type";
         DetailLine."Serial No. (Entry)" := EntryNo;
         DetailLine.Insert();
+    end;
+
+    local procedure MockVendorPaymentHistoryWithLongAppliedDocs(var PaymentHistory: Record "Payment History"; var PaymentHistoryLine: Record "Payment History Line")
+    var
+        Index: Integer;
+    begin
+        PaymentHistory.Init();
+        PaymentHistory."Our Bank" := LibraryERM.CreateBankAccountNo();
+        PaymentHistory."Run No." := LibraryUtility.GenerateGUID();
+        PaymentHistory.Insert();
+
+        PaymentHistoryLine.Init();
+        PaymentHistoryLine."Our Bank" := PaymentHistory."Our Bank";
+        PaymentHistoryLine."Run No." := PaymentHistory."Run No.";
+        PaymentHistoryLine."Line No." := 10000;
+        PaymentHistoryLine."Account Type" := PaymentHistoryLine."Account Type"::Vendor;
+        PaymentHistoryLine."Account No." := LibraryPurchase.CreateVendorNo();
+        PaymentHistoryLine."Description 1" := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(PaymentHistoryLine."Description 1"));
+        PaymentHistoryLine.Insert();
+
+        // 12 applied documents of 30 characters each exceed Description plus Message to Recipient combined
+        for Index := 1 to 12 do
+            MockAppliedVendorDocument(PaymentHistoryLine, Index);
+    end;
+
+    local procedure MockAppliedVendorDocument(PaymentHistoryLine: Record "Payment History Line"; Index: Integer)
+    var
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+    begin
+        VendorLedgerEntry.Init();
+        VendorLedgerEntry."Entry No." := LibraryUtility.GetNewRecNo(VendorLedgerEntry, VendorLedgerEntry.FieldNo("Entry No."));
+        VendorLedgerEntry."External Document No." := CopyStr(PadStr('EXTDOC' + Format(Index), 30, '0'), 1, 30);
+        VendorLedgerEntry.Insert();
+        CreateDetailLine(PaymentHistoryLine, VendorLedgerEntry."Entry No.");
     end;
 
     local procedure CreateExportProtocol(): Code[20]


### PR DESCRIPTION
[NL][Telebank] Payment History export crashes when combining entries because of string length overflow

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Introducing a standard string-length cap when saving the combined remittance text to the 140-character SEPA CT "ustrd" text element.
<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#647493](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647493)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

Added a new automated test for the string-length cap.
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility
Low risk
Compatibility: Makes the combined export more flexible instead of crashing.

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->






