### PR TITLE
[28.x]-Missing VAT Identifier in Peppol XML for Zero-Value Invoice

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Impl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Impl.Codeunit.al
@@ -1041,7 +1041,8 @@ codeunit 37201 "PEPPOL30 Impl."
         if VATAmtLine.InsertLine() then begin
             VATAmtLine."Line Amount" += SalesLine."Line Amount";
             VATAmtLine.Modify();
-        end;
+        end else
+            InsertZeroAmountVATAmtLine(VATAmtLine, PurchaseLine."Line Amount");
     end;
 
     procedure GetTaxCategories(SalesLine: Record "Sales Line"; var VATProductPostingGroupCategory: Record "VAT Product Posting Group")
@@ -1378,5 +1379,18 @@ codeunit 37201 "PEPPOL30 Impl."
         TaxCategorySchemeID := '';
         Percent := Format(VATAmtLine."VAT %", 0, 9);
         AllowanceChargeTaxSchemeID := VATTxt;
+    end;
+
+    local procedure InsertZeroAmountVATAmtLine(var VATAmtLine: Record "VAT Amount Line"; LineAmount: Decimal)
+    begin
+        VATAmtLine.Validate(Positive, LineAmount >= 0);
+        if VATAmtLine.Find() then begin
+            VATAmtLine."Line Amount" += LineAmount;
+            VATAmtLine.Modify();
+        end else begin
+            VATAmtLine."VAT Amount" := VATAmtLine."Amount Including VAT" - VATAmtLine."VAT Base";
+            VATAmtLine."Line Amount" += LineAmount;
+            VATAmtLine.Insert();
+        end;
     end;
 }

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Impl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Impl.Codeunit.al
@@ -1042,7 +1042,7 @@ codeunit 37201 "PEPPOL30 Impl."
             VATAmtLine."Line Amount" += SalesLine."Line Amount";
             VATAmtLine.Modify();
         end else
-            InsertZeroAmountVATAmtLine(VATAmtLine, PurchaseLine."Line Amount");
+            InsertZeroAmountVATAmtLine(VATAmtLine, SalesLine."Line Amount");
     end;
 
     procedure GetTaxCategories(SalesLine: Record "Sales Line"; var VATProductPostingGroupCategory: Record "VAT Product Posting Group")


### PR DESCRIPTION
Fixes [AB#633222](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633222)

Automation file is in ADO (Devops) while fix is in BCApps







