### PR TITLE
Track receipt on invoice per purchase order line

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -88,6 +88,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
                 SkipCheckVendorRegistered: Boolean;
             begin
@@ -215,6 +216,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2787,10 +2790,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -428,7 +428,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3900,6 +3901,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(12100; "No. of Fixed Asset Cards"; Integer)
         {
             BlankZero = true;
@@ -4604,6 +4623,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4889,7 +4909,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -245,6 +245,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;
@@ -2042,4 +2047,3 @@ page 54 "Purchase Order Subform"
     begin
     end;
 }
-

--- a/src/Layers/APAC/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1686,6 +1686,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(11620; ABN; Text[11])
         {
             Caption = 'ABN';

--- a/src/Layers/APAC/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -617,6 +617,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/AT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/AT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4032,19 +4032,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/AT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/AT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -249,6 +249,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4018,6 +4019,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/BE/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/BE/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -259,6 +259,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4130,6 +4131,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/BE/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/BE/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4144,19 +4144,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/BE/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
+++ b/src/Layers/BE/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
@@ -198,6 +198,7 @@ codeunit 9998 "Upgrade Tag Definitions"
         PerCompanyUpgradeTags.Add(GetServiceShptLineFieldsUpgradeTag());
         PerCompanyUpgradeTags.Add(GetZeroClosedBankAccountLedgerEntriesUpgradeTag());
         PerCompanyUpgradeTags.Add(GetDepreciationBooksGLIntegrationUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetPurchLineReceiptOnInvoiceUpgradeTag());
         PerCompanyUpgradeTags.Add(GetWarehouseActivitySourceTypeForJobPlanningLineUpgradeTag());
         PerCompanyUpgradeTags.Add(GetRemittanceAdviceReportSelectionUpgradeTag());
         PerCompanyUpgradeTags.Add(GetProdDefinitionDisplaySetupUpgradeTag());
@@ -1374,6 +1375,11 @@ codeunit 9998 "Upgrade Tag Definitions"
     internal procedure GetDepreciationBooksGLIntegrationUpgradeTag(): Code[250]
     begin
         exit('MS-626097-DepreciationBooksGLIntegrationUpgradeTag-20260319');
+    end;
+
+    internal procedure GetPurchLineReceiptOnInvoiceUpgradeTag(): Code[250]
+    begin
+        exit('MS-625392-PurchLineReceiptOnInvoiceUpgradeTag-20260703');
     end;
 
     internal procedure GetRemittanceAdviceReportSelectionUpgradeTag(): Code[250]

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -203,6 +204,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2781,10 +2784,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -420,7 +420,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3876,6 +3877,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(11303; "Suggested Line"; Boolean)
         {
             Caption = 'Suggested Line';
@@ -4520,6 +4539,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4803,7 +4823,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/BE/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1688,6 +1688,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(11310; "Enterprise No."; Text[50])
         {
             Caption = 'Enterprise No.';

--- a/src/Layers/BE/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/BE/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -544,6 +544,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/CH/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/CH/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -261,6 +261,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4084,6 +4085,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/CH/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/CH/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4098,19 +4098,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -207,6 +208,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2776,10 +2779,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -420,7 +420,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3878,6 +3879,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(12100; "No. of Fixed Asset Cards"; Integer)
         {
             BlankZero = true;
@@ -4519,6 +4538,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4801,7 +4821,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/CH/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
 #if not CLEANSCHEMA25
         field(11000; "Registration No."; Text[20])
         {

--- a/src/Layers/CH/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/CH/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -533,6 +533,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -203,6 +204,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2771,10 +2774,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -420,7 +420,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3874,6 +3875,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(12100; "No. of Fixed Asset Cards"; Integer)
         {
             BlankZero = true;
@@ -4517,6 +4536,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4799,7 +4819,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/DACH/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
 #if not CLEANSCHEMA25
         field(11000; "Registration No."; Text[20])
         {

--- a/src/Layers/DACH/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -533,6 +533,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -87,6 +87,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -203,6 +204,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2831,10 +2834,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -420,7 +420,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3878,6 +3879,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(10701; "EC %"; Decimal)
         {
             AutoFormatType = 0;
@@ -4523,6 +4542,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4805,7 +4825,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -233,6 +233,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;
@@ -2034,4 +2039,3 @@ page 54 "Purchase Order Subform"
     begin
     end;
 }
-

--- a/src/Layers/ES/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1688,6 +1688,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(10700; "Payment Days Code"; Code[20])
         {
             Caption = 'Payment Days Code';

--- a/src/Layers/ES/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -543,6 +543,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -202,6 +203,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2769,10 +2772,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -421,7 +421,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3875,6 +3876,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
 #if not CLEANSCHEMA25
         field(11200; "Auto. Acc. Group"; Code[10])
         {
@@ -4510,6 +4529,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4792,7 +4812,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/FI/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(32000000; "Business Identity Code"; Text[20])
         {
             Caption = 'Business Identity Code';

--- a/src/Layers/FI/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/FI/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -538,6 +538,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/FR/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/FR/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -233,6 +233,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;
@@ -2028,4 +2033,3 @@ page 54 "Purchase Order Subform"
     begin
     end;
 }
-

--- a/src/Layers/FR/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/FR/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1688,6 +1688,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(10805; "SIREN No."; Code[9])
         {
             Caption = 'SIREN No.';

--- a/src/Layers/FR/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/FR/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -580,6 +580,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -202,6 +203,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2769,10 +2772,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -423,7 +423,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3891,6 +3892,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
 #if not CLEANSCHEMA30
         field(10500; "Reverse Charge Item"; Boolean)
         {
@@ -4542,6 +4561,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4824,7 +4844,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/GB/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
 #if not CLEANSCHEMA26
         field(10501; "Exclude from Pmt. Pract. Rep."; Boolean)
         {

--- a/src/Layers/GB/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/GB/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -578,6 +578,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/IS/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/IS/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -533,6 +533,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/IT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/IT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4163,19 +4163,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/IT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/IT/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -255,6 +255,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4149,6 +4150,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/IT/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
+++ b/src/Layers/IT/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
@@ -181,6 +181,7 @@ codeunit 9998 "Upgrade Tag Definitions"
         PerCompanyUpgradeTags.Add(GetZeroClosedBankAccountLedgerEntriesUpgradeTag());
         PerCompanyUpgradeTags.Add(GetDepreciationBooksGLIntegrationUpgradeTag());
         PerCompanyUpgradeTags.Add(GetLegacySubcontractingUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetPurchLineReceiptOnInvoiceUpgradeTag());
         PerCompanyUpgradeTags.Add(GetWarehouseActivitySourceTypeForJobPlanningLineUpgradeTag());
         PerCompanyUpgradeTags.Add(GetRemittanceAdviceReportSelectionUpgradeTag());
         PerCompanyUpgradeTags.Add(GetProdDefinitionDisplaySetupUpgradeTag());
@@ -1274,6 +1275,11 @@ codeunit 9998 "Upgrade Tag Definitions"
     internal procedure GetLegacySubcontractingUpgradeTag(): Code[250]
     begin
         exit('MS-406123-LegacySubcontracting-20260507');
+    end;
+
+    internal procedure GetPurchLineReceiptOnInvoiceUpgradeTag(): Code[250]
+    begin
+        exit('MS-625392-PurchLineReceiptOnInvoiceUpgradeTag-20260703');
     end;
 
     internal procedure GetRemittanceAdviceReportSelectionUpgradeTag(): Code[250]

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -93,6 +93,7 @@ table 38 "Purchase Header"
 #if not CLEAN28
                 LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
 #endif
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -230,6 +231,8 @@ table 38 "Purchase Header"
 
                 if xRec."Buy-from Vendor No." = "Buy-from Vendor No." then
                     UpdatePurchLinesByFieldNo(FieldNo("Buy-from Vendor No."), CurrFieldNo <> 0);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2847,10 +2850,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -438,7 +438,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3929,6 +3930,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(12100; "No. of Fixed Asset Cards"; Integer)
         {
             BlankZero = true;
@@ -4769,6 +4788,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -5051,7 +5071,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -254,6 +254,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;
@@ -2050,4 +2055,3 @@ page 54 "Purchase Order Subform"
     begin
     end;
 }
-

--- a/src/Layers/IT/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1699,6 +1699,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(12100; "Int. on Arrears Code"; Code[10])
         {
             Caption = 'Int. on Arrears Code';

--- a/src/Layers/IT/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -747,6 +747,11 @@ page 26 "Vendor Card"
 #pragma warning restore AS0072
                 }
 #endif
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -203,6 +204,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2825,10 +2828,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -463,7 +463,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3970,6 +3971,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(10001; "Tax To Be Expensed"; Decimal)
         {
             AutoFormatType = 0;
@@ -4680,6 +4699,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4962,7 +4982,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -238,6 +238,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;

--- a/src/Layers/NA/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(10004; "UPS Zone"; Code[2])
         {
             Caption = 'UPS Zone';

--- a/src/Layers/NA/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -580,6 +580,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/NL/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/NL/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4080,19 +4080,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/NL/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/NL/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -254,6 +254,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4066,6 +4067,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -202,6 +203,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2773,10 +2776,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -420,7 +420,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3874,6 +3875,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(11303; "Suggested Line"; Boolean)
         {
             Caption = 'Suggested Line';
@@ -4504,6 +4523,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4786,7 +4806,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/NL/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1725,6 +1725,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(11000000; "Transaction Mode Code"; Code[20])
         {
             Caption = 'Transaction Mode Code';

--- a/src/Layers/NL/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/NL/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -538,6 +538,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/NO/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/NO/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -251,6 +251,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4019,6 +4020,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/NO/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/NO/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4033,19 +4033,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -205,6 +206,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2776,10 +2779,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -421,7 +421,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3878,6 +3879,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
 #if not CLEANSCHEMA26
         field(10604; "VAT Code"; Code[10])
         {
@@ -4523,6 +4542,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4805,7 +4825,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/NO/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(15000000; Remittance; Boolean)
         {
             Caption = 'Remittance';

--- a/src/Layers/NO/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/NO/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -548,6 +548,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/RU/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/RU/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -256,6 +256,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4169,6 +4170,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/RU/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/RU/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4183,19 +4183,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/RU/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
+++ b/src/Layers/RU/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
@@ -184,6 +184,7 @@ codeunit 9998 "Upgrade Tag Definitions"
         PerCompanyUpgradeTags.Add(GetServiceShptLineFieldsUpgradeTag());
         PerCompanyUpgradeTags.Add(GetZeroClosedBankAccountLedgerEntriesUpgradeTag());
         PerCompanyUpgradeTags.Add(GetDepreciationBooksGLIntegrationUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetPurchLineReceiptOnInvoiceUpgradeTag());
         PerCompanyUpgradeTags.Add(GetWarehouseActivitySourceTypeForJobPlanningLineUpgradeTag());
         PerCompanyUpgradeTags.Add(GetRemittanceAdviceReportSelectionUpgradeTag());
         PerCompanyUpgradeTags.Add(GetProdDefinitionDisplaySetupUpgradeTag());
@@ -1294,6 +1295,11 @@ codeunit 9998 "Upgrade Tag Definitions"
     internal procedure GetDepreciationBooksGLIntegrationUpgradeTag(): Code[250]
     begin
         exit('MS-626097-DepreciationBooksGLIntegrationUpgradeTag-20260319');
+    end;
+
+    internal procedure GetPurchLineReceiptOnInvoiceUpgradeTag(): Code[250]
+    begin
+        exit('MS-625392-PurchLineReceiptOnInvoiceUpgradeTag-20260703');
     end;
 
     internal procedure GetRemittanceAdviceReportSelectionUpgradeTag(): Code[250]

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -87,6 +87,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -202,6 +203,8 @@ table 38 "Purchase Header"
 
                 if "Empl. Purchase" then
                     "Vendor Invoice No." := "No.";
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2778,10 +2781,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -425,7 +425,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3880,6 +3881,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(12100; "No. of Fixed Asset Cards"; Integer)
         {
             BlankZero = true;
@@ -4693,6 +4712,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4979,7 +4999,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
         if Item."Gross Weight Mandatory" then
             Item.TestField("Gross Weight");

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -233,6 +233,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;
@@ -2068,4 +2073,3 @@ page 54 "Purchase Order Subform"
     begin
     end;
 }
-

--- a/src/Layers/RU/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1733,6 +1733,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
         field(12400; "Default Bank Code"; Code[20])
         {
             Caption = 'Default Bank Code';

--- a/src/Layers/RU/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -642,6 +642,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -202,6 +203,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2769,10 +2772,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -421,7 +421,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3875,6 +3876,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
 #if not CLEANSCHEMA25
         field(11200; "Auto. Acc. Group"; Code[10])
         {
@@ -4510,6 +4529,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4792,7 +4812,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
@@ -11,6 +11,7 @@ using Microsoft.Inventory.Location;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Posting;
+using Microsoft.Purchases.Vendor;
 using System.Telemetry;
 using System.Text;
 
@@ -18,6 +19,64 @@ codeunit 5826 "Matched Order Line Mgmt."
 {
     Access = Public;
     Permissions = TableData "Posted Matched Order Line" = RIMD;
+
+    internal procedure ApplyVendorsReceiptOnInvoicePolicy(var PurchaseHeader: Record "Purchase Header")
+    var
+        Vendor: Record Vendor;
+        NewReceiptOnInvoice: Boolean;
+        ResetReceiptOnInvoiceQst: Label 'The vendor''s receipt on invoice policy disables %1, which is currently enabled on this document. Do you want to reset it on the document and its lines?', Comment = '%1 = Receipt on Invoice field caption';
+    begin
+        if not Vendor.Get(PurchaseHeader."Buy-from Vendor No.") then
+            exit;
+        case Vendor."Receipt on Invoice Policy" of
+            Vendor."Receipt on Invoice Policy"::Automatic:
+                NewReceiptOnInvoice := true;
+            Vendor."Receipt on Invoice Policy"::Manual:
+                NewReceiptOnInvoice := false;
+            else
+                exit;
+        end;
+        if PurchaseHeader."Receipt on Invoice" = NewReceiptOnInvoice then
+            exit;
+        if PurchaseHeader."Receipt on Invoice" and not NewReceiptOnInvoice then
+            if GuiAllowed() then
+                if not Confirm(ResetReceiptOnInvoiceQst, false, PurchaseHeader.FieldCaption("Receipt on Invoice")) then
+                    exit;
+
+        PurchaseHeader."Receipt on Invoice" := NewReceiptOnInvoice;
+        ApplyReceiptOnInvoiceToEligibleLines(PurchaseHeader);
+    end;
+
+    internal procedure ApplyReceiptOnInvoiceToLines(PurchaseHeader: Record "Purchase Header")
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        if PurchaseLine.FindSet() then
+            repeat
+                PurchaseLine.Validate("Receipt on Invoice", PurchaseHeader."Receipt on Invoice");
+                PurchaseLine.Modify();
+            until PurchaseLine.Next() = 0;
+    end;
+
+    local procedure ApplyReceiptOnInvoiceToEligibleLines(PurchaseHeader: Record "Purchase Header")
+    var
+        PurchaseLine: Record "Purchase Line";
+        LineReceiptOnInvoice: Boolean;
+        ErrorMessage: Text;
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        if PurchaseLine.FindSet() then
+            repeat
+                LineReceiptOnInvoice := PurchaseHeader."Receipt on Invoice";
+                if LineReceiptOnInvoice and not IsLineReceiptOnInvoiceAllowed(PurchaseLine, ErrorMessage) then
+                    LineReceiptOnInvoice := false;
+                PurchaseLine.Validate("Receipt on Invoice", LineReceiptOnInvoice);
+                PurchaseLine.Modify();
+            until PurchaseLine.Next() = 0;
+    end;
 
     internal procedure ProcessMatchedReceiptOnInvoice(var PurchaseLine: Record "Purchase Line")
     var
@@ -38,8 +97,9 @@ codeunit 5826 "Matched Order Line Mgmt."
                     repeat
                         PurchaseLineOrder.GetBySystemId(MatchedOrderLine."Matched Order Line SystemId");
 
+                        PurchaseLineOrder.TestField("Receipt on Invoice");
+                        CheckLineReceiptOnInvoiceAllowed(PurchaseLineOrder);
                         PurchaseHeaderOrder.Get(PurchaseLineOrder."Document Type", PurchaseLineOrder."Document No.");
-                        PurchaseHeaderOrder.TestField("Receipt on Invoice");
                         TempPurchaseHeader := PurchaseHeaderOrder;
                         if TempPurchaseHeader.Insert() then;
 
@@ -97,8 +157,8 @@ codeunit 5826 "Matched Order Line Mgmt."
             exit;
 
         if PurchaseHeader."Document Type" = PurchaseHeader."Document Type"::Order then
-            if PurchaseHeader."Receipt on Invoice" and IsNullGuid(PurchaseLine."Invoicing From Line SystemId") then
-                Error(ReceiptOnInvoicePostFromMatchedInvoiceErr, PurchaseHeader.FieldCaption("Receipt on Invoice"));
+            if PurchaseLine."Receipt on Invoice" and IsNullGuid(PurchaseLine."Invoicing From Line SystemId") then
+                Error(ReceiptOnInvoicePostFromMatchedInvoiceErr, PurchaseLine.FieldCaption("Receipt on Invoice"));
 
         if PurchaseHeader."Document Type" = PurchaseHeader."Document Type"::Invoice then begin
             if not PurchaseLine.IsMatchedToOrder() then
@@ -669,7 +729,7 @@ codeunit 5826 "Matched Order Line Mgmt."
                     if PurchaseHeaderOrder."No." <> PurchaseLineOrder."Document No." then
                         PurchaseHeaderOrder.Get(PurchaseLineOrder."Document Type", PurchaseLineOrder."Document No.");
 
-                    InsertMatchedOrderLine(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, NullGuid, PurchaseLineOrder."Qty. Rcd. Not Invoiced", PurchaseLineOrder."Qty. Rcd. Not Invoiced (Base)", PurchaseHeaderOrder."Receipt on Invoice");
+                    InsertMatchedOrderLine(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, NullGuid, PurchaseLineOrder."Qty. Rcd. Not Invoiced", PurchaseLineOrder."Qty. Rcd. Not Invoiced (Base)", PurchaseLineOrder."Receipt on Invoice");
 
                     PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
                     PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
@@ -737,7 +797,7 @@ codeunit 5826 "Matched Order Line Mgmt."
                     if IsNullGuid(DetailedMatchedOrderLine."Matched Order Line SystemId") then begin
                         PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, PurchRcptLine."Order No.", PurchRcptLine."Order Line No.");
                         PurchaseHeaderOrder.Get(PurchaseLineOrder."Document Type", PurchaseLineOrder."Document No.");
-                        InsertMatchedOrderLine(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, NullGuid, PurchaseLineOrder."Qty. Rcd. Not Invoiced", PurchaseLineOrder."Qty. Rcd. Not Invoiced (Base)", PurchaseHeaderOrder."Receipt on Invoice");
+                        InsertMatchedOrderLine(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, NullGuid, PurchaseLineOrder."Qty. Rcd. Not Invoiced", PurchaseLineOrder."Qty. Rcd. Not Invoiced (Base)", PurchaseLineOrder."Receipt on Invoice");
                     end;
                     ItemTrackingMgt.CopyMatchedItemTrkgToPurchLine(
                         PurchaseLineOrder,
@@ -967,7 +1027,7 @@ codeunit 5826 "Matched Order Line Mgmt."
                         QtyBase := PurchaseLineOrder."Outstanding Qty. (Base)";
                     end;
 
-                    InsertMatchedOrderLine(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, NullGuid, Qty, QtyBase, PurchaseHeaderOrder."Receipt on Invoice");
+                    InsertMatchedOrderLine(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, NullGuid, Qty, QtyBase, PurchaseLineOrder."Receipt on Invoice");
 
                     PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
                     PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
@@ -999,79 +1059,103 @@ codeunit 5826 "Matched Order Line Mgmt."
 
     internal procedure CheckReceiptOnInvoiceAllowed(PurchaseHeader: Record "Purchase Header")
     var
-        Item: Record Item;
-        ItemTrackingCode: record "Item Tracking Code";
-        Location: Record Location;
         PurchaseLine: Record "Purchase Line";
-        PurchRcptLine: Record "Purch. Rcpt. Line";
     begin
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
         PurchaseLine.SetLoadFields(Type, "No.", "Location Code");
         if PurchaseLine.FindSet() then
             repeat
-                if Location.Get(PurchaseLine."Location Code") and Location."Directed Put-away and Pick" then
-                    Error(ReceiptOnInvoiceLocationErr, PurchaseHeader.FieldCaption("Receipt on Invoice"), PurchaseLine."Location Code", PurchaseLine."Line No.");
-                if PurchaseLine.Type = PurchaseLine.Type::Item then
-                    if Item.Get(PurchaseLine."No.") and (Item."Item Tracking Code" <> '') then
-                        if ItemTrackingCode.Get(Item."Item Tracking Code") and (ItemTrackingCode."SN Specific Tracking" or ItemTrackingCode."Lot Specific Tracking" or ItemTrackingCode."Package Specific Tracking") then
-                            Error(ReceiptOnInvoiceItemTrackingErr, PurchaseHeader.FieldCaption("Receipt on Invoice"), PurchaseLine."No.", PurchaseLine."Line No.");
-
-                PurchRcptLine.SetRange("Order No.", PurchaseLine."Document No.");
-                PurchRcptLine.SetRange("Order Line No.", PurchaseLine."Line No.");
-                if not PurchRcptLine.IsEmpty() then
-                    Error(ReceiptOnInvoicePostedReceiptErr, PurchaseHeader.FieldCaption("Receipt on Invoice"), PurchaseLine."Line No.");
+                CheckLineReceiptOnInvoiceAllowed(PurchaseLine);
             until PurchaseLine.Next() = 0;
+    end;
+
+    internal procedure CheckLineReceiptOnInvoiceAllowed(PurchaseLine: Record "Purchase Line")
+    var
+        ErrorMessage: Text;
+    begin
+        if not IsLineReceiptOnInvoiceAllowed(PurchaseLine, ErrorMessage) then
+            Error(ErrorMessage);
+    end;
+
+    internal procedure IsLineReceiptOnInvoiceAllowed(PurchaseLine: Record "Purchase Line"; var ErrorMessage: Text): Boolean
+    var
+        Item: Record Item;
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        ReceiptOnInvoiceCaption: Text;
+    begin
+        ReceiptOnInvoiceCaption := PurchaseLine.FieldCaption("Receipt on Invoice");
+        if not IsReceiptOnInvoiceAllowedForLocation(PurchaseLine."Location Code") then begin
+            ErrorMessage := StrSubstNo(ReceiptOnInvoiceLocationErr, ReceiptOnInvoiceCaption, PurchaseLine."Location Code", PurchaseLine."Line No.");
+            exit(false);
+        end;
+        if (PurchaseLine.Type = PurchaseLine.Type::Item) and Item.Get(PurchaseLine."No.") then
+            if not IsReceiptOnInvoiceAllowedForItem(Item) then begin
+                ErrorMessage := StrSubstNo(ReceiptOnInvoiceItemTrackingErr, ReceiptOnInvoiceCaption, PurchaseLine."No.", PurchaseLine."Line No.");
+                exit(false);
+            end;
+        PurchRcptLine.SetRange("Order No.", PurchaseLine."Document No.");
+        PurchRcptLine.SetRange("Order Line No.", PurchaseLine."Line No.");
+        if not PurchRcptLine.IsEmpty() then begin
+            ErrorMessage := StrSubstNo(ReceiptOnInvoicePostedReceiptErr, ReceiptOnInvoiceCaption, PurchaseLine."Line No.");
+            exit(false);
+        end;
+        exit(true);
+    end;
+
+    internal procedure IsReceiptOnInvoiceAllowedForItem(Item: Record Item): Boolean
+    var
+        ItemTrackingCode: Record "Item Tracking Code";
+    begin
+        if Item."Item Tracking Code" = '' then
+            exit(true);
+        if ItemTrackingCode.Get(Item."Item Tracking Code") then
+            if ItemTrackingCode."SN Specific Tracking" or ItemTrackingCode."Lot Specific Tracking" or ItemTrackingCode."Package Specific Tracking" then
+                exit(false);
+        exit(true);
+    end;
+
+    internal procedure IsReceiptOnInvoiceAllowedForLocation(LocationCode: Code[10]): Boolean
+    var
+        Location: Record Location;
+    begin
+        if Location.Get(LocationCode) then
+            if Location."Directed Put-away and Pick" then
+                exit(false);
+        exit(true);
+    end;
+
+    internal procedure CheckReceiptOnInvoiceAllowedForItem(Item: Record Item; PurchaseHeader: Record "Purchase Header")
+    begin
+        if PurchaseHeader."Receipt on Invoice" and not IsReceiptOnInvoiceAllowedForItem(Item) then
+            Error(ReceiptOnInvoiceItemTrackingLineValidationErr, Item."No.", PurchaseHeader.FieldCaption("Receipt on Invoice"));
+    end;
+
+    internal procedure CheckReceiptOnInvoiceAllowedForLocation(LocationCode: Code[10]; PurchaseHeader: Record "Purchase Header")
+    begin
+        if PurchaseHeader."Receipt on Invoice" and not IsReceiptOnInvoiceAllowedForLocation(LocationCode) then
+            Error(ReceiptOnInvoiceLocationLineValidationErr, LocationCode, PurchaseHeader.FieldCaption("Receipt on Invoice"));
+    end;
+
+    internal procedure ApplyPurchaseLineReceiptSettingToMatches(PurchaseLine: Record "Purchase Line")
+    var
+        MatchedOrderLine: Record "Matched Order Line";
+    begin
+        MatchedOrderLine.SetRange("Matched Order Line SystemId", PurchaseLine.SystemId);
+        MatchedOrderLine.ModifyAll("Receipt on Invoice", PurchaseLine."Receipt on Invoice");
     end;
 
     internal procedure RefreshMatchedOrderLineReceipt(PurchaseHeader: Record "Purchase Header")
     var
         PurchaseLine: Record "Purchase Line";
-        PurchaseLineSystemIDFilter: Text;
-        FilterValueCount: Integer;
     begin
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
-        PurchaseLine.SetLoadFields(SystemId);
+        PurchaseLine.SetLoadFields("Receipt on Invoice");
         if PurchaseLine.FindSet() then
             repeat
-                PurchaseLineSystemIDFilter += Format(PurchaseLine.SystemId) + '|';
-                FilterValueCount += 1;
-                if FilterValueCount = MaxFilterValues() then begin
-                    RefreshMatchedOrderLinesBatch(PurchaseLineSystemIDFilter, PurchaseHeader."Receipt on Invoice");
-                    Clear(PurchaseLineSystemIDFilter);
-                    FilterValueCount := 0;
-                end;
+                ApplyPurchaseLineReceiptSettingToMatches(PurchaseLine);
             until PurchaseLine.Next() = 0;
-
-        if PurchaseLineSystemIDFilter <> '' then
-            RefreshMatchedOrderLinesBatch(PurchaseLineSystemIDFilter, PurchaseHeader."Receipt on Invoice");
-    end;
-
-    local procedure RefreshMatchedOrderLinesBatch(SystemIDFilter: Text; ReceiptOnInvoice: Boolean)
-    var
-        MatchedOrderLine: Record "Matched Order Line";
-    begin
-        MatchedOrderLine.SetFilter("Matched Order Line SystemId", CopyStr(SystemIDFilter, 1, StrLen(SystemIDFilter) - 1));
-        MatchedOrderLine.ModifyAll("Receipt on Invoice", ReceiptOnInvoice);
-    end;
-
-    internal procedure CheckReceiptOnInvoiceAllowedForItem(Item: Record Item; PurchHeader: Record "Purchase Header")
-    var
-        ItemTrackingCode: Record "Item Tracking Code";
-    begin
-        if PurchHeader."Receipt on Invoice" and (Item."Item Tracking Code" <> '') then
-            if ItemTrackingCode.Get(Item."Item Tracking Code") and (ItemTrackingCode."SN Specific Tracking" or ItemTrackingCode."Lot Specific Tracking" or ItemTrackingCode."Package Specific Tracking") then
-                Error(ReceiptOnInvoiceItemTrackingLineValidationErr, Item."No.", PurchHeader.FieldCaption("Receipt on Invoice"));
-    end;
-
-    internal procedure CheckReceiptOnInvoiceAllowedForLocation("Location Code": Code[10]; PurchHeader: Record "Purchase Header")
-    var
-        Location: Record Location;
-    begin
-        if PurchHeader."Receipt on Invoice" then
-            if Location.Get("Location Code") and Location."Directed Put-away and Pick" then
-                Error(ReceiptOnInvoiceLocationLineValidationErr, "Location Code", PurchHeader.FieldCaption("Receipt on Invoice"));
     end;
 
     internal procedure LineCanBeDeleted(var DetailedMatchedOrderLine: Record "Detailed Matched Order Line"; SourceIsOpenDocument: Boolean): Boolean

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
@@ -1125,18 +1125,6 @@ codeunit 5826 "Matched Order Line Mgmt."
         exit(true);
     end;
 
-    internal procedure CheckReceiptOnInvoiceAllowedForItem(Item: Record Item; PurchaseHeader: Record "Purchase Header")
-    begin
-        if PurchaseHeader."Receipt on Invoice" and not IsReceiptOnInvoiceAllowedForItem(Item) then
-            Error(ReceiptOnInvoiceItemTrackingLineValidationErr, Item."No.", PurchaseHeader.FieldCaption("Receipt on Invoice"));
-    end;
-
-    internal procedure CheckReceiptOnInvoiceAllowedForLocation(LocationCode: Code[10]; PurchaseHeader: Record "Purchase Header")
-    begin
-        if PurchaseHeader."Receipt on Invoice" and not IsReceiptOnInvoiceAllowedForLocation(LocationCode) then
-            Error(ReceiptOnInvoiceLocationLineValidationErr, LocationCode, PurchaseHeader.FieldCaption("Receipt on Invoice"));
-    end;
-
     internal procedure ApplyPurchaseLineReceiptSettingToMatches(PurchaseLine: Record "Purchase Line")
     var
         MatchedOrderLine: Record "Matched Order Line";

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
@@ -98,7 +98,6 @@ codeunit 5826 "Matched Order Line Mgmt."
                         PurchaseLineOrder.GetBySystemId(MatchedOrderLine."Matched Order Line SystemId");
 
                         PurchaseLineOrder.TestField("Receipt on Invoice");
-                        CheckLineReceiptOnInvoiceAllowed(PurchaseLineOrder);
                         PurchaseHeaderOrder.Get(PurchaseLineOrder."Document Type", PurchaseLineOrder."Document No.");
                         TempPurchaseHeader := PurchaseHeaderOrder;
                         if TempPurchaseHeader.Insert() then;

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
@@ -1253,8 +1253,6 @@ codeunit 5826 "Matched Order Line Mgmt."
         MustBeMatchedToReceiptErr: Label 'Line No. %1 must be matched to at least one receipt or shipment line.', Comment = ' %1 = Line No.';
         ReceiptOnInvoiceLocationErr: Label 'You cannot use %1 Directed Put-away and Pick Location %2 on Line %3.', Comment = '%1 = Receipt on Invoice field name, %2 = Location Code, %3 = Line No.';
         ReceiptOnInvoiceItemTrackingErr: Label 'You cannot use %1 because Item %2 on Line %3 requires item tracking.', Comment = '%1 = Receipt on Invoice field name, %2 = Item No., %3 = Line No.';
-        ReceiptOnInvoiceLocationLineValidationErr: Label 'You cannot use Directed Put-away and Pick location %1 on purchase orders with %2 enabled.', Comment = '%1 = Location Code, %2 = Receipt on Invoice field name';
-        ReceiptOnInvoiceItemTrackingLineValidationErr: Label 'You cannot use item %1 with specific tracking on purchase orders with %2 enabled.', Comment = '%1 = Item No., %2 = Receipt on Invoice field name';
         ReceiptOnInvoicePostedReceiptErr: Label 'You cannot use %1 because Line %2 already has posted receipts.', Comment = '%1 = Receipt on Invoice field name, %2 = Line No.';
         ReceiptOnInvoicePostFromMatchedInvoiceErr: Label 'Purchase Order with %1 selected can only be posted from matched purchase invoice', Comment = '%1 = Receipt on Invoice field name';
         DeletePostedLinesErr: Label 'You cannot delete posted document lines.';

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/POMatchingGroup.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/POMatchingGroup.Codeunit.al
@@ -386,12 +386,10 @@ codeunit 5829 "PO Matching Group"
 
     local procedure ReceiptOnInvoiceForMatch(OrderLineSystemId: Guid): Boolean
     var
-        OrderHeader: Record "Purchase Header";
         OrderLine: Record "Purchase Line";
     begin
         OrderLine.GetBySystemId(OrderLineSystemId);
-        OrderHeader.Get(OrderLine."Document Type", OrderLine."Document No.");
-        exit(OrderHeader."Receipt on Invoice");
+        exit(OrderLine."Receipt on Invoice");
     end;
     #endregion
 

--- a/src/Layers/W1/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -4077,19 +4077,14 @@ codeunit 104000 "Upgrade - BaseApp"
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
             exit;
 
-        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
-        PurchaseHeader.SetRange("Receipt on Invoice", true);
-        PurchaseHeader.SetLoadFields("No.");
-        if PurchaseHeader.FindSet() then
-            repeat
-                Clear(ReceiptOnInvoiceDataTransfer);
-                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
-                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
-                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
-                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
-                ReceiptOnInvoiceDataTransfer.CopyFields();
-            until PurchaseHeader.Next() = 0;
+        ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Header", Database::"Purchase Line");
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Document Type"), '=%1', PurchaseHeader."Document Type"::Order);
+        ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseHeader.FieldNo("Receipt on Invoice"), '=%1', true);
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("Document Type"), PurchaseLine.FieldNo("Document Type"));
+        ReceiptOnInvoiceDataTransfer.AddJoin(PurchaseHeader.FieldNo("No."), PurchaseLine.FieldNo("Document No."));
+        ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+        ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+        ReceiptOnInvoiceDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;

--- a/src/Layers/W1/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/Upgrade/UpgradeBaseApp.Codeunit.al
@@ -253,6 +253,7 @@ codeunit 104000 "Upgrade - BaseApp"
         UpgradeFinancialReportAuditLogAddRetentionPolicy();
         UpgradeZeroClosedBankAccountLedgerEntries();
         UpgradeDepreciationBooksGLIntegration();
+        UpgradePurchaseLineReceiptOnInvoice();
         UpgradeWarehouseActivitySourceTypeForJobPlanningLine();
     end;
 
@@ -4063,6 +4064,34 @@ codeunit 104000 "Upgrade - BaseApp"
         DepreciationBookDataTransfer.CopyFields();
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetDepreciationBooksGLIntegrationUpgradeTag());
+    end;
+
+    local procedure UpgradePurchaseLineReceiptOnInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        UpgradeTag: Codeunit "Upgrade Tag";
+        UpgradeTagDefinitions: Codeunit "Upgrade Tag Definitions";
+        ReceiptOnInvoiceDataTransfer: DataTransfer;
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag()) then
+            exit;
+
+        PurchaseHeader.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
+        PurchaseHeader.SetRange("Receipt on Invoice", true);
+        PurchaseHeader.SetLoadFields("No.");
+        if PurchaseHeader.FindSet() then
+            repeat
+                Clear(ReceiptOnInvoiceDataTransfer);
+                ReceiptOnInvoiceDataTransfer.SetTables(Database::"Purchase Line", Database::"Purchase Line");
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document Type"), '=%1', PurchaseLine."Document Type"::Order);
+                ReceiptOnInvoiceDataTransfer.AddSourceFilter(PurchaseLine.FieldNo("Document No."), '=%1', PurchaseHeader."No.");
+                ReceiptOnInvoiceDataTransfer.AddConstantValue(true, PurchaseLine.FieldNo("Receipt on Invoice"));
+                ReceiptOnInvoiceDataTransfer.UpdateAuditFields := false;
+                ReceiptOnInvoiceDataTransfer.CopyFields();
+            until PurchaseHeader.Next() = 0;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitions.GetPurchLineReceiptOnInvoiceUpgradeTag());
     end;
 
     local procedure UpgradeWarehouseActivitySourceTypeForJobPlanningLine()

--- a/src/Layers/W1/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/Upgrade/UpgradeTagDefinitions.Codeunit.al
@@ -180,6 +180,7 @@ codeunit 9998 "Upgrade Tag Definitions"
         PerCompanyUpgradeTags.Add(GetServiceShptLineFieldsUpgradeTag());
         PerCompanyUpgradeTags.Add(GetZeroClosedBankAccountLedgerEntriesUpgradeTag());
         PerCompanyUpgradeTags.Add(GetDepreciationBooksGLIntegrationUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetPurchLineReceiptOnInvoiceUpgradeTag());
         PerCompanyUpgradeTags.Add(GetWarehouseActivitySourceTypeForJobPlanningLineUpgradeTag());
         PerCompanyUpgradeTags.Add(GetRemittanceAdviceReportSelectionUpgradeTag());
         PerCompanyUpgradeTags.Add(GetProdDefinitionDisplaySetupUpgradeTag());
@@ -1268,6 +1269,11 @@ codeunit 9998 "Upgrade Tag Definitions"
     internal procedure GetDepreciationBooksGLIntegrationUpgradeTag(): Code[250]
     begin
         exit('MS-626097-DepreciationBooksGLIntegrationUpgradeTag-20260319');
+    end;
+
+    internal procedure GetPurchLineReceiptOnInvoiceUpgradeTag(): Code[250]
+    begin
+        exit('MS-625392-PurchLineReceiptOnInvoiceUpgradeTag-20260703');
     end;
 
     internal procedure GetRemittanceAdviceReportSelectionUpgradeTag(): Code[250]

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseHeader.Table.al
@@ -86,6 +86,7 @@ table 38 "Purchase Header"
 
             trigger OnValidate()
             var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                 IsHandled: Boolean;
             begin
                 IsHandled := false;
@@ -202,6 +203,8 @@ table 38 "Purchase Header"
                         Rec.Validate("Remit-to Code", '');
                 end else
                     SelectDefaultRemitAddress(Rec);
+
+                MatchedOrderLineMgmt.ApplyVendorsReceiptOnInvoicePolicy(Rec);
             end;
         }
         field(3; "No."; Code[20])
@@ -2769,10 +2772,7 @@ table 38 "Purchase Header"
             var
                 MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
             begin
-                if "Receipt on Invoice" then
-                    MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowed(Rec);
-
-                MatchedOrderLineMgmt.RefreshMatchedOrderLineReceipt(Rec);
+                MatchedOrderLineMgmt.ApplyReceiptOnInvoiceToLines(Rec);
             end;
         }
         field(7000; "Price Calculation Method"; Enum "Price Calculation Method")

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -420,7 +420,8 @@ table 39 "Purchase Line"
 
                 GetDefaultBin();
                 CheckWMS();
-                MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForLocation("Location Code", GetPurchHeader());
+                if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForLocation("Location Code") then
+                    Rec.Validate("Receipt on Invoice", false);
 
                 if "Document Type" = "Document Type"::"Return Order" then
                     ValidateReturnReasonCode(FieldNo("Location Code"));
@@ -3874,6 +3875,24 @@ table 39 "Purchase Line"
             Editable = false;
             FieldClass = FlowField;
         }
+        field(8513; "Receipt on Invoice"; Boolean)
+        {
+            Caption = 'Receipt on Invoice';
+            ToolTip = 'Specifies whether the receipt is posted automatically with the invoice.';
+
+            trigger OnValidate()
+            var
+                MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+            begin
+                if "Receipt on Invoice" then
+                    MatchedOrderLineMgmt.CheckLineReceiptOnInvoiceAllowed(Rec);
+
+                if "Document Type" = "Document Type"::Order then
+                    InitQtyToReceive();
+
+                MatchedOrderLineMgmt.ApplyPurchaseLineReceiptSettingToMatches(Rec);
+            end;
+        }
         field(12100; "No. of Fixed Asset Cards"; Integer)
         {
             BlankZero = true;
@@ -4499,6 +4518,7 @@ table 39 "Purchase Line"
         "Promised Receipt Date" := PurchHeader."Promised Receipt Date";
         "Inbound Whse. Handling Time" := PurchHeader."Inbound Whse. Handling Time";
         "Order Date" := PurchHeader."Order Date";
+        Rec."Receipt on Invoice" := PurchHeader."Receipt on Invoice";
 
         OnAfterInitHeaderDefaults(Rec, PurchHeader, TempPurchLine);
     end;
@@ -4781,7 +4801,8 @@ table 39 "Purchase Line"
                 Item.TestField("Inventory Posting Group");
                 "Posting Group" := Item."Inventory Posting Group";
             end;
-            MatchedOrderLineMgmt.CheckReceiptOnInvoiceAllowedForItem(Item, GetPurchHeader());
+            if Rec."Receipt on Invoice" and not MatchedOrderLineMgmt.IsReceiptOnInvoiceAllowedForItem(Item) then
+                Rec.Validate("Receipt on Invoice", false);
         end;
 
         OnCopyFromItemOnAfterCheck(Rec, Item, CurrFieldNo);

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseOrderSubform.Page.al
@@ -233,6 +233,11 @@ page 54 "Purchase Order Subform"
                     Importance = Additional;
                     Visible = false;
                 }
+                field("Receipt on Invoice"; Rec."Receipt on Invoice")
+                {
+                    ApplicationArea = All;
+                    Visible = false;
+                }
                 field("Drop Shipment"; Rec."Drop Shipment")
                 {
                     ApplicationArea = Suite;
@@ -2029,4 +2034,3 @@ page 54 "Purchase Order Subform"
     begin
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Purchases/Vendor/ReceiptOnInvoicePolicy.Enum.al
+++ b/src/Layers/W1/BaseApp/Purchases/Vendor/ReceiptOnInvoicePolicy.Enum.al
@@ -1,0 +1,13 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Purchases.Vendor;
+
+enum 5820 "Receipt on Invoice Policy"
+{
+    Extensible = true;
+
+    value(0; Manual) { Caption = 'Manual'; }
+    value(1; Automatic) { Caption = 'Automatic'; }
+}

--- a/src/Layers/W1/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1685,6 +1685,11 @@ table 23 Vendor
             ToolTip = 'Specifies the policy that will be used for the vendor if more items than ordered are received.';
             TableRelation = "Over-Receipt Code";
         }
+        field(8551; "Receipt on Invoice Policy"; Enum "Receipt on Invoice Policy")
+        {
+            Caption = 'Receipt on Invoice Policy';
+            ToolTip = 'Specifies whether receipt on invoice is enabled automatically for new purchase orders from this vendor.';
+        }
     }
 
     keys

--- a/src/Layers/W1/BaseApp/Purchases/Vendor/VendorCard.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Vendor/VendorCard.Page.al
@@ -534,6 +534,11 @@ page 26 "Vendor Card"
                     ApplicationArea = All;
                     Visible = OverReceiptAllowed;
                 }
+                field("Receipt on Invoice Policy"; Rec."Receipt on Invoice Policy")
+                {
+                    ApplicationArea = All;
+                    Caption = 'Receipt on Invoice';
+                }
             }
         }
         area(factboxes)

--- a/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
@@ -4672,7 +4672,7 @@ codeunit 134468 "ERM Matched Order Line Tests"
         LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
         LibraryPurchase.CreatePurchaseLine(PurchaseLineInvoice, PurchaseHeaderInvoice, PurchaseLineInvoice.Type::Item, Item."No.", Quantity);
 
-        POMatchingGroup.AddMatch(POMatching.InvoiceOrderEdge(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, Quantity, Quantity));
+        POMatchingGroup.AddMatch(POMatching.InvoiceOrderEdge(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, Quantity));
         POMatchingGroup.SaveMatchingGroups();
 
         MatchedOrderLine.SetRange("Document Line SystemId", PurchaseLineInvoice.SystemId);

--- a/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
@@ -1397,9 +1397,9 @@ codeunit 134468 "ERM Matched Order Line Tests"
         PurchaseHeaderOrder.Modify(true);
 
         // [WHEN] Add line with tracked item
-        // [THEN] Error: Item tracking not supported with Receipt on Invoice
-        asserterror LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
-        Assert.ExpectedError('specific tracking');
+        // [THEN] Line is created but Receipt on Invoice is silently disabled on the line
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        Assert.IsFalse(PurchaseLineOrder."Receipt on Invoice", 'Receipt on Invoice should be disabled on a line with specific item tracking');
     end;
 
 
@@ -1480,9 +1480,9 @@ codeunit 134468 "ERM Matched Order Line Tests"
         PurchaseLineOrder.Modify(true);
 
         // [WHEN] Use WMS location
-        // [THEN] Error: Directed Put-away and Pick not supported
-        asserterror PurchaseLineOrder.Validate("Location Code", WMSLocation.Code);
-        Assert.ExpectedError('Directed Put-away and Pick');
+        // [THEN] Receipt on Invoice is silently disabled on the line
+        PurchaseLineOrder.Validate("Location Code", WMSLocation.Code);
+        Assert.IsFalse(PurchaseLineOrder."Receipt on Invoice", 'Receipt on Invoice should be disabled on a Directed Put-away and Pick location');
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
@@ -4554,6 +4554,134 @@ codeunit 134468 "ERM Matched Order Line Tests"
         Assert.RecordIsEmpty(MatchedOrderLine);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure E2E_ReceiptOnInvoiceLineLevelDrivesAutoReceiveWithoutHeaderFlag()
+    var
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        MatchedOrderLine: Record "Matched Order Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        Quantity: Decimal;
+    begin
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 100);
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        PurchaseLineOrder.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        PurchaseLineOrder.Validate("Receipt on Invoice", true);
+        PurchaseLineOrder.Modify(true);
+        PurchaseHeaderOrder.Get(PurchaseHeaderOrder."Document Type", PurchaseHeaderOrder."No.");
+        Assert.IsFalse(PurchaseHeaderOrder."Receipt on Invoice", 'Header receipt on invoice should remain disabled');
+
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineInvoice, PurchaseHeaderInvoice, PurchaseLineInvoice.Type::Item, Item."No.", Quantity);
+        PurchaseLineInvoice.Validate("Direct Unit Cost", PurchaseLineOrder."Direct Unit Cost");
+        PurchaseLineInvoice.Modify(true);
+        MatchedOrderLine."Document Line SystemId" := PurchaseLineInvoice.SystemId;
+        MatchedOrderLine."Matched Order Line SystemId" := PurchaseLineOrder.SystemId;
+        MatchedOrderLine."Qty. to Invoice" := Quantity;
+        MatchedOrderLine."Qty. to Invoice (Base)" := Quantity;
+        MatchedOrderLine."Receipt on Invoice" := true;
+        MatchedOrderLine.Insert();
+
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderInvoice, false, true);
+
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type", PurchaseLineOrder."Document No.", PurchaseLineOrder."Line No.");
+        Assert.AreEqual(Quantity, PurchaseLineOrder."Quantity Received", 'Order line should be auto-received');
+        Assert.AreEqual(Quantity, PurchaseLineOrder."Quantity Invoiced", 'Order line should be fully invoiced');
+        PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
+        PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
+        PurchRcptLine.FindFirst();
+        Assert.AreEqual(Quantity, PurchRcptLine.Quantity, 'Auto-posted receipt should cover the full quantity');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure VendorAutomaticReceiptOnInvoicePolicyInitializesOrderAndLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+    begin
+        Initialize();
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("Receipt on Invoice Policy", Vendor."Receipt on Invoice Policy"::Automatic);
+        Vendor.Modify(true);
+        LibraryInventory.CreateItem(Item);
+
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+        PurchaseHeader.Get(PurchaseHeader."Document Type", PurchaseHeader."No.");
+
+        Assert.IsTrue(PurchaseHeader."Receipt on Invoice", 'Vendor policy should enable receipt on invoice on the order');
+        Assert.IsTrue(PurchaseLine."Receipt on Invoice", 'Order line should inherit receipt on invoice from the order');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReceiptOnInvoiceLineRejectsExistingReceipts()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+    begin
+        Initialize();
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+
+        asserterror PurchaseLine.Validate("Receipt on Invoice", true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure POMatchingGroupUsesOrderLineReceiptOnInvoiceSetting()
+    var
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        MatchedOrderLine: Record "Matched Order Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        POMatching: Codeunit "PO Matching";
+        POMatchingGroup: Codeunit "PO Matching Group";
+        Quantity: Decimal;
+    begin
+        Initialize();
+        Quantity := LibraryRandom.RandInt(10);
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        PurchaseLineOrder.Validate("Receipt on Invoice", true);
+        PurchaseLineOrder.Modify(true);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineInvoice, PurchaseHeaderInvoice, PurchaseLineInvoice.Type::Item, Item."No.", Quantity);
+
+        POMatchingGroup.AddMatch(POMatching.InvoiceOrderEdge(PurchaseLineInvoice.SystemId, PurchaseLineOrder.SystemId, Quantity, Quantity));
+        POMatchingGroup.SaveMatchingGroups();
+
+        MatchedOrderLine.SetRange("Document Line SystemId", PurchaseLineInvoice.SystemId);
+        MatchedOrderLine.SetRange("Matched Order Line SystemId", PurchaseLineOrder.SystemId);
+        MatchedOrderLine.SetRange("Matched Rcpt./Shpt. Line SysId", EmptyGuid);
+        MatchedOrderLine.FindFirst();
+        Assert.IsTrue(MatchedOrderLine."Receipt on Invoice", 'Match should use the order line receipt-on-invoice setting');
+    end;
+
     // ============================================================================
     // REGION: Local Helper Functions
     // ============================================================================

--- a/src/Layers/W1/Tests/ERM/POMatchingGroupTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/POMatchingGroupTests.Codeunit.al
@@ -956,22 +956,22 @@ codeunit 134469 "PO Matching Group Tests"
         MatchedOrderLine: Record "Matched Order Line";
         POMatchingGroup: Codeunit "PO Matching Group";
     begin
-        // [SCENARIO] Receipt on Invoice is computed at persist time from the order header, not while building the buffer.
+        // [SCENARIO] Receipt on Invoice is computed at persist time from the order line, not while building the buffer.
         Initialize(Vendor, Item);
         CreateOrderLineWithHeader(Vendor, Item, 100, OrderHeader, OrderLine);
-        OrderHeader."Receipt on Invoice" := true; // enable directly, bypassing setup validations
-        OrderHeader.Modify();
+        OrderLine."Receipt on Invoice" := true; // enable directly on the line, bypassing setup validations
+        OrderLine.Modify();
         CreateInvoiceLine(Vendor, Item, 40, InvoiceLine);
 
         // [WHEN] Adding an invoice-order edge and saving
         POMatchingGroup.AddMatch(POMatching.InvoiceOrderEdge(InvoiceLine.SystemId, OrderLine.SystemId, 40));
         POMatchingGroup.SaveMatchingGroups();
 
-        // [THEN] The persisted budget row's Receipt on Invoice reflects the header
+        // [THEN] The persisted budget row's Receipt on Invoice reflects the order line
         MatchedOrderLine.SetRange("Document Line SystemId", InvoiceLine.SystemId);
         MatchedOrderLine.SetRange("Matched Rcpt./Shpt. Line SysId", EmptyGuid);
         Assert.IsTrue(MatchedOrderLine.FindFirst(), 'Budget row should exist');
-        Assert.IsTrue(MatchedOrderLine."Receipt on Invoice", 'Receipt on Invoice should be computed from the header at persist');
+        Assert.IsTrue(MatchedOrderLine."Receipt on Invoice", 'Receipt on Invoice should be computed from the order line at persist');
     end;
     #endregion
 


### PR DESCRIPTION
This PR adds the ability in BaseApp's new PO Matching module to set "receipt on invoice" in a more granular level. Before we would only be able to specify it per purchase order, and now we can have that control per purchase order line. By default this column is hidden under personalization in the purchase order page.

We inherit on the lines the value on the header, and this value is now also inherited from a vendor-level configuration introduced in this PR.

Pat of the agreed scope of the Payables Agent PO matching improvements.

Stacked on #10526 (stack #10527).

[AB#625392](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625392)






















