### PR TITLE
Fix PEPPOL DE publish order in groups.json

### DIFF
--- a/build/groups.json
+++ b/build/groups.json
@@ -5035,28 +5035,6 @@
     ]
   },
   {
-    "name": "PEPPOL DE",
-    "groups": [
-      {
-        "name": "AllExtensions"
-      },
-      {
-        "name": "Financials"
-      },
-      {
-        "name": "FinancialsExtensions"
-      },
-      {
-        "name": "OnPrem",
-        "doNotInstall": true
-      },
-      {
-        "name": "OnPremExtensions",
-        "doNotInstall": true
-      }
-    ]
-  },
-  {
     "name": "PEPPOL NA",
     "groups": [
       {
@@ -5239,6 +5217,28 @@
       },
       {
         "name": "Internal"
+      }
+    ]
+  },
+  {
+    "name": "PEPPOL DE",
+    "groups": [
+      {
+        "name": "AllExtensions"
+      },
+      {
+        "name": "Financials"
+      },
+      {
+        "name": "FinancialsExtensions"
+      },
+      {
+        "name": "OnPrem",
+        "doNotInstall": true
+      },
+      {
+        "name": "OnPremExtensions",
+        "doNotInstall": true
       }
     ]
   },


### PR DESCRIPTION
## What & why

The `PEPPOL DE` app was listed before `E-Document Core` in `build/groups.json`. Since apps in `groups.json` are published in list order, and `PEPPOL DE` now depends on `E-Document Core` (introduced in #10349), publishing failed with `AL1024: ... E-Document Core ... could not be found in the database` because the dependency's symbols weren't available yet.

This moves **only** the `PEPPOL DE` entry to immediately after `E-Document Core`, so its dependency is published first. Nothing else is reordered or changed. The diff is a clean move (22 insertions / 22 deletions) and the JSON validates.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>". -->

Fixes #

[AB#647670](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647670)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Validated `build/groups.json` parses as valid JSON after the change.
- Confirmed the resulting order: `E-Document Core` precedes `PEPPOL DE`, matching the dependency direction.
- No tests added: this is a build-ordering config change with no app logic affected.

## Risk & compatibility

Low risk. Ordering-only change in `build/groups.json`; no app code or manifests touched. Restores the correct publish order broken by the dependency added in #10349.

