### PR TITLE
[Shopify] Index Has Order State Error to fix slow Shopify Activities cue

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -959,6 +959,9 @@ table 30118 "Shpfy Order Header"
         key(Key3; "Created At")
         {
         }
+        key(Key4; "Has Order State Error")
+        {
+        }
     }
     var
         ShopifyOrderLine: Record "Shpfy Order Line";


### PR DESCRIPTION
## Summary

The **Shopify Activities** cue (`Page 30100 "Shpfy Activities"`) was the largest server cost in a production CPU profile — roughly **50s of ~126s active time**. Its **Unprocessed Order Updates** tile is a `COUNT` FlowField over `Shpfy Order Header` filtered on `"Has Order State Error"`, which led **no key** and therefore ran a full clustered-index scan of the ~100-column table (**~16.5s**, two executions at ~8s each).

## Change

Add key `Key4` on `"Has Order State Error"` to `Shpfy Order Header`. The key is covering for the `COUNT`, so SQL seeks a narrow index instead of scanning the wide table; because `true` rows are rare (often zero), the count becomes near-instant.

```al
key(Key4; "Has Order State Error") { }
```

Fixes [AB#647742](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647742)


