### PR TITLE
[Shopify] Fix Shpfy Order Totals FB Test posting tests failing in CZ

### DIFF
--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTotalsFBTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTotalsFBTest.Codeunit.al
@@ -21,11 +21,14 @@ codeunit 139587 "Shpfy Order Totals FB Test"
         LibrarySales: Codeunit "Library - Sales";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibraryAssert: Codeunit "Library Assert";
+        LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         Any: Codeunit Any;
 
     local procedure Initialize()
     begin
         LibraryVariableStorage.Clear();
+        LibraryERMCountryData.CreateVATData();
+        LibraryERMCountryData.UpdateGeneralPostingSetup();
     end;
 
     [Test]


### PR DESCRIPTION
## Summary
`TestPostedSalesInvoiceResolvedAndNavigated` and `TestNumberOfLinesDrillDownPostedInvoice` in codeunit 139587 `Shpfy Order Totals FB Test` post a sales invoice. Under the Czech (CZ) localization, posting requires a VAT Period to exist for the posting date, which the test never sets up. As a result the two tests failed CZ-only (`VAT Period does not exist for date …` — `VAT Date Handler CZL.VATPeriodCZLCheck`) and were disabled after the BCApps uptake.

## Fix
Seed the country-specific VAT setup in `Initialize()` via `LibraryERMCountryData.CreateVATData()` and `UpdateGeneralPostingSetup()`, matching the other Shopify posting tests (`ShpfyInvoicesTest`, `ShpfySuggestPaymentTest`). In the CZ test layer `CreateVATData()` creates the required VAT Period; both calls are safe no-ops on W1.

## Test plan
Ran the CZ integration test job (`RunALIntegrationTests_CZ_Extensions`): codeunit 139587 passes 10/10, including the two previously-failing posted-invoice tests.

Fixes [AB#647314](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647314)


