### PR TITLE
[Extensibility Request] issue 29092: expose Ship-to Name in ES

### DIFF
--- a/src/Layers/ES/BaseApp/Sales/History/PostedSalesInvoices.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/History/PostedSalesInvoices.Page.al
@@ -147,7 +147,15 @@ page 143 "Posted Sales Invoices"
                 field("<Ship-to Code>"; Rec."Ship-to Name")
                 {
                     ApplicationArea = Basic, Suite;
+                    ObsoleteReason = 'Use Ship-to Name instead.';
+                    ObsoleteState = Pending;
+                    ObsoleteTag = '28.0';
                     ToolTip = 'Specifies the name of the customer that the items were shipped to.';
+                    Visible = false;
+                }
+                field("Ship-to Name"; Rec."Ship-to Name")
+                {
+                    ApplicationArea = Basic, Suite;
                     Visible = false;
                 }
                 field("Ship-to Post Code"; Rec."Ship-to Post Code")

--- a/src/Layers/ES/BaseApp/Sales/History/PostedSalesInvoices.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/History/PostedSalesInvoices.Page.al
@@ -149,13 +149,14 @@ page 143 "Posted Sales Invoices"
                     ApplicationArea = Basic, Suite;
                     ObsoleteReason = 'Use Ship-to Name instead.';
                     ObsoleteState = Pending;
-                    ObsoleteTag = '28.0';
+                    ObsoleteTag = '29.0';
                     ToolTip = 'Specifies the name of the customer that the items were shipped to.';
                     Visible = false;
                 }
                 field("Ship-to Name"; Rec."Ship-to Name")
                 {
                     ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies the name of the customer that the items were shipped to.';
                     Visible = false;
                 }
                 field("Ship-to Post Code"; Rec."Ship-to Post Code")


### PR DESCRIPTION
## Summary
Extensions that compile against the W1 Posted Sales Invoices page cannot reference the same Ship-to Name control in ES because that control was emitted with an incorrect name. This change adds the standard control name in ES while retaining the legacy control as pending obsolete to avoid breaking existing consumers.

Source issue repository: microsoft/AlAppExtensions; issue number: 29092

## Changes Made
- `Posted Sales Invoices` page - added the W1-compatible `Ship-to Name` control in ES and marked the legacy `<Ship-to Code>` control pending obsolete for backward compatibility

Fixes [AB#598451](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/598451)





