### PR TITLE
Discover the team taxonomy instead of hardcoding it

### DIFF
--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -116,10 +116,14 @@ jobs:
               const teamByNormalised = new Map();
               for (const label of labelNames) {
                 const team = label.slice(TEAM_LABEL_PREFIX.length).trim();
-                if (!team) {
-                  throw new Error(`Label "${label}" has no team name after the prefix.`);
-                }
                 const key = normaliseTeam(team);
+                // Emptiness is checked after normalising, not before: a label
+                // like "Team: !!!" has a name but not a comparable one, and an
+                // empty key would become a bucket that every unusable answer
+                // -- null, "", [] -- silently normalises into.
+                if (!key) {
+                  throw new Error(`Label "${label}" has no usable team name after the prefix.`);
+                }
                 if (teamByNormalised.has(key)) {
                   throw new Error(
                     `Team labels "${teamByNormalised.get(key)}" and "${team}" are indistinguishable ` +
@@ -129,8 +133,20 @@ jobs:
                 labelByTeam.set(team, label);
                 teamByNormalised.set(key, team);
               }
+              // The unresolved bucket is load-bearing -- it is what
+              // "Ownership: Needs Review" keys off -- and discovery cannot
+              // infer which team it is, so it is required by name. Without
+              // this, deleting the label makes every unresolved answer look
+              // like a malformed one from BCAppsTriage, and renaming it stops
+              // anything being flagged for review without saying so.
+              if (!teamByNormalised.has(normaliseTeam(UNRESOLVED_TEAM))) {
+                throw new Error(
+                  `No "${TEAM_LABEL_PREFIX}${UNRESOLVED_TEAM}" label exists; found ` +
+                  `${[...labelByTeam.keys()].map(name => `"${name}"`).join(', ')}. This repository ` +
+                  'needs that label for work the agent cannot attribute to a team.',
+                );
+              }
               return {
-                teams: [...labelByTeam.keys()],
                 teamLabelNames: [...labelByTeam.values()],
                 labelFor: team => labelByTeam.get(team),
                 canonicalTeam: value => teamByNormalised.get(normaliseTeam(value)) ?? null,
@@ -328,10 +344,10 @@ jobs:
               const teamByNormalised = new Map();
               for (const label of labelNames) {
                 const team = label.slice(TEAM_LABEL_PREFIX.length).trim();
-                if (!team) {
-                  throw new Error(`Label "${label}" has no team name after the prefix.`);
-                }
                 const key = normaliseTeam(team);
+                if (!key) {
+                  throw new Error(`Label "${label}" has no usable team name after the prefix.`);
+                }
                 if (teamByNormalised.has(key)) {
                   throw new Error(
                     `Team labels "${teamByNormalised.get(key)}" and "${team}" are indistinguishable ` +
@@ -341,8 +357,14 @@ jobs:
                 labelByTeam.set(team, label);
                 teamByNormalised.set(key, team);
               }
+              if (!teamByNormalised.has(normaliseTeam(UNRESOLVED_TEAM))) {
+                throw new Error(
+                  `No "${TEAM_LABEL_PREFIX}${UNRESOLVED_TEAM}" label exists; found ` +
+                  `${[...labelByTeam.keys()].map(name => `"${name}"`).join(', ')}. This repository ` +
+                  'needs that label for work the agent cannot attribute to a team.',
+                );
+              }
               return {
-                teams: [...labelByTeam.keys()],
                 teamLabelNames: [...labelByTeam.values()],
                 labelFor: team => labelByTeam.get(team),
                 canonicalTeam: value => teamByNormalised.get(normaliseTeam(value)) ?? null,
@@ -394,6 +416,11 @@ jobs:
               result.subject.kind !== process.env.SUBJECT_KIND ||
               result.subject.number !== issue_number ||
               !Number.isSafeInteger(result.subject.number) ||
+              // Checked as a string before it is normalised. normaliseTeam
+              // coerces, so without this ["Finance"] from the artifact would
+              // stringify to a valid team name -- something the hardcoded
+              // teams.includes() rejected for free.
+              typeof result.ownership.team !== 'string' ||
               canonicalTeam(result.ownership.team) === null ||
               !confidenceValues.includes(result.ownership.confidence) ||
               !sources.includes(result.ownership.source) ||

--- a/.github/workflows/ownership-classification.yml
+++ b/.github/workflows/ownership-classification.yml
@@ -55,7 +55,7 @@ jobs:
           ) && (
             !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
             github.event.label.name == 'Ownership: Manual' ||
-            contains(fromJSON('["Team: Finance","Team: SCM","Team: Integrations","Team: Other"]'), github.event.label.name)
+            startsWith(github.event.label.name, 'Team: ')
           )
         )
       )
@@ -76,32 +76,67 @@ jobs:
           SUBJECT_NUMBER: ${{ env.SUBJECT_NUMBER }}
         with:
           script: |
-            // A team NAME and the LABEL recording it stopped being the same
-            // string when this repository namespaced its team labels. The agent
-            // speaks in names; the repository stores labels. Map, do not assume.
-            const teamLabels = {
-              Finance: 'Team: Finance',
-              SCM: 'Team: SCM',
-              Integrations: 'Team: Integrations',
-              Other: 'Team: Other',
-            };
-            // The rename also corrected Integration to the plural the team uses.
-            // Accepting the old spelling from the agent keeps this workflow and
-            // BCAppsTriage from having to deploy in lockstep.
-            // Accepted spellings for the agent's answer: the pre-rename
-            // "Integration", and the label form of every team. The agent is
-            // expected to send a name, but rejecting a label would be a hard
-            // failure over a cosmetic difference, and the two repositories
-            // deploy independently.
-            const teamAliases = Object.assign(
-              { Integration: 'Integrations' },
-              Object.fromEntries(Object.entries(teamLabels).map(([name, label]) => [label, name])),
-            );
-            const canonicalTeam = name => teamAliases[name] || name;
-            const teams = Object.keys(teamLabels);
-            const teamLabelNames = Object.values(teamLabels);
+            // The team taxonomy belongs to the repository's label set, not to
+            // this workflow. It is DISCOVERED from the "Team: " namespace, so
+            // adding a team or renaming one is a label change with no code
+            // change here. Hardcoding the list is what broke this workflow when
+            // the labels were namespaced.
+            const TEAM_LABEL_PREFIX = 'Team: ';
+            // A floor, so that discovery finding nothing fails loudly rather
+            // than quietly deciding the repository has no teams.
+            const MIN_TEAM_LABELS = 2;
+            // Semantic rules, not taxonomy: these mean something to this
+            // workflow whichever teams happen to exist.
+            const UNRESOLVED_TEAM = 'Other';
             const ownershipLabels = ['Ownership: Manual', 'Ownership: Needs Review'];
-            const valid = [...teamLabelNames, ...ownershipLabels];
+
+            // Compare team names loosely, so a cosmetic rename -- case,
+            // punctuation, or the singular-to-plural change that turned
+            // Integration into Integrations -- does not require BCAppsTriage to
+            // redeploy in lockstep with this repository. A genuine rename to a
+            // different word still needs the agent updated, and is rejected
+            // here rather than guessed at.
+            const normaliseTeam = value => String(value ?? '')
+              .replace(/^team:\s*/i, '')
+              .toLowerCase()
+              .replace(/[^a-z0-9]/g, '')
+              .replace(/s$/, '');
+
+            const deriveTeams = repoLabels => {
+              const labelNames = repoLabels
+                .map(label => label.name)
+                .filter(name => name.startsWith(TEAM_LABEL_PREFIX));
+              if (labelNames.length < MIN_TEAM_LABELS) {
+                throw new Error(
+                  `Found ${labelNames.length} "${TEAM_LABEL_PREFIX}" label(s), expected at least ` +
+                  `${MIN_TEAM_LABELS}. Team ownership labels are missing from this repository.`,
+                );
+              }
+              const labelByTeam = new Map();
+              const teamByNormalised = new Map();
+              for (const label of labelNames) {
+                const team = label.slice(TEAM_LABEL_PREFIX.length).trim();
+                if (!team) {
+                  throw new Error(`Label "${label}" has no team name after the prefix.`);
+                }
+                const key = normaliseTeam(team);
+                if (teamByNormalised.has(key)) {
+                  throw new Error(
+                    `Team labels "${teamByNormalised.get(key)}" and "${team}" are indistinguishable ` +
+                    'once normalised, so the agent\'s answer would be ambiguous. Rename one.',
+                  );
+                }
+                labelByTeam.set(team, label);
+                teamByNormalised.set(key, team);
+              }
+              return {
+                teams: [...labelByTeam.keys()],
+                teamLabelNames: [...labelByTeam.values()],
+                labelFor: team => labelByTeam.get(team),
+                canonicalTeam: value => teamByNormalised.get(normaliseTeam(value)) ?? null,
+              };
+            };
+
             const subjectKind = process.env.SUBJECT_KIND;
             const issue_number = Number(process.env.SUBJECT_NUMBER);
             const action = context.payload.action;
@@ -135,7 +170,8 @@ jobs:
               github.rest.issues.listLabelsForRepo, { ...context.repo, per_page: 100 },
             );
             const available = new Set(repoLabels.map(label => label.name));
-            const missing = valid.filter(name => !available.has(name));
+            const { teamLabelNames } = deriveTeams(repoLabels);
+            const missing = ownershipLabels.filter(name => !available.has(name));
             if (missing.length) {
               throw new Error(`Provision required ownership labels before running automation: ${missing.join(', ')}`);
             }
@@ -265,28 +301,54 @@ jobs:
           script: |
             const fs = require('fs');
             const { TextDecoder } = require('util');
-            // See the preflight step: team names and team labels are different
-            // strings since the labels were namespaced, and are mapped here too.
-            const teamLabels = {
-              Finance: 'Team: Finance',
-              SCM: 'Team: SCM',
-              Integrations: 'Team: Integrations',
-              Other: 'Team: Other',
-            };
-            // Accepted spellings for the agent's answer: the pre-rename
-            // "Integration", and the label form of every team. The agent is
-            // expected to send a name, but rejecting a label would be a hard
-            // failure over a cosmetic difference, and the two repositories
-            // deploy independently.
-            const teamAliases = Object.assign(
-              { Integration: 'Integrations' },
-              Object.fromEntries(Object.entries(teamLabels).map(([name, label]) => [label, name])),
-            );
-            const canonicalTeam = name => teamAliases[name] || name;
-            const teams = Object.keys(teamLabels);
-            const teamLabelNames = Object.values(teamLabels);
+            // See the preflight step: the team taxonomy is discovered from the
+            // repository's "Team: " labels rather than hardcoded here.
+            const TEAM_LABEL_PREFIX = 'Team: ';
+            const MIN_TEAM_LABELS = 2;
+            const UNRESOLVED_TEAM = 'Other';
             const ownershipLabels = ['Ownership: Manual', 'Ownership: Needs Review'];
-            const valid = [...teamLabelNames, ...ownershipLabels];
+
+            const normaliseTeam = value => String(value ?? '')
+              .replace(/^team:\s*/i, '')
+              .toLowerCase()
+              .replace(/[^a-z0-9]/g, '')
+              .replace(/s$/, '');
+
+            const deriveTeams = repoLabels => {
+              const labelNames = repoLabels
+                .map(label => label.name)
+                .filter(name => name.startsWith(TEAM_LABEL_PREFIX));
+              if (labelNames.length < MIN_TEAM_LABELS) {
+                throw new Error(
+                  `Found ${labelNames.length} "${TEAM_LABEL_PREFIX}" label(s), expected at least ` +
+                  `${MIN_TEAM_LABELS}. Team ownership labels are missing from this repository.`,
+                );
+              }
+              const labelByTeam = new Map();
+              const teamByNormalised = new Map();
+              for (const label of labelNames) {
+                const team = label.slice(TEAM_LABEL_PREFIX.length).trim();
+                if (!team) {
+                  throw new Error(`Label "${label}" has no team name after the prefix.`);
+                }
+                const key = normaliseTeam(team);
+                if (teamByNormalised.has(key)) {
+                  throw new Error(
+                    `Team labels "${teamByNormalised.get(key)}" and "${team}" are indistinguishable ` +
+                    'once normalised, so the agent\'s answer would be ambiguous. Rename one.',
+                  );
+                }
+                labelByTeam.set(team, label);
+                teamByNormalised.set(key, team);
+              }
+              return {
+                teams: [...labelByTeam.keys()],
+                teamLabelNames: [...labelByTeam.values()],
+                labelFor: team => labelByTeam.get(team),
+                canonicalTeam: value => teamByNormalised.get(normaliseTeam(value)) ?? null,
+              };
+            };
+
             const confidenceValues = ['high', 'medium', 'low'];
             const sources = [
               'issue:path', 'issue:localization', 'issue:title-object',
@@ -312,6 +374,19 @@ jobs:
               throw new Error('ownership-result.json must contain the v1 result object');
             }
             const reason = result.ownership.reason;
+            // Discovery has to happen before the result is validated, because
+            // the set of valid teams IS the set of team labels in the
+            // repository. The label list was already being fetched a few lines
+            // below; it is simply read earlier now.
+            const repoLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo, { ...context.repo, per_page: 100 },
+            );
+            const available = new Set(repoLabels.map(label => label.name));
+            const { teamLabelNames, labelFor, canonicalTeam } = deriveTeams(repoLabels);
+            const missing = ownershipLabels.filter(name => !available.has(name));
+            if (missing.length) {
+              throw new Error(`Required ownership labels disappeared: ${missing.join(', ')}`);
+            }
             if (
               result.schemaVersion !== 1 ||
               result.correlationToken !== process.env.CORRELATION_TOKEN ||
@@ -319,7 +394,7 @@ jobs:
               result.subject.kind !== process.env.SUBJECT_KIND ||
               result.subject.number !== issue_number ||
               !Number.isSafeInteger(result.subject.number) ||
-              !teams.includes(canonicalTeam(result.ownership.team)) ||
+              canonicalTeam(result.ownership.team) === null ||
               !confidenceValues.includes(result.ownership.confidence) ||
               !sources.includes(result.ownership.source) ||
               typeof reason !== 'string' ||
@@ -329,15 +404,6 @@ jobs:
               /[\u0000-\u001F\u007F]/.test(reason)
             ) {
               throw new Error('The ownership result from BCAppsTriage was malformed, so no labels were changed.');
-            }
-
-            const repoLabels = await github.paginate(
-              github.rest.issues.listLabelsForRepo, { ...context.repo, per_page: 100 },
-            );
-            const available = new Set(repoLabels.map(label => label.name));
-            const missing = valid.filter(name => !available.has(name));
-            if (missing.length) {
-              throw new Error(`Required ownership labels disappeared: ${missing.join(', ')}`);
             }
 
             const getLabels = async () => (await github.paginate(github.rest.issues.listLabelsOnIssue, {
@@ -373,8 +439,12 @@ jobs:
             }
 
             const team = canonicalTeam(result.ownership.team);
-            const teamLabel = teamLabels[team];
-            const needsReview = team === 'Other' || result.ownership.confidence === 'low';
+            const teamLabel = labelFor(team);
+            // Compared loosely for the same reason the team name is: the
+            // unresolved bucket is a semantic rule, and should survive its
+            // label being spelled slightly differently.
+            const needsReview = normaliseTeam(team) === normaliseTeam(UNRESOLVED_TEAM)
+              || result.ownership.confidence === 'low';
             const safeReason = reason.replace(/[\r\n|]+/g, ' ').trim();
             await core.summary.addHeading('Ownership decision').addTable([
               [{ data: 'Field', header: true }, { data: 'Value', header: true }],


### PR DESCRIPTION
Fixes [AB#648222](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648222)

> **#10601 has merged**, so this is now based on `main` and the diff is just this change. That PR was the outage fix; this one stops the outage recurring.

## Why

#10601 fixed the symptom. This fixes the cause.

The workflow kept its own copy of a list the repository owns:

```js
const teams = ['Finance', 'SCM', 'Integration', 'Other'];
```

That copy went stale the moment the labels were renamed, and every run failed. The same failure is waiting for the next rename — and for the next team, which is a thing that happens.

**Adding a team or renaming one is now a label change with no code change here.**

## The list was already in hand, and thrown away

Both scripts already paginated every label in the repository:

```js
const repoLabels = await github.paginate(github.rest.issues.listLabelsForRepo, …);
const available = new Set(repoLabels.map(label => label.name));
const missing = valid.filter(name => !available.has(name));   // ← only to check a hardcoded array
```

The authoritative answer was fetched and then used to validate a guess. Now the labels *are* the answer: anything in the `Team: ` namespace is a team, and the name is whatever follows the prefix. The apply step reads that list slightly earlier, because the set of valid teams is the set of team labels — nothing extra is fetched.

## Namespacing is what makes this possible

While the labels were bare words there was no way to tell a team label from any other, so the list had to be written down somewhere. `Team: ` is a machine-readable contract. This is the payoff for having introduced it.

## Cosmetic renames no longer need a lockstep deploy

Team names are compared with case, punctuation and singular/plural ignored. That is what the hardcoded `Integration → Integrations` alias in #10601 was for, now handled generically.

A rename to a genuinely *different* word still needs BCAppsTriage updating — and is rejected rather than guessed at.

## The failure stays loud

Loud failure was the one virtue of the hardcoded list, and discovery could easily have thrown it away. Four guards keep it:

- **Fewer than two team labels throws**, rather than concluding the repository has no teams and marking everything unresolved.
- **Two labels that normalise identically throw**, rather than silently resolving the agent's answer to whichever was seen first.
- **A label with no usable name throws.** `Team: !!!` has a name but not a comparable one, and it normalises to `""` — a bucket every unusable answer would otherwise resolve into, and to a real label. The emptiness check runs on the normalised key for that reason.
- **A missing `Team: Other` throws, and says so.** `Ownership: Needs Review` keys off the unresolved bucket and discovery cannot infer which team that is. Deleting the label left three teams — past the floor — and turned every unresolved answer into "the result from BCAppsTriage was malformed", blaming the agent for a label missing here. Renaming it stopped flagging anything for review at all, silently. It is now required by name.

## Discovery must not weaken the trust boundary

`ownership-result.json` crosses a repository boundary and is untrusted. Loose comparison coerces with `String()`, so `"team": ["Finance"]` stringified straight back to a valid team and would have been applied — something the hardcoded `teams.includes()` rejected for free. The type is now checked at the boundary rather than assumed.

## The trigger condition too

The job's `if:` could not call the API, so it also carried a hardcoded array. It is now:

```yaml
startsWith(github.event.label.name, 'Team: ')
```

`startsWith` is a built-in expression function, so a newly created team label triggers the workflow without a code change either.

## Verification

Exercised against the code in these commits, not a copy of it. The script blocks are extracted from the YAML as committed and run. YAML parses; both `github-script` blocks pass a syntax check; and the discovery logic was run over nine scenarios:

| Scenario | Result |
| --- | --- |
| Today's labels | `SCM`, `Integration`, `Integrations`, `Team: SCM`, `Other` all resolve; `Marketing` rejected |
| **New team added** (`Team: Platform`) | Discovered; `Platform`, `platform`, `Team: Platform` all resolve — **no code change** |
| **Cosmetic rename** (`Integrations` → `Integration`) | Both spellings still resolve |
| **Rename to a different word** (`SCM` → `Supply Chain`) | New name resolves; old name correctly **rejected** |
| **All team labels deleted** | Throws: `Found 0 "Team: " label(s), expected at least 2` |
| **Ambiguous labels** (`Team: Integration` + `Team: Integrations`) | Throws rather than guessing |
| **Non-string team from the artifact** (`["SCM"]`, `{}`) | Rejected by validation, though it normalises to a real team |
| **Punctuation-only label** (`Team: -`) | Throws; previously it became a bucket matching `null`, `""` and `[]` |
| **`Team: Other` renamed** (→ `Team: Triage`) | Throws naming the missing label, instead of blaming the agent |

## Scope

Deliberately limited to this workflow. `bc-extrequest-triage-manual.yml`, BCAppsTriage and the DME repository on GHE also hold copies of this taxonomy — but they have a 1 September deadline and this does not, so they are better left alone until after the migration.


