### PR TITLE
Fix Report Inbox API E2E cross-company tests to create a second company

### DIFF
--- a/src/Layers/W1/Tests/Report/ReportInboxAPIE2E.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportInboxAPIE2E.Codeunit.al
@@ -573,13 +573,28 @@ codeunit 135549 "Report Inbox API E2E"
 
     local procedure OtherCompanyName(): Text
     var
-        Company: Record Company;
+        ExistingCompany: Record Company;
     begin
-        Company.SetFilter(Name, '<>%1', CompanyName());
-        Assert.IsTrue(
-            Company.FindFirst(),
-            'This scenario needs a second company; the database has only ' + CompanyName() + '.');
-        exit(Company.Name);
+        ExistingCompany.SetFilter(Name, '<>%1', CompanyName());
+        if ExistingCompany.FindFirst() then
+            exit(ExistingCompany.Name);
+
+        // The addressed company may be the only one in the database (for example the
+        // W1 web services test lane ships only CRONUS International Ltd.). Create an
+        // empty company so the cross-company scenarios have a real second company to
+        // address instead of failing during arrangement.
+        exit(CreateSecondaryCompany());
+    end;
+
+    local procedure CreateSecondaryCompany(): Text
+    var
+        NewCompany: Record Company;
+    begin
+        NewCompany.LockTable(true);
+        NewCompany.Name := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(NewCompany.Name));
+        NewCompany.Insert(true);
+        Commit();
+        exit(NewCompany.Name);
     end;
 
     local procedure SeedEntryForApiCallerIn(CompanyToSeed: Text; NewDescription: Text)

--- a/src/Layers/W1/Tests/Report/ReportInboxAPIE2E.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/ReportInboxAPIE2E.Codeunit.al
@@ -579,10 +579,6 @@ codeunit 135549 "Report Inbox API E2E"
         if ExistingCompany.FindFirst() then
             exit(ExistingCompany.Name);
 
-        // The addressed company may be the only one in the database (for example the
-        // W1 web services test lane ships only CRONUS International Ltd.). Create an
-        // empty company so the cross-company scenarios have a real second company to
-        // address instead of failing during arrangement.
         exit(CreateSecondaryCompany());
     end;
 


### PR DESCRIPTION
## What & why

Fixes [AB#647605](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647605)

Codeunit 135549 `"Report Inbox API E2E"` helper `OtherCompanyName()` asserted that a second company exists. In the W1 web services test lane (`RunALTests_W1_WebServices`) the database contains only CRONUS International Ltd., so four cross-company scenarios failed during arrangement (0s, no Report Inbox API behavior exercised):

- `TestGetReportInboxItemsAcrossCompanies`
- `TestGetReportInboxFileForEntryInAnotherCompanyIsNotWidenedSilently`
- `TestGetReportInboxFileForEntryInAnotherCompanyWhenNamed`
- `TestGetReportInboxContentDoesNotResolveAnotherCompany`

## Change

`OtherCompanyName()` now ensures a second company instead of asserting one:
- returns an existing second company when present;
- otherwise creates an empty company via `Company.Insert(true)` (new `CreateSecondaryCompany()` helper), mirroring the established pattern in `CompanyConsolWizardTests.Codeunit.al`. The name comes from `LibraryUtility.GenerateGUID()` (URL/OData-safe, e.g. `GU00000001`).

## Validation

- Built the Tests-Report project locally (symbols from a local BC server); the modified procedures produce no diagnostics.
- These are web-service E2E tests that only run in the downstream NAV `RunALTests_W1_WebServices` lane, so full run validation happens there.

## Follow-up (NAV repo)

The four tests are disabled on the NAV side in `App/DisabledTests/ReportInboxAPIE2E.DisabledTest.json`. Remove those entries to re-enable them once this fix flows into NAV via BCApps uptake. The BCApps `Tests-Report.DisabledTest.json` entries stay, since web-service E2E tests are not run in BCApps CI.



