### PR TITLE
[W1] Subscription Billing - Configurable Text for Billing Period

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Pages/ContractTypes.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Pages/ContractTypes.Page.al
@@ -47,6 +47,23 @@ page 8054 "Contract Types"
                 }
                 field(AllowDiffCurrInVendUD; Rec."Allow Diff. Curr. in Vend. UD") { }
                 field(AllowDiffCurrInCustUD; Rec."Allow Diff. Curr. in Cust. UD") { }
+                field(BillingPeriodDescription; Rec."Billing Period Description")
+                {
+                    ToolTip = 'Specifies the text used for the billing period line on generated sales and purchase documents for contracts of this type. Use the placeholder %1 for the billing period start date and %2 for the billing period end date. Leave empty to use the standard text.';
+                }
+                field(NoOfBillingPeriodTranslationsCtrl; FieldTranslation.GetNumberOfTranslations(Rec, Rec.FieldNo("Billing Period Description")))
+                {
+                    BlankZero = true;
+                    Caption = 'No. of Billing Period Translations';
+                    ToolTip = 'Specifies the number of billing period description translations.';
+                    Editable = false;
+
+                    trigger OnDrillDown()
+                    begin
+                        FieldTranslation.OpenTranslationsForField(Rec, Rec.FieldNo("Billing Period Description"));
+                        CurrPage.Update();
+                    end;
+                }
                 field(NoOfTranslationsCtrl; FieldTranslation.GetNumberOfTranslations(Rec, Rec.FieldNo(Description)))
                 {
                     BlankZero = true;
@@ -81,6 +98,19 @@ page 8054 "Contract Types"
                     CurrPage.Update();
                 end;
             }
+            action(OpenTranslationsForBillingPeriodDescription)
+            {
+                ApplicationArea = All;
+                Caption = 'Billing Period Translations';
+                Image = Translate;
+                ToolTip = 'Displays or edits translations for the billing period description. Translations are automatically considered and used according to the language code when printing.';
+
+                trigger OnAction()
+                begin
+                    FieldTranslation.OpenTranslationsForField(Rec, Rec.FieldNo("Billing Period Description"));
+                    CurrPage.Update();
+                end;
+            }
         }
         area(Promoted)
         {
@@ -88,6 +118,9 @@ page 8054 "Contract Types"
             {
                 Caption = 'Process';
                 actionref(OpenTranslation_Promoted; OpenTranslation)
+                {
+                }
+                actionref(OpenTranslationsForBillingPeriodDescription_Promoted; OpenTranslationsForBillingPeriodDescription)
                 {
                 }
             }

--- a/src/Apps/W1/Subscription Billing/App/Base/Tables/SubscriptionContractType.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Tables/SubscriptionContractType.Table.al
@@ -70,6 +70,18 @@ table 8053 "Subscription Contract Type"
             Caption = 'Allow Different Currency in Customer Usage Data';
             ToolTip = 'Specifies whether customer contracts of this type allow usage data with a currency different from the contract currency. If enabled, amounts will be automatically converted to the customer contract currency when creating usage data billing. If disabled, an error will be raised when the usage data currency differs from the customer contract currency.';
         }
+        field(8; "Billing Period Description"; Text[50])
+        {
+            Caption = 'Billing Period Description';
+
+            trigger OnValidate()
+            var
+                FieldTranslation: Record "Field Translation";
+            begin
+                if "Billing Period Description" = '' then
+                    FieldTranslation.DeleteRelatedTranslations(Rec, Rec.FieldNo("Billing Period Description"));
+            end;
+        }
     }
 
     keys
@@ -97,6 +109,7 @@ table 8053 "Subscription Contract Type"
         if not VendorContract.IsEmpty() then
             Error(CannotDeleteErr, TableCaption(), CustomerContract.TableCaption);
         FieldTranslation.DeleteRelatedTranslations(Rec, Rec.FieldNo(Description));
+        FieldTranslation.DeleteRelatedTranslations(Rec, Rec.FieldNo("Billing Period Description"));
     end;
 
     var

--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -416,7 +416,7 @@ codeunit 8060 "Create Billing Documents"
 
         Language.SetOverrideFormatRegion(Language.GetFormatRegionOrDefault(PurchaseHeader."Format Region"), false);
         InsertDescriptionPurchaseLine(
-             StrSubstNo(GetBillingPeriodDescriptionTxt(PurchaseHeader."Language Code"), PurchaseLine."Recurring Billing from", PurchaseLine."Recurring Billing to"), PurchaseLine."Line No.");
+             StrSubstNo(GetBillingPeriodDescriptionTxt(ServiceCommitment."Subscription Contract No.", Enum::"Service Partner"::Vendor, PurchaseHeader."Language Code"), PurchaseLine."Recurring Billing from", PurchaseLine."Recurring Billing to"), PurchaseLine."Line No.");
         Language.SetOverrideFormatRegion('', false);
 
         if CreateContractInvoice then
@@ -1170,10 +1170,36 @@ codeunit 8060 "Create Billing Documents"
     end;
 
     procedure GetBillingPeriodDescriptionTxt(LanguageCode: Code[10]) DescriptionText: Text
+    var
+        LocalTranslationHelper: Codeunit "Translation Helper";
     begin
-        TranslationHelper.SetGlobalLanguageByCode(LanguageCode);
+        // Use a local Translation Helper instance so the global-language save/restore is re-entrant.
+        // This method can be reached while an outer SetGlobalLanguageByCode block is still open
+        // (e.g. from GetAdditionalLineText), and the shared instance only stores a single saved language.
+        LocalTranslationHelper.SetGlobalLanguageByCode(LanguageCode);
         DescriptionText := GetBillingPeriodDescriptionTxt();
-        TranslationHelper.RestoreGlobalLanguage();
+        LocalTranslationHelper.RestoreGlobalLanguage();
+    end;
+
+    procedure GetBillingPeriodDescriptionTxt(ContractNo: Code[20]; Partner: Enum "Service Partner"; LanguageCode: Code[10]): Text
+    var
+        CustomerContract: Record "Customer Subscription Contract";
+        VendorContract: Record "Vendor Subscription Contract";
+        ContractType: Record "Subscription Contract Type";
+        FieldTranslation: Record "Field Translation";
+        ContractTypeCode: Code[10];
+    begin
+        case Partner of
+            Enum::"Service Partner"::Customer:
+                if CustomerContract.Get(ContractNo) then
+                    ContractTypeCode := CustomerContract."Contract Type";
+            Enum::"Service Partner"::Vendor:
+                if VendorContract.Get(ContractNo) then
+                    ContractTypeCode := VendorContract."Contract Type";
+        end;
+        if ContractType.Get(ContractTypeCode) and (ContractType."Billing Period Description" <> '') then
+            exit(FieldTranslation.FindTranslation(ContractType, ContractType.FieldNo("Billing Period Description"), LanguageCode));
+        exit(GetBillingPeriodDescriptionTxt(LanguageCode));
     end;
 
     local procedure CreateAdditionalInvoiceLine(ServiceContractSetupFieldNo: Integer; SalesHeader2: Record "Sales Header"; ParentSalesLine: Record "Sales Line"; ServiceObject: Record "Subscription Header"; ServiceCommitment: Record "Subscription Line")
@@ -1220,7 +1246,7 @@ codeunit 8060 "Create Billing Documents"
                 begin
                     Language.SetOverrideFormatRegion(Language.GetFormatRegionOrDefault(SalesHeader."Format Region"), false);
                     DescriptionText := StrSubstNo(
-                                                    GetBillingPeriodDescriptionTxt(),
+                                                    GetBillingPeriodDescriptionTxt(ServiceCommitment."Subscription Contract No.", Enum::"Service Partner"::Customer, SalesHeader."Language Code"),
                                                     ParentSalesLine."Recurring Billing from",
                                                     ParentSalesLine."Recurring Billing to");
                     Language.SetOverrideFormatRegion('', false);

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
@@ -462,6 +462,119 @@ codeunit 139687 "Recurring Billing Docs Test"
     end;
 
     [Test]
+    [HandlerFunctions('CreateCustomerBillingDocsContractPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure CheckBillingPeriodDescriptionFromContractType()
+    var
+        ContractType: Record "Subscription Contract Type";
+        BillingPeriodTemplateTok: Label 'Rental period: %1 to %2', Locked = true;
+    begin
+        // [SCENARIO] The billing period description defined on the Subscription Contract Type is used on generated sales documents
+        Initialize();
+
+        // [GIVEN] A contract type with a custom billing period description
+        ContractTestLibrary.CreateContractType(ContractType);
+        ContractType."Billing Period Description" := BillingPeriodTemplateTok;
+        ContractType.Modify(false);
+
+        // [GIVEN] A customer contract of that type with subscription lines and a billing proposal
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, '');
+        CustomerContract.Validate("Contract Type", ContractType.Code);
+        CustomerContract.Modify(true);
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer);
+
+        // [WHEN] Creating billing documents
+        CreateBillingDocuments();
+
+        // [THEN] The billing period line uses the contract type text and not the standard text
+        BillingLine.Reset();
+        BillingLine.FindFirst();
+        SalesLine.Reset();
+        SalesLine.SetRange("Document Type", BillingLine.GetSalesDocumentTypeFromBillingDocumentType());
+        SalesLine.SetRange("Document No.", BillingLine."Document No.");
+        SalesLine.SetFilter(Description, '@*Rental period*');
+        Assert.RecordIsNotEmpty(SalesLine);
+        SalesLine.SetFilter(Description, '@*Billing period*');
+        Assert.RecordIsEmpty(SalesLine);
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateCustomerBillingDocsContractPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure CheckBillingPeriodDescriptionIsTranslated()
+    var
+        ContractType: Record "Subscription Contract Type";
+        Customer: Record Customer;
+        FieldTranslation: Record "Field Translation";
+        LanguageMgt: Codeunit Language;
+        BillingPeriodTemplateTok: Label 'Rental period: %1 to %2', Locked = true;
+    begin
+        // [SCENARIO] The translated billing period description is used according to the document language code
+        Initialize();
+
+        // [GIVEN] A contract type with a billing period description and a translation for it
+        ContractTestLibrary.CreateContractType(ContractType);
+        ContractType."Billing Period Description" := BillingPeriodTemplateTok;
+        ContractType.Modify(false);
+        ContractTestLibrary.CreateTranslationForField(FieldTranslation, ContractType, ContractType.FieldNo("Billing Period Description"), LanguageMgt.GetLanguageCode(GlobalLanguage));
+
+        // [GIVEN] A customer contract of that type whose customer uses the translated language
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, '');
+        CustomerContract.Validate("Contract Type", ContractType.Code);
+        CustomerContract.Modify(true);
+        Customer.Get(CustomerContract."Bill-to Customer No.");
+        Customer.Validate("Language Code", FieldTranslation."Language Code");
+        Customer.Modify(false);
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer);
+
+        // [WHEN] Creating billing documents
+        CreateBillingDocuments();
+
+        // [THEN] The billing period line uses the translated text
+        BillingLine.Reset();
+        BillingLine.FindFirst();
+        SalesLine.Reset();
+        SalesLine.SetRange("Document Type", BillingLine.GetSalesDocumentTypeFromBillingDocumentType());
+        SalesLine.SetRange("Document No.", BillingLine."Document No.");
+        SalesLine.SetRange(Description, FieldTranslation.Translation);
+        Assert.AreEqual(1, SalesLine.Count, 'Translated Billing Period Description not found');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
+    procedure CheckBillingPeriodDescriptionFromContractTypeForPurchase()
+    var
+        ContractType: Record "Subscription Contract Type";
+        BillingPeriodTemplateTok: Label 'Rental period: %1 to %2', Locked = true;
+    begin
+        // [SCENARIO] The billing period description defined on the Subscription Contract Type is used on generated purchase documents
+        Initialize();
+
+        // [GIVEN] A contract type with a custom billing period description
+        ContractTestLibrary.CreateContractType(ContractType);
+        ContractType."Billing Period Description" := BillingPeriodTemplateTok;
+        ContractType.Modify(false);
+
+        // [GIVEN] A vendor contract of that type with subscription lines and a billing proposal
+        ContractTestLibrary.CreateVendorContractAndCreateContractLinesForItems(VendorContract, ServiceObject, '');
+        VendorContract.Validate("Contract Type", ContractType.Code);
+        VendorContract.Modify(true);
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Vendor);
+
+        // [WHEN] Creating billing documents
+        CreateBillingDocuments();
+
+        // [THEN] The billing period line uses the contract type text and not the standard text
+        BillingLine.Reset();
+        BillingLine.FindFirst();
+        PurchaseLine.Reset();
+        PurchaseLine.SetRange("Document Type", BillingLine.GetPurchaseDocumentTypeFromBillingDocumentType());
+        PurchaseLine.SetRange("Document No.", BillingLine."Document No.");
+        PurchaseLine.SetFilter(Description, '@*Rental period*');
+        Assert.RecordIsNotEmpty(PurchaseLine);
+        PurchaseLine.SetFilter(Description, '@*Billing period*');
+        Assert.RecordIsEmpty(PurchaseLine);
+    end;
+
+    [Test]
     [HandlerFunctions('CreateCustomerBillingDocsBillToCustomerPageHandler,ExchangeRateSelectionModalPageHandler,MessageHandler')]
     procedure CheckContractZeroNamesAreTransferredToSalesDocumentOnBillingPerBillToContractOptionsOff()
     var

--- a/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Customer Contracts/ContractsTest.Codeunit.al
@@ -1092,6 +1092,60 @@ codeunit 148155 "Contracts Test"
     end;
 
     [Test]
+    procedure DeleteBillingPeriodTranslationsWhenDeletingContractType()
+    var
+        ContractType: Record "Subscription Contract Type";
+        FieldTranslation: Record "Field Translation";
+        LanguageMgt: Codeunit Language;
+    begin
+        Initialize();
+
+        FieldTranslation.Reset();
+        if not FieldTranslation.IsEmpty() then
+            FieldTranslation.DeleteAll(false);
+        ContractTestLibrary.CreateContractType(ContractType);
+        ContractTestLibrary.CreateTranslationForField(FieldTranslation, ContractType, ContractType.FieldNo("Billing Period Description"), LanguageMgt.GetLanguageCode(GlobalLanguage));
+
+        FieldTranslation.Reset();
+        // Setup-Failure: expected exactly one translation
+        Assert.RecordCount(FieldTranslation, 1);
+
+        ContractType.Delete(true);
+
+        // Translation has been deleted with its master-record
+        Assert.RecordIsEmpty(FieldTranslation);
+    end;
+
+    [Test]
+    procedure DeleteBillingPeriodTranslationsWhenClearingField()
+    var
+        ContractType: Record "Subscription Contract Type";
+        FieldTranslation: Record "Field Translation";
+        LanguageMgt: Codeunit Language;
+    begin
+        Initialize();
+
+        FieldTranslation.Reset();
+        if not FieldTranslation.IsEmpty() then
+            FieldTranslation.DeleteAll(false);
+        ContractTestLibrary.CreateContractType(ContractType);
+        ContractType.Validate("Billing Period Description", 'Rental period: %1 to %2');
+        ContractType.Modify(false);
+        ContractTestLibrary.CreateTranslationForField(FieldTranslation, ContractType, ContractType.FieldNo("Billing Period Description"), LanguageMgt.GetLanguageCode(GlobalLanguage));
+
+        FieldTranslation.Reset();
+        // Setup-Failure: expected exactly one translation
+        Assert.RecordCount(FieldTranslation, 1);
+
+        // [WHEN] Clearing the billing period description
+        ContractType.Validate("Billing Period Description", '');
+
+        // [THEN] Related translations have been deleted
+        FieldTranslation.Reset();
+        Assert.RecordIsEmpty(FieldTranslation);
+    end;
+
+    [Test]
     procedure ManuallyCreateContractLineForItem()
     var
         Customer: Record Customer;


### PR DESCRIPTION
## What & why

The billing period line that the Subscription Billing app writes onto generated sales and purchase documents used a single hardcoded label (`Billing period: %1 to %2`). Many customers need different wording ("Subscription Period", "Rental Period", etc.), and it needs to work per language.

This change makes that text configurable per Subscription Contract Type via a new `Billing Period Description field` (Text[50]), with multi-language support through the existing Field Translation pattern already used for the contract type Description. At billing time the text is resolved from the contract's type (falling back to the language translation, then to the standard label). Leaving the field blank keeps the current standard text, so behavior is unchanged for existing data.

## Linked work


Fixes #5255

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [X] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

- Backward compatible: the new field is optional. Blank = existing standard "Billing period" text, so no behavior change and no data upgrade needed.
- New field is Text[50] (kept short intentionally to leave room for the two formatted date values).
- No breaking changes, no permission changes, no schema removals. Translations are runtime Field Translation records, consistent with the existing contract type Description mechanism.
