### PR TITLE
Fix E-Document test object ID collision

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocMessageResponseTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocMessageResponseTests.Codeunit.al
@@ -11,7 +11,7 @@ using Microsoft.Peppol.Response;
 using Microsoft.Sales.Customer;
 using System.Utilities;
 
-codeunit 139898 "E-Doc. Message Response Tests"
+codeunit 139864 "E-Doc. Message Response Tests"
 {
     Subtype = Test;
     TestType = IntegrationTest;


### PR DESCRIPTION
## Why

NAV buddy validation failed while merging AL code coverage because codeunit ID 139898 was used by both the BCApps E-Document response tests and NAV Sustainability Copilot brand tests. The duplicate key caused `RunALTestBusinessFoundationModules_Group1` to fail.

## Summary

- **Changed** the E-Document message response test codeunit ID from 139898 to the unused ID 139864 within the app's allocated range.
- **Verified** that 139864 is unique across BCApps and NAV and produces no AL diagnostics.

Fixes [AB#647666](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647666)


