### PR TITLE
Ruleset hardening: promote AL0659 and AL0685 to Error

### DIFF
--- a/src/Apps/CH/SwissQRBill/app/src/core/SwissQRBillPaymentReferenceType.Enum.al
+++ b/src/Apps/CH/SwissQRBill/app/src/core/SwissQRBillPaymentReferenceType.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Bank.Payment;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 11512 "Swiss QR-Bill Payment Reference Type"
+#pragma warning restore AL0659
 {
     Extensible = false;
 

--- a/src/Apps/DE/IntrastatDE/app/src/IntrastatSubmissionChannelDE.Enum.al
+++ b/src/Apps/DE/IntrastatDE/app/src/IntrastatSubmissionChannelDE.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Inventory.Intrastat;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 11035 "Intrastat Submission Channel DE"
+#pragma warning restore AL0659
 {
     Extensible = true;
     Caption = 'Intrastat Submission Channel';

--- a/src/Apps/IN/INGST/app/GSTReturnSettlement/src/table/GSTJournalTemplate.table.al
+++ b/src/Apps/IN/INGST/app/GSTReturnSettlement/src/table/GSTJournalTemplate.table.al
@@ -79,7 +79,9 @@ table 18323 "GST Journal Template"
             TableRelation = "Reason Code";
             DataClassification = CustomerContent;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(7; "Page Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = Lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Page), "Object ID" = field("Page ID")));
             Caption = 'Page Name';

--- a/src/Apps/IN/INTCS/app/TCSReturnAndSettlement/src/TCS-Journal/table/TCSJournalTemplate.table.al
+++ b/src/Apps/IN/INTCS/app/TCSReturnAndSettlement/src/TCS-Journal/table/TCSJournalTemplate.table.al
@@ -50,7 +50,9 @@ table 18871 "TCS Journal Template"
         {
             DataClassification = CustomerContent;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(5; "Form Name"; Text[80])
+#pragma warning restore AL0685
         {
             Editable = false;
             FieldClass = FlowField;

--- a/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/TDS-Journal/TDSJournalTemplate.table.al
+++ b/src/Apps/IN/INTDS/app/TDSReturnAndSettlement/src/TDS-Journal/TDSJournalTemplate.table.al
@@ -59,7 +59,9 @@ table 18748 "TDS Journal Template"
             DataClassification = CustomerContent;
             TableRelation = "Reason Code";
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(7; "Form Name"; Text[80])
+#pragma warning restore AL0685
         {
             Caption = 'Form Name';
             Editable = false;

--- a/src/Layers/BE/BaseApp/Local/BankMgt/Payment/DomiciliationJournalTemplate.Table.al
+++ b/src/Layers/BE/BaseApp/Local/BankMgt/Payment/DomiciliationJournalTemplate.Table.al
@@ -52,7 +52,9 @@ table 2000020 "Domiciliation Journal Template"
             Caption = 'Reason Code';
             TableRelation = "Reason Code";
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(15; "Test Report Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Report),
                                                                            "Object ID" = field("Test Report ID")));
@@ -60,7 +62,9 @@ table 2000020 "Domiciliation Journal Template"
             Editable = false;
             FieldClass = FlowField;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(16; "Page Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Page),
                                                                            "Object ID" = field("Page ID")));

--- a/src/Layers/BE/BaseApp/Local/BankMgt/Payment/PaymentJournalTemplate.Table.al
+++ b/src/Layers/BE/BaseApp/Local/BankMgt/Payment/PaymentJournalTemplate.Table.al
@@ -52,7 +52,9 @@ table 2000000 "Payment Journal Template"
             Caption = 'Reason Code';
             TableRelation = "Reason Code";
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(15; "Test Report Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Report),
                                                                            "Object ID" = field("Test Report ID")));
@@ -60,7 +62,9 @@ table 2000000 "Payment Journal Template"
             Editable = false;
             FieldClass = FlowField;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(16; "Page Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Page),
                                                                            "Object ID" = field("Page ID")));

--- a/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/DataExportRecordField.Table.al
+++ b/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/DataExportRecordField.Table.al
@@ -38,7 +38,9 @@ table 11005 "Data Export Record Field"
                 UpdateFieldProperties();
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(4; "Table Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Table),
                                                                            "Object ID" = field("Table No.")));

--- a/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/DataExportRecordSource.Table.al
+++ b/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/DataExportRecordSource.Table.al
@@ -47,7 +47,9 @@ table 11004 "Data Export Record Source"
                 FindDataFilterField();
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(4; "Table Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Table),
                                                                            "Object ID" = field("Table No.")));
@@ -83,7 +85,9 @@ table 11004 "Data Export Record Source"
             Caption = 'Relation To Table No.';
             TableRelation = AllObj."Object ID" where("Object Type" = const(Table));
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(8; "Relation To Table Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Table),
                                                                            "Object ID" = field("Relation To Table No.")));

--- a/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/DataExportTableRelation.Table.al
+++ b/src/Layers/DACH/BaseApp/Local/Finance/AuditFileExport/DataExportTableRelation.Table.al
@@ -33,7 +33,9 @@ table 11006 "Data Export Table Relation"
             NotBlank = true;
             TableRelation = AllObj."Object ID" where("Object Type" = const(Table));
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(4; "From Table Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Table),
                                                                            "Object ID" = field("From Table No.")));
@@ -90,7 +92,9 @@ table 11006 "Data Export Table Relation"
             NotBlank = true;
             TableRelation = AllObj."Object ID" where("Object Type" = const(Table));
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(8; "To Table Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Table),
                                                                            "Object ID" = field("To Table No.")));

--- a/src/Layers/DACH/BaseApp/Local/Foundation/DACHReportSelections.Table.al
+++ b/src/Layers/DACH/BaseApp/Local/Foundation/DACHReportSelections.Table.al
@@ -33,7 +33,9 @@ table 26100 "DACH Report Selections"
             Caption = 'Report ID';
             TableRelation = AllObjWithCaption."Object ID" where("Object Type" = const(Report));
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(4; "Report Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Report),
                                                                            "Object ID" = field("Report ID")));

--- a/src/Layers/DACH/BaseApp/Local/Purchases/Reminders/ReportSelectionUsageDelRem.EnumExt.al
+++ b/src/Layers/DACH/BaseApp/Local/Purchases/Reminders/ReportSelectionUsageDelRem.EnumExt.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Foundation.Reporting;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enumextension 26101 "Report Selection Usage Del. Rem." extends "Report Selection Usage"
+#pragma warning restore AL0659
 {
     value(5005272; "Delivery Reminder Test") { Caption = 'Delivery Reminder Test'; }
     value(5005273; "Issued Delivery Reminder") { Caption = 'Issued Delivery Reminder'; } 

--- a/src/Layers/ES/BaseApp/Local/HistoryofEquivalencesCOA.Table.al
+++ b/src/Layers/ES/BaseApp/Local/HistoryofEquivalencesCOA.Table.al
@@ -36,7 +36,9 @@ table 10724 "History of Equivalences COA"
             TableRelation = "G/L Account"."No.";
             ValidateTableRelation = true;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(5; "New G/L Account Name"; Text[30])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("New G/L Account No.")));
             Caption = 'New G/L Account Name';

--- a/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIIDocUploadStateDocumentSource.Enum.al
+++ b/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIIDocUploadStateDocumentSource.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.EServices.EDocument;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 10755 "SII Doc. Upload State Document Source"
+#pragma warning restore AL0659
 {
     Extensible = true;
 

--- a/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIIDocUploadStateDocumentType.Enum.al
+++ b/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIIDocUploadStateDocumentType.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.EServices.EDocument;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 10756 "SII Doc. Upload State Document Type"
+#pragma warning restore AL0659
 {
     Extensible = true;
 

--- a/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIIPurchUploadCrMemoType.Enum.al
+++ b/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIIPurchUploadCrMemoType.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.EServices.EDocument;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 10715 "SII Purch. Upload Cr. Memo Type"
+#pragma warning restore AL0659
 {
     Extensible = true;
     AssignmentCompatibility = true;

--- a/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIISalesUploadCreditMemoType.Enum.al
+++ b/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIISalesUploadCreditMemoType.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.EServices.EDocument;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 10714 "SII Sales Upload Credit Memo Type"
+#pragma warning restore AL0659
 {
     Extensible = true;
     AssignmentCompatibility = true;

--- a/src/Layers/FI/BaseApp/Local/FinancialMgt/AutomaticAccounts/AutomaticAccLine.Table.al
+++ b/src/Layers/FI/BaseApp/Local/FinancialMgt/AutomaticAccounts/AutomaticAccLine.Table.al
@@ -66,7 +66,9 @@ table 11204 "Automatic Acc. Line"
                 Rec.ValidateShortcutDimCode(2, "Shortcut Dimension 2 Code");
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(7; Description; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("G/L Account No.")));
             Caption = 'Description';

--- a/src/Layers/IT/BaseApp/Local/Purchases/Vendor/CustomsAuthorityVendor.Table.al
+++ b/src/Layers/IT/BaseApp/Local/Purchases/Vendor/CustomsAuthorityVendor.Table.al
@@ -19,7 +19,9 @@ table 12122 "Customs Authority Vendor"
             Caption = 'Vendor No.';
             TableRelation = Vendor;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(2; Name; Text[30])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(Vendor.Name where("No." = field("Vendor No.")));
             Caption = 'Name';

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/ExportProtocol.Table.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/ExportProtocol.Table.al
@@ -78,7 +78,9 @@ table 11000005 "Export Protocol"
         {
             Caption = 'Parameter';
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(30; "Check Name"; Text[30])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Codeunit),
                                                                            "Object ID" = field("Check ID")));
@@ -91,7 +93,9 @@ table 11000005 "Export Protocol"
             Caption = 'Export Name';
             Editable = false;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(32; "Docket Name"; Text[30])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Report),
                                                                            "Object ID" = field("Docket ID")));

--- a/src/Layers/NL/BaseApp/Local/Bank/Statement/CBGStatementLineAccountType.Enum.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Statement/CBGStatementLineAccountType.Enum.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Bank.Statement;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 11000007 "CBG Statement Line Account Type"
+#pragma warning restore AL0659
 {
     Extensible = true;
     AssignmentCompatibility = true;

--- a/src/Layers/NO/DemoTool/AccSchedulesConversion.Table.al
+++ b/src/Layers/NO/DemoTool/AccSchedulesConversion.Table.al
@@ -15,7 +15,9 @@ table 160801 "Acc. Schedules Conversion"
             Caption = 'Line No.';
             TableRelation = "Acc. Schedule Line"."Line No." where("Schedule Name" = field("Schedule Name"));
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(3; "Totaling (Old)"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("Acc. Schedule Line".Totaling where("Schedule Name" = field("Schedule Name"),
                                                                       "Line No." = field("Line No.")));
@@ -35,7 +37,9 @@ table 160801 "Acc. Schedules Conversion"
             Editable = false;
             FieldClass = FlowField;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(6; Description; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("Acc. Schedule Line".Description where("Schedule Name" = field("Schedule Name"),
                                                                          "Line No." = field("Line No.")));

--- a/src/Layers/RU/BaseApp/Finance/FinancialReports/AccScheduleLineTotalingType.Enum.al
+++ b/src/Layers/RU/BaseApp/Finance/FinancialReports/AccScheduleLineTotalingType.Enum.al
@@ -13,7 +13,9 @@ namespace Microsoft.Finance.FinancialReports;
 /// cash flow forecasting, formulas, and percentage calculations. Enables flexible financial reporting
 /// across multiple data dimensions and calculation methodologies.
 /// </remarks>
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enum 85 "Acc. Schedule Line Totaling Type"
+#pragma warning restore AL0659
 {
     Extensible = true;
     AssignmentCompatibility = true;

--- a/src/Layers/RU/BaseApp/Local/TaxCalcDimFilter.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxCalcDimFilter.Table.al
@@ -69,7 +69,9 @@ table 17313 "Tax Calc. Dim. Filter"
                     "If No Value" := "If No Value"::Ignore;
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(9; "Dimension Name"; Text[30])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("Dimension Value".Name where("Dimension Code" = field("Dimension Code"),
                                                                Code = field("Dimension Value Filter")));

--- a/src/Layers/RU/BaseApp/Local/TaxCalcGLCorrEntry.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxCalcGLCorrEntry.Table.al
@@ -52,14 +52,18 @@ table 17319 "Tax Calc. G/L Corr. Entry"
         {
             Caption = 'Where Used Register IDs';
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(21; "Debit Account Name"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("Debit Account No.")));
             Caption = 'Debit Account Name';
             Editable = false;
             FieldClass = FlowField;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(22; "Credit Account Name"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("Credit Account No.")));
             Caption = 'Credit Account Name';

--- a/src/Layers/RU/BaseApp/Local/TaxCalcSection.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxCalcSection.Table.al
@@ -90,7 +90,9 @@ table 17307 "Tax Calc. Section"
                 CheckUseDimCode(4, xRec."Dimension 4 Code", "Dimension 4 Code");
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(16; "Page Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Page),
                                                                            "Object ID" = field("Page ID")));

--- a/src/Layers/RU/BaseApp/Local/TaxDiffJournalTemplate.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxDiffJournalTemplate.Table.al
@@ -62,7 +62,9 @@ table 17303 "Tax Diff. Journal Template"
             Caption = 'Reason Code';
             TableRelation = "Reason Code";
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(16; "Page Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Page),
                                                                            "Object ID" = field("Page ID")));

--- a/src/Layers/RU/BaseApp/Local/TaxRegisterFAEntry.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxRegisterFAEntry.Table.al
@@ -147,7 +147,9 @@ table 17211 "Tax Register FA Entry"
             Editable = false;
             FieldClass = FlowField;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(83; "Taken Off Books Reason"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("FA Ledger Entry".Description where("FA No." = field("FA No."),
                                                                       "Depreciation Book Code" = field("Depreciation Book Code"),

--- a/src/Layers/RU/BaseApp/Local/TaxRegisterGLCorrEntry.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxRegisterGLCorrEntry.Table.al
@@ -50,14 +50,18 @@ table 17203 "Tax Register G/L Corr. Entry"
         {
             Caption = 'Where Used Register IDs';
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(21; "Debit Account Name"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("Debit Account No.")));
             Caption = 'Debit Account Name';
             Editable = false;
             FieldClass = FlowField;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(22; "Credit Account Name"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("Credit Account No.")));
             Caption = 'Credit Account Name';

--- a/src/Layers/RU/BaseApp/Local/TaxRegisterSection.Table.al
+++ b/src/Layers/RU/BaseApp/Local/TaxRegisterSection.Table.al
@@ -107,7 +107,9 @@ table 17207 "Tax Register Section"
                 CheckUseDimCode(4, xRec."Dimension 4 Code", "Dimension 4 Code");
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(16; "Page Name"; Text[80])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(AllObjWithCaption."Object Caption" where("Object Type" = const(Page),
                                                                            "Object ID" = field("Page ID")));

--- a/src/Layers/RU/BaseApp/Purchases/Vendor/Vendor.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Vendor/Vendor.Table.al
@@ -1763,7 +1763,9 @@ table 23 Vendor
                 end;
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(12404; "Customer Name"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(Customer.Name where("No." = field("Customer No.")));
             Caption = 'Customer Name';

--- a/src/Layers/RU/BaseApp/Sales/Customer/Customer.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/Customer/Customer.Table.al
@@ -2394,7 +2394,9 @@ table 18 Customer
                 end;
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(12402; "Vendor Name"; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup(Vendor.Name where("No." = field("Vendor No.")));
             Caption = 'Vendor Name';

--- a/src/Layers/SE/BaseApp/Local/FinancialMgt/AutomaticAccounts/AutomaticAccLine.Table.al
+++ b/src/Layers/SE/BaseApp/Local/FinancialMgt/AutomaticAccounts/AutomaticAccLine.Table.al
@@ -66,7 +66,9 @@ table 11204 "Automatic Acc. Line"
                 Rec.ValidateShortcutDimCode(2, "Shortcut Dimension 2 Code");
             end;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(7; Description; Text[50])
+#pragma warning restore AL0685
         {
             CalcFormula = lookup("G/L Account".Name where("No." = field("G/L Account No.")));
             Caption = 'Description';

--- a/src/Layers/W1/BaseApp/Integration/FieldService/FSProjectTask.Table.al
+++ b/src/Layers/W1/BaseApp/Integration/FieldService/FSProjectTask.Table.al
@@ -86,7 +86,9 @@ table 6404 "FS Project Task"
             TableRelation = "CRM SystemUser".SystemUserId;
             DataClassification = SystemMetadata;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(8; CreatedByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM SystemUser".FullName where(SystemUserId = field(CreatedBy)));
@@ -94,7 +96,9 @@ table 6404 "FS Project Task"
             ExternalType = 'String';
             ExternalAccess = Read;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(10; CreatedOnBehalfByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM SystemUser".FullName where(SystemUserId = field(CreatedOnBehalfBy)));
@@ -102,7 +106,9 @@ table 6404 "FS Project Task"
             ExternalType = 'String';
             ExternalAccess = Read;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(12; ModifiedByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM Systemuser".FullName where(SystemUserId = field(ModifiedBy)));
@@ -110,7 +116,9 @@ table 6404 "FS Project Task"
             ExternalType = 'String';
             ExternalAccess = Read;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(14; ModifiedOnBehalfByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM Systemuser".FullName where(SystemUserId = field(ModifiedOnBehalfBy)));

--- a/src/Layers/W1/BaseApp/Integration/FieldService/FSResourcePayType.Table.al
+++ b/src/Layers/W1/BaseApp/Integration/FieldService/FSResourcePayType.Table.al
@@ -85,7 +85,9 @@ table 6206 "FS Resource Pay Type"
             TableRelation = "CRM Systemuser".SystemUserId;
             DataClassification = SystemMetadata;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(8; CreatedByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM Systemuser".FullName where(SystemUserId = field(CreatedBy)));
@@ -93,7 +95,9 @@ table 6206 "FS Resource Pay Type"
             ExternalType = 'String';
             ExternalAccess = Read;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(10; CreatedOnBehalfByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM Systemuser".FullName where(SystemUserId = field(CreatedOnBehalfBy)));
@@ -101,7 +105,9 @@ table 6206 "FS Resource Pay Type"
             ExternalType = 'String';
             ExternalAccess = Read;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(12; ModifiedByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM Systemuser".FullName where(SystemUserId = field(ModifiedBy)));
@@ -109,7 +115,9 @@ table 6206 "FS Resource Pay Type"
             ExternalType = 'String';
             ExternalAccess = Read;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(14; ModifiedOnBehalfByName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM Systemuser".FullName where(SystemUserId = field(ModifiedOnBehalfBy)));
@@ -155,7 +163,9 @@ table 6206 "FS Resource Pay Type"
             TableRelation = "CRM Team".TeamId;
             DataClassification = SystemMetadata;
         }
+#pragma warning disable AL0685 // Accepted: changing the field length is a breaking schema change
         field(24; OwningBusinessUnitName; Text[100])
+#pragma warning restore AL0685
         {
             FieldClass = FlowField;
             CalcFormula = lookup("CRM BusinessUnit".Name where(BusinessUnitId = field(OwningBusinessUnit)));

--- a/src/Layers/W1/BaseApp/Manufacturing/Warehouse/Activity/MfgWhsePickRqstDocType.EnumExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Warehouse/Activity/MfgWhsePickRqstDocType.EnumExt.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Warehouse.Activity;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enumextension 99000776 "Mfg. Whse. Pick Rqst. Doc. Type" extends "Warehouse Pick Request Document Type"
+#pragma warning restore AL0659
 {
     value(2; "Production") { Caption = 'Production'; }
 }

--- a/src/Layers/W1/BaseApp/Manufacturing/Warehouse/Activity/MfgWhsePutAwayRqstDocType.EnumExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Warehouse/Activity/MfgWhsePutAwayRqstDocType.EnumExt.al
@@ -4,7 +4,9 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Warehouse.Activity;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enumextension 99000780 "Mfg. Whse. PutAway Rqst. Doc. Type" extends "Warehouse Put-away Request Document Type"
+#pragma warning restore AL0659
 {
     value(2; "Production") { Caption = 'Production'; }
 }

--- a/src/Layers/W1/BaseApp/OtherCapabilities/RetentionPolicy/RetenPolDocArchiveFltrng.EnumExt.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/RetentionPolicy/RetenPolDocArchiveFltrng.EnumExt.al
@@ -1,6 +1,8 @@
 namespace System.DataAdministration;
 
+#pragma warning disable AL0659 // Accepted: renaming the enum is a breaking change
 enumextension 3999 "Reten. Pol. Doc. Archive Fltrng." extends "Reten. Pol. Filtering"
+#pragma warning restore AL0659
 {
     value(3999; "Document Archive Filtering")
     {

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -46,11 +46,6 @@
       "action": "Warning"
     },
     {
-      "id": "AL0659",
-      "action": "Warning",
-      "justification": "The length of the enum identifier 'Acc. Schedule Line Totaling Type' should not exceed 30 characters as it may result in runtime issues in cases where there are other enums with the same first 30 characters."
-    },
-    {
       "id": "AL0667",
       "action": "Warning",
       "justification": "'ObsoleteReason' is being deprecated in the versions: '1.0' or greater. This property is not allowed on areas. This warning will become an error in a future release."
@@ -59,10 +54,6 @@
       "id": "AL0684",
       "action": "None",
       "justification": "The permissionset contains permissionsets or permission for objects from other module. Permissions on objects from other modules will be ignored."
-    },
-    {
-      "id": "AL0685",
-      "action": "Warning"
     },
     {
       "id": "AL0717",


### PR DESCRIPTION
Continues the ruleset hardening work for [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773): two more analyzer rules go back to `Error`.

## What changed

`src/rulesets/base.ruleset.json`: removed the `AL0659` and `AL0685` overrides (94 -> 92 remaining). Both now inherit `Error` from `./ruleset.json`.

Everything else in the diff is pragma insertions - **106 insertions, 0 deletions outside the ruleset**.

## Scope

Sites were taken from a full repo-wide analyzer census (all projects, all layers), attributed per `project|file|line|column`:

| Rule | Sites | Files | Meaning |
|---|---|---|---|
| `AL0659` | 12 | 12 | Enum identifier exceeds 30 characters, so it may collide with another enum sharing the same first 30 characters |
| `AL0685` | 41 | 26 | FlowField calculation formula target is longer than the source flow field |

Pre-flight checks run before applying: `#if not CLEAN<NN>` gating in target files, and nesting inside existing file-wide pragmas (restores are ID-qualified, so nesting is safe). After applying, the pragma count was reconciled against the census per rule - 12/12 and 41/41.

## Accepted violations

- **`AL0659`** - shortening an enum identifier is a breaking change for anyone referencing it, so the existing names are accepted in place.
- **`AL0685`** - worth calling out explicitly: the calculation formula's target field really *is* longer than its source flow field, so **there is genuine truncation risk here**. Widening the source or shortening the target is a breaking schema change, so this PR accepts the risk rather than changing the schema. If you think any specific site should be changed instead of pragma'd, please flag it and I'll split it out.

## Known real collision - follow-up needed

Review flagged, correctly, that `AL0659` is not purely theoretical in one case. These two ES enums truncate to the **same** first 30 characters:

| Enum | Length | First 30 chars |
|---|---|---|
| `SII Doc. Upload State Document Source` (10755) | 37 | `SII Doc. Upload State Document` |
| `SII Doc. Upload State Document Type` (10756) | 35 | `SII Doc. Upload State Document` |

That is an actual, unresolved collision risk rather than a long-name false positive. Renaming either enum is a breaking change and does not belong in a ruleset-hardening PR, so it is suppressed here and tracked as a deliberate follow-up. The remaining 10 `AL0659` sites were checked and share no 30-character prefix with another enum.

## Verification

- Local `Invoke-MiSnapApp` propagation gate: SUCCESS (39 files).
- Every pragma site was verified against the actual declaration line before insertion.

Related to [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773)

