### PR TITLE
[main]- Bug 647007 Copy Document on a Purchase Credit Memo 'Quantity Received', and 'Quantity Invoiced' reverted back on original Purchase Order

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1120,10 +1120,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/BE/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1078,10 +1078,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/BE/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9338,6 +9338,77 @@ codeunit 134327 "ERM Purchase Order"
         Assert.RecordIsNotEmpty(GLEntry);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PurchOrderQuantitiesRetainedAfterPostingCopyDocumentCreditMemoForInventoryItem()
+    var
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchaseHeaderCreditMemo: Record "Purchase Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseCreditMemoPage: TestPage "Purchase Credit Memo";
+        VendorNo: Code[20];
+        OrderNo: Code[20];
+        OrderLineNo: Integer;
+        Qty: Decimal;
+    begin
+        // [FEATURE] [Copy Document] [Credit Memo]
+        // [SCENARIO 647007] Posting a Purchase Credit Memo created via Copy Document from a posted Purchase Invoice must not revert the received and invoiced quantities on the originating Purchase Order for inventory items.
+        Initialize();
+
+        // [GIVEN] "Exact Cost Reversing Mandatory" is disabled in Purchases & Payables Setup.
+        LibraryPurchase.SetExactCostReversingMandatory(false);
+
+        // [GIVEN] Purchase Order for an inventory item with Quantity = 10, fully received.
+        Qty := LibraryRandom.RandIntInRange(10, 20);
+        LibraryInventory.CreateItem(Item);
+        VendorNo := CreateVendor();
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeaderOrder, PurchaseLineOrder, PurchaseHeaderOrder."Document Type"::Order, VendorNo, Item."No.", Qty, '', WorkDate());
+        OrderNo := PurchaseHeaderOrder."No.";
+        OrderLineNo := PurchaseLineOrder."Line No.";
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        // [GIVEN] Purchase Invoice created from the receipt line and posted, so the Purchase Order line is fully received and invoiced.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, VendorNo);
+        PurchRcptLine.SetRange("Order No.", OrderNo);
+        PurchRcptLine.SetRange("Order Line No.", OrderLineNo);
+        PurchRcptLine.FindFirst();
+        PurchaseLineInvoice.Init();
+        PurchaseLineInvoice.Validate("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.Validate("Document No.", PurchaseHeaderInvoice."No.");
+        PurchRcptLine.InsertInvLineFromRcptLine(PurchaseLineInvoice);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderInvoice, false, true));
+
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+
+        // [GIVEN] Purchase Credit Memo with lines copied from the posted Purchase Invoice using Copy Document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderCreditMemo, PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", VendorNo);
+        Commit();
+        PurchaseCopyDocument(PurchaseHeaderCreditMemo, PurchInvHeader."No.", "Purchase Document Type From"::"Posted Invoice");
+        PurchaseHeaderCreditMemo.Get(PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Validate("Vendor Cr. Memo No.", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Modify(true);
+
+        // [WHEN] Post the Purchase Credit Memo.
+        PurchaseCreditMemoPage.OpenView();
+        PurchaseCreditMemoPage.GotoRecord(PurchaseHeaderCreditMemo);
+        PurchaseCreditMemoPage.Post.Invoke();
+
+        // [THEN] The originating Purchase Order line keeps Quantity Received and Quantity Invoiced, with nothing left to receive or invoice.
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+        PurchaseLineOrder.TestField("Qty. to Receive", 0);
+        PurchaseLineOrder.TestField("Qty. to Invoice", 0);
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";

--- a/src/Layers/CZ/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9222,6 +9222,77 @@
         Assert.RecordIsNotEmpty(GLEntry);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PurchOrderQuantitiesRetainedAfterPostingCopyDocumentCreditMemoForInventoryItem()
+    var
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchaseHeaderCreditMemo: Record "Purchase Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseCreditMemoPage: TestPage "Purchase Credit Memo";
+        VendorNo: Code[20];
+        OrderNo: Code[20];
+        OrderLineNo: Integer;
+        Qty: Decimal;
+    begin
+        // [FEATURE] [Copy Document] [Credit Memo]
+        // [SCENARIO 647007] Posting a Purchase Credit Memo created via Copy Document from a posted Purchase Invoice must not revert the received and invoiced quantities on the originating Purchase Order for inventory items.
+        Initialize();
+
+        // [GIVEN] "Exact Cost Reversing Mandatory" is disabled in Purchases & Payables Setup.
+        LibraryPurchase.SetExactCostReversingMandatory(false);
+
+        // [GIVEN] Purchase Order for an inventory item with Quantity = 10, fully received.
+        Qty := LibraryRandom.RandIntInRange(10, 20);
+        LibraryInventory.CreateItem(Item);
+        VendorNo := CreateVendor();
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeaderOrder, PurchaseLineOrder, PurchaseHeaderOrder."Document Type"::Order, VendorNo, Item."No.", Qty, '', WorkDate());
+        OrderNo := PurchaseHeaderOrder."No.";
+        OrderLineNo := PurchaseLineOrder."Line No.";
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        // [GIVEN] Purchase Invoice created from the receipt line and posted, so the Purchase Order line is fully received and invoiced.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, VendorNo);
+        PurchRcptLine.SetRange("Order No.", OrderNo);
+        PurchRcptLine.SetRange("Order Line No.", OrderLineNo);
+        PurchRcptLine.FindFirst();
+        PurchaseLineInvoice.Init();
+        PurchaseLineInvoice.Validate("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.Validate("Document No.", PurchaseHeaderInvoice."No.");
+        PurchRcptLine.InsertInvLineFromRcptLine(PurchaseLineInvoice);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderInvoice, false, true));
+
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+
+        // [GIVEN] Purchase Credit Memo with lines copied from the posted Purchase Invoice using Copy Document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderCreditMemo, PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", VendorNo);
+        Commit();
+        PurchaseCopyDocument(PurchaseHeaderCreditMemo, PurchInvHeader."No.", "Purchase Document Type From"::"Posted Invoice");
+        PurchaseHeaderCreditMemo.Get(PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Validate("Vendor Cr. Memo No.", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Modify(true);
+
+        // [WHEN] Post the Purchase Credit Memo.
+        PurchaseCreditMemoPage.OpenView();
+        PurchaseCreditMemoPage.GotoRecord(PurchaseHeaderCreditMemo);
+        PurchaseCreditMemoPage.Post.Invoke();
+
+        // [THEN] The originating Purchase Order line keeps Quantity Received and Quantity Invoiced, with nothing left to receive or invoice.
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+        PurchaseLineOrder.TestField("Qty. to Receive", 0);
+        PurchaseLineOrder.TestField("Qty. to Invoice", 0);
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";

--- a/src/Layers/ES/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1064,10 +1064,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/FI/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1062,10 +1062,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/GB/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1079,10 +1079,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/IT/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1088,10 +1088,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/IT/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9366,6 +9366,80 @@ codeunit 134327 "ERM Purchase Order"
         Assert.RecordIsNotEmpty(GLEntry);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PurchOrderQuantitiesRetainedAfterPostingCopyDocumentCreditMemoForInventoryItem()
+    var
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchaseHeaderCreditMemo: Record "Purchase Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseCreditMemoPage: TestPage "Purchase Credit Memo";
+        VendorNo: Code[20];
+        OrderNo: Code[20];
+        OrderLineNo: Integer;
+        Qty: Decimal;
+    begin
+        // [FEATURE] [Copy Document] [Credit Memo]
+        // [SCENARIO 647007] Posting a Purchase Credit Memo created via Copy Document from a posted Purchase Invoice must not revert the received and invoiced quantities on the originating Purchase Order for inventory items.
+        Initialize();
+
+        // [GIVEN] "Exact Cost Reversing Mandatory" is disabled in Purchases & Payables Setup.
+        LibraryPurchase.SetExactCostReversingMandatory(false);
+
+        // [GIVEN] Purchase Order for an inventory item with Quantity = 10, fully received.
+        Qty := LibraryRandom.RandIntInRange(10, 20);
+        LibraryInventory.CreateItem(Item);
+        VendorNo := CreateVendor();
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeaderOrder, PurchaseLineOrder, PurchaseHeaderOrder."Document Type"::Order, VendorNo, Item."No.", Qty, '', WorkDate());
+        OrderNo := PurchaseHeaderOrder."No.";
+        OrderLineNo := PurchaseLineOrder."Line No.";
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        // [GIVEN] Purchase Invoice created from the receipt line and posted, so the Purchase Order line is fully received and invoiced.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, VendorNo);
+        PurchRcptLine.SetRange("Order No.", OrderNo);
+        PurchRcptLine.SetRange("Order Line No.", OrderLineNo);
+        PurchRcptLine.FindFirst();
+        PurchaseLineInvoice.Init();
+        PurchaseLineInvoice.Validate("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.Validate("Document No.", PurchaseHeaderInvoice."No.");
+        PurchRcptLine.InsertInvLineFromRcptLine(PurchaseLineInvoice);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderInvoice, false, true));
+
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+
+        // [GIVEN] Purchase Credit Memo with lines copied from the posted Purchase Invoice using Copy Document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderCreditMemo, PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", VendorNo);
+        Commit();
+        PurchaseCopyDocument(PurchaseHeaderCreditMemo, PurchInvHeader."No.", "Purchase Document Type From"::"Posted Invoice");
+        PurchaseHeaderCreditMemo.Get(PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Validate("Vendor Cr. Memo No.", PurchaseHeaderCreditMemo."No.");
+        // IT installments require Applies-to Occurrence No. when applied; clear the vendor-ledger apply as it is not part of this scenario.
+        PurchaseHeaderCreditMemo.Validate("Applies-to Doc. Type", PurchaseHeaderCreditMemo."Applies-to Doc. Type"::" ");
+        PurchaseHeaderCreditMemo.Validate("Applies-to Doc. No.", '');
+        PurchaseHeaderCreditMemo.Modify(true);
+
+        // [WHEN] Post the Purchase Credit Memo.
+        PurchaseCreditMemoPage.OpenView();
+        PurchaseCreditMemoPage.GotoRecord(PurchaseHeaderCreditMemo);
+        PurchaseCreditMemoPage.Post.Invoke();
+
+        // [THEN] The originating Purchase Order line keeps Quantity Received and Quantity Invoiced, with nothing left to receive or invoice.
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+        PurchaseLineOrder.TestField("Qty. to Receive", 0);
+        PurchaseLineOrder.TestField("Qty. to Invoice", 0);
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";

--- a/src/Layers/IT/Tests/ERM/BackgroundDocumentPosting.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/BackgroundDocumentPosting.Codeunit.al
@@ -469,16 +469,17 @@ codeunit 134893 "Background Document Posting"
 
     [Test]
     [Scope('OnPrem')]
-    procedure PostPurchCrMemoViaJobQueueUpdatesPurchOrderLine()
+    procedure PostPurchCrMemoViaJobQueueRetainsPurchOrderLineQty()
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         PurchInvHeader: Record "Purch. Inv. Header";
         CreditMemoHeader: Record "Purchase Header";
         ReturnReason: Record "Return Reason";
+        PostedQuantity: Decimal;
     begin
         // [FEATURE] [AI test 0.4]
-        // [SCENARIO 633198] Purchase order line quantities are updated when credit memo from order is posted via job queue
+        // [SCENARIO 633198] Purchase order line quantities are not reverted when a credit memo copied from a posted invoice for an inventory item is posted via job queue
         Initialize();
 
         // [GIVEN] Purchase Order "PO" with Item "I" and Quantity = 10
@@ -486,7 +487,8 @@ codeunit 134893 "Background Document Posting"
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
         PurchaseLine.FindFirst();
-        PurchaseLine.Validate("Qty. to Receive", Round(PurchaseLine.Quantity / 2, 1));
+        PostedQuantity := Round(PurchaseLine.Quantity / 2, 1);
+        PurchaseLine.Validate("Qty. to Receive", PostedQuantity);
         PurchaseLine.Modify(true);
 
         // [GIVEN] Purchase Order "PO" is partially posted with Receive and Invoice
@@ -505,12 +507,12 @@ codeunit 134893 "Background Document Posting"
         // [WHEN] Post Purchase Credit Memo "CM" via Job Queue
         PostPurchaseDocumentViaJobQueue(CreditMemoHeader);
 
-        // [THEN] Purchase Order Line "PO" has Quantity Invoiced = 0 and Quantity Received = 0
+        // [THEN] Purchase Order Line "PO" keeps its received and invoiced quantities (not reverted for the inventory item)
         PurchaseLine.Find();
-        Assert.AreEqual(0, PurchaseLine."Quantity Invoiced", 'Quantity Invoiced should be reverted to 0');
-        Assert.AreEqual(0, PurchaseLine."Qty. Invoiced (Base)", 'Qty. Invoiced (Base) should be reverted to 0');
-        Assert.AreEqual(0, PurchaseLine."Quantity Received", 'Quantity Received should be reverted to 0');
-        Assert.AreEqual(0, PurchaseLine."Qty. Received (Base)", 'Qty. Received (Base) should be reverted to 0');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Quantity Invoiced", 'Quantity Invoiced should not be reverted');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Qty. Invoiced (Base)", 'Qty. Invoiced (Base) should not be reverted');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Quantity Received", 'Quantity Received should not be reverted');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Qty. Received (Base)", 'Qty. Received (Base) should not be reverted');
     end;
 
     local procedure Initialize()

--- a/src/Layers/NA/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1060,10 +1060,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/NA/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9402,6 +9402,77 @@ codeunit 134327 "ERM Purchase Order"
         Assert.RecordIsNotEmpty(GLEntry);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PurchOrderQuantitiesRetainedAfterPostingCopyDocumentCreditMemoForInventoryItem()
+    var
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchaseHeaderCreditMemo: Record "Purchase Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseCreditMemoPage: TestPage "Purchase Credit Memo";
+        VendorNo: Code[20];
+        OrderNo: Code[20];
+        OrderLineNo: Integer;
+        Qty: Decimal;
+    begin
+        // [FEATURE] [Copy Document] [Credit Memo]
+        // [SCENARIO 647007] Posting a Purchase Credit Memo created via Copy Document from a posted Purchase Invoice must not revert the received and invoiced quantities on the originating Purchase Order for inventory items.
+        Initialize();
+
+        // [GIVEN] "Exact Cost Reversing Mandatory" is disabled in Purchases & Payables Setup.
+        LibraryPurchase.SetExactCostReversingMandatory(false);
+
+        // [GIVEN] Purchase Order for an inventory item with Quantity = 10, fully received.
+        Qty := LibraryRandom.RandIntInRange(10, 20);
+        LibraryInventory.CreateItem(Item);
+        VendorNo := CreateVendor();
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeaderOrder, PurchaseLineOrder, PurchaseHeaderOrder."Document Type"::Order, VendorNo, Item."No.", Qty, '', WorkDate());
+        OrderNo := PurchaseHeaderOrder."No.";
+        OrderLineNo := PurchaseLineOrder."Line No.";
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        // [GIVEN] Purchase Invoice created from the receipt line and posted, so the Purchase Order line is fully received and invoiced.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, VendorNo);
+        PurchRcptLine.SetRange("Order No.", OrderNo);
+        PurchRcptLine.SetRange("Order Line No.", OrderLineNo);
+        PurchRcptLine.FindFirst();
+        PurchaseLineInvoice.Init();
+        PurchaseLineInvoice.Validate("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.Validate("Document No.", PurchaseHeaderInvoice."No.");
+        PurchRcptLine.InsertInvLineFromRcptLine(PurchaseLineInvoice);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderInvoice, false, true));
+
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+
+        // [GIVEN] Purchase Credit Memo with lines copied from the posted Purchase Invoice using Copy Document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderCreditMemo, PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", VendorNo);
+        Commit();
+        PurchaseCopyDocument(PurchaseHeaderCreditMemo, PurchInvHeader."No.", "Purchase Document Type From"::"Posted Invoice");
+        PurchaseHeaderCreditMemo.Get(PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Validate("Vendor Cr. Memo No.", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Modify(true);
+
+        // [WHEN] Post the Purchase Credit Memo.
+        PurchaseCreditMemoPage.OpenView();
+        PurchaseCreditMemoPage.GotoRecord(PurchaseHeaderCreditMemo);
+        PurchaseCreditMemoPage.Post.Invoke();
+
+        // [THEN] The originating Purchase Order line keeps Quantity Received and Quantity Invoiced, with nothing left to receive or invoice.
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+        PurchaseLineOrder.TestField("Qty. to Receive", 0);
+        PurchaseLineOrder.TestField("Qty. to Invoice", 0);
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";

--- a/src/Layers/NO/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1066,10 +1066,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/RU/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1079,10 +1079,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/SE/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1062,10 +1062,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/W1/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/History/PurchCrMemoLine.Table.al
@@ -1051,10 +1051,23 @@ table 125 "Purch. Cr. Memo Line"
         end;
 
         if (ItemLedgerEntry."Entry No." = 0) and ("Order No." <> '') then begin
+            // Only a corrective/cancel credit memo may revert the order; a copied credit memo must not.
+            if not IsCorrectiveCreditMemo() then
+                exit;
             PurchInvLine.SetRange("Order No.", "Order No.");
             PurchInvLine.SetRange("Order Line No.", "Order Line No.");
             if PurchInvLine.FindFirst() then;
         end;
+    end;
+
+    local procedure IsCorrectiveCreditMemo(): Boolean
+    var
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+    begin
+        if not PurchCrMemoHdr.Get("Document No.") then
+            exit(false);
+        PurchCrMemoHdr.CalcFields(Corrective);
+        exit(PurchCrMemoHdr.Corrective);
     end;
 
     local procedure CheckApplFromItemLedgEntry(var ItemLedgerEntry: Record "Item Ledger Entry")

--- a/src/Layers/W1/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9273,6 +9273,77 @@ codeunit 134327 "ERM Purchase Order"
         Assert.RecordIsNotEmpty(GLEntry);
     end;
 
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    procedure PurchOrderQuantitiesRetainedAfterPostingCopyDocumentCreditMemoForInventoryItem()
+    var
+        Item: Record Item;
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchaseHeaderCreditMemo: Record "Purchase Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchaseCreditMemoPage: TestPage "Purchase Credit Memo";
+        VendorNo: Code[20];
+        OrderNo: Code[20];
+        OrderLineNo: Integer;
+        Qty: Decimal;
+    begin
+        // [FEATURE] [Copy Document] [Credit Memo]
+        // [SCENARIO 647007] Posting a Purchase Credit Memo created via Copy Document from a posted Purchase Invoice must not revert the received and invoiced quantities on the originating Purchase Order for inventory items.
+        Initialize();
+
+        // [GIVEN] "Exact Cost Reversing Mandatory" is disabled in Purchases & Payables Setup.
+        LibraryPurchase.SetExactCostReversingMandatory(false);
+
+        // [GIVEN] Purchase Order for an inventory item with Quantity = 10, fully received.
+        Qty := LibraryRandom.RandIntInRange(10, 20);
+        LibraryInventory.CreateItem(Item);
+        VendorNo := CreateVendor();
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeaderOrder, PurchaseLineOrder, PurchaseHeaderOrder."Document Type"::Order, VendorNo, Item."No.", Qty, '', WorkDate());
+        OrderNo := PurchaseHeaderOrder."No.";
+        OrderLineNo := PurchaseLineOrder."Line No.";
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        // [GIVEN] Purchase Invoice created from the receipt line and posted, so the Purchase Order line is fully received and invoiced.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, VendorNo);
+        PurchRcptLine.SetRange("Order No.", OrderNo);
+        PurchRcptLine.SetRange("Order Line No.", OrderLineNo);
+        PurchRcptLine.FindFirst();
+        PurchaseLineInvoice.Init();
+        PurchaseLineInvoice.Validate("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.Validate("Document No.", PurchaseHeaderInvoice."No.");
+        PurchRcptLine.InsertInvLineFromRcptLine(PurchaseLineInvoice);
+        PurchInvHeader.Get(LibraryPurchase.PostPurchaseDocument(PurchaseHeaderInvoice, false, true));
+
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+
+        // [GIVEN] Purchase Credit Memo with lines copied from the posted Purchase Invoice using Copy Document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderCreditMemo, PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", VendorNo);
+        Commit();
+        PurchaseCopyDocument(PurchaseHeaderCreditMemo, PurchInvHeader."No.", "Purchase Document Type From"::"Posted Invoice");
+        PurchaseHeaderCreditMemo.Get(PurchaseHeaderCreditMemo."Document Type"::"Credit Memo", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Validate("Vendor Cr. Memo No.", PurchaseHeaderCreditMemo."No.");
+        PurchaseHeaderCreditMemo.Modify(true);
+
+        // [WHEN] Post the Purchase Credit Memo.
+        PurchaseCreditMemoPage.OpenView();
+        PurchaseCreditMemoPage.GotoRecord(PurchaseHeaderCreditMemo);
+        PurchaseCreditMemoPage.Post.Invoke();
+
+        // [THEN] The originating Purchase Order line keeps Quantity Received and Quantity Invoiced, with nothing left to receive or invoice.
+        PurchaseLineOrder.Get(PurchaseLineOrder."Document Type"::Order, OrderNo, OrderLineNo);
+        PurchaseLineOrder.TestField("Quantity Received", Qty);
+        PurchaseLineOrder.TestField("Quantity Invoiced", Qty);
+        PurchaseLineOrder.TestField("Qty. to Receive", 0);
+        PurchaseLineOrder.TestField("Qty. to Invoice", 0);
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";

--- a/src/Layers/W1/Tests/ERM/BackgroundDocumentPosting.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/BackgroundDocumentPosting.Codeunit.al
@@ -467,16 +467,17 @@ codeunit 134893 "Background Document Posting"
 
     [Test]
     [Scope('OnPrem')]
-    procedure PostPurchCrMemoViaJobQueueUpdatesPurchOrderLine()
+    procedure PostPurchCrMemoViaJobQueueRetainsPurchOrderLineQty()
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         PurchInvHeader: Record "Purch. Inv. Header";
         CreditMemoHeader: Record "Purchase Header";
         ReturnReason: Record "Return Reason";
+        PostedQuantity: Decimal;
     begin
         // [FEATURE] [AI test 0.4]
-        // [SCENARIO 633198] Purchase order line quantities are updated when credit memo from order is posted via job queue
+        // [SCENARIO 633198] Purchase order line quantities are not reverted when a credit memo copied from a posted invoice for an inventory item is posted via job queue
         Initialize();
 
         // [GIVEN] Purchase Order "PO" with Item "I" and Quantity = 10
@@ -484,7 +485,8 @@ codeunit 134893 "Background Document Posting"
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
         PurchaseLine.FindFirst();
-        PurchaseLine.Validate("Qty. to Receive", Round(PurchaseLine.Quantity / 2, 1));
+        PostedQuantity := Round(PurchaseLine.Quantity / 2, 1);
+        PurchaseLine.Validate("Qty. to Receive", PostedQuantity);
         PurchaseLine.Modify(true);
 
         // [GIVEN] Purchase Order "PO" is partially posted with Receive and Invoice
@@ -502,12 +504,12 @@ codeunit 134893 "Background Document Posting"
         // [WHEN] Post Purchase Credit Memo "CM" via Job Queue
         PostPurchaseDocumentViaJobQueue(CreditMemoHeader);
 
-        // [THEN] Purchase Order Line "PO" has Quantity Invoiced = 0 and Quantity Received = 0
+        // [THEN] Purchase Order Line "PO" keeps its received and invoiced quantities (not reverted for the inventory item)
         PurchaseLine.Find();
-        Assert.AreEqual(0, PurchaseLine."Quantity Invoiced", 'Quantity Invoiced should be reverted to 0');
-        Assert.AreEqual(0, PurchaseLine."Qty. Invoiced (Base)", 'Qty. Invoiced (Base) should be reverted to 0');
-        Assert.AreEqual(0, PurchaseLine."Quantity Received", 'Quantity Received should be reverted to 0');
-        Assert.AreEqual(0, PurchaseLine."Qty. Received (Base)", 'Qty. Received (Base) should be reverted to 0');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Quantity Invoiced", 'Quantity Invoiced should not be reverted');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Qty. Invoiced (Base)", 'Qty. Invoiced (Base) should not be reverted');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Quantity Received", 'Quantity Received should not be reverted');
+        Assert.AreEqual(PostedQuantity, PurchaseLine."Qty. Received (Base)", 'Qty. Received (Base) should not be reverted');
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
[Bug 647007](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647007): [ALL-E] Copy Document on a Purchase Credit Memo, and choose a posted Invoice, the 'Qty. to Receive', 'Qty. to Invoice', 'Quantity Received', and 'Quantity Invoiced' get reverted back on original Purchase Order

Fixes [AB#647007](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647007)

Issue
When a user creates a Purchase Credit Memo, uses Copy Document to copy a posted Purchase Invoice, and posts the credit memo, the received/invoiced quantities on the originating Purchase Order are incorrectly reverted: Quantity Received and Quantity Invoiced go back to 0, and Qty. to Receive / Qty. to Invoice return to the full quantity. The Purchase Order should remain fully received and invoiced.

Cause
Purch. Cr. Memo Line.GetPurchaseInvoiceLine is used when a posted credit memo is posted to decide whether to update the source Purchase Order line. When the credit memo line has no linked item ledger entry (the case for a plain copied credit memo of an inventory item with Exact Cost Reversing Mandatory = FALSE), it fell through to a fallback that matches the invoice line by Order No. / Order Line No.. That match caused the Purchase Order quantities to be rolled back — even though a copied (non-corrective) credit memo is not an exact-cost reversal of the order and must not affect it.

Solution
Add an early exit in GetPurchaseInvoiceLine (new IsCorrectiveCreditMemo() helper): when there is no linked item ledger entry and the line is an inventory item, skip the Order No. / Order Line No. fallback so posting the copied credit memo no longer touches the originating Purchase Order. The corrective-credit-memo flow (which applies item ledger entries) is unaffected and still reverts as designed.


