### PR TITLE
[Expense Agent] Grant policy builder execute permission

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Permissions/ExpenseManagementObjects.permissionset.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Permissions/ExpenseManagementObjects.permissionset.al
@@ -210,6 +210,7 @@ permissionset 6904 "Expense Management - Objects"
         codeunit "Expense Capabilities Provider" = X,
         codeunit "Expense Activity Log Mgt." = X,
         codeunit "Expense Projects Builder" = X,
+        codeunit "Exp. Policies To Eval Builder" = X,
         codeunit "Import Expense User" = X,
         report "Expense Report Cover Page" = X,
         report "Expense Report Summary Page" = X,

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpensePermissionsTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpensePermissionsTest.Codeunit.al
@@ -37,6 +37,26 @@ codeunit 148338 "Expense Permissions Test"
     end;
 
     [Test]
+    procedure D365BasicCanGetExpensePolicyStatus()
+    var
+        ExpenseReportLine: Record "Expense Report Line";
+        PolicyStatus: Enum "Expense Policy Status";
+    begin
+        Initialize();
+
+        ExpenseReportLine.Init();
+        ExpenseReportLine."Document No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(ExpenseReportLine."Document No."));
+        ExpenseReportLine."Line No." := 10000;
+        ExpenseReportLine.Insert(false);
+
+        LibraryLowerPermissions.SetExactPermissionSet(D365BasicPermissionSetTok);
+        PolicyStatus := ExpenseReportLine.GetPolicyStatus();
+        RestoreFullPermissions();
+
+        Assert.AreEqual("Expense Policy Status"::"No Policies", PolicyStatus, 'A D365 BASIC user must be able to get the expense policy status.');
+    end;
+
+    [Test]
     procedure ExpenseAgentCanInsertActivityIndirectly()
     begin
         VerifyPermissionSetCanInsertActivity(ExpenseAgentPermissionSetTok);


### PR DESCRIPTION
Fixes [AB#647696](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647696)

## Summary

- Grant interactive Expense Management roles execute permission on codeunit 7107, `Exp. Policies To Eval Builder`.
- Prevent `DB:ExecuteObjDenied` when the Expense Report SubPage calculates policy status.

## Root cause

`Expense Report Line.GetPolicyStatus` calls the policy builder when the report subpage opens. The agent-only object permission set included the codeunit, but `Expense Management - Objects`, inherited by normal Expense Management roles, did not.

## Validation

- Ran `build/scripts/VerifyExecutePermissions.ps1` for the Expense Agent app.
- Audited all objects and explicit object references added by #10031; no additional permission omissions were found.





