### PR TITLE
[Bug 638696] Add teaching tip to Effective Permissions page 9852

### DIFF
--- a/src/Layers/W1/BaseApp/System/Permissions/EffectivePermissions.Page.al
+++ b/src/Layers/W1/BaseApp/System/Permissions/EffectivePermissions.Page.al
@@ -9,6 +9,8 @@ page 9852 "Effective Permissions"
 {
     ApplicationArea = All;
     Caption = 'Effective Permissions';
+    AboutTitle = 'About Effective Permissions';
+    AboutText = 'View the permissions a user actually has in Business Central. Effective permissions combine all assigned permission sets and filters to show the final access to objects and data, helping you verify access, troubleshoot permission issues, and support audits.';
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = false;


### PR DESCRIPTION
## What & why

Page 9852 (Effective Permissions) was missing a teaching tip, so users opening the page got no in-product explanation of what "effective permissions" are or how to use them. This adds the page-level `AboutTitle` and `AboutText` properties so the page shows a teaching tip, consistent with the sibling permission pages (e.g. Permission Set by User, Permissions Overview, Permission Sets).

## Linked work

Fixes [AB#638696](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638696)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected file locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Change is limited to two static page metadata properties (`AboutTitle`/`AboutText`) on page 9852, mirroring the exact pattern used by neighboring pages in `System/Permissions`.
- Verified with the AL compiler (`al_getdiagnostics`) that `EffectivePermissions.Page.al` compiles with **0 errors and 0 new warnings** after the change. The only diagnostic on the file is a pre-existing warning about `SourceTable = Permission` being marked for removal, which is unrelated to this change.
- No tests added: teaching tips are static UI metadata (`AboutTitle`/`AboutText`) with no logic to exercise, and sibling permission pages that define the same properties have no dedicated tests.

## Risk & compatibility

None. This is a metadata-only addition of a teaching tip; there is no behavioral, data, permission, or upgrade impact. The strings are translatable and will be picked up by the standard translation extraction.



