### PR TITLE
SOA - Try it out : agent activation after closing the page

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOACreateTask.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOACreateTask.Page.al
@@ -155,14 +155,30 @@ page 4409 "SOA Create Task"
     }
 
     trigger OnQueryClosePage(CloseAction: Action): Boolean
-    var
-        TempAgentTaskFile: Record "Agent Task File" temporary;
     begin
         if not (CloseAction in [Action::Ok, Action::LookupOK, Action::Yes]) then
             exit(true);
 
-        if CurrPage.MessageAttachments.Page.GetUploadedFiles(TempAgentTaskFile) then;
-        SOACreateTaskImpl.CreateTask(SenderEmail, MessageText, TempAgentTaskFile);
+        SOACreateTaskImpl.ValidateTaskData(SenderEmail, MessageText);
+
+        Clear(TempConfirmedAttachment);
+        if CurrPage.MessageAttachments.Page.GetUploadedFiles(TempConfirmedAttachment) then;
+        TaskDataConfirmed := true;
+        exit(true);
+    end;
+
+    internal procedure GetConfirmedTaskData(var SenderEmailValue: Text[250]; var MessageTextValue: Text; var TempAgentTaskFile: Record "Agent Task File" temporary): Boolean
+    begin
+        if not TaskDataConfirmed then
+            exit(false);
+
+        SenderEmailValue := SenderEmail;
+        MessageTextValue := MessageText;
+        if TempConfirmedAttachment.FindSet() then
+            repeat
+                TempAgentTaskFile.Copy(TempConfirmedAttachment);
+                TempAgentTaskFile.Insert();
+            until TempConfirmedAttachment.Next() = 0;
         exit(true);
     end;
 
@@ -191,10 +207,12 @@ page 4409 "SOA Create Task"
     end;
 
     var
+        TempConfirmedAttachment: Record "Agent Task File" temporary;
         SOACreateTaskImpl: Codeunit "SOA Create Task Impl";
         MessageText: Text;
         SenderEmail: Text[250];
         Sender: Option Contact,Customer;
+        TaskDataConfirmed: Boolean;
         UseSampleMessageLbl: Label 'Use sample message';
         SampleMessageOptionsQst: Label 'Message with text only,Message with attachment', Comment = 'Comma-separated options shown when choosing which sample message to load.';
         SampleMessageInstructionQst: Label 'Use a sample:';

--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOACreateTaskImpl.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOACreateTaskImpl.Codeunit.al
@@ -27,11 +27,25 @@ codeunit 4415 "SOA Create Task Impl"
 
     internal procedure OpenCreateTaskPage(AgentUserSecurityID: Guid)
     var
+        TempAgentTaskFile: Record "Agent Task File" temporary;
+        SenderEmail: Text[250];
+        MessageText: Text;
+    begin
+        if not OpenCreateTaskPageForData(AgentUserSecurityID, SenderEmail, MessageText, TempAgentTaskFile) then
+            exit;
+
+        SetAgentUserSecurityID(AgentUserSecurityID);
+        CreateTask(SenderEmail, MessageText, TempAgentTaskFile);
+    end;
+
+    internal procedure OpenCreateTaskPageForData(AgentUserSecurityID: Guid; var SenderEmail: Text[250]; var MessageText: Text; var TempAgentTaskFile: Record "Agent Task File" temporary): Boolean
+    var
         SOACreateTask: Page "SOA Create Task";
     begin
         SOACreateTask.SetAgentUserSecurityID(AgentUserSecurityID);
         SOACreateTask.LookupMode(true);
         SOACreateTask.RunModal();
+        exit(SOACreateTask.GetConfirmedTaskData(SenderEmail, MessageText, TempAgentTaskFile));
     end;
 
     internal procedure GetCurrentUserSalespersonCode(): Code[20]
@@ -79,6 +93,15 @@ codeunit 4415 "SOA Create Task Impl"
         Clear(CachedAvailBalance);
     end;
 
+    internal procedure ValidateTaskData(SenderEmail: Text[250]; MessageText: Text)
+    begin
+        if SenderEmail = '' then
+            Error(YouMustSetSenderEmailErr);
+
+        if MessageText = '' then
+            Error(YouMustSetMessageTextErr);
+    end;
+
     internal procedure CreateTask(SenderEmail: Text[250]; MessageText: Text; var TempAgentTaskFile: Record "Agent Task File" temporary)
     var
         SOASetup: Record "SOA Setup";
@@ -87,11 +110,7 @@ codeunit 4415 "SOA Create Task Impl"
         AgentTaskMessageBuilder: Codeunit "Agent Task Message Builder";
         AgentTaskTitle: Text[150];
     begin
-        if SenderEmail = '' then
-            Error(YouMustSetSenderEmailErr);
-
-        if MessageText = '' then
-            Error(YouMustSetMessageTextErr);
+        ValidateTaskData(SenderEmail, MessageText);
 
         SOASetup.SetRange("User Security ID", GlobalAgentUserSecurityID);
         if not SOASetup.FindFirst() then

--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
@@ -123,24 +123,31 @@ page 4400 "SOA Setup"
 
                         trigger OnDrillDown()
                         var
+                            TempAgentTaskFile: Record "Agent Task File" temporary;
                             SOACreateTaskImpl: Codeunit "SOA Create Task Impl";
+                            SenderEmail: Text[250];
+                            MessageText: Text;
                         begin
                             if AgentIsArchived then begin
                                 Message(AgentArchivedNotificationMsg);
                                 exit;
                             end;
 
+                            if not SOACreateTaskImpl.OpenCreateTaskPageForData(Rec."User Security ID", SenderEmail, MessageText, TempAgentTaskFile) then
+                                exit;
+
                             CurrPage.AgentSetupPart.Page.GetAgentSetupBuffer(TempAgentSetupBuffer);
-                            if (TempAgentSetupBuffer.State <> TempAgentSetupBuffer.State::Enabled) and (Rec."Email Monitoring" or (Rec."Email Address" <> '')) then begin
+                            if (TempAgentSetupBuffer.State <> TempAgentSetupBuffer.State::Enabled) then begin
                                 if not Confirm(EnableAgentForTaskQst) then
                                     exit;
                                 TempAgentSetupBuffer.Validate(State, TempAgentSetupBuffer.State::Enabled);
                                 TempAgentSetupBuffer.Modify();
                                 CurrPage.AgentSetupPart.Page.SetAgentSetupBuffer(TempAgentSetupBuffer);
                                 CurrPage.AgentSetupPart.Page.Update();
-                                Rec."Email Monitoring" := false;
-                                Rec."Incoming Monitoring" := false;
-                                Rec.Modify();
+                                if Rec."Email Monitoring" and (MailboxName = '') then begin
+                                    Rec."Email Monitoring" := false;
+                                    Rec.Modify();
+                                end
                             end;
 
                             if not ApplySetup(true) then
@@ -154,7 +161,8 @@ page 4400 "SOA Setup"
 
                             Commit();
 
-                            SOACreateTaskImpl.OpenCreateTaskPage(Rec."User Security ID");
+                            SOACreateTaskImpl.SetAgentUserSecurityID(Rec."User Security ID");
+                            SOACreateTaskImpl.CreateTask(SenderEmail, MessageText, TempAgentTaskFile);
                             CurrPage.Update(false);
                         end;
                     }
@@ -845,7 +853,7 @@ page 4400 "SOA Setup"
         SelectMailboxFirstMsg: Label 'Please select an email account first.';
         ConfiguredBy: Text[80];
         SOACreateTaskLbl: Label 'Create task for the agent';
-        EnableAgentForTaskQst: Label 'Trying out the agent will activate it and turn off incoming email monitoring immediately.\\Do you want to continue?';
+        EnableAgentForTaskQst: Label 'Trying out the agent will activate it with the current settings.\\Do you want to continue?';
         IsConfigUpdated: Boolean;
         InboxFolderNameTok: Label 'Inbox', Locked = true;
         InboxFolderIdTok: Label 'inbox', Locked = true;


### PR DESCRIPTION
Fixes [AB#640603](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640603)

Defer SOA agent activation in "Try it out" until the task is submitted; cancelling the Create Task form no longer activates the agent 
