### PR TITLE
Bug 647600: [28.2] Fix site scoped contextinfo

### DIFF
--- a/src/System Application/App/SharePoint/src/SharePointClientImpl.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/SharePointClientImpl.Codeunit.al
@@ -370,7 +370,7 @@ codeunit 9101 "SharePoint Client Impl."
         Request.Add('Title', ListTitle);
 
         SharePointHttpContent.FromJson(Request);
-        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
+        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetSiteUrl()));
 
         SharePointRequestHelper.SetAuthorization(Authorization);
         SharePointOperationResponse := SharePointRequestHelper.Post(SharePointUriBuilder, SharePointHttpContent);
@@ -399,7 +399,7 @@ codeunit 9101 "SharePoint Client Impl."
         Request.Add('Title', ListItemTitle);
 
         SharePointHttpContent.FromJson(Request);
-        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
+        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetSiteUrl()));
 
         SharePointRequestHelper.SetAuthorization(Authorization);
         SharePointOperationResponse := SharePointRequestHelper.Post(SharePointUriBuilder, SharePointHttpContent);
@@ -427,7 +427,7 @@ codeunit 9101 "SharePoint Client Impl."
         Request.Add('Title', ListItemTitle);
 
         SharePointHttpContent.FromJson(Request);
-        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
+        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetSiteUrl()));
 
         SharePointRequestHelper.SetAuthorization(Authorization);
         SharePointOperationResponse := SharePointRequestHelper.Post(SharePointUriBuilder, SharePointHttpContent);
@@ -640,7 +640,7 @@ codeunit 9101 "SharePoint Client Impl."
         Request.Add('ServerRelativeUrl', ServerRelativeUrl);
 
         SharePointHttpContent.FromJson(Request);
-        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
+        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetSiteUrl()));
 
         SharePointRequestHelper.SetAuthorization(Authorization);
         SharePointOperationResponse := SharePointRequestHelper.Post(SharePointUriBuilder, SharePointHttpContent);
@@ -786,7 +786,7 @@ codeunit 9101 "SharePoint Client Impl."
 
         SharePointHttpContent.GetContent().ReadAs(Txt);
 
-        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetHost()));
+        SharePointHttpContent.SetRequestDigest(GetRequestDigest(SharePointUriBuilder.GetSiteUrl()));
         SharePointHttpContent.SetXHttpMethod('MERGE');
         SharePointHttpContent.SetIfMatch('*');
 

--- a/src/System Application/App/SharePoint/src/helpers/SharePointUriBuilder.Codeunit.al
+++ b/src/System Application/App/SharePoint/src/helpers/SharePointUriBuilder.Codeunit.al
@@ -31,6 +31,11 @@ codeunit 9110 "SharePoint Uri Builder"
         exit(NewUri.GetHost());
     end;
 
+    procedure GetSiteUrl(): Text
+    begin
+        exit(ServerName.TrimStart('/').TrimEnd('/'));
+    end;
+
     procedure AddQueryParameter(ParameterName: Text; ParameterValue: Text)
     begin
         QueryParameters.Add(ParameterName, ParameterValue);

--- a/src/System Application/Test Library/SharePoint/src/SharePointTestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/SharePoint/src/SharePointTestLibrary.Codeunit.al
@@ -12,6 +12,9 @@ codeunit 132973 "SharePoint Test Library"
 {
     EventSubscriberInstance = Manual;
 
+    var
+        LastContextInfoRequestUri: Text;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"SharePoint Request Helper", 'OnBeforeSendRequest', '', false, false)]
     local procedure RunOnBeforeSendRequest(HttpRequestMessage: HttpRequestMessage; var SharePointOperationResponse: Codeunit "SharePoint Operation Response"; var IsHandled: Boolean; Method: Text)
     var
@@ -33,6 +36,7 @@ codeunit 132973 "SharePoint Test Library"
         Uri := LocalUri.UnescapeDataString(Uri);
 
         if Uri.EndsWith('/_api/contextinfo/') then begin
+            LastContextInfoRequestUri := Uri;
             GetContextDigestTestResponse(SharePointOperationResponse, BaseUrl, ParentUrl);
             exit;
         end;
@@ -107,6 +111,15 @@ codeunit 132973 "SharePoint Test Library"
             end;
 
         Error('No matching test response for %1', Uri);
+    end;
+
+    /// <summary>
+    /// Returns the full request URI of the last "_api/contextinfo" request digest call that was intercepted by this test library.
+    /// </summary>
+    /// <returns>The full, unescaped request URI, or an empty string if no request digest call has been made yet.</returns>
+    procedure GetLastContextInfoRequestUri(): Text
+    begin
+        exit(LastContextInfoRequestUri);
     end;
 
     local procedure GetContextDigestTestResponse(var SharePointOperationResponse: Codeunit "SharePoint Operation Response"; BaseUrl: Text; ParentUrl: Text)

--- a/src/System Application/Test/SharePoint/src/SharePointClientTest.Codeunit.al
+++ b/src/System Application/Test/SharePoint/src/SharePointClientTest.Codeunit.al
@@ -399,6 +399,45 @@ codeunit 132970 "SharePoint Client Test"
         Assert.IsTrue(TempSharePointFolder.OdataId.EndsWith('_api/Web/GetFolderByServerRelativePath(decodedurl=''' + ParentUrl + '/Lists/Test Documents/Attachments/TestSubfolder'')'), StrSubstNo('Different %1 value expected', TempSharePointFolder.FieldCaption("OdataId")));
         Assert.AreEqual('SP.Folder', TempSharePointFolder.OdataType, StrSubstNo('Different %1 value expected', TempSharePointFolder.FieldCaption("OdataType")));
         Assert.IsTrue(TempSharePointFolder."Server Relative Url".EndsWith('/Lists/Test Documents/Attachments/TestSubfolder'), StrSubstNo('Different %1 value expected', TempSharePointFolder.FieldCaption("Server Relative Url")));
+
+        // [THEN] The request digest ("_api/contextinfo") call was made against the site-scoped URL, not the tenant root
+        Assert.AreEqual('https://' + BaseUrl + '/_api/contextinfo/', SharePointTestLibrary.GetLastContextInfoRequestUri(), 'Request digest should be requested from the site-scoped URL, not the tenant root.');
+    end;
+
+    [Test]
+    procedure TestCreateListRequestDigestUsesSiteScopedUrl()
+    var
+        TempSharePointList: Record "SharePoint List" temporary;
+        IsSuccess: Boolean;
+    begin
+        // [Scenario] CreateList requests the digest from the site-scoped URL, not the tenant root, so it works under Sites.Selected
+        Initialize();
+
+        // [WHEN] CreateList is called for a site-scoped account (BaseUrl contains a "/sites/<site>" segment)
+        IsSuccess := SharePointClient.CreateList('Test Sample List Title', 'Test Sample List Description', TempSharePointList);
+        Assert.AreEqual(true, IsSuccess, 'Successfull operation expected');
+
+        // [THEN] The request digest ("_api/contextinfo") call was made against the site-scoped URL, not the tenant root
+        Assert.AreEqual('https://' + BaseUrl + '/_api/contextinfo/', SharePointTestLibrary.GetLastContextInfoRequestUri(), 'Request digest should be requested from the site-scoped URL, not the tenant root.');
+    end;
+
+    [Test]
+    procedure TestCreateListItemRequestDigestUsesSiteScopedUrl()
+    var
+        TempSharePointListItem: Record "SharePoint List Item" temporary;
+        Guid: Guid;
+        IsSuccess: Boolean;
+    begin
+        // [Scenario] CreateListItem requests the digest from the site-scoped URL, not the tenant root, so it works under Sites.Selected
+        Initialize();
+        Evaluate(Guid, '{854D7F21-1C6A-43AB-A081-20404894B449}');
+
+        // [WHEN] CreateListItem is called for a site-scoped account (BaseUrl contains a "/sites/<site>" segment)
+        IsSuccess := SharePointClient.CreateListItem(Guid, 'SP.Data.My_x0020_Test_x0020_DocumentsListItem', 'Test List Item', TempSharePointListItem);
+        Assert.AreEqual(true, IsSuccess, 'Successfull operation expected');
+
+        // [THEN] The request digest ("_api/contextinfo") call was made against the site-scoped URL, not the tenant root
+        Assert.AreEqual('https://' + BaseUrl + '/_api/contextinfo/', SharePointTestLibrary.GetLastContextInfoRequestUri(), 'Request digest should be requested from the site-scoped URL, not the tenant root.');
     end;
 
     [Test]


### PR DESCRIPTION
#### Summary

Backport of #9454 to `releases/28.2`.

`SharePoint Uri Builder.GetHost()` intentionally returns only the hostname, but request-digest calls used it for `/_api/contextinfo`. For site-scoped URLs such as `https://tenant.sharepoint.com/sites/site` the request therefore targeted the tenant root instead of the configured site, so folder and list creation failed when the Entra ID application was granted only `Sites.Selected` permissions on Microsoft Graph and SharePoint.

This adds a site-base URL accessor and uses it for request-digest acquisition in `CreateList`, both `CreateListItem` overloads, `CreateFolder` and `UpdateListItemMetaDataField`. `GetHost()` is unchanged, so existing hostname-only consumers keep their behavior.

Regression tests verify that contextinfo requests retain the configured `/sites/<site>` path.

#### Work Item(s)

Fixes [AB#647600](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647600) (backport of [AB#630670](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/630670))

#### Cherry-pick

Clean cherry-pick of df80e17f469b77c4d3680f3efce7dd7d0e460cd8 (the `releases/28.x` backport, #10309) with `-x`, no conflicts and no manual edits. The diff is identical to the change merged to `main`: 4 files, 62 insertions, 5 deletions.

#### Risk & compatibility

Internal URI-construction change only. No schema, data-upgrade, permission or public API contract changes.

