### PR TITLE
[Master]-When Intrastat line is added manually the "Intrastat Country/Region Code" is not automatically populated after adding the "Country/Region Code"

### DIFF
--- a/src/Apps/W1/Intrastat/app/src/IntrastatReport/IntrastatReportLine.Table.al
+++ b/src/Apps/W1/Intrastat/app/src/IntrastatReport/IntrastatReportLine.Table.al
@@ -94,6 +94,18 @@ table 4812 "Intrastat Report Line"
             Caption = 'Country/Region Code';
             TableRelation = "Country/Region";
             ToolTip = 'Specifies the country/region of the address.';
+
+            trigger OnValidate()
+            var
+                IntrastatReportMgt: Codeunit IntrastatReportManagement;
+            begin
+                if "Country/Region Code" = '' then begin
+                    Validate("Intrastat Country/Region Code", '');
+                    exit;
+                end;
+
+                Validate("Intrastat Country/Region Code", IntrastatReportMgt.GetIntrastatCodeFromCountryRegion("Country/Region Code"));
+            end;
         }
         field(8; "Transaction Type"; Code[10])
         {

--- a/src/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
+++ b/src/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
@@ -4829,6 +4829,37 @@ codeunit 139550 "Intrastat Report Test"
         Assert.AreEqual(TariffNo."No.", ItemTempl."Tariff No.", '');
     end;
 
+    [Test]
+    procedure ManualIntrastatReportLineUsesIntrastatCode()
+    var
+        CountryRegion: array[2] of Record "Country/Region";
+        IntrastatReportLine: Record "Intrastat Report Line";
+    begin
+        // [SCENARIO 644797] A manually added Intrastat report line uses the country's Intrastat Code.
+        Initialize();
+
+        // [GIVEN] Create country/region with a different Intrastat Code.
+        LibraryIntrastat.CreateCountryRegion(CountryRegion[1], true);
+        LibraryIntrastat.CreateCountryRegion(CountryRegion[2], true);
+        CountryRegion[1].Validate("Intrastat Code", CountryRegion[2].Code);
+        CountryRegion[1].Modify(true);
+
+        // [GIVEN] Create a manually added Intrastat report line.
+        LibraryIntrastat.CreateIntrastatReportLine(IntrastatReportLine);
+
+        // [WHEN] The Country/Region Code is validated on the line.
+        IntrastatReportLine.Validate("Country/Region Code", CountryRegion[1].Code);
+
+        // [THEN] The Intrastat Country/Region Code uses the country's Intrastat Code.
+        IntrastatReportLine.TestField("Intrastat Country/Region Code", CountryRegion[2].Code);
+
+        // [WHEN] The Country/Region Code is cleared.
+        IntrastatReportLine.Validate("Country/Region Code", '');
+
+        // [THEN] The Intrastat Country/Region Code is also cleared.
+        IntrastatReportLine.TestField("Intrastat Country/Region Code", '');
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";

--- a/src/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
+++ b/src/Apps/W1/Intrastat/test/src/IntrastatReportTest.Codeunit.al
@@ -4835,6 +4835,7 @@ codeunit 139550 "Intrastat Report Test"
         CountryRegion: array[2] of Record "Country/Region";
         IntrastatReportLine: Record "Intrastat Report Line";
     begin
+        // [FEATURE] [AI test 0.4]
         // [SCENARIO 644797] A manually added Intrastat report line uses the country's Intrastat Code.
         Initialize();
 


### PR DESCRIPTION
**Issue:** When an Intrastat Report line is added manually, the Intrastat Country/Region Code stays blank after the user enters the Country/Region Code.

**Cause:** The Country/Region Code field on table IntrastatReportLine had no OnValidate logic to derive the Intrastat code, so only the Suggest Lines path populated Intrastat Country/Region Code.

**Solution:** Added an OnValidate trigger on Country/Region Code that sets Intrastat Country/Region Code.

Workitem : [Bug 646599](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646599): [Master][ALL-E][SaaS] When Intrastat line is added manually the "Intrastat Country/Region Code" is not automatically populated after adding the "Country/Region Code"

Fixes [AB#646599](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646599)

