### PR TITLE
[master]-Bug 647093-[Subscription Billing] Incorrect Invoice Amounts when using explicit values in Subscription Line End Date

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -1997,21 +1997,29 @@ table 8059 "Subscription Line"
     var
         DistanceToEndOfMonth: Integer;
         LastDateInLastMonth: Date;
+        PeriodFormulaInteger: Integer;
+        Letter: Char;
     begin
         case Rec."Period Calculation" of
             Rec."Period Calculation"::"Align to Start of Month":
                 NextToDate := CalcDate(PeriodFormula, FromDate) - 1;
             Rec."Period Calculation"::"Align to End of Month":
                 begin
-                    DistanceToEndOfMonth := CalcDate('<CM>', GetBillingReferenceDate()) - GetBillingReferenceDate();
-                    if DistanceToEndOfMonth > 2 then
+                    DateFormulaManagement.FindDateFormulaType(PeriodFormula, PeriodFormulaInteger, Letter);
+                    if Letter in ['D', 'W'] then
+                        // Day/week periods have a fixed length and must not be aligned to the end of the month.
                         NextToDate := CalcDate(PeriodFormula, FromDate) - 1
                     else begin
-                        LastDateInLastMonth := CalcDate(PeriodFormula, FromDate);
-                        LastDateInLastMonth := CalcDate('<CM>', LastDateInLastMonth);
-                        NextToDate := LastDateInLastMonth - DistanceToEndOfMonth - 1;
-                        if NextToDate < FromDate then
-                            NextToDate := CalcDate(PeriodFormula, FromDate) - 1;
+                        DistanceToEndOfMonth := CalcDate('<CM>', GetBillingReferenceDate()) - GetBillingReferenceDate();
+                        if DistanceToEndOfMonth > 2 then
+                            NextToDate := CalcDate(PeriodFormula, FromDate) - 1
+                        else begin
+                            LastDateInLastMonth := CalcDate(PeriodFormula, FromDate);
+                            LastDateInLastMonth := CalcDate('<CM>', LastDateInLastMonth);
+                            NextToDate := LastDateInLastMonth - DistanceToEndOfMonth - 1;
+                            if NextToDate < FromDate then
+                                NextToDate := CalcDate(PeriodFormula, FromDate) - 1;
+                        end;
                     end;
                 end;
         end;

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SubLinePeriodCalcTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SubLinePeriodCalcTest.Codeunit.al
@@ -1,0 +1,154 @@
+namespace Microsoft.SubscriptionBilling;
+
+codeunit 139893 "Sub. Line Period Calc. Test"
+{
+    Subtype = Test;
+    TestType = Uncategorized;
+    Access = Internal;
+
+    var
+        Assert: Codeunit Assert;
+        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        PeriodStretchedErr: Label 'Day/week period must not be aligned to the end of the month.', Locked = true;
+
+    [Test]
+    procedure DayRhythmAlignToEndOfMonthNotStretchedAtMonthEnd()
+    var
+        SubscriptionLine: Record "Subscription Line";
+    begin
+        // [SCENARIO 647093] A day rhythm must keep its fixed length even when the line starts at month-end and uses 'Align to End of Month'.
+        Initialize();
+
+        // [GIVEN] A subscription line starting on a month-end date (30.04.2026) with 'Align to End of Month'
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLine, DMY2Date(30, 4, 2026), SubscriptionLine."Period Calculation"::"Align to End of Month");
+
+        // [WHEN] The end of the first 10-day period is calculated
+        // [THEN] The period spans exactly 10 days (30.04 - 09.05) and is not stretched to the end of the month
+        Assert.AreEqual(DMY2Date(9, 5, 2026), SubscriptionLine.CalculateNextToDate(EvaluateDateFormula('<10D>'), DMY2Date(30, 4, 2026)), PeriodStretchedErr);
+    end;
+
+    [Test]
+    procedure WeekRhythmAlignToEndOfMonthNotStretchedAtMonthEnd()
+    var
+        SubscriptionLine: Record "Subscription Line";
+    begin
+        // [SCENARIO 647093] A week rhythm must keep its fixed length even when the line starts at month-end and uses 'Align to End of Month'.
+        Initialize();
+
+        // [GIVEN] A subscription line starting on a month-end date (30.04.2026) with 'Align to End of Month'
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLine, DMY2Date(30, 4, 2026), SubscriptionLine."Period Calculation"::"Align to End of Month");
+
+        // [WHEN] The end of the first 2-week period is calculated
+        // [THEN] The period spans exactly 14 days (30.04 - 13.05) and is not stretched to the end of the month
+        Assert.AreEqual(DMY2Date(13, 5, 2026), SubscriptionLine.CalculateNextToDate(EvaluateDateFormula('<2W>'), DMY2Date(30, 4, 2026)), PeriodStretchedErr);
+    end;
+
+    [Test]
+    procedure DayRhythmPeriodLengthIndependentOfMonthEndProximity()
+    var
+        SubscriptionLineAtMonthEnd: Record "Subscription Line";
+        SubscriptionLineShifted: Record "Subscription Line";
+        PeriodEndAtMonthEnd: Date;
+        PeriodEndShifted: Date;
+    begin
+        // [SCENARIO 647093] Shifting the start date by a few days must not change the length of a day-rhythm period.
+        Initialize();
+
+        // [GIVEN] Two subscription lines with 'Align to End of Month', one starting at month-end (30.04) and one shifted 3 days earlier (27.04)
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLineAtMonthEnd, DMY2Date(30, 4, 2026), SubscriptionLineAtMonthEnd."Period Calculation"::"Align to End of Month");
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLineShifted, DMY2Date(27, 4, 2026), SubscriptionLineShifted."Period Calculation"::"Align to End of Month");
+
+        // [WHEN] The first 10-day period is calculated for both lines
+        PeriodEndAtMonthEnd := SubscriptionLineAtMonthEnd.CalculateNextToDate(EvaluateDateFormula('<10D>'), DMY2Date(30, 4, 2026));
+        PeriodEndShifted := SubscriptionLineShifted.CalculateNextToDate(EvaluateDateFormula('<10D>'), DMY2Date(27, 4, 2026));
+
+        // [THEN] Both periods cover the same number of days
+        Assert.AreEqual(
+            PeriodEndAtMonthEnd - DMY2Date(30, 4, 2026),
+            PeriodEndShifted - DMY2Date(27, 4, 2026),
+            PeriodStretchedErr);
+    end;
+
+    [Test]
+    procedure DayRhythmAlignToEndOfMonthLeapYearFebruary()
+    var
+        SubscriptionLine: Record "Subscription Line";
+    begin
+        // [SCENARIO 647093] A day rhythm starting on the 29th of February (leap year) with 'Align to End of Month' keeps its fixed length.
+        Initialize();
+
+        // [GIVEN] A subscription line starting on 29.02.2028 (leap year) with 'Align to End of Month'
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLine, DMY2Date(29, 2, 2028), SubscriptionLine."Period Calculation"::"Align to End of Month");
+
+        // [WHEN] The end of the first 10-day period is calculated
+        // [THEN] The period spans exactly 10 days (29.02 - 09.03) and is not stretched to the end of the month
+        Assert.AreEqual(DMY2Date(9, 3, 2028), SubscriptionLine.CalculateNextToDate(EvaluateDateFormula('<10D>'), DMY2Date(29, 2, 2028)), PeriodStretchedErr);
+    end;
+
+    [Test]
+    procedure MonthRhythmStillAlignsToEndOfMonth()
+    var
+        SubscriptionLine: Record "Subscription Line";
+    begin
+        // [SCENARIO 647093] Month rhythms must keep aligning to the end of the month (regression guard for the day/week fix).
+        Initialize();
+
+        // [GIVEN] A subscription line starting on a month-end date (28.02.2026) with 'Align to End of Month'
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLine, DMY2Date(28, 2, 2026), SubscriptionLine."Period Calculation"::"Align to End of Month");
+
+        // [WHEN] The end of the first month period is calculated
+        // [THEN] The period is aligned to the end of the month (30.03.2026), not the plain formula result (27.03.2026)
+        Assert.AreEqual(DMY2Date(30, 3, 2026), SubscriptionLine.CalculateNextToDate(EvaluateDateFormula('<1M>'), DMY2Date(28, 2, 2026)), 'Month rhythm must still align to the end of the month.');
+    end;
+
+    [Test]
+    procedure UnitPriceEqualForShiftedMonthEndStartDates()
+    var
+        SubscriptionLineAtMonthEnd: Record "Subscription Line";
+        SubscriptionLineShifted: Record "Subscription Line";
+        UnitPriceAtMonthEnd: Decimal;
+        UnitPriceShifted: Decimal;
+    begin
+        // [SCENARIO 647093] The billed amount for a full day-rhythm period must not depend on the start date's proximity to month-end.
+        Initialize();
+
+        // [GIVEN] A subscription line with a 10D rhythm and base period, price 1050, starting at month-end (30.04.2026)
+        CreateSubscriptionLineForProration(SubscriptionLineAtMonthEnd, DMY2Date(30, 4, 2026), '<10D>', '<10D>', 1050);
+        // [GIVEN] An identical line shifted 3 days earlier (27.04.2026)
+        CreateSubscriptionLineForProration(SubscriptionLineShifted, DMY2Date(27, 4, 2026), '<10D>', '<10D>', 1050);
+
+        // [WHEN] The unit price for the first full 10-day period is calculated for both lines
+        UnitPriceAtMonthEnd := SubscriptionLineAtMonthEnd.UnitPriceForPeriod(DMY2Date(30, 4, 2026), DMY2Date(9, 5, 2026));
+        UnitPriceShifted := SubscriptionLineShifted.UnitPriceForPeriod(DMY2Date(27, 4, 2026), DMY2Date(6, 5, 2026));
+
+        // [THEN] Both lines are billed the full period price and the amounts are identical
+        Assert.AreEqual(1050, UnitPriceAtMonthEnd, 'Full period at month-end must be billed the complete period price.');
+        Assert.AreEqual(UnitPriceAtMonthEnd, UnitPriceShifted, 'Shifting the start date must not change the billed amount.');
+    end;
+
+    local procedure Initialize()
+    begin
+        LibraryTestInitialize.OnTestInitialize(Codeunit::"Sub. Line Period Calc. Test");
+    end;
+
+    local procedure CreateSubscriptionLineForPeriodCalc(var SubscriptionLine: Record "Subscription Line"; StartDate: Date; PeriodCalculation: Enum "Period Calculation")
+    begin
+        SubscriptionLine.Init();
+        SubscriptionLine."Entry No." := 0;
+        SubscriptionLine."Subscription Line Start Date" := StartDate;
+        SubscriptionLine."Period Calculation" := PeriodCalculation;
+    end;
+
+    local procedure CreateSubscriptionLineForProration(var SubscriptionLine: Record "Subscription Line"; StartDate: Date; BillingBasePeriodText: Text; BillingRhythmText: Text; Price: Decimal)
+    begin
+        CreateSubscriptionLineForPeriodCalc(SubscriptionLine, StartDate, SubscriptionLine."Period Calculation"::"Align to End of Month");
+        SubscriptionLine."Billing Base Period" := EvaluateDateFormula(BillingBasePeriodText);
+        SubscriptionLine."Billing Rhythm" := EvaluateDateFormula(BillingRhythmText);
+        SubscriptionLine.Price := Price;
+    end;
+
+    local procedure EvaluateDateFormula(DateFormulaText: Text) DateFormulaResult: DateFormula
+    begin
+        Evaluate(DateFormulaResult, DateFormulaText);
+    end;
+}


### PR DESCRIPTION
[Bug 647093](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647093): [All-E][Subscription Billing] Incorrect Invoice Amounts when using explicit values in Subscription Line End Date

Fixes [AB#647093](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647093)

Issue
For non-usage-based subscription lines using Period Calculation = Align to End of Month with a day/week billing rhythm (e.g. 10D, 2W), the recurring billing proposal produced incorrect billing period boundaries and amounts. The distortion depended on how close the line's start date was to month-end.

Root cause
In Subscription Line.CalculateNextToDate(), the Align to End of Month branch applied month-end alignment to every period formula, including day/week formulas. When the start/reference date was within the last 2 days of the month (DistanceToEndOfMonth <= 2), a fixed-length day/week period was snapped onto a month-end boundary.
CalculatePeriodCountAndDaysCount() then counted these distorted spans as complete periods and prorated the remainder against the wrong day count, so proration depended purely on proximity to month-end. Because both the period-boundary calculation and the per-line proration route through CalculateNextToDate(), both the billing boundaries and the amounts were wrong.

Solution
CalculateNextToDate() now skips end-of-month alignment for day (D) and week (W) formulas, which have a fixed length, and returns the plain period end. Month/Quarter/Year rhythms keep aligning to month-end unchanged. This single, targeted change corrects both the billing boundaries and the amounts at the source — no event subscriber or PTE required — and mirrors the behavior of the ad-hoc PTE previously shared with the customer.


