### PR TITLE
Add default manufacturing version number series

### DIFF
--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgNoSeries.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgNoSeries.Codeunit.al
@@ -19,8 +19,10 @@ codeunit 4784 "Create Mfg No Series"
     begin
         ContosoNoSeries.InsertNoSeries(WorkCenter(), WorkCentersLbl, 'W10', 'W99990', '', '', 10, Enum::"No. Series Implementation"::Sequence, true);
         ContosoNoSeries.InsertNoSeries(ProductionBOM(), ProductionBOMsLbl, 'P10', 'P99990', '', '', 10, Enum::"No. Series Implementation"::Sequence, true);
+        ContosoNoSeries.InsertNoSeries(ProductionBOMVersion(), ProductionBOMVersionsLbl, 'PV10', 'PV99990', '', '', 10, Enum::"No. Series Implementation"::Sequence, true);
         ContosoNoSeries.InsertNoSeries(MachineCenter(), MachineCentersLbl, 'M10', 'M99990', '', '', 10, Enum::"No. Series Implementation"::Sequence, true);
         ContosoNoSeries.InsertNoSeries(Routing(), RoutingLbl, 'R10', 'R99990', '', '', 10, Enum::"No. Series Implementation"::Sequence, true);
+        ContosoNoSeries.InsertNoSeries(RoutingVersion(), RoutingVersionsLbl, 'RV10', 'RV99990', '', '', 10, Enum::"No. Series Implementation"::Sequence, true);
 
         ContosoNoSeries.InsertNoSeries(SimulatedOrder(), SimulatedOrdersLbl, '1001', '2999', '2995', '', 1, Enum::"No. Series Implementation"::Normal, false);
 
@@ -34,10 +36,14 @@ codeunit 4784 "Create Mfg No Series"
         WorkCentersLbl: Label 'Work Centers', MaxLength = 100;
         ProductionBOMTok: Label 'PRODBOM', MaxLength = 20;
         ProductionBOMsLbl: Label 'Production BOMs', MaxLength = 100;
+        ProductionBOMVersionTok: Label 'PRODBOM-V', MaxLength = 20;
+        ProductionBOMVersionsLbl: Label 'Production BOM Versions', MaxLength = 100;
         MachineCenterTok: Label 'MACHCTR', MaxLength = 20;
         MachineCentersLbl: Label 'Machine Centers', MaxLength = 100;
         RoutingTok: Label 'ROUTING', MaxLength = 20;
         RoutingLbl: Label 'Routings', MaxLength = 100;
+        RoutingVersionTok: Label 'ROUTING-V', MaxLength = 20;
+        RoutingVersionsLbl: Label 'Routing Versions', MaxLength = 100;
         SimulatedTok: Label 'M-SIM', MaxLength = 20;
         SimulatedOrdersLbl: Label 'Simulated orders', MaxLength = 100;
         PlannedOrderTok: Label 'M-PLAN', MaxLength = 20;
@@ -57,6 +63,11 @@ codeunit 4784 "Create Mfg No Series"
         exit(ProductionBOMTok);
     end;
 
+    procedure ProductionBOMVersion(): Code[20]
+    begin
+        exit(ProductionBOMVersionTok);
+    end;
+
     procedure MachineCenter(): Code[20]
     begin
         exit(MachineCenterTok);
@@ -65,6 +76,11 @@ codeunit 4784 "Create Mfg No Series"
     procedure Routing(): Code[20]
     begin
         exit(RoutingTok);
+    end;
+
+    procedure RoutingVersion(): Code[20]
+    begin
+        exit(RoutingVersionTok);
     end;
 
     procedure SimulatedOrder(): Code[20]

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgNoSeries.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgNoSeries.Codeunit.al
@@ -36,13 +36,13 @@ codeunit 4784 "Create Mfg No Series"
         WorkCentersLbl: Label 'Work Centers', MaxLength = 100;
         ProductionBOMTok: Label 'PRODBOM', MaxLength = 20;
         ProductionBOMsLbl: Label 'Production BOMs', MaxLength = 100;
-        ProductionBOMVersionTok: Label 'PRODBOM-V', MaxLength = 20;
+        ProductionBOMVersionTok: Label 'PRODBOM-V', Locked = true, MaxLength = 20;
         ProductionBOMVersionsLbl: Label 'Production BOM Versions', MaxLength = 100;
         MachineCenterTok: Label 'MACHCTR', MaxLength = 20;
         MachineCentersLbl: Label 'Machine Centers', MaxLength = 100;
         RoutingTok: Label 'ROUTING', MaxLength = 20;
         RoutingLbl: Label 'Routings', MaxLength = 100;
-        RoutingVersionTok: Label 'ROUTING-V', MaxLength = 20;
+        RoutingVersionTok: Label 'ROUTING-V', Locked = true, MaxLength = 20;
         RoutingVersionsLbl: Label 'Routing Versions', MaxLength = 100;
         SimulatedTok: Label 'M-SIM', MaxLength = 20;
         SimulatedOrdersLbl: Label 'Simulated orders', MaxLength = 100;

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgPostingSetup.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgPostingSetup.Codeunit.al
@@ -72,8 +72,12 @@ codeunit 4768 "Create Mfg Posting Setup"
             ManufacturingSetup.Validate("Machine Center Nos.", MfgNoSeries.MachineCenter());
         if ManufacturingSetup."Production BOM Nos." = '' then
             ManufacturingSetup.Validate("Production BOM Nos.", MfgNoSeries.ProductionBOM());
+        if ManufacturingSetup."Production BOM Version Nos." = '' then
+            ManufacturingSetup.Validate("Production BOM Version Nos.", MfgNoSeries.ProductionBOMVersion());
         if ManufacturingSetup."Routing Nos." = '' then
             ManufacturingSetup.Validate("Routing Nos.", MfgNoSeries.Routing());
+        if ManufacturingSetup."Routing Version Nos." = '' then
+            ManufacturingSetup.Validate("Routing Version Nos.", MfgNoSeries.RoutingVersion());
 
         if ManufacturingSetup."Simulated Order Nos." = '' then
             ManufacturingSetup.Validate("Simulated Order Nos.", MfgNoSeries.SimulatedOrder());

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgPostingSetup.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Manufacturing/1.Setup data/CreateMfgPostingSetup.Codeunit.al
@@ -47,7 +47,7 @@ codeunit 4768 "Create Mfg Posting Setup"
         ContosoPostingSetup.InsertGeneralPostingSetup(CommonPostingGroup.Domestic(), MfgPostingGroup.Manufacturing(), CommonGLAccount.SalesDomestic(), CommonGLAccount.PurchaseDomestic(), CommonGLAccount.InventoryAdjRawMat(), CommonGLAccount.DirectCostAppliedRawMat(), CommonGLAccount.OverheadAppliedRawMat(), CommonGLAccount.PurchaseVarianceRawMat());
     end;
 
-    local procedure CreateManufacturingSetup()
+    internal procedure CreateManufacturingSetup()
     var
         ManufacturingSetup: Record "Manufacturing Setup";
         MfgNoSeries: Codeunit "Create Mfg No Series";

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -242,8 +242,8 @@ codeunit 148049 "Demo Tool Language Test"
         FinanceModule: Codeunit "Finance Module";
         ManufacturingModule: Codeunit "Manufacturing Module";
     begin
-        FinanceModule.CreateSetupData();
         CommonModule.CreateSetupData();
+        FinanceModule.CreateSetupData();
         ManufacturingModule.CreateSetupData();
     end;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -96,6 +96,9 @@ codeunit 148049 "Demo Tool Language Test"
     begin
         // [SCENARIO 647371] Contoso creates and assigns the production BOM and routing version number series.
 
+        // [GIVEN] Manufacturing Setup has no version number series
+        SetManufacturingVersionNoSeries('', '');
+
         // [WHEN] Manufacturing setup data is created
         CreateManufacturingSetupData();
 
@@ -134,6 +137,7 @@ codeunit 148049 "Demo Tool Language Test"
         // [SCENARIO 647371] Contoso headers inherit version series that generate PV10 and RV10 without changing explicit version codes.
 
         // [GIVEN] Contoso manufacturing setup data
+        SetManufacturingVersionNoSeries('', '');
         CreateManufacturingSetupData();
 
         // [WHEN] New production BOM and routing headers are inserted
@@ -163,20 +167,16 @@ codeunit 148049 "Demo Tool Language Test"
         ManufacturingSetup: Record "Manufacturing Setup";
         ProductionBOMHeader: Record "Production BOM Header";
         RoutingHeader: Record "Routing Header";
+        UnitOfMeasure: Record "Unit of Measure";
         CreateMfgNoSeries: Codeunit "Create Mfg No Series";
     begin
         // [SCENARIO 647371] Rerunning Contoso setup does not backfill existing production BOM or routing headers.
 
         // [GIVEN] Existing headers were inserted while both setup defaults were blank
-        if not ManufacturingSetup.Get() then
-            ManufacturingSetup.Insert();
-        ManufacturingSetup."Production BOM Version Nos." := '';
-        ManufacturingSetup."Routing Version Nos." := '';
-        ManufacturingSetup.Modify();
-        ProductionBOMHeader."No." := 'EXISTING-BOM';
-        ProductionBOMHeader.Insert(true);
-        RoutingHeader."No." := 'EXISTING-ROUTING';
-        RoutingHeader.Insert(true);
+        SetManufacturingVersionNoSeries('', '');
+        LibraryInventory.CreateUnitOfMeasureCode(UnitOfMeasure);
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, UnitOfMeasure.Code);
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
 
         // [WHEN] Contoso manufacturing setup is rerun
         CreateManufacturingSetupData();
@@ -223,6 +223,17 @@ codeunit 148049 "Demo Tool Language Test"
         NoSeriesLine.TestField("Starting No.", ExpectedStartingNo);
         NoSeriesLine.TestField("Ending No.", ExpectedEndingNo);
         NoSeriesLine.TestField("Increment-by No.", ExpectedIncrement);
+    end;
+
+    local procedure SetManufacturingVersionNoSeries(ProductionBOMVersionNos: Code[20]; RoutingVersionNos: Code[20])
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+    begin
+        if not ManufacturingSetup.Get() then
+            ManufacturingSetup.Insert();
+        ManufacturingSetup."Production BOM Version Nos." := ProductionBOMVersionNos;
+        ManufacturingSetup."Routing Version Nos." := RoutingVersionNos;
+        ManufacturingSetup.Modify();
     end;
 
     local procedure CreateManufacturingSetupData()

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -1,8 +1,14 @@
 namespace Microsoft.Test.DemoTool;
 
+using Microsoft.DemoData.Common;
+using Microsoft.DemoData.Manufacturing;
 using Microsoft.DemoData.Inventory;
 using Microsoft.DemoData.Warehousing;
 using Microsoft.DemoTool;
+using Microsoft.Foundation.NoSeries;
+using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
 
 codeunit 148049 "Demo Tool Language Test"
 {
@@ -78,6 +84,114 @@ codeunit 148049 "Demo Tool Language Test"
         Assert.AreEqual(CreateLocation.OwnLogLocation(), CreateWhseLocation.TransitLocation(), 'Inventory and Warehousing must use the same own-logistics in-transit location.');
     end;
 
+    [Test]
+    procedure ManufacturingVersionNoSeriesAreCreatedAndAssignedOnlyWhenBlank()
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+        CreateMfgNoSeries: Codeunit "Create Mfg No Series";
+    begin
+        // [SCENARIO 647371] Contoso creates and assigns the production BOM and routing version number series.
+
+        // [WHEN] Manufacturing setup data is created
+        CreateManufacturingSetupData();
+
+        // [THEN] Both version number series have the expected definitions
+        VerifyNoSeries(CreateMfgNoSeries.ProductionBOMVersion(), 'Production BOM Versions', 'PV10', 'PV99990', 10);
+        VerifyNoSeries(CreateMfgNoSeries.RoutingVersion(), 'Routing Versions', 'RV10', 'RV99990', 10);
+
+        // [THEN] Manufacturing Setup uses both version number series
+        ManufacturingSetup.Get();
+        ManufacturingSetup.TestField("Production BOM Version Nos.", CreateMfgNoSeries.ProductionBOMVersion());
+        ManufacturingSetup.TestField("Routing Version Nos.", CreateMfgNoSeries.RoutingVersion());
+
+        // [WHEN] Setup is rerun after alternate version number series have been selected
+        ManufacturingSetup.Validate("Production BOM Version Nos.", CreateMfgNoSeries.ProductionBOM());
+        ManufacturingSetup.Validate("Routing Version Nos.", CreateMfgNoSeries.Routing());
+        ManufacturingSetup.Modify(true);
+        CreateManufacturingSetupData();
+
+        // [THEN] The existing setup choices are retained
+        ManufacturingSetup.Get();
+        ManufacturingSetup.TestField("Production BOM Version Nos.", CreateMfgNoSeries.ProductionBOM());
+        ManufacturingSetup.TestField("Routing Version Nos.", CreateMfgNoSeries.Routing());
+    end;
+
+    [Test]
+    procedure ManufacturingHeadersUseContosoVersionNoSeries()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMVersion: Record "Production BOM Version";
+        RoutingHeader: Record "Routing Header";
+        RoutingVersion: Record "Routing Version";
+        CreateMfgNoSeries: Codeunit "Create Mfg No Series";
+        ExplicitBOMVersionCode: Code[20];
+    begin
+        // [SCENARIO 647371] Contoso headers inherit version series that generate PV10 and RV10 without changing explicit version codes.
+
+        // [GIVEN] Contoso manufacturing setup data
+        CreateManufacturingSetupData();
+
+        // [WHEN] New production BOM and routing headers are inserted
+        ProductionBOMHeader."No." := 'SP-SCM1009';
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader."No." := 'TEST-ROUTING';
+        RoutingHeader.Insert(true);
+
+        // [THEN] The headers inherit the Contoso version number series
+        ProductionBOMHeader.TestField("Version Nos.", CreateMfgNoSeries.ProductionBOMVersion());
+        RoutingHeader.TestField("Version Nos.", CreateMfgNoSeries.RoutingVersion());
+
+        // [WHEN] An explicit BOM version and blank-code BOM and routing versions are inserted
+        ExplicitBOMVersionCode := 'SP-SCM1009-V1';
+        ProductionBOMVersion."Production BOM No." := ProductionBOMHeader."No.";
+        ProductionBOMVersion."Version Code" := ExplicitBOMVersionCode;
+        ProductionBOMVersion.Insert(true);
+        Clear(ProductionBOMVersion);
+        ProductionBOMVersion."Production BOM No." := ProductionBOMHeader."No.";
+        ProductionBOMVersion.Insert(true);
+        RoutingVersion."Routing No." := RoutingHeader."No.";
+        RoutingVersion.Insert(true);
+
+        // [THEN] The explicit code is preserved and blank codes use the inherited series
+        Assert.IsTrue(ProductionBOMVersion.Get(ProductionBOMHeader."No.", ExplicitBOMVersionCode), 'The explicit production BOM version must remain unchanged.');
+        Assert.IsTrue(ProductionBOMVersion.Get(ProductionBOMHeader."No.", 'PV10'), 'The inherited production BOM version series must generate PV10.');
+        Assert.IsTrue(RoutingVersion.Get(RoutingHeader."No.", 'RV10'), 'The inherited routing version series must generate RV10.');
+    end;
+
+    [Test]
+    procedure ManufacturingSetupRerunDoesNotBackfillExistingHeaders()
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        CreateMfgNoSeries: Codeunit "Create Mfg No Series";
+    begin
+        // [SCENARIO 647371] Rerunning Contoso setup does not backfill existing production BOM or routing headers.
+
+        // [GIVEN] Existing headers were inserted while both setup defaults were blank
+        if not ManufacturingSetup.Get() then
+            ManufacturingSetup.Insert();
+        ManufacturingSetup."Production BOM Version Nos." := '';
+        ManufacturingSetup."Routing Version Nos." := '';
+        ManufacturingSetup.Modify();
+        ProductionBOMHeader."No." := 'EXISTING-BOM';
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader."No." := 'EXISTING-ROUTING';
+        RoutingHeader.Insert(true);
+
+        // [WHEN] Contoso manufacturing setup is rerun
+        CreateManufacturingSetupData();
+
+        // [THEN] Setup receives the defaults but existing headers remain blank
+        ManufacturingSetup.Get();
+        ManufacturingSetup.TestField("Production BOM Version Nos.", CreateMfgNoSeries.ProductionBOMVersion());
+        ManufacturingSetup.TestField("Routing Version Nos.", CreateMfgNoSeries.RoutingVersion());
+        ProductionBOMHeader.Get(ProductionBOMHeader."No.");
+        RoutingHeader.Get(RoutingHeader."No.");
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
     [ConfirmHandler]
     procedure DifferentLanguageDialogHandler(Question: Text; var Reply: Boolean)
     begin
@@ -96,5 +210,28 @@ codeunit 148049 "Demo Tool Language Test"
         ContosoDemoDataModule.Validate(Module, Enum::"Contoso Demo Data Module"::"Contoso Test 1");
         if not ContosoDemoDataModule.Get(Enum::"Contoso Demo Data Module"::"Contoso Test 1") then
             ContosoDemoDataModule.Insert();
+    end;
+
+    local procedure VerifyNoSeries(NoSeriesCode: Code[20]; ExpectedDescription: Text[100]; ExpectedStartingNo: Code[20]; ExpectedEndingNo: Code[20]; ExpectedIncrement: Integer)
+    var
+        NoSeries: Record "No. Series";
+        NoSeriesLine: Record "No. Series Line";
+    begin
+        NoSeries.Get(NoSeriesCode);
+        NoSeries.TestField(Description, ExpectedDescription);
+        NoSeries.TestField("Manual Nos.", true);
+        NoSeriesLine.Get(NoSeriesCode, 10000);
+        NoSeriesLine.TestField("Starting No.", ExpectedStartingNo);
+        NoSeriesLine.TestField("Ending No.", ExpectedEndingNo);
+        NoSeriesLine.TestField("Increment-by No.", ExpectedIncrement);
+    end;
+
+    local procedure CreateManufacturingSetupData()
+    var
+        CommonModule: Codeunit "Common Module";
+        ManufacturingModule: Codeunit "Manufacturing Module";
+    begin
+        CommonModule.CreateSetupData();
+        ManufacturingModule.CreateSetupData();
     end;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -1,6 +1,7 @@
 namespace Microsoft.Test.DemoTool;
 
 using Microsoft.DemoData.Common;
+using Microsoft.DemoData.Finance;
 using Microsoft.DemoData.Inventory;
 using Microsoft.DemoData.Manufacturing;
 using Microsoft.DemoData.Warehousing;
@@ -227,8 +228,10 @@ codeunit 148049 "Demo Tool Language Test"
     local procedure CreateManufacturingSetupData()
     var
         CommonModule: Codeunit "Common Module";
+        FinanceModule: Codeunit "Finance Module";
         ManufacturingModule: Codeunit "Manufacturing Module";
     begin
+        FinanceModule.CreateSetupData();
         CommonModule.CreateSetupData();
         ManufacturingModule.CreateSetupData();
     end;

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -1,11 +1,12 @@
 namespace Microsoft.Test.DemoTool;
 
 using Microsoft.DemoData.Common;
-using Microsoft.DemoData.Manufacturing;
 using Microsoft.DemoData.Inventory;
+using Microsoft.DemoData.Manufacturing;
 using Microsoft.DemoData.Warehousing;
 using Microsoft.DemoTool;
 using Microsoft.Foundation.NoSeries;
+using Microsoft.Foundation.UOM;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
@@ -17,6 +18,8 @@ codeunit 148049 "Demo Tool Language Test"
 
     var
         Assert: Codeunit Assert;
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryManufacturing: Codeunit "Library - Manufacturing";
 
     [Test]
     procedure ContosoDemoToolLanguageInitializationTest()
@@ -123,6 +126,7 @@ codeunit 148049 "Demo Tool Language Test"
         ProductionBOMVersion: Record "Production BOM Version";
         RoutingHeader: Record "Routing Header";
         RoutingVersion: Record "Routing Version";
+        UnitOfMeasure: Record "Unit of Measure";
         CreateMfgNoSeries: Codeunit "Create Mfg No Series";
         ExplicitBOMVersionCode: Code[20];
     begin
@@ -132,25 +136,19 @@ codeunit 148049 "Demo Tool Language Test"
         CreateManufacturingSetupData();
 
         // [WHEN] New production BOM and routing headers are inserted
-        ProductionBOMHeader."No." := 'SP-SCM1009';
-        ProductionBOMHeader.Insert(true);
-        RoutingHeader."No." := 'TEST-ROUTING';
-        RoutingHeader.Insert(true);
+        LibraryInventory.CreateUnitOfMeasureCode(UnitOfMeasure);
+        LibraryManufacturing.CreateProductionBOMHeader(ProductionBOMHeader, UnitOfMeasure.Code);
+        LibraryManufacturing.CreateRoutingHeader(RoutingHeader, RoutingHeader.Type::Serial);
 
         // [THEN] The headers inherit the Contoso version number series
         ProductionBOMHeader.TestField("Version Nos.", CreateMfgNoSeries.ProductionBOMVersion());
         RoutingHeader.TestField("Version Nos.", CreateMfgNoSeries.RoutingVersion());
 
         // [WHEN] An explicit BOM version and blank-code BOM and routing versions are inserted
-        ExplicitBOMVersionCode := 'SP-SCM1009-V1';
-        ProductionBOMVersion."Production BOM No." := ProductionBOMHeader."No.";
-        ProductionBOMVersion."Version Code" := ExplicitBOMVersionCode;
-        ProductionBOMVersion.Insert(true);
-        Clear(ProductionBOMVersion);
-        ProductionBOMVersion."Production BOM No." := ProductionBOMHeader."No.";
-        ProductionBOMVersion.Insert(true);
-        RoutingVersion."Routing No." := RoutingHeader."No.";
-        RoutingVersion.Insert(true);
+        ExplicitBOMVersionCode := 'EXPLICIT-V1';
+        LibraryManufacturing.CreateProductionBOMVersion(ProductionBOMVersion, ProductionBOMHeader."No.", ExplicitBOMVersionCode, UnitOfMeasure.Code);
+        LibraryManufacturing.CreateProductionBOMVersion(ProductionBOMVersion, ProductionBOMHeader."No.", '', UnitOfMeasure.Code);
+        LibraryManufacturing.CreateRoutingVersion(RoutingVersion, RoutingHeader."No.", '');
 
         // [THEN] The explicit code is preserved and blank codes use the inherited series
         Assert.IsTrue(ProductionBOMVersion.Get(ProductionBOMHeader."No.", ExplicitBOMVersionCode), 'The explicit production BOM version must remain unchanged.');

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -1,7 +1,5 @@
 namespace Microsoft.Test.DemoTool;
 
-using Microsoft.DemoData.Common;
-using Microsoft.DemoData.Finance;
 using Microsoft.DemoData.Inventory;
 using Microsoft.DemoData.Manufacturing;
 using Microsoft.DemoData.Warehousing;
@@ -238,12 +236,12 @@ codeunit 148049 "Demo Tool Language Test"
 
     local procedure CreateManufacturingSetupData()
     var
-        CommonModule: Codeunit "Common Module";
-        FinanceModule: Codeunit "Finance Module";
-        ManufacturingModule: Codeunit "Manufacturing Module";
+        ContosoDemoDataModule: Record "Contoso Demo Data Module";
+        ContosoDemoTool: Codeunit "Contoso Demo Tool";
     begin
-        CommonModule.CreateSetupData();
-        FinanceModule.CreateSetupData();
-        ManufacturingModule.CreateSetupData();
+        ContosoDemoDataModule.DeleteAll();
+        ContosoDemoTool.RefreshModules();
+        ContosoDemoDataModule.SetRange(Module, Enum::"Contoso Demo Data Module"::"Manufacturing Module");
+        ContosoDemoTool.CreateDemoData(ContosoDemoDataModule, Enum::"Contoso Demo Data Level"::"Setup Data");
     end;
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -67,11 +67,14 @@ codeunit 148049 "Demo Tool Language Test"
 
         // [WHEN] Changing the current language
         NewLanguageID := 2057; // English (United Kingdom)
+        if NewLanguageID = CurrentLanguageID then
+            NewLanguageID := 1033; // English (United States)
         GlobalLanguage(NewLanguageID);
 
         // [THEN] When running of the Contoso Demo Tool again, there should be dialog pops up warning a language mismatch 
         // Checking for the dialog is done in the handler function
         ContosoDemoTool.CreateDemoData(ContosoDemoDataModule, Enum::"Contoso Demo Data Level"::All);
+        GlobalLanguage(CurrentLanguageID);
     end;
 
     [Test]
@@ -89,6 +92,7 @@ codeunit 148049 "Demo Tool Language Test"
     [Test]
     procedure ManufacturingVersionNoSeriesAreCreatedAndAssignedOnlyWhenBlank()
     var
+        ContosoCoffeeDemoDataSetup: Record "Contoso Coffee Demo Data Setup";
         ManufacturingSetup: Record "Manufacturing Setup";
         CreateMfgNoSeries: Codeunit "Create Mfg No Series";
     begin
@@ -97,8 +101,21 @@ codeunit 148049 "Demo Tool Language Test"
         // [GIVEN] Manufacturing Setup has no version number series
         SetManufacturingVersionNoSeries('', '');
 
+        // [GIVEN] Previous demo data was generated in a different language
+        ContosoCoffeeDemoDataSetup.InitRecord();
+        ContosoCoffeeDemoDataSetup.Get();
+        if GlobalLanguage() = 2057 then
+            ContosoCoffeeDemoDataSetup.Validate("Language ID", 1033)
+        else
+            ContosoCoffeeDemoDataSetup.Validate("Language ID", 2057);
+        ContosoCoffeeDemoDataSetup.Modify(true);
+
         // [WHEN] Manufacturing setup data is created
         CreateManufacturingSetupData();
+
+        // [THEN] The fixture uses the current language without a confirmation dialog
+        ContosoCoffeeDemoDataSetup.Get();
+        ContosoCoffeeDemoDataSetup.TestField("Language ID", GlobalLanguage());
 
         // [THEN] Both version number series have the expected definitions
         VerifyNoSeries(CreateMfgNoSeries.ProductionBOMVersion(), 'Production BOM Versions', 'PV10', 'PV99990', 10);
@@ -236,11 +253,18 @@ codeunit 148049 "Demo Tool Language Test"
 
     local procedure CreateManufacturingSetupData()
     var
+        ContosoCoffeeDemoDataSetup: Record "Contoso Coffee Demo Data Setup";
         ContosoDemoDataModule: Record "Contoso Demo Data Module";
         ContosoDemoTool: Codeunit "Contoso Demo Tool";
     begin
         ContosoDemoDataModule.DeleteAll();
         ContosoDemoTool.RefreshModules();
+
+        // Manufacturing tests must not depend on language state left by other tests.
+        ContosoCoffeeDemoDataSetup.Get();
+        ContosoCoffeeDemoDataSetup.Validate("Language ID", GlobalLanguage());
+        ContosoCoffeeDemoDataSetup.Modify(true);
+
         ContosoDemoDataModule.SetRange(Module, Enum::"Contoso Demo Data Module"::"Manufacturing Module");
         ContosoDemoTool.CreateDemoData(ContosoDemoDataModule, Enum::"Contoso Demo Data Level"::"Setup Data");
     end;

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/DemoToolLanguageTest.Codeunit.al
@@ -92,7 +92,6 @@ codeunit 148049 "Demo Tool Language Test"
     [Test]
     procedure ManufacturingVersionNoSeriesAreCreatedAndAssignedOnlyWhenBlank()
     var
-        ContosoCoffeeDemoDataSetup: Record "Contoso Coffee Demo Data Setup";
         ManufacturingSetup: Record "Manufacturing Setup";
         CreateMfgNoSeries: Codeunit "Create Mfg No Series";
     begin
@@ -101,25 +100,12 @@ codeunit 148049 "Demo Tool Language Test"
         // [GIVEN] Manufacturing Setup has no version number series
         SetManufacturingVersionNoSeries('', '');
 
-        // [GIVEN] Previous demo data was generated in a different language
-        ContosoCoffeeDemoDataSetup.InitRecord();
-        ContosoCoffeeDemoDataSetup.Get();
-        if GlobalLanguage() = 2057 then
-            ContosoCoffeeDemoDataSetup.Validate("Language ID", 1033)
-        else
-            ContosoCoffeeDemoDataSetup.Validate("Language ID", 2057);
-        ContosoCoffeeDemoDataSetup.Modify(true);
-
         // [WHEN] Manufacturing setup data is created
         CreateManufacturingSetupData();
 
-        // [THEN] The fixture uses the current language without a confirmation dialog
-        ContosoCoffeeDemoDataSetup.Get();
-        ContosoCoffeeDemoDataSetup.TestField("Language ID", GlobalLanguage());
-
-        // [THEN] Both version number series have the expected definitions
-        VerifyNoSeries(CreateMfgNoSeries.ProductionBOMVersion(), 'Production BOM Versions', 'PV10', 'PV99990', 10);
-        VerifyNoSeries(CreateMfgNoSeries.RoutingVersion(), 'Routing Versions', 'RV10', 'RV99990', 10);
+        // [THEN] Both version number series have definitions padded to the ending number's width
+        VerifyNoSeries(CreateMfgNoSeries.ProductionBOMVersion(), 'Production BOM Versions', 'PV00010', 'PV99990', 10);
+        VerifyNoSeries(CreateMfgNoSeries.RoutingVersion(), 'Routing Versions', 'RV00010', 'RV99990', 10);
 
         // [THEN] Manufacturing Setup uses both version number series
         ManufacturingSetup.Get();
@@ -147,9 +133,12 @@ codeunit 148049 "Demo Tool Language Test"
         RoutingVersion: Record "Routing Version";
         UnitOfMeasure: Record "Unit of Measure";
         CreateMfgNoSeries: Codeunit "Create Mfg No Series";
+        NoSeries: Codeunit "No. Series";
         ExplicitBOMVersionCode: Code[20];
+        ExpectedBOMVersionCode: Code[20];
+        ExpectedRoutingVersionCode: Code[20];
     begin
-        // [SCENARIO 647371] Contoso headers inherit version series that generate PV10 and RV10 without changing explicit version codes.
+        // [SCENARIO 647371] Contoso headers use the next numbers from their inherited version series without changing explicit version codes.
 
         // [GIVEN] Contoso manufacturing setup data
         SetManufacturingVersionNoSeries('', '');
@@ -164,6 +153,10 @@ codeunit 148049 "Demo Tool Language Test"
         ProductionBOMHeader.TestField("Version Nos.", CreateMfgNoSeries.ProductionBOMVersion());
         RoutingHeader.TestField("Version Nos.", CreateMfgNoSeries.RoutingVersion());
 
+        // [GIVEN] The next numbers are captured before the explicit insertion, even if the series were already used
+        ExpectedBOMVersionCode := NoSeries.PeekNextNo(CreateMfgNoSeries.ProductionBOMVersion());
+        ExpectedRoutingVersionCode := NoSeries.PeekNextNo(CreateMfgNoSeries.RoutingVersion());
+
         // [WHEN] An explicit BOM version and blank-code BOM and routing versions are inserted
         ExplicitBOMVersionCode := 'EXPLICIT-V1';
         LibraryManufacturing.CreateProductionBOMVersion(ProductionBOMVersion, ProductionBOMHeader."No.", ExplicitBOMVersionCode, UnitOfMeasure.Code);
@@ -171,9 +164,11 @@ codeunit 148049 "Demo Tool Language Test"
         LibraryManufacturing.CreateRoutingVersion(RoutingVersion, RoutingHeader."No.", '');
 
         // [THEN] The explicit code is preserved and blank codes use the inherited series
+        Assert.AreEqual(ExpectedBOMVersionCode, ProductionBOMVersion."Version Code", 'The production BOM version must use the next number from the inherited series without consuming a number for the explicit version.');
+        ProductionBOMVersion.TestField("No. Series", CreateMfgNoSeries.ProductionBOMVersion());
+        Assert.AreEqual(ExpectedRoutingVersionCode, RoutingVersion."Version Code", 'The routing version must use the next number from the inherited series.');
+        RoutingVersion.TestField("No. Series", CreateMfgNoSeries.RoutingVersion());
         Assert.IsTrue(ProductionBOMVersion.Get(ProductionBOMHeader."No.", ExplicitBOMVersionCode), 'The explicit production BOM version must remain unchanged.');
-        Assert.IsTrue(ProductionBOMVersion.Get(ProductionBOMHeader."No.", 'PV10'), 'The inherited production BOM version series must generate PV10.');
-        Assert.IsTrue(RoutingVersion.Get(RoutingHeader."No.", 'RV10'), 'The inherited routing version series must generate RV10.');
     end;
 
     [Test]
@@ -233,11 +228,13 @@ codeunit 148049 "Demo Tool Language Test"
     begin
         NoSeries.Get(NoSeriesCode);
         NoSeries.TestField(Description, ExpectedDescription);
+        NoSeries.TestField("Default Nos.", true);
         NoSeries.TestField("Manual Nos.", true);
         NoSeriesLine.Get(NoSeriesCode, 10000);
         NoSeriesLine.TestField("Starting No.", ExpectedStartingNo);
         NoSeriesLine.TestField("Ending No.", ExpectedEndingNo);
         NoSeriesLine.TestField("Increment-by No.", ExpectedIncrement);
+        NoSeriesLine.TestField(Implementation, Enum::"No. Series Implementation"::Sequence);
     end;
 
     local procedure SetManufacturingVersionNoSeries(ProductionBOMVersionNos: Code[20]; RoutingVersionNos: Code[20])
@@ -253,19 +250,11 @@ codeunit 148049 "Demo Tool Language Test"
 
     local procedure CreateManufacturingSetupData()
     var
-        ContosoCoffeeDemoDataSetup: Record "Contoso Coffee Demo Data Setup";
-        ContosoDemoDataModule: Record "Contoso Demo Data Module";
-        ContosoDemoTool: Codeunit "Contoso Demo Tool";
+        CreateMfgPostingSetup: Codeunit "Create Mfg Posting Setup";
     begin
-        ContosoDemoDataModule.DeleteAll();
-        ContosoDemoTool.RefreshModules();
-
-        // Manufacturing tests must not depend on language state left by other tests.
-        ContosoCoffeeDemoDataSetup.Get();
-        ContosoCoffeeDemoDataSetup.Validate("Language ID", GlobalLanguage());
-        ContosoCoffeeDemoDataSetup.Modify(true);
-
-        ContosoDemoDataModule.SetRange(Module, Enum::"Contoso Demo Data Module"::"Manufacturing Module");
-        ContosoDemoTool.CreateDemoData(ContosoDemoDataModule, Enum::"Contoso Demo Data Level"::"Setup Data");
+        // Exercise the production setup routine without regenerating unrelated localized Finance and Inventory data.
+        Codeunit.Run(Codeunit::"Create Mfg Cap Unit of Measure");
+        Codeunit.Run(Codeunit::"Create Mfg No Series");
+        CreateMfgPostingSetup.CreateManufacturingSetup();
     end;
 }

--- a/src/Apps/W1/Quality Management/Test Library/src/QltyProdOrderGenerator.Codeunit.al
+++ b/src/Apps/W1/Quality Management/Test Library/src/QltyProdOrderGenerator.Codeunit.al
@@ -472,7 +472,7 @@ codeunit 139942 "Qlty. Prod. Order Generator"
         CapacityNo: Code[20];
     begin
         CreateRandomCapacity(CapacityType, CapacityNo);
-        LibraryManufacturing.CreateRoutingLine(RoutingHeader, RoutingLine, RoutingHeader."Version Nos.", CopyStr(LibraryRandom.RandText(MaxStrLen(RoutingLine."Operation No.")), 1, 10), CapacityType, CapacityNo);
+        LibraryManufacturing.CreateRoutingLine(RoutingHeader, RoutingLine, '', CopyStr(LibraryRandom.RandText(MaxStrLen(RoutingLine."Operation No.")), 1, 10), CapacityType, CapacityNo);
         RoutingLine."Setup Time" := LibraryRandom.RandDecInDecimalRange(SetupTimeMin, SetupTimeMax, DecimalPrecision);
         RoutingLine."Run Time" := LibraryRandom.RandDecInDecimalRange(RunTimeMin, RunTimeMax, DecimalPrecision);
         RoutingLine."Send-Ahead Quantity" := SendAheadQty;

--- a/src/Layers/BE/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/BE/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -2484,6 +2484,111 @@ codeunit 137063 "SCM Manufacturing 7.0"
 
     [Test]
     [Scope('OnPrem')]
+    procedure ProductionBOMAndRoutingHeadersInheritVersionNoSeriesFromManufacturingSetup()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        ProductionBOMVersionNos: Code[20];
+        RoutingVersionNos: Code[20];
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] New production BOM and routing headers inherit version number series from Manufacturing Setup.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has default production BOM and routing version number series
+        ProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        RoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        SetManufacturingVersionNoSeries(ProductionBOMVersionNos, RoutingVersionNos);
+
+        // [WHEN] Production BOM and routing headers are inserted without explicit version number series
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both headers inherit their respective defaults
+        Assert.AreEqual(ProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(RoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExplicitHeaderVersionNoSeriesTakePrecedenceOverManufacturingSetup()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        ExplicitProductionBOMVersionNos: Code[20];
+        ExplicitRoutingVersionNos: Code[20];
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Explicit header version number series take precedence over Manufacturing Setup defaults.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has default version number series and both headers have explicit series
+        SetManufacturingVersionNoSeries(LibraryERM.CreateNoSeriesCode(), LibraryERM.CreateNoSeriesCode());
+        ExplicitProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        ExplicitRoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        ProductionBOMHeader.Validate("Version Nos.", ExplicitProductionBOMVersionNos);
+        RoutingHeader.Validate("Version Nos.", ExplicitRoutingVersionNos);
+
+        // [WHEN] The headers are inserted
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both explicit series are retained
+        Assert.AreEqual(ExplicitProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(ExplicitRoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure BlankManufacturingSetupLeavesHeaderVersionNoSeriesBlank()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Blank Manufacturing Setup defaults preserve blank header version number series.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has no default version number series
+        SetManufacturingVersionNoSeries('', '');
+
+        // [WHEN] Production BOM and routing headers are inserted
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both header version number series remain blank
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManufacturingSetupVersionNoSeriesDoNotBackfillExistingHeaders()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Configuring Manufacturing Setup does not backfill existing headers.
+        Initialize();
+
+        // [GIVEN] Production BOM and routing headers were inserted while the setup defaults were blank
+        SetManufacturingVersionNoSeries('', '');
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [WHEN] Default version number series are configured in Manufacturing Setup
+        SetManufacturingVersionNoSeries(LibraryERM.CreateNoSeriesCode(), LibraryERM.CreateNoSeriesCode());
+        ProductionBOMHeader.Get(ProductionBOMHeader."No.");
+        RoutingHeader.Get(RoutingHeader."No.");
+
+        // [THEN] The existing header version number series remain blank
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure ReValidatingUnitOfMeasureCodeOnProdBOMLine()
     var
         ProductionBOMLine: Record "Production BOM Line";
@@ -5339,6 +5444,16 @@ codeunit 137063 "SCM Manufacturing 7.0"
         ManufacturingSetup.Get();
         DocNoIsProdOrderNo := ManufacturingSetup."Doc. No. Is Prod. Order No.";
         ManufacturingSetup.Validate("Doc. No. Is Prod. Order No.", NewDocNoIsProdOrderNo);
+        ManufacturingSetup.Modify(true);
+    end;
+
+    local procedure SetManufacturingVersionNoSeries(ProductionBOMVersionNos: Code[20]; RoutingVersionNos: Code[20])
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+    begin
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Production BOM Version Nos.", ProductionBOMVersionNos);
+        ManufacturingSetup.Validate("Routing Version Nos.", RoutingVersionNos);
         ManufacturingSetup.Modify(true);
     end;
 

--- a/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
@@ -115,7 +115,15 @@ page 99000768 "Manufacturing Setup"
                 {
                     ApplicationArea = Manufacturing;
                 }
+                field("Production BOM Version Nos."; Rec."Production BOM Version Nos.")
+                {
+                    ApplicationArea = Manufacturing;
+                }
                 field("Routing Nos."; Rec."Routing Nos.")
+                {
+                    ApplicationArea = Manufacturing;
+                }
+                field("Routing Version Nos."; Rec."Routing Version Nos.")
                 {
                     ApplicationArea = Manufacturing;
                 }

--- a/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
@@ -418,6 +418,7 @@ table 99000765 "Manufacturing Setup"
         {
             AccessByPermission = TableData "Production BOM Header" = R;
             Caption = 'Production BOM Version Nos.';
+            DataClassification = CustomerContent;
             ToolTip = 'Specifies the number series used to assign codes to new production BOM versions when the production BOM does not specify its own version number series.';
             TableRelation = "No. Series";
         }
@@ -425,6 +426,7 @@ table 99000765 "Manufacturing Setup"
         {
             AccessByPermission = TableData "Routing Header" = R;
             Caption = 'Routing Version Nos.';
+            DataClassification = CustomerContent;
             ToolTip = 'Specifies the number series used to assign codes to new routing versions when the routing does not specify its own version number series.';
             TableRelation = "No. Series";
         }

--- a/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
@@ -20,6 +20,7 @@ using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Forecast;
 using Microsoft.Manufacturing.MachineCenter;
 using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Wizard;
 using Microsoft.Manufacturing.WorkCenter;
 using System.Telemetry;
@@ -412,6 +413,20 @@ table 99000765 "Manufacturing Setup"
             Caption = 'Default Prod. Wiz. Flushing Method';
             DataClassification = CustomerContent;
             ToolTip = 'Specifies the default flushing method applied to Production Order Components when creating a new production BOM from scratch through the production order creation wizard. This is only used for temporary BOM creation; existing BOMs retain their original flushing method.';
+        }
+        field(312; "Production BOM Version Nos."; Code[20])
+        {
+            AccessByPermission = TableData "Production BOM Header" = R;
+            Caption = 'Production BOM Version Nos.';
+            ToolTip = 'Specifies the number series used to assign codes to new production BOM versions when the production BOM does not specify its own version number series.';
+            TableRelation = "No. Series";
+        }
+        field(313; "Routing Version Nos."; Code[20])
+        {
+            AccessByPermission = TableData "Routing Header" = R;
+            Caption = 'Routing Version Nos.';
+            ToolTip = 'Specifies the number series used to assign codes to new routing versions when the routing does not specify its own version number series.';
+            TableRelation = "No. Series";
         }
         field(5500; "Preset Output Quantity"; Option)
         {

--- a/src/Layers/IT/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/IT/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -2477,6 +2477,111 @@ codeunit 137063 "SCM Manufacturing 7.0"
 
     [Test]
     [Scope('OnPrem')]
+    procedure ProductionBOMAndRoutingHeadersInheritVersionNoSeriesFromManufacturingSetup()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        ProductionBOMVersionNos: Code[20];
+        RoutingVersionNos: Code[20];
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] New production BOM and routing headers inherit version number series from Manufacturing Setup.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has default production BOM and routing version number series
+        ProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        RoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        SetManufacturingVersionNoSeries(ProductionBOMVersionNos, RoutingVersionNos);
+
+        // [WHEN] Production BOM and routing headers are inserted without explicit version number series
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both headers inherit their respective defaults
+        Assert.AreEqual(ProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(RoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExplicitHeaderVersionNoSeriesTakePrecedenceOverManufacturingSetup()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        ExplicitProductionBOMVersionNos: Code[20];
+        ExplicitRoutingVersionNos: Code[20];
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Explicit header version number series take precedence over Manufacturing Setup defaults.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has default version number series and both headers have explicit series
+        SetManufacturingVersionNoSeries(LibraryERM.CreateNoSeriesCode(), LibraryERM.CreateNoSeriesCode());
+        ExplicitProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        ExplicitRoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        ProductionBOMHeader.Validate("Version Nos.", ExplicitProductionBOMVersionNos);
+        RoutingHeader.Validate("Version Nos.", ExplicitRoutingVersionNos);
+
+        // [WHEN] The headers are inserted
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both explicit series are retained
+        Assert.AreEqual(ExplicitProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(ExplicitRoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure BlankManufacturingSetupLeavesHeaderVersionNoSeriesBlank()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Blank Manufacturing Setup defaults preserve blank header version number series.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has no default version number series
+        SetManufacturingVersionNoSeries('', '');
+
+        // [WHEN] Production BOM and routing headers are inserted
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both header version number series remain blank
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManufacturingSetupVersionNoSeriesDoNotBackfillExistingHeaders()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Configuring Manufacturing Setup does not backfill existing headers.
+        Initialize();
+
+        // [GIVEN] Production BOM and routing headers were inserted while the setup defaults were blank
+        SetManufacturingVersionNoSeries('', '');
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [WHEN] Default version number series are configured in Manufacturing Setup
+        SetManufacturingVersionNoSeries(LibraryERM.CreateNoSeriesCode(), LibraryERM.CreateNoSeriesCode());
+        ProductionBOMHeader.Get(ProductionBOMHeader."No.");
+        RoutingHeader.Get(RoutingHeader."No.");
+
+        // [THEN] The existing header version number series remain blank
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure ReValidatingUnitOfMeasureCodeOnProdBOMLine()
     var
         ProductionBOMLine: Record "Production BOM Line";
@@ -5348,6 +5453,16 @@ codeunit 137063 "SCM Manufacturing 7.0"
         ManufacturingSetup.Get();
         DocNoIsProdOrderNo := ManufacturingSetup."Doc. No. Is Prod. Order No.";
         ManufacturingSetup.Validate("Doc. No. Is Prod. Order No.", NewDocNoIsProdOrderNo);
+        ManufacturingSetup.Modify(true);
+    end;
+
+    local procedure SetManufacturingVersionNoSeries(ProductionBOMVersionNos: Code[20]; RoutingVersionNos: Code[20])
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+    begin
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Production BOM Version Nos.", ProductionBOMVersionNos);
+        ManufacturingSetup.Validate("Routing Version Nos.", RoutingVersionNos);
         ManufacturingSetup.Modify(true);
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/ProductionBOMHeader.Table.al
@@ -203,6 +203,9 @@ table 99000771 "Production BOM Header"
 
     begin
         MfgSetup.Get();
+        if "Version Nos." = '' then
+            "Version Nos." := MfgSetup."Production BOM Version Nos.";
+
         if "No." = '' then begin
             MfgSetup.TestField("Production BOM Nos.");
             if NoSeries.AreRelated(MfgSetup."Production BOM Nos.", xRec."No. Series") then

--- a/src/Layers/W1/BaseApp/Manufacturing/Routing/RoutingHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Routing/RoutingHeader.Table.al
@@ -155,6 +155,9 @@ table 99000763 "Routing Header"
         NoSeries: Codeunit "No. Series";
     begin
         MfgSetup.Get();
+        if "Version Nos." = '' then
+            "Version Nos." := MfgSetup."Routing Version Nos.";
+
         if "No." = '' then begin
             MfgSetup.TestField("Routing Nos.");
                 "No. Series" := MfgSetup."Routing Nos.";

--- a/src/Layers/W1/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
@@ -115,7 +115,15 @@ page 99000768 "Manufacturing Setup"
                 {
                     ApplicationArea = Manufacturing;
                 }
+                field("Production BOM Version Nos."; Rec."Production BOM Version Nos.")
+                {
+                    ApplicationArea = Manufacturing;
+                }
                 field("Routing Nos."; Rec."Routing Nos.")
+                {
+                    ApplicationArea = Manufacturing;
+                }
+                field("Routing Version Nos."; Rec."Routing Version Nos.")
                 {
                     ApplicationArea = Manufacturing;
                 }

--- a/src/Layers/W1/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
@@ -415,6 +415,7 @@ table 99000765 "Manufacturing Setup"
         {
             AccessByPermission = TableData "Production BOM Header" = R;
             Caption = 'Production BOM Version Nos.';
+            DataClassification = CustomerContent;
             ToolTip = 'Specifies the number series used to assign codes to new production BOM versions when the production BOM does not specify its own version number series.';
             TableRelation = "No. Series";
         }
@@ -422,6 +423,7 @@ table 99000765 "Manufacturing Setup"
         {
             AccessByPermission = TableData "Routing Header" = R;
             Caption = 'Routing Version Nos.';
+            DataClassification = CustomerContent;
             ToolTip = 'Specifies the number series used to assign codes to new routing versions when the routing does not specify its own version number series.';
             TableRelation = "No. Series";
         }

--- a/src/Layers/W1/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Setup/ManufacturingSetup.Table.al
@@ -17,6 +17,7 @@ using Microsoft.Manufacturing.Capacity;
 using Microsoft.Manufacturing.Forecast;
 using Microsoft.Manufacturing.MachineCenter;
 using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Wizard;
 using Microsoft.Manufacturing.WorkCenter;
 using System.Telemetry;
@@ -409,6 +410,20 @@ table 99000765 "Manufacturing Setup"
             Caption = 'Default Prod. Wiz. Flushing Method';
             DataClassification = CustomerContent;
             ToolTip = 'Specifies the default flushing method applied to Production Order Components when creating a new production BOM from scratch through the production order creation wizard. This is only used for temporary BOM creation; existing BOMs retain their original flushing method.';
+        }
+        field(312; "Production BOM Version Nos."; Code[20])
+        {
+            AccessByPermission = TableData "Production BOM Header" = R;
+            Caption = 'Production BOM Version Nos.';
+            ToolTip = 'Specifies the number series used to assign codes to new production BOM versions when the production BOM does not specify its own version number series.';
+            TableRelation = "No. Series";
+        }
+        field(313; "Routing Version Nos."; Code[20])
+        {
+            AccessByPermission = TableData "Routing Header" = R;
+            Caption = 'Routing Version Nos.';
+            ToolTip = 'Specifies the number series used to assign codes to new routing versions when the routing does not specify its own version number series.';
+            TableRelation = "No. Series";
         }
         field(5500; "Preset Output Quantity"; Option)
         {

--- a/src/Layers/W1/Tests/SCM-Manufacturing/ProductionDefinitionWizard/ProdDefWizItemStrTest.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/ProductionDefinitionWizard/ProdDefWizItemStrTest.Codeunit.al
@@ -6,6 +6,8 @@ namespace Microsoft.Manufacturing.Test;
 
 using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.ProductionBOM;
+using Microsoft.Manufacturing.Routing;
+using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.Wizard;
 
 codeunit 137432 "Prod. Def. Wiz. Item Str. Test"
@@ -22,6 +24,7 @@ codeunit 137432 "Prod. Def. Wiz. Item Str. Test"
 
     var
         Assert: Codeunit Assert;
+        LibraryERM: Codeunit "Library - ERM";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
@@ -162,12 +165,16 @@ codeunit 137432 "Prod. Def. Wiz. Item Str. Test"
     procedure TestK3_DefineItemStructure_SaveTrue_ItemBOMAndRoutingAssigned()
     var
         Item: Record Item;
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
         ProdDefManager: Codeunit "Production Definition Manager";
         ItemNo: Code[20];
         PreWizardLastBOMNo: Code[20];
         PostWizardLastBOMNo: Code[20];
         PreWizardLastRoutingNo: Code[20];
         PostWizardLastRoutingNo: Code[20];
+        ProductionBOMVersionNos: Code[20];
+        RoutingVersionNos: Code[20];
         WizardShouldHaveFinishedLbl: Label 'Wizard should have finished';
         WizardShouldHaveCreatedNewBOMLbl: Label 'Wizard should have created a new Production BOM';
         WizardShouldHaveCreatedNewRoutingLbl: Label 'Wizard should have created a new Routing';
@@ -181,6 +188,9 @@ codeunit 137432 "Prod. Def. Wiz. Item Str. Test"
         Item.Get(ItemNo);
         ProdDefWizSetupLib.ConfigureForNothingAvailable(
             "Prod. Definition Display"::Edit, "Prod. Definition Display"::Edit);
+        ProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        RoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        SetManufacturingVersionNoSeries(ProductionBOMVersionNos, RoutingVersionNos);
 
         // [WHEN] User enables Save = Item and finishes the wizard
         PreWizardLastBOMNo := ProdDefWizCheckLib.GetLastProductionBOMNo();
@@ -196,6 +206,22 @@ codeunit 137432 "Prod. Def. Wiz. Item Str. Test"
         Assert.AreNotEqual(PreWizardLastRoutingNo, PostWizardLastRoutingNo, WizardShouldHaveCreatedNewRoutingLbl);
         ProdDefWizCheckLib.VerifyItemHasBOM(ItemNo, PostWizardLastBOMNo);
         ProdDefWizCheckLib.VerifyItemHasRouting(ItemNo, PostWizardLastRoutingNo);
+
+        // [THEN] The wizard-created headers inherited the Manufacturing Setup version number series
+        ProductionBOMHeader.Get(PostWizardLastBOMNo);
+        RoutingHeader.Get(PostWizardLastRoutingNo);
+        Assert.AreEqual(ProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(RoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    local procedure SetManufacturingVersionNoSeries(ProductionBOMVersionNos: Code[20]; RoutingVersionNos: Code[20])
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+    begin
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Production BOM Version Nos.", ProductionBOMVersionNos);
+        ManufacturingSetup.Validate("Routing Version Nos.", RoutingVersionNos);
+        ManufacturingSetup.Modify(true);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -2477,6 +2477,111 @@ codeunit 137063 "SCM Manufacturing 7.0"
 
     [Test]
     [Scope('OnPrem')]
+    procedure ProductionBOMAndRoutingHeadersInheritVersionNoSeriesFromManufacturingSetup()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        ProductionBOMVersionNos: Code[20];
+        RoutingVersionNos: Code[20];
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] New production BOM and routing headers inherit version number series from Manufacturing Setup.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has default production BOM and routing version number series
+        ProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        RoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        SetManufacturingVersionNoSeries(ProductionBOMVersionNos, RoutingVersionNos);
+
+        // [WHEN] Production BOM and routing headers are inserted without explicit version number series
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both headers inherit their respective defaults
+        Assert.AreEqual(ProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(RoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ExplicitHeaderVersionNoSeriesTakePrecedenceOverManufacturingSetup()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+        ExplicitProductionBOMVersionNos: Code[20];
+        ExplicitRoutingVersionNos: Code[20];
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Explicit header version number series take precedence over Manufacturing Setup defaults.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has default version number series and both headers have explicit series
+        SetManufacturingVersionNoSeries(LibraryERM.CreateNoSeriesCode(), LibraryERM.CreateNoSeriesCode());
+        ExplicitProductionBOMVersionNos := LibraryERM.CreateNoSeriesCode();
+        ExplicitRoutingVersionNos := LibraryERM.CreateNoSeriesCode();
+        ProductionBOMHeader.Validate("Version Nos.", ExplicitProductionBOMVersionNos);
+        RoutingHeader.Validate("Version Nos.", ExplicitRoutingVersionNos);
+
+        // [WHEN] The headers are inserted
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both explicit series are retained
+        Assert.AreEqual(ExplicitProductionBOMVersionNos, ProductionBOMHeader."Version Nos.", ProductionBOMHeader.FieldCaption("Version Nos."));
+        Assert.AreEqual(ExplicitRoutingVersionNos, RoutingHeader."Version Nos.", RoutingHeader.FieldCaption("Version Nos."));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure BlankManufacturingSetupLeavesHeaderVersionNoSeriesBlank()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Blank Manufacturing Setup defaults preserve blank header version number series.
+        Initialize();
+
+        // [GIVEN] Manufacturing Setup has no default version number series
+        SetManufacturingVersionNoSeries('', '');
+
+        // [WHEN] Production BOM and routing headers are inserted
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [THEN] Both header version number series remain blank
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ManufacturingSetupVersionNoSeriesDoNotBackfillExistingHeaders()
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+        RoutingHeader: Record "Routing Header";
+    begin
+        // [FEATURE] [No. Series] [Production BOM Version] [Routing Version]
+        // [SCENARIO 647371] Configuring Manufacturing Setup does not backfill existing headers.
+        Initialize();
+
+        // [GIVEN] Production BOM and routing headers were inserted while the setup defaults were blank
+        SetManufacturingVersionNoSeries('', '');
+        ProductionBOMHeader.Insert(true);
+        RoutingHeader.Insert(true);
+
+        // [WHEN] Default version number series are configured in Manufacturing Setup
+        SetManufacturingVersionNoSeries(LibraryERM.CreateNoSeriesCode(), LibraryERM.CreateNoSeriesCode());
+        ProductionBOMHeader.Get(ProductionBOMHeader."No.");
+        RoutingHeader.Get(RoutingHeader."No.");
+
+        // [THEN] The existing header version number series remain blank
+        ProductionBOMHeader.TestField("Version Nos.", '');
+        RoutingHeader.TestField("Version Nos.", '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure ReValidatingUnitOfMeasureCodeOnProdBOMLine()
     var
         ProductionBOMLine: Record "Production BOM Line";
@@ -5229,6 +5334,16 @@ codeunit 137063 "SCM Manufacturing 7.0"
         ManufacturingSetup.Get();
         DocNoIsProdOrderNo := ManufacturingSetup."Doc. No. Is Prod. Order No.";
         ManufacturingSetup.Validate("Doc. No. Is Prod. Order No.", NewDocNoIsProdOrderNo);
+        ManufacturingSetup.Modify(true);
+    end;
+
+    local procedure SetManufacturingVersionNoSeries(ProductionBOMVersionNos: Code[20]; RoutingVersionNos: Code[20])
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+    begin
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Production BOM Version Nos.", ProductionBOMVersionNos);
+        ManufacturingSetup.Validate("Routing Version Nos.", RoutingVersionNos);
         ManufacturingSetup.Modify(true);
     end;
 


### PR DESCRIPTION
## What & why

Adds optional default number series for production BOM versions and routing versions to Manufacturing Setup.

New production BOM and routing headers inherit the corresponding setup value only when their own Version Nos. is blank. Explicit header values remain authoritative, blank setup preserves existing behavior, and existing headers are not backfilled. The Contoso manufacturing dataset now creates PRODBOM-V and ROUTING-V and assigns them only when the setup fields are blank.

The Manufacturing Setup schema change is mirrored in the customized Italian layer, and focused BaseApp, wizard, and Contoso tests cover inheritance, precedence, blank setup, no backfill, and zero-padded PV00010/RV00010 series starts and generated version codes.

## Linked work

Fixes [AB#647371](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647371)

## How I validated this

- [x] Reviewed the full diff; it contains only the intended 13 files.
- [x] `git diff --check` passes.
- [x] `Invoke-MiSnapApp` reports no missing layer integrations.
- [x] VS Code AL diagnostics are clean for every touched file.
- [x] Added focused BaseApp, Production Definition Wizard, and Contoso tests.
- [ ] Tests were not executed locally.

A direct Base Application compile with CodeCop resolved the changed manufacturing files after adding the required routing namespace, then stopped on nine unrelated errors in untouched reporting, isolated-storage, and API files because the local BC 29 symbol cache is older than current `main`. CI remains authoritative for the full Base Application, IT layer, Tests-SCM-Manufacturing, and Contoso Coffee projects.

## Risk & compatibility

Low. The new setup fields are optional. Existing records are unchanged, partner-supplied nonblank header values take precedence, and no fallback to the header number series is introduced.











## CI follow-up (2026-09-09)

Commit a1d2c26dea addresses both remaining failure classes in run 34124592865. All 22 failing country default buckets failed only in the three new manufacturing tests: some reached incorrect unpadded number assertions; others failed during unrelated localized Finance/Inventory regeneration, followed by subscriber-binding cascades.

The two-file repair changes only the existing manufacturing setup routine from local to internal and narrows its test fixture to the capacity-UOM and number-series prerequisites. Production logic and its call path are unchanged. Tests retain default assignment, precedence, inheritance, explicit-code preservation and no-backfill coverage; they verify padded definitions and peek the next sequence values before explicit insertion rather than assuming unused shared sequences. These are focused manufacturing tests, not full localized demo-generation tests.

Validation: both Contoso app and test projects compile with CodeCop against cached PR symbols; editor diagnostics and git diff --check pass. Runtime tests were not run locally because the installed Base Application lacks the new fields. Fresh CI is required before treating this PR as unblocked.



