### PR TITLE
[Extensibility Request] issue 30338: expose internal put-away line event

### DIFF
--- a/src/Layers/W1/BaseApp/Warehouse/Request/WhseSourceCreateDocument.Report.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Request/WhseSourceCreateDocument.Report.al
@@ -349,7 +349,7 @@ report 7305 "Whse.-Source - Create Document"
                     "Whse. Document Type", WhseWkshLine."Whse. Document Type"::"Internal Put-away");
                     WhseWkshLine.SetRange("Whse. Document No.", WhseInternalPutAwayHeader."No.");
 
-                    OnBeforeProcessWhseMovWkshLines("Whse. Put-away Worksheet Line");
+                    OnAfterWhseInternalPutAwayLineOnPreDataItem("Whse. Internal Put-away Line");
                 end;
             }
             dataitem("Assembly Line"; "Assembly Line")
@@ -1376,6 +1376,11 @@ report 7305 "Whse.-Source - Create Document"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterWhsePutAwayWorksheetLineOnPostDataItem(var WhseWorksheetLine: Record "Whse. Worksheet Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterWhseInternalPutAwayLineOnPreDataItem(var WhseInternalPutAwayLine: Record "Whse. Internal Put-away Line")
     begin
     end;
 


### PR DESCRIPTION
## Summary
Report 7305 calls an event with a warehouse worksheet line while preparing internal put-away lines, preventing extensions from receiving and adjusting the actual source record. This PR raises a dedicated, correctly typed event after the internal put-away dataitem filters are prepared.

Source issue repository: microsoft/AlAppExtensions; issue number: 30338

## Changes Made
- `Whse.-Source - Create Document.OnAfterWhseInternalPutAwayLineOnPreDataItem` - expose the internal put-away line record to subscribers at the end of the dataitem's `OnPreDataItem` trigger

Fixes [AB#641690](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641690)


