### PR TITLE
Disable Production Definition Wizard entry points

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Document/CreateOrderFromSales.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/CreateOrderFromSales.Page.al
@@ -36,18 +36,6 @@ page 99000884 "Create Order From Sales"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Order Type';
-
-                trigger OnValidate()
-                begin
-                    UpdateWizardEditable();
-                end;
-            }
-            field(UseProductDefinitionWizard; UseProductDefinitionWizard)
-            {
-                ApplicationArea = Manufacturing;
-                Caption = 'Use Production Definition Wizard';
-                Editable = UseWizardEditable;
-                ToolTip = 'Prepare to create a production order for the selected sales demand. Optionally use the Production Definition Wizard to customize the order for a single line.';
             }
         }
     }
@@ -66,10 +54,6 @@ page 99000884 "Create Order From Sales"
         OrderType: Enum "Create Production Order Type";
         OrderStatus: Enum "Production Order Status";
         CreateStatus: Enum "Create Production Order Status";
-        UseProductDefinitionWizard: Boolean;
-        SingleLineSelected: Boolean;
-        UseWizardEditable: Boolean;
-
 
     procedure GetParameters(var NewStatus: Enum "Production Order Status"; var NewOrderType: Enum "Create Production Order Type")
     begin
@@ -82,30 +66,5 @@ page 99000884 "Create Order From Sales"
         OrderStatus := NewStatus;
         CreateStatus := OrderStatus;
         OrderType := NewOrderType;
-    end;
-
-    /// <summary>
-    /// Returns whether the Production Definition Wizard should be used for order creation.
-    /// </summary>
-    internal procedure GetUseProductDefinitionWizard(): Boolean
-    begin
-        exit(UseProductDefinitionWizard and SingleLineSelected);
-    end;
-
-    /// <summary>
-    /// Sets whether exactly one sales planning line is selected on the parent page.
-    /// Controls editability of the UseProductDefinitionWizard toggle.
-    /// </summary>
-    internal procedure SetSingleLineSelected(IsSingleLine: Boolean)
-    begin
-        SingleLineSelected := IsSingleLine;
-        UpdateWizardEditable();
-    end;
-
-    local procedure UpdateWizardEditable()
-    begin
-        UseWizardEditable := SingleLineSelected and (OrderType = "Create Production Order Type"::ItemOrder);
-        if not UseWizardEditable then
-            UseProductDefinitionWizard := false;
     end;
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Item/MfgItemCard.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Item/MfgItemCard.PageExt.al
@@ -6,7 +6,6 @@ namespace Microsoft.Inventory.Item;
 
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.StandardCost;
-using Microsoft.Manufacturing.Wizard;
 
 pageextension 99000750 "Mfg. Item Card" extends "Item Card"
 {
@@ -161,23 +160,6 @@ pageextension 99000750 "Mfg. Item Card" extends "Item Card"
                 begin
                     Item.SetRange("No.", Rec."No.");
                     Xmlport.Run(XmlPort::"Mfg. Export Item Data", false, false, Item);
-                end;
-            }
-        }
-        addafter("&Create Stockkeeping Unit")
-        {
-            action("Mfg. RunProdDefinition")
-            {
-                ApplicationArea = Manufacturing;
-                Caption = 'Production Definition';
-                Image = ProductionSetup;
-                ToolTip = 'Define or review the bill of materials and routing for this item using the Production Definition Wizard.';
-
-                trigger OnAction()
-                var
-                    ProductionDefinitionManager: Codeunit "Production Definition Manager";
-                begin
-                    ProductionDefinitionManager.RunForSource(Rec, "Prod. Definition Mode"::DefineItemStructure);
                 end;
             }
         }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Item/MfgItemList.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Item/MfgItemList.PageExt.al
@@ -10,7 +10,6 @@ using Microsoft.Inventory.Reports;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Reports;
 using Microsoft.Manufacturing.StandardCost;
-using Microsoft.Manufacturing.Wizard;
 
 pageextension 99000751 "Mfg. Item List" extends "Item List"
 {
@@ -174,23 +173,6 @@ pageextension 99000751 "Mfg. Item List" extends "Item List"
                 Caption = 'Compare Production Cost Shares';
                 Image = "Report";
                 RunObject = Report "Compare Production Cost Shares";
-            }
-        }
-        addafter("&Create Stockkeeping Unit")
-        {
-            action("Mfg. RunProdDefinition")
-            {
-                ApplicationArea = Manufacturing;
-                Caption = 'Production Definition';
-                Image = ProductionSetup;
-                ToolTip = 'Define or review the bill of materials and routing for this item using the Production Definition Wizard.';
-
-                trigger OnAction()
-                var
-                    ProductionDefinitionManager: Codeunit "Production Definition Manager";
-                begin
-                    ProductionDefinitionManager.RunForSource(Rec, "Prod. Definition Mode"::DefineItemStructure);
-                end;
             }
         }
     }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Location/MfgStockkeepingUnitCard.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Location/MfgStockkeepingUnitCard.PageExt.al
@@ -4,8 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Inventory.Location;
 
-using Microsoft.Manufacturing.Wizard;
-
 pageextension 99000754 "Mfg. Stockkeeping Unit Card" extends "Stockkeeping Unit Card"
 {
     layout
@@ -88,23 +86,6 @@ pageextension 99000754 "Mfg. Stockkeeping Unit Card" extends "Stockkeeping Unit 
                     CalculateStandardCost: Codeunit Microsoft.Manufacturing.StandardCost."Calculate Standard Cost";
                 begin
                     CalculateStandardCost.CalcItemSKU(Rec."Item No.", Rec."Location Code", Rec."Variant Code");
-                end;
-            }
-        }
-        addlast("F&unctions")
-        {
-            action("Mfg. RunProdDefinition")
-            {
-                ApplicationArea = Manufacturing;
-                Caption = 'Production Definition';
-                Image = ProductionSetup;
-                ToolTip = 'Define or review the bill of materials and routing for this item using the Production Definition Wizard.';
-
-                trigger OnAction()
-                var
-                    ProductionDefinitionManager: Codeunit "Production Definition Manager";
-                begin
-                    ProductionDefinitionManager.RunForSource(Rec, "Prod. Definition Mode"::DefineItemStructure);
                 end;
             }
         }

--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Location/MfgStockkeepingUnitList.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Location/MfgStockkeepingUnitList.PageExt.al
@@ -4,8 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Inventory.Location;
 
-using Microsoft.Manufacturing.Wizard;
-
 pageextension 99000755 "Mfg. Stockkeeping Unit List" extends "Stockkeeping Unit List"
 {
     actions
@@ -40,23 +38,6 @@ pageextension 99000755 "Mfg. Stockkeeping Unit List" extends "Stockkeeping Unit 
                         Rec.OpenActiveProductionBOMForSKUItem(Rec."Production BOM No.", Rec."Item No.");
                     end;
                 }
-            }
-        }
-        addlast("F&unctions")
-        {
-            action("Mfg. RunProdDefinition")
-            {
-                ApplicationArea = Manufacturing;
-                Caption = 'Production Definition';
-                Image = ProductionSetup;
-                ToolTip = 'Define or review the bill of materials and routing for this item using the Production Definition Wizard.';
-
-                trigger OnAction()
-                var
-                    ProductionDefinitionManager: Codeunit "Production Definition Manager";
-                begin
-                    ProductionDefinitionManager.RunForSource(Rec, "Prod. Definition Mode"::DefineItemStructure);
-                end;
             }
         }
     }

--- a/src/Layers/W1/BaseApp/Manufacturing/Sales/Document/MfgSalesOrderPlanning.PageExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Sales/Document/MfgSalesOrderPlanning.PageExt.al
@@ -5,7 +5,6 @@
 namespace Microsoft.Sales.Document;
 
 using Microsoft.Manufacturing.Document;
-using Microsoft.Manufacturing.Wizard;
 
 pageextension 99000883 "Mfg. Sales Order Planning" extends "Sales Order Planning"
 {
@@ -38,7 +37,6 @@ pageextension 99000883 "Mfg. Sales Order Planning" extends "Sales Order Planning
     var
         NewStatus: Enum "Production Order Status";
         NewOrderType: Enum "Create Production Order Type";
-        UseWizard: Boolean;
         NothingToPlanMsg: Label 'There is nothing to plan.';
 
     procedure CreateProdOrder()
@@ -49,7 +47,6 @@ pageextension 99000883 "Mfg. Sales Order Planning" extends "Sales Order Planning
         ShowCreateOrderForm: Boolean;
         IsHandled: Boolean;
     begin
-        UseWizard := false;
         ShowCreateOrderForm := true;
         IsHandled := false;
         NewOrderTypeOption := NewOrderType.AsInteger();
@@ -64,12 +61,10 @@ pageextension 99000883 "Mfg. Sales Order Planning" extends "Sales Order Planning
             exit;
 
         if ShowCreateOrderForm then begin
-            CreateOrderFromSales.SetSingleLineSelected(TempSalesPlanningLine.Count() = 1);
             if CreateOrderFromSales.RunModal() <> ACTION::Yes then
                 exit;
 
             CreateOrderFromSales.GetParameters(NewStatus, NewOrderType);
-            UseWizard := CreateOrderFromSales.GetUseProductDefinitionWizard();
             OnCreateProdOrderOnAfterGetParameters(Rec, NewStatus, NewOrderType);
             Clear(CreateOrderFromSales);
         end;
@@ -130,23 +125,19 @@ pageextension 99000883 "Mfg. Sales Order Planning" extends "Sales Order Planning
 
     local procedure CreateOrder(var TempSalesPlanningLine: Record "Sales Planning Line" temporary; DoCreateProdOrder: Boolean; var SalesLine: Record "Sales Line"; var EndLoop: Boolean; var OrdersCreated: Boolean)
     var
-        ProductionDefinitionManager: Codeunit "Production Definition Manager";
         CreateProdOrderFromSale: Codeunit "Create Prod. Order from Sale";
         HideValidationDialog: Boolean;
     begin
         HideValidationDialog := false;
         OnBeforeCreateOrder(TempSalesPlanningLine, SalesLine, DoCreateProdOrder, HideValidationDialog);
 
-        if DoCreateProdOrder then
-            if not UseWizard then begin
-                OrdersCreated := true;
-                CreateProdOrderFromSale.SetHideValidationDialog(HideValidationDialog);
-                CreateProdOrderFromSale.CreateProductionOrder(SalesLine, NewStatus, NewOrderType);
-                if NewOrderType = NewOrderType::ProjectOrder then
-                    EndLoop := true;
-            end else
-                if ProductionDefinitionManager.RunForSource(SalesLine, "Prod. Definition Mode"::CreateProductionOrder, NewStatus) then
-                    OrdersCreated := true;
+        if DoCreateProdOrder then begin
+            OrdersCreated := true;
+            CreateProdOrderFromSale.SetHideValidationDialog(HideValidationDialog);
+            CreateProdOrderFromSale.CreateProductionOrder(SalesLine, NewStatus, NewOrderType);
+            if NewOrderType = NewOrderType::ProjectOrder then
+                EndLoop := true;
+        end;
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
## What & why

The Production Definition Wizard UX needs further improvements before it is available to users. This change makes the wizard inaccessible without reverting its implementation, allowing the existing code and configuration to remain for future fixes.

## Changes

- Remove the Production Definition actions from Item Card and Item List.
- Remove the Production Definition actions from Stockkeeping Unit Card and List.
- Remove the Use Production Definition Wizard option from the sales production-order dialog.
- Restore sales planning to always use the standard production-order creation path.

## Validation

- Manufacturing app compiled with 0 errors and 0 warnings.
- Manufacturing Tests compiled with 0 errors and 0 warnings.
- Targeted sales-order planning tests passed.
- Verified no removed UI entry-point references remain.
- Wizard implementation, setup configuration, and tests remain intact.
