### PR TITLE
[Main] Reopening and re-finishing production order reposts backward-flushed routing capacityupdate

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderStatusManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdOrderStatusManagement.Codeunit.al
@@ -1162,6 +1162,8 @@ codeunit 5407 "Prod. Order Status Management"
                   ItemJnlLine, ProdOrderRtngLine, OutputQtyBase,
                   GetOutputQtyForProdOrderRoutingLine(ProdOrderLine, ProdOrderRtngLine, IsLastOperation, OutputQty),
                   PutawayQtyBaseToCalc);
+                if ProdOrder.Reopened then
+                    ExcludePostedSetupTimeForReopenedProdOrder(ItemJnlLine, ProdOrderRtngLine);
                 ItemJnlLine."Concurrent Capacity" := ProdOrderRtngLine."Concurrent Capacities";
                 ItemJnlLine."Source Code" := SourceCodeSetup.Flushing;
                 if not (ItemJnlLine.TimeIsEmpty() and (ItemJnlLine."Output Quantity" = 0)) then begin
@@ -1516,6 +1518,21 @@ codeunit 5407 "Prod. Order Status Management"
             ItemJnlLine.Validate("Output Quantity", OutputQty);
             OnAfterSetTimeAndQuantityOmItemJnlLine(ItemJnlLine, ProdOrderRtngLine, OutputQtyBase, OutputQty);
         end;
+    end;
+
+    local procedure ExcludePostedSetupTimeForReopenedProdOrder(var ItemJnlLine: Record "Item Journal Line"; ProdOrderRtngLine: Record "Prod. Order Routing Line")
+    var
+        RemainingSetupTime: Decimal;
+    begin
+        if ItemJnlLine."Setup Time" = 0 then
+            exit;
+
+        ProdOrderRtngLine.CalcFields("Posted Setup Time");
+        RemainingSetupTime := ItemJnlLine."Setup Time" - ProdOrderRtngLine."Posted Setup Time";
+        if RemainingSetupTime < 0 then
+            RemainingSetupTime := 0;
+        if RemainingSetupTime <> ItemJnlLine."Setup Time" then
+            ItemJnlLine.Validate("Setup Time", RemainingSetupTime);
     end;
 
     local procedure GetOutputQtyForProdOrderRoutingLine(ProdOrderLine: Record "Prod. Order Line"; ProdOrderRtngLine: Record "Prod. Order Routing Line"; IsLastOperation: Boolean; LastOutputQty: Decimal): Decimal

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMProductionOrders.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMProductionOrders.Codeunit.al
@@ -5162,6 +5162,42 @@ codeunit 137069 "SCM Production Orders"
         Assert.ExpectedTestFieldError(RoutingHeader.FieldCaption(Status), Format(RoutingHeader.Status::Certified));
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReopenRefinishDoesNotRepostSetupTimeForBackwardFlushedProdOrder()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        FinishedProdOrder: Record "Production Order";
+        ProdOrderStatusMgt: Codeunit "Prod. Order Status Management";
+        SetupTimeAfterFirstFinish: Decimal;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 646792] Reopening and re-finishing a production order does not repost the backward-flushed routing setup time.
+        Initialize();
+
+        // [GIVEN] Item with a backward-flushed routing that has Setup Time and Run Time.
+        CreateItemWithRoutingSetUpForBackwardFlushing(Item);
+
+        // [GIVEN] Released production order changed to Finished, posting the setup time once.
+        CreateAndRefreshReleasedProductionOrder(ProductionOrder, Item."No.", LibraryRandom.RandIntInRange(10, 20));
+        LibraryManufacturing.ChangeStatusReleasedToFinished(ProductionOrder."No.");
+        SetupTimeAfterFirstFinish := GetTotalSetupTimeOnCapacityLedgerEntries(ProductionOrder."No.");
+        Assert.IsTrue(SetupTimeAfterFirstFinish > 0, 'Setup time must be posted when the production order is finished.');
+
+        // [GIVEN] The finished production order is reopened back to Released.
+        FinishedProdOrder.Get(FinishedProdOrder.Status::Finished, ProductionOrder."No.");
+        ProdOrderStatusMgt.ProcessProdOrderForReopen(FinishedProdOrder);
+
+        // [WHEN] The production order is changed to Finished again.
+        LibraryManufacturing.ChangeStatusReleasedToFinished(ProductionOrder."No.");
+
+        // [THEN] The total setup time on the capacity ledger entries is not doubled.
+        Assert.AreEqual(
+          SetupTimeAfterFirstFinish, GetTotalSetupTimeOnCapacityLedgerEntries(ProductionOrder."No."),
+          'Setup time must not be reposted when reopening and re-finishing the production order.');
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -6582,6 +6618,16 @@ codeunit 137069 "SCM Production Orders"
         CapacityLedgerEntry.SetRange("Order No.", ProdOrderNo);
         CapacityLedgerEntry.CalcSums("Run Time");
         CapacityLedgerEntry.TestField("Run Time", RunTime);
+    end;
+
+    local procedure GetTotalSetupTimeOnCapacityLedgerEntries(ProdOrderNo: Code[20]): Decimal
+    var
+        CapacityLedgerEntry: Record "Capacity Ledger Entry";
+    begin
+        CapacityLedgerEntry.SetRange("Order Type", CapacityLedgerEntry."Order Type"::Production);
+        CapacityLedgerEntry.SetRange("Order No.", ProdOrderNo);
+        CapacityLedgerEntry.CalcSums("Setup Time");
+        exit(CapacityLedgerEntry."Setup Time");
     end;
 
     local procedure VerifyTrackingOnRequisitionLine(ItemNo: Code[20]; LotNo: Variant; Quantity: Variant)


### PR DESCRIPTION
[Bug 647590](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647590): [All-e] Reopening and re-finishing production order reposts backward-flushed routing capacity


Fixes [AB#647590](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647590)




