### PR TITLE
Follow the team label rename in ownership classification

### DIFF
--- a/.github/workflows/bc-extrequest-triage-manual.yml
+++ b/.github/workflows/bc-extrequest-triage-manual.yml
@@ -108,12 +108,23 @@ jobs:
               );
             }
 
+            // Labels this workflow clears before applying the agent's result.
+            // Both spellings of the team labels are listed: BCApps renamed them
+            // to the "Team: " namespace, and a rename does not rewrite items
+            // that nothing has touched since, so an issue can still carry the
+            // old one. Removing a label that is not present is a no-op here, so
+            // listing both is free and leaving one out would silently strand it.
             const managedLabels = [
               'missing-info',
               'agent-not-processable',
+              'Team: Finance',
+              'Team: SCM',
+              'Team: Integrations',
+              'Team: Other',
               'Finance',
               'SCM',
               'Integration',
+              'Other',
               'event-request',
               'request-for-external',
               'enum-request',

--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -55,7 +55,7 @@ jobs:
           ) && (
             !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
             github.event.label.name == 'Ownership: Manual' ||
-            contains(fromJSON('["Finance","SCM","Integration","Other"]'), github.event.label.name)
+            contains(fromJSON('["Team: Finance","Team: SCM","Team: Integrations","Team: Other"]'), github.event.label.name)
           )
         )
       )
@@ -76,9 +76,32 @@ jobs:
           SUBJECT_NUMBER: ${{ env.SUBJECT_NUMBER }}
         with:
           script: |
-            const teams = ['Finance', 'SCM', 'Integration', 'Other'];
+            // A team NAME and the LABEL recording it stopped being the same
+            // string when this repository namespaced its team labels. The agent
+            // speaks in names; the repository stores labels. Map, do not assume.
+            const teamLabels = {
+              Finance: 'Team: Finance',
+              SCM: 'Team: SCM',
+              Integrations: 'Team: Integrations',
+              Other: 'Team: Other',
+            };
+            // The rename also corrected Integration to the plural the team uses.
+            // Accepting the old spelling from the agent keeps this workflow and
+            // BCAppsTriage from having to deploy in lockstep.
+            // Accepted spellings for the agent's answer: the pre-rename
+            // "Integration", and the label form of every team. The agent is
+            // expected to send a name, but rejecting a label would be a hard
+            // failure over a cosmetic difference, and the two repositories
+            // deploy independently.
+            const teamAliases = Object.assign(
+              { Integration: 'Integrations' },
+              Object.fromEntries(Object.entries(teamLabels).map(([name, label]) => [label, name])),
+            );
+            const canonicalTeam = name => teamAliases[name] || name;
+            const teams = Object.keys(teamLabels);
+            const teamLabelNames = Object.values(teamLabels);
             const ownershipLabels = ['Ownership: Manual', 'Ownership: Needs Review'];
-            const valid = [...teams, ...ownershipLabels];
+            const valid = [...teamLabelNames, ...ownershipLabels];
             const subjectKind = process.env.SUBJECT_KIND;
             const issue_number = Number(process.env.SUBJECT_NUMBER);
             const action = context.payload.action;
@@ -121,7 +144,7 @@ jobs:
               ...context.repo, issue_number, per_page: 100,
             })).map(label => label.name);
             const labels = await getLabels();
-            const selected = teams.filter(team => labels.includes(team));
+            const selected = teamLabelNames.filter(name => labels.includes(name));
             const manual = labels.includes('Ownership: Manual');
 
             if (manual) {
@@ -242,9 +265,28 @@ jobs:
           script: |
             const fs = require('fs');
             const { TextDecoder } = require('util');
-            const teams = ['Finance', 'SCM', 'Integration', 'Other'];
+            // See the preflight step: team names and team labels are different
+            // strings since the labels were namespaced, and are mapped here too.
+            const teamLabels = {
+              Finance: 'Team: Finance',
+              SCM: 'Team: SCM',
+              Integrations: 'Team: Integrations',
+              Other: 'Team: Other',
+            };
+            // Accepted spellings for the agent's answer: the pre-rename
+            // "Integration", and the label form of every team. The agent is
+            // expected to send a name, but rejecting a label would be a hard
+            // failure over a cosmetic difference, and the two repositories
+            // deploy independently.
+            const teamAliases = Object.assign(
+              { Integration: 'Integrations' },
+              Object.fromEntries(Object.entries(teamLabels).map(([name, label]) => [label, name])),
+            );
+            const canonicalTeam = name => teamAliases[name] || name;
+            const teams = Object.keys(teamLabels);
+            const teamLabelNames = Object.values(teamLabels);
             const ownershipLabels = ['Ownership: Manual', 'Ownership: Needs Review'];
-            const valid = [...teams, ...ownershipLabels];
+            const valid = [...teamLabelNames, ...ownershipLabels];
             const confidenceValues = ['high', 'medium', 'low'];
             const sources = [
               'issue:path', 'issue:localization', 'issue:title-object',
@@ -277,7 +319,7 @@ jobs:
               result.subject.kind !== process.env.SUBJECT_KIND ||
               result.subject.number !== issue_number ||
               !Number.isSafeInteger(result.subject.number) ||
-              !teams.includes(result.ownership.team) ||
+              !teams.includes(canonicalTeam(result.ownership.team)) ||
               !confidenceValues.includes(result.ownership.confidence) ||
               !sources.includes(result.ownership.source) ||
               typeof reason !== 'string' ||
@@ -304,7 +346,7 @@ jobs:
 
             let labels = await getLabels();
             if (labels.includes('Ownership: Manual')) {
-              const selected = teams.filter(team => labels.includes(team));
+              const selected = teamLabelNames.filter(name => labels.includes(name));
               if (selected.length === 1) {
                 if (labels.includes('Ownership: Needs Review')) {
                   try {
@@ -330,7 +372,8 @@ jobs:
               );
             }
 
-            const team = result.ownership.team;
+            const team = canonicalTeam(result.ownership.team);
+            const teamLabel = teamLabels[team];
             const needsReview = team === 'Other' || result.ownership.confidence === 'low';
             const safeReason = reason.replace(/[\r\n|]+/g, ' ').trim();
             await core.summary.addHeading('Ownership decision').addTable([
@@ -343,7 +386,7 @@ jobs:
             ]).write();
 
             const additions = [];
-            if (!labels.includes(team)) additions.push(team);
+            if (!labels.includes(teamLabel)) additions.push(teamLabel);
             if (needsReview && !labels.includes('Ownership: Needs Review')) {
               additions.push('Ownership: Needs Review');
             }
@@ -351,7 +394,7 @@ jobs:
               await github.rest.issues.addLabels({ ...context.repo, issue_number, labels: additions });
             }
 
-            for (const other of teams.filter(name => name !== team && labels.includes(name))) {
+            for (const other of teamLabelNames.filter(name => name !== teamLabel && labels.includes(name))) {
               try {
                 await github.rest.issues.removeLabel({ ...context.repo, issue_number, name: other });
               } catch (error) {
@@ -369,15 +412,15 @@ jobs:
             }
 
             const verified = await getLabels();
-            const selected = teams.filter(name => verified.includes(name));
+            const selected = teamLabelNames.filter(name => verified.includes(name));
             if (
               selected.length !== 1 ||
-              selected[0] !== team ||
+              selected[0] !== teamLabel ||
               verified.includes('Ownership: Needs Review') !== needsReview
             ) {
               throw new Error('Ownership labels could not be applied consistently. Rerun this workflow.');
             }
-            core.info(`Applied and verified ${team}.`);
+            core.info(`Applied and verified ${teamLabel}.`);
 
       - name: Report visible failure
         if: failure()


### PR DESCRIPTION
Fixes [AB#647697](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647697).

## This workflow is currently failing on every run

The team labels were renamed to `Team: SCM`, `Team: Finance`, `Team: Integrations` and `Team: Other`. This workflow still lists the old bare names, and it verifies that every label it needs exists before doing anything:

```js
const missing = valid.filter(name => !available.has(name));
if (missing.length) {
  throw new Error(`Provision required ownership labels before running automation: ${missing.join(', ')}`);
}
```

The old labels no longer exist, so `missing` is now all four team names and the check throws.

**This is already happening.** Clean break in the run history today: last green at 07:47:22, then failures at 08:03:40, 08:15:09 and 08:17:43. From the log of run `32825876165`:

```
Error: Provision required ownership labels before running automation: Finance, SCM, Integration, Other
```

Nothing is being classified until this lands.

## What was wrong

The names were doing two jobs at once:

1. the vocabulary `BCAppsTriage` answers in — `!teams.includes(result.ownership.team)`
2. the labels written to the item — `additions.push(team)`

Those were the same string until the rename and are not any more. They are now separate concerns: **the agent speaks in team names, the repository stores team labels, and the two are mapped.**

```js
const teamLabels = {
  Finance: 'Team: Finance',
  SCM: 'Team: SCM',
  Integrations: 'Team: Integrations',
  Other: 'Team: Other',
};
```

## Note this was not a pure prefix change

`Integration` became the plural `Integrations`, matching the GitHub team `D365 BC Integrations`. `Team: Integration` does not exist.

## Deliberate tolerance in the agent's answer

The agent's answer is normalised before use, so it may say either spelling of Integration, and either a team name or a team label:

| Agent says | Result |
| --- | --- |
| `SCM` | `Team: SCM` |
| `Integration` | `Team: Integrations` |
| `Integrations` | `Team: Integrations` |
| `Team: SCM` | `Team: SCM` |
| `Marketing` | rejected |

This is intentional. This repository and `BCAppsTriage` deploy independently, and a hard failure over a cosmetic spelling difference is precisely what has just taken the workflow down. Strictness is kept where it matters — an unrecognised team is still rejected.

## Verification

- YAML parses.
- All three `github-script` blocks pass `node --check`.
- The mapping was exercised **against the code in this PR**, not a copy, for every spelling in the table above including the one that must be rejected.

## Related work

Anything else reading these labels needs the same treatment:

- **BCAppsTriage** — being updated separately. This PR does not depend on it landing first, by design.
- **Saved GitHub filters** using `label:SCM` will silently return nothing.
- The BCApps engineering dashboard has already been updated.

One thing worth knowing for anything reading this data downstream: a GitHub rename does **not** emit an event per affected item, so analytics built on webhook snapshots keep the old label until something else touches the item. When `approved`, `linked` and `automation` were renamed in this repository in February 2024, 118 items still carried the old spelling eighteen months later. Downstream readers should accept both names indefinitely rather than transitionally.

## Follow-up worth considering

The pre-flight check is strict by design, and that is right — silently mislabelling would be worse than failing. But it means a label rename takes the workflow down with no warning. A scheduled check that the labels this automation depends on still exist would catch it before classification stops rather than after.



