### PR TITLE
[Extensibility Request] issue 30429: add events to disambiguate CRM integration table mappings

### DIFF
--- a/src/Layers/W1/BaseApp/Integration/D365Sales/CRMOrderStatusUpdateJob.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/D365Sales/CRMOrderStatusUpdateJob.Codeunit.al
@@ -58,6 +58,7 @@ codeunit 5352 "CRM Order Status Update Job"
     begin
         IntegrationTableMapping.SetRange(Type, IntegrationTableMapping.Type::Dataverse);
         IntegrationTableMapping.SetRange("Table ID", DATABASE::"Sales Header");
+        OnUpdateSalesOrdersOnBeforeFindIntegrationTableMapping(IntegrationTableMapping);
         if IntegrationTableMapping.FindFirst() then
             IntegrationTableSynch.BeginIntegrationSynchJob(TABLECONNECTIONTYPE::CRM, IntegrationTableMapping, DATABASE::"Sales Header")
         else
@@ -257,6 +258,11 @@ codeunit 5352 "CRM Order Status Update Job"
     begin
         if CRMPostBuffer.Get(TempCRMPostBuffer.ID) then
             CRMPostBuffer.Delete();
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesOrdersOnBeforeFindIntegrationTableMapping(var IntegrationTableMapping: Record "Integration Table Mapping")
+    begin
     end;
 }
 

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CRMIntegrationManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CRMIntegrationManagement.Codeunit.al
@@ -1254,6 +1254,7 @@ codeunit 5330 "CRM Integration Management"
             exit;
         end;
 
+        OnRemoveCouplingOnBeforeGetIntegrationTableMappingForUncoupling(IntegrationTableMapping, LocalRecordRef);
         if GetIntegrationTableMappingForUncoupling(IntegrationTableMapping, LocalRecordRef.Number()) then
             if Schedule then
                 ScheduleUncoupling(IntegrationTableMapping, IntegrationRecordSynch.GetTableViewForLocalRecords(LocalRecordRef), '')
@@ -1340,6 +1341,7 @@ codeunit 5330 "CRM Integration Management"
             exit;
         end;
 
+        OnMatchBasedCouplingOnBeforeGetIntegrationTableMappingForMatchBasedCoupling(IntegrationTableMapping, LocalRecordRef);
         if GetIntegrationTableMappingForCoupling(IntegrationTableMapping, LocalRecordRef.Number()) then begin
             IntegrationFieldMapping.SetMatchBasedCouplingFilters(IntegrationTableMapping);
             if Page.RunModal(Page::"Match Based Coupling Criteria", IntegrationFieldMapping) = Action::LookupOK then
@@ -4255,6 +4257,16 @@ codeunit 5330 "CRM Integration Management"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeRescheduleJobQueueEntries(TableNo: Integer; var RescheduleOffSetInMs: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnRemoveCouplingOnBeforeGetIntegrationTableMappingForUncoupling(var IntegrationTableMapping: Record "Integration Table Mapping"; LocalRecordRef: RecordRef)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnMatchBasedCouplingOnBeforeGetIntegrationTableMappingForMatchBasedCoupling(var IntegrationTableMapping: Record "Integration Table Mapping"; LocalRecordRef: RecordRef)
     begin
     end;
 }

--- a/src/Layers/W1/BaseApp/Integration/Dataverse/CouplingRecordBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/Integration/Dataverse/CouplingRecordBuffer.Table.al
@@ -224,6 +224,8 @@ table 5332 "Coupling Record Buffer"
                 "Saved CRM Option Id" := "CRM Option Id";
             end;
         end;
+
+        OnAfterInitialize(Rec);
     end;
 
     procedure Initialize(NAVRecordID: RecordID)
@@ -424,6 +426,11 @@ table 5332 "Coupling Record Buffer"
 
     [IntegrationEvent(false, false)]
     local procedure OnFindCRMOptionByName(CRMTableID: Integer; var EntityName: Text; var FieldName: Text; var Handled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterInitialize(var CouplingRecordBuffer: Record "Coupling Record Buffer")
     begin
     end;
 }


### PR DESCRIPTION
## Summary

Adds four integration events so extensions can select the correct `Integration Table Mapping` when several mappings share the same Business Central `Table ID` — for example, a `Sales Header` mapping that syncs quotes alongside the standard sales order mapping. Today the base code disambiguates only by `Table ID`, so extensions with additional same-table mappings can resolve the wrong mapping during order-status updates, coupling, uncoupling, and match-based coupling.

Requested via [ALAppExtensions #30429](https://github.com/microsoft/ALAppExtensions/issues/30429).

## Changes

| Object | Procedure | New event |
| --- | --- | --- |
| Codeunit "CRM Order Status Update Job" | `UpdateSalesOrders` | `OnUpdateSalesOrdersOnBeforeFindIntegrationTableMapping` |
| Table "Coupling Record Buffer" | `Initialize` | `OnAfterInitialize` |
| Codeunit "CRM Integration Management" | `RemoveCoupling` | `OnRemoveCouplingOnBeforeGetIntegrationTableMappingForUncoupling` |
| Codeunit "CRM Integration Management" | `MatchBasedCoupling` | `OnMatchBasedCouplingOnBeforeGetIntegrationTableMappingForMatchBasedCoupling` |

All events are thin `[IntegrationEvent(false, false)]` publishers. `RecordRef` context parameters are passed by value (read-only) so subscribers can inspect the source record to choose the mapping without mutating the caller's state, matching the existing input-only `RecordRef` events in the integration sync engine.

Fixes [AB#647520](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647520)


