### PR TITLE
[Extensibility Request] issue 29640: use document type enum in blocked customer event

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/Customer/Customer.Table.al
@@ -4648,7 +4648,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4661,7 +4661,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/APAC/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/Customer/Customer.Table.al
@@ -4648,7 +4648,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4660,8 +4664,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/BE/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Customer/Customer.Table.al
@@ -4640,7 +4640,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4652,8 +4656,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/BE/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Customer/Customer.Table.al
@@ -4640,7 +4640,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4653,7 +4653,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/CH/BaseApp/Sales/Customer/Customer.Table.al
@@ -4572,7 +4572,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4585,7 +4585,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/CH/BaseApp/Sales/Customer/Customer.Table.al
@@ -4572,7 +4572,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4584,8 +4588,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Customer/Customer.Table.al
@@ -4596,7 +4596,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4609,7 +4609,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Customer/Customer.Table.al
@@ -4596,7 +4596,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4608,8 +4612,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/FR/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/FR/BaseApp/Sales/Customer/Customer.Table.al
@@ -4607,7 +4607,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4620,7 +4620,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/FR/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/FR/BaseApp/Sales/Customer/Customer.Table.al
@@ -4607,7 +4607,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4619,8 +4623,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/IT/BaseApp/Sales/Customer/Customer.Table.al
@@ -4790,7 +4790,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4803,7 +4803,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/IT/BaseApp/Sales/Customer/Customer.Table.al
@@ -4790,7 +4790,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4802,8 +4806,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Customer/Customer.Table.al
@@ -4706,7 +4706,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4718,8 +4722,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Customer/Customer.Table.al
@@ -4706,7 +4706,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4719,7 +4719,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/NL/BaseApp/Sales/Customer/Customer.Table.al
@@ -4645,7 +4645,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4657,8 +4661,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/NL/BaseApp/Sales/Customer/Customer.Table.al
@@ -4645,7 +4645,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4658,7 +4658,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NO/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Customer/Customer.Table.al
@@ -4594,7 +4594,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4607,7 +4607,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NO/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Customer/Customer.Table.al
@@ -4594,7 +4594,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4606,8 +4610,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/Customer/Customer.Table.al
@@ -4905,7 +4905,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4917,8 +4921,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/Customer/Customer.Table.al
@@ -4905,7 +4905,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4918,7 +4918,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Customer/Customer.Table.al
@@ -4567,7 +4567,11 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
+#if not CLEAN29
+        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled);
+#endif
+        if not IsHandled then
+            OnBeforeCheckBlockedCust2(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4579,8 +4583,16 @@ table 18 Customer
     /// <param name="Shipment">Indicates if this is a shipment operation.</param>
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
+#if not CLEAN29
+    [Obsolete('Replaced by OnBeforeCheckBlockedCust2', '29.0')]
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+#endif
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCheckBlockedCust2(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Customer/Customer.Table.al
@@ -4567,7 +4567,7 @@ table 18 Customer
 
     local procedure IsOnBeforeCheckBlockedCustHandled(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean) IsHandled: Boolean
     begin
-        OnBeforeCheckBlockedCust(Customer, Source, DocType.AsInteger(), Shipment, Transaction, IsHandled)
+        OnBeforeCheckBlockedCust(Customer, Source, DocType, Shipment, Transaction, IsHandled)
     end;
 
     /// <summary>
@@ -4580,7 +4580,7 @@ table 18 Customer
     /// <param name="Transaction">Indicates if this is a posting transaction.</param>
     /// <param name="IsHandled">Set to true to skip the default blocked check.</param>
     [IntegrationEvent(false, false)]
-    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Option; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBlockedCust(Customer: Record Customer; Source: Option Journal,Document; DocType: Enum "Gen. Journal Document Type"; Shipment: Boolean; Transaction: Boolean; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need the blocked-customer check to preserve extensible general journal document type values instead of reducing them to an option integer. This PR changes the event contract to use the `Gen. Journal Document Type` enum and publishes the enum value directly.

Source issue repository: microsoft/AlAppExtensions; issue number: 29640

## Changes Made
- `Customer.OnBeforeCheckBlockedCust` - changed `DocType` from an option to the extensible `Gen. Journal Document Type` enum and removed the integer conversion across W1 and all existing layer counterparts.

Fixes [AB#620150](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/620150)




