### PR TITLE
Bug 641415: [Expense Agent] Incorrect Payment Method Assignment for Card-Based Expenses

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseAgentSetup.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseAgentSetup.Codeunit.al
@@ -222,9 +222,9 @@ codeunit 6970 "Create Expense Agent Setup"
         CardTok: Label 'Card', Locked = true;
         CashTok: Label 'Cash', Locked = true;
         BankTok: Label 'Bank', Locked = true;
-        XCARDTxt: Label 'Card';
-        XCASHTxt: Label 'Cash';
-        XBANKTxt: Label 'Bank';
+        XCARDTxt: Label 'Company credit card', MaxLength = 100;
+        XCASHTxt: Label 'Cash paid by employee', MaxLength = 100;
+        XBANKTxt: Label 'Company paid by bank transfer', MaxLength = 100;
         MilesTxt: Label 'Miles';
         MilesCodeTxt: Label 'MILES';
 }


### PR DESCRIPTION
Added more descriptive descriptions for expense payment methods to avoid confusion about company credit cards vs. employee paid expenses.

Fixes [AB#641415](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641415)



