### PR TITLE
Calculate Inventory: scope Default Dimension reads by source table

### DIFF
--- a/src/Layers/RU/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
+++ b/src/Layers/RU/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
@@ -962,29 +962,27 @@ report 790 "Calculate Inventory"
     end;
 
     local procedure CreateDimFromDefault() DimEntryNo: Integer
-    var
-        DefaultDimension: Record "Default Dimension";
     begin
-        DefaultDimension.SetRange("Table ID", DATABASE::Item);
-        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Item No.");
-        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
-        if DefaultDimension.FindSet() then
-            repeat
-                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
-            until DefaultDimension.Next() = 0;
-
-        DefaultDimension.SetRange("Table ID", DATABASE::Location);
-        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Location Code");
-        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
-        if DefaultDimension.FindSet() then
-            repeat
-                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
-            until DefaultDimension.Next() = 0;
+        InsertDefaultDimensions(DATABASE::Item, TempQuantityOnHandBuffer."Item No.");
+        InsertDefaultDimensions(DATABASE::Location, TempQuantityOnHandBuffer."Location Code");
 
         DimEntryNo := DimBufMgt.InsertDimensions(TempDimBufIn);
 
         TempDimBufIn.SetFilter("Table ID",'%1|%2',DATABASE::Item, Database::Location);
         TempDimBufIn.DeleteAll();
+    end;
+
+    local procedure InsertDefaultDimensions(TableID: Integer; No: Code[20])
+    var
+        DefaultDimension: Record "Default Dimension";
+    begin
+        DefaultDimension.SetRange("Table ID", TableID);
+        DefaultDimension.SetRange("No.", No);
+        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
+        if DefaultDimension.FindSet() then
+            repeat
+                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
+            until DefaultDimension.Next() = 0;
     end;
 
     local procedure InsertDim(TableID: Integer; EntryNo: Integer; DimCode: Code[20]; DimValueCode: Code[20])

--- a/src/Layers/RU/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
+++ b/src/Layers/RU/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
@@ -965,8 +965,16 @@ report 790 "Calculate Inventory"
     var
         DefaultDimension: Record "Default Dimension";
     begin
-        DefaultDimension.SetFilter("No.", '%1|%2', TempQuantityOnHandBuffer."Item No.", TempQuantityOnHandBuffer."Location Code");
-        DefaultDimension.SetFilter("Table ID", '%1|%2', DATABASE::Item, DATABASE::Location);
+        DefaultDimension.SetRange("Table ID", DATABASE::Item);
+        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Item No.");
+        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
+        if DefaultDimension.FindSet() then
+            repeat
+                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
+            until DefaultDimension.Next() = 0;
+
+        DefaultDimension.SetRange("Table ID", DATABASE::Location);
+        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Location Code");
         DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
         if DefaultDimension.FindSet() then
             repeat

--- a/src/Layers/W1/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
+++ b/src/Layers/W1/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
@@ -959,8 +959,16 @@ report 790 "Calculate Inventory"
     var
         DefaultDimension: Record "Default Dimension";
     begin
-        DefaultDimension.SetFilter("No.", '%1|%2', TempQuantityOnHandBuffer."Item No.", TempQuantityOnHandBuffer."Location Code");
-        DefaultDimension.SetFilter("Table ID", '%1|%2', DATABASE::Item, DATABASE::Location);
+        DefaultDimension.SetRange("Table ID", DATABASE::Item);
+        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Item No.");
+        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
+        if DefaultDimension.FindSet() then
+            repeat
+                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
+            until DefaultDimension.Next() = 0;
+
+        DefaultDimension.SetRange("Table ID", DATABASE::Location);
+        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Location Code");
         DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
         if DefaultDimension.FindSet() then
             repeat

--- a/src/Layers/W1/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
+++ b/src/Layers/W1/BaseApp/Inventory/Counting/Journal/CalculateInventory.Report.al
@@ -956,29 +956,27 @@ report 790 "Calculate Inventory"
     end;
 
     local procedure CreateDimFromDefault() DimEntryNo: Integer
-    var
-        DefaultDimension: Record "Default Dimension";
     begin
-        DefaultDimension.SetRange("Table ID", DATABASE::Item);
-        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Item No.");
-        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
-        if DefaultDimension.FindSet() then
-            repeat
-                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
-            until DefaultDimension.Next() = 0;
-
-        DefaultDimension.SetRange("Table ID", DATABASE::Location);
-        DefaultDimension.SetRange("No.", TempQuantityOnHandBuffer."Location Code");
-        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
-        if DefaultDimension.FindSet() then
-            repeat
-                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
-            until DefaultDimension.Next() = 0;
+        InsertDefaultDimensions(DATABASE::Item, TempQuantityOnHandBuffer."Item No.");
+        InsertDefaultDimensions(DATABASE::Location, TempQuantityOnHandBuffer."Location Code");
 
         DimEntryNo := DimBufMgt.InsertDimensions(TempDimBufIn);
 
         TempDimBufIn.SetFilter("Table ID", '%1|%2', DATABASE::Item, Database::Location);
         TempDimBufIn.DeleteAll();
+    end;
+
+    local procedure InsertDefaultDimensions(TableID: Integer; No: Code[20])
+    var
+        DefaultDimension: Record "Default Dimension";
+    begin
+        DefaultDimension.SetRange("Table ID", TableID);
+        DefaultDimension.SetRange("No.", No);
+        DefaultDimension.SetFilter("Dimension Value Code", '<>%1', '');
+        if DefaultDimension.FindSet() then
+            repeat
+                InsertDim(DefaultDimension."Table ID", 0, DefaultDimension."Dimension Code", DefaultDimension."Dimension Value Code");
+            until DefaultDimension.Next() = 0;
     end;
 
     local procedure InsertDim(TableID: Integer; EntryNo: Integer; DimCode: Code[20]; DimValueCode: Code[20])

--- a/src/Layers/W1/Tests/SCM/SCMInventoryJournals.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM/SCMInventoryJournals.Codeunit.al
@@ -928,6 +928,72 @@ codeunit 137275 "SCM Inventory Journals"
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure CalcInventoryDoesNotLeakDefaultDimWhenItemNoEqualsAnotherLocationCode()
+    var
+        Item: Record Item;
+        OverlapLocation: Record Location;
+        TargetLocation: Record Location;
+        OverlapDimension: Record Dimension;
+        TargetDimension: Record Dimension;
+        OverlapDimensionValue: Record "Dimension Value";
+        TargetDimensionValue: Record "Dimension Value";
+        OverlapDefaultDim: Record "Default Dimension";
+        TargetDefaultDim: Record "Default Dimension";
+        ItemJournalLine: Record "Item Journal Line";
+        ItemJournalBatch: Record "Item Journal Batch";
+        DimensionSetEntry: Record "Dimension Set Entry";
+        SharedCode: Code[10];
+    begin
+        // [FEATURE] [Dimensions] [Physical Inventory]
+        // [SCENARIO 9100] When an Item's "No." equals an unrelated Location's "Code", Calculate Inventory must apply only the actually-counted Location's Default Dimensions and must not leak Default Dimensions of the unrelated Location whose Code happens to match the Item's No.
+        Initialize();
+
+        // [GIVEN] Item "X" renamed to a code that also fits Location.Code (Code[10]), so an unrelated Location can carry the same value
+        CreateItem(Item, Item."Costing Method"::FIFO);
+        SharedCode := LibraryUtility.GenerateRandomCode(OverlapLocation.FieldNo(Code), DATABASE::Location);
+        Item.Rename(SharedCode);
+
+        // [GIVEN] An unrelated Location with Code = Item."No.", carrying Default Dimension "D1" = "V1"
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(OverlapLocation);
+        OverlapLocation.Rename(SharedCode);
+        LibraryDimension.CreateDimension(OverlapDimension);
+        LibraryDimension.CreateDimensionValue(OverlapDimensionValue, OverlapDimension.Code);
+        LibraryDimension.CreateDefaultDimension(
+          OverlapDefaultDim, DATABASE::Location, OverlapLocation.Code, OverlapDimension.Code, OverlapDimensionValue.Code);
+
+        // [GIVEN] A target Location, carrying Default Dimension "D2" = "V2" with a different Dimension Code from "D1"
+        LibraryWarehouse.CreateLocationWithInventoryPostingSetup(TargetLocation);
+        LibraryDimension.CreateDimension(TargetDimension);
+        LibraryDimension.CreateDimensionValue(TargetDimensionValue, TargetDimension.Code);
+        LibraryDimension.CreateDefaultDimension(
+          TargetDefaultDim, DATABASE::Location, TargetLocation.Code, TargetDimension.Code, TargetDimensionValue.Code);
+
+        // [GIVEN] Posted stock of Item "X" on the target Location
+        UpdateItemInventory(
+          Item."No.", TargetLocation.Code, '', LibraryRandom.RandDec(10, 2),
+          ItemJournalLine."Entry Type"::"Positive Adjmt.", LibraryRandom.RandDec(10, 2));
+
+        // [WHEN] Calculate Inventory for Item "X"
+        CreateAndPostPhysInventoryJournal(ItemJournalLine, ItemJournalBatch, Item."No.", false);
+
+        // [THEN] The generated Phys. Inventory Journal Line is on the target Location
+        FindItemJournalLine(ItemJournalLine, ItemJournalBatch, Item."No.");
+        ItemJournalLine.TestField("Location Code", TargetLocation.Code);
+
+        // [THEN] The line's Dimension Set carries the target Location's Default Dimension ("D2" = "V2")
+        DimensionSetEntry.SetRange("Dimension Set ID", ItemJournalLine."Dimension Set ID");
+        DimensionSetEntry.SetRange("Dimension Code", TargetDimension.Code);
+        DimensionSetEntry.SetRange("Dimension Value Code", TargetDimensionValue.Code);
+        Assert.RecordIsNotEmpty(DimensionSetEntry);
+
+        // [THEN] The line's Dimension Set does NOT carry the unrelated Location's Default Dimension ("D1")
+        DimensionSetEntry.SetRange("Dimension Code", OverlapDimension.Code);
+        DimensionSetEntry.SetRange("Dimension Value Code");
+        Assert.RecordIsEmpty(DimensionSetEntry);
+    end;
+
+    [Test]
     [HandlerFunctions('CalculateInventoryIncludeItemWithoutTransactionHandler')]
     [Scope('OnPrem')]
     procedure CalcInventoryWithIncludeItemWithoutTransactionComplexLocationFilter()


### PR DESCRIPTION
## What & why

Report 790 "Calculate Inventory", procedure `CreateDimFromDefault()`, reads Default Dimensions with two independent OR-filters: one on `"No."` (Item No. or Location Code) and one on `"Table ID"` (Item or Location). Because the two filters are applied independently, the pairs are never scoped per table and the read expands into a cross-product. When an Item's `No.` happens to equal an unrelated Location's `Code`, that Location's default dimensions pass both filters and land on the physical inventory journal line, even though the count is being made for a completely different location.

This change replaces the cross-product read with two scoped passes, one per intended `(Table ID, No.)` pair: `(Item, Item No.)` and `(Location, Location Code)`. Each pass feeds the same `InsertDim` call, so the `TempDimBufIn` buffer, the `DimBufMgt.InsertDimensions()` call and the trailing buffer cleanup are untouched. When Item No. and Location Code do not collide, the set of dimensions applied is exactly the same as before.

The RU layer carries a full copy of the report with the same two filter lines, and receives the same change, as requested in the approval comment on the issue.

This is a re-submission of microsoft/BusinessCentralApps#1908 (pilot repository, retired). The fix and the regression test were reviewed there; the test was added at the reviewer's request. The pilot PR was closed unmerged by the repository retirement.

## Linked work

Fixes #9100

Original pilot review: microsoft/BusinessCentralApps#1908 (fixing microsoft/BusinessCentralApps#1542).

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Verified against current main that the defect is still present: the two independent OR-filters are in `CreateDimFromDefault()` in both the W1 and the RU copy of the report, byte-identical apart from unrelated whitespace on a line this change does not touch.
- Verified that `CalculateInventory.Report.al` exists only in the W1 and RU layers, so no further layer propagation is needed, and that the two fixed `CreateDimFromDefault()` bodies are identical between the two layers. Codeunit 137275 "SCM Inventory Journals" exists only in W1, so the regression test has no layer copy to mirror.
- Swept the rest of the repository for the same shape, two independent OR-filters on `"No."` and `"Table ID"` against Default Dimension. Report 790 is the only occurrence. Other Default Dimension reads pin `"Table ID"` to a single value, which is safe, and the `'%1|%2'` form with a blank second value is the deliberate specific-or-blank idiom rather than a cross-product.
- New regression test `CalcInventoryDoesNotLeakDefaultDimWhenItemNoEqualsAnotherLocationCode` in codeunit 137275 "SCM Inventory Journals": the Item and an unrelated Location are both renamed to the same generated 10 character code, that Location is given a Default Dimension, stock for the Item is posted on a different target Location that carries its own Default Dimension, and Calculate Inventory is run. The test asserts both directions: the target Location's Default Dimension is present on the generated line's dimension set, and the unrelated Location's Default Dimension is not.
- The shared code comes from `LibraryUtility.GenerateRandomCode(Location.FieldNo(Code), DATABASE::Location)`, so it is unique and fits `Location.Code` by construction rather than by relying on the length the Item No. series happens to produce. This follows the rename pattern already used in `ERMDimensionLocations.Codeunit.al`.
- The two Locations carry Default Dimensions on different Dimension Codes on purpose. With the same Dimension Code, `if TempDimBufIn.Insert() then` would resolve the duplicate by insertion order and the test could pass on the unfixed code depending on how the values sort.
- The test reuses the helpers already in the codeunit (`CreateItem`, `UpdateItemInventory`, `CreateAndPostPhysInventoryJournal`, `FindItemJournalLine`); no new test infrastructure is added.
- I did not build the Base Application locally. The change is two scoped reads per report copy plus one test, and relies on CI for the compile and the test run.

## Risk & compatibility

- Low and localized: the change lives entirely inside the local `CreateDimFromDefault()` of report 790. No public surface, no signature change, no event change.
- Behavior is identical when an Item No. and a Location Code do not collide; only the colliding case changes, and it changes to the intended result.
- The `InsertDim` / `TempDimBufIn` flow, the `DimBufMgt.InsertDimensions()` call and the trailing `TempDimBufIn` cleanup are unchanged. The `TempDimBufIn.SetFilter("Table ID", '%1|%2', ...)` a few lines below the fix looks like the same shape but is not: it clears the temporary Dimension Buffer for both source tables at once, which is what that cleanup is meant to do, so it is deliberately left alone.
- Ordering is unaffected. "Dimension Buffer" is keyed on `("Table ID", "Entry No.", "Dimension Code")`, so Item and Location rows never collide in the buffer and it is iterated in key order rather than insertion order. The two passes therefore hand `DimBufMgt.InsertDimensions()` the same rows in the same order as the single pass did, and a Dimension Code held by both the Item and the Location resolves to the same winner as before.
- The two passes are kept inline, as reviewed in the pilot PR, where extracting a shared helper was raised as an optional, non-blocking suggestion.
- No schema, permission, or upgrade impact.


