### PR TITLE
[releases/28.x] [Shopify] Fix customer matching when phone numbers contain spaces

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerAPI.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Customers/Codeunits/ShpfyCustomerAPI.Codeunit.al
@@ -132,14 +132,19 @@ codeunit 30114 "Shpfy Customer API"
         JResponse: JsonToken;
         GraphQLType: Enum "Shpfy GraphQL Type";
         Parameters: Dictionary of [Text, Text];
+        SearchEMail: Text;
     begin
         if EMail <> '' then begin
-            Parameters.Add('EMail', EMail.ToLower());
+            SearchEMail := EMail.ToLower();
+            Parameters.Add('EMail', SearchEMail);
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType::FindCustomerIdByEMail, Parameters);
             if JsonHelper.GetJsonArray(JResponse, JCustomers, 'data.customers.edges') then
                 foreach JItem in JCustomers do
                     if JsonHelper.GetJsonObject(JItem.AsObject(), JCustomer, 'node') then
-                        exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
+                        // Shopify's search syntax tokenizes the query, so it can return customers that do not match
+                        // the requested e-mail exactly. Only accept a result when the e-mail matches exactly.
+                        if JsonHelper.GetValueAsText(JCustomer, 'defaultEmailAddress.emailAddress').ToLower() = SearchEMail then
+                            exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
         end;
     end;
 
@@ -156,15 +161,34 @@ codeunit 30114 "Shpfy Customer API"
         JResponse: JsonToken;
         GraphQLType: Enum "Shpfy GraphQL Type";
         Parameters: Dictionary of [Text, Text];
+        SearchPhone: Text;
     begin
-        if Phone <> '' then begin
-            Parameters.Add('Phone', Phone);
+        // Reduce the phone number to '+' and digits. Shopify's search syntax treats whitespace as a term
+        // separator (implicit AND), so a formatted phone number such as '+45 4545 4545' would be parsed as
+        // 'phone:+45' plus two loose '4545' terms and match unrelated customers. Sending the normalized,
+        // whitespace-free value keeps the whole number scoped to the phone filter.
+        SearchPhone := FormatPhoneNo(Phone);
+        if SearchPhone <> '' then begin
+            Parameters.Add('Phone', SearchPhone);
             JResponse := CommunicationMgt.ExecuteGraphQL(GraphQLType::FindCustomerIdByPhone, Parameters);
             if JsonHelper.GetJsonArray(JResponse, JCustomers, 'data.customers.edges') then
                 foreach JItem in JCustomers do
                     if JsonHelper.GetJsonObject(JItem.AsObject(), JCustomer, 'node') then
-                        exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
+                        // Only accept a result when the returned phone number matches the requested one exactly,
+                        // so a tokenized or partial Shopify search result is not treated as an existing customer.
+                        if FormatPhoneNo(JsonHelper.GetValueAsText(JCustomer, 'defaultPhoneNumber.phoneNumber')) = SearchPhone then
+                            exit(CommunicationMgt.GetIdOfGId(JsonHelper.GetValueAsText(JCustomer, 'id')));
         end;
+    end;
+
+    /// <summary>
+    /// Reduces a phone number to a comparable form containing only the leading '+' and digits.
+    /// </summary>
+    /// <param name="PhoneNo">Parameter of type Text.</param>
+    /// <returns>Return value of type Text.</returns>
+    internal procedure FormatPhoneNo(PhoneNo: Text): Text
+    begin
+        exit(DelChr(PhoneNo, '=', DelChr(PhoneNo, '=', '+0123456789')));
     end;
 
     /// <summary> 

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLFindCustByEMail.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLFindCustByEMail.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30129 "Shpfy GQL FindCustByEMail" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{customers(first: 1, query:\"email:{{EMail}}\") {edges {node {id}}}}"}');
+        exit('{"query":"{customers(first: 1, query:\"email:{{EMail}}\") {edges {node {id defaultEmailAddress { emailAddress }}}}}"}');
     end;
 
     /// <summary>
@@ -27,7 +27,7 @@ codeunit 30129 "Shpfy GQL FindCustByEMail" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Integer.</returns>
     internal procedure GetExpectedCost(): Integer
     begin
-        exit(3);
+        exit(4);
     end;
 
 }

--- a/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLFindCustByPhone.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/GraphQL/Codeunits/ShpfyGQLFindCustByPhone.Codeunit.al
@@ -18,7 +18,7 @@ codeunit 30130 "Shpfy GQL FindCustByPhone" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Text.</returns>
     internal procedure GetGraphQL(): Text
     begin
-        exit('{"query":"{customers(first: 1, query:\"phone:{{Phone}}\") {edges {node {id}}}}"}');
+        exit('{"query":"{customers(first: 1, query:\"phone:{{Phone}}\") {edges {node {id defaultPhoneNumber { phoneNumber }}}}}"}');
     end;
 
     /// <summary>
@@ -27,7 +27,7 @@ codeunit 30130 "Shpfy GQL FindCustByPhone" implements "Shpfy IGraphQL"
     /// <returns>Return value of type Integer.</returns>
     internal procedure GetExpectedCost(): Integer
     begin
-        exit(3);
+        exit(4);
     end;
 
 }

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -14,10 +14,20 @@ using System.TestLibraries.Utilities;
 codeunit 139589 "Shpfy Customer API Test"
 {
     Subtype = Test;
+    TestType = IntegrationTest;
     TestPermissions = Disabled;
+    TestHttpRequestPolicy = BlockOutboundRequests;
 
     var
+        Shop: Record "Shpfy Shop";
         LibraryAssert: Codeunit "Library Assert";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        Any: Codeunit Any;
+        ResponseContent: Text;
+        IsInitialized: Boolean;
+        CustomerSearchResponseTok: Label '{"data":{"customers":{"edges":[{"node":{"id":"gid://shopify/Customer/%1",%2}}]}},"extensions":{"cost":{"requestedQueryCost":4,"actualQueryCost":4,"throttleStatus":{"maximumAvailable":20000.0,"currentlyAvailable":19996,"restoreRate":1000.0}}}}', Locked = true;
+        DefaultPhoneNumberNodeTok: Label '"defaultPhoneNumber":{"phoneNumber":"%1"}', Locked = true;
+        DefaultEMailAddressNodeTok: Label '"defaultEmailAddress":{"emailAddress":"%1"}', Locked = true;
 
     [Test]
     procedure UnitTestCreateCustomerGraphQuery()
@@ -98,5 +108,150 @@ codeunit 139589 "Shpfy Customer API Test"
         CustomerInitTest.TextFieldsContainsFieldName(ShopifyCustomer);
         CustomerAddress.Get(CustomerAddress.Id);
         CustomerInitTest.TextFieldsContainsFieldName(CustomerAddress);
+    end;
+
+    [Test]
+    procedure UnitTestFormatPhoneNoStripsSpacesAndSeparators()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+    begin
+        // [SCENARIO] A formatted phone number is reduced to a comparable form of '+' and digits only,
+        // so it can be sent to Shopify as a single, whitespace-free search term.
+
+        // [THEN] Spaces are removed.
+        LibraryAssert.AreEqual('+4545454545', CustomerApi.FormatPhoneNo('+45 4545 4545'), 'Spaces should be removed.');
+        // [THEN] Other formatting characters are removed as well.
+        LibraryAssert.AreEqual('+4545454545', CustomerApi.FormatPhoneNo('+45 (45) 45.45/45'), 'Separators should be removed.');
+    end;
+
+    [Test]
+    [HandlerFunctions('HttpClientHandler')]
+    procedure UnitTestFindIdByPhoneIgnoresTokenizedPartialMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+        NoCustomerId: BigInteger;
+    begin
+        // [SCENARIO] A spaced phone number must not match an unrelated Shopify customer that is only returned
+        // because Shopify's search syntax tokenizes '+45 4545 4545' into 'phone:+45' plus loose '4545' terms.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer whose phone number differs from the requested one.
+        ResponseContent := CustomerPhoneSearchResponse(ShopifyCustomerId(), '+4545455555');
+
+        // [WHEN] Searching by the spaced phone number '+45 4545 4545'.
+        CustomerId := CustomerApi.FindIdByPhone('+45 4545 4545');
+
+        // [THEN] No customer id is returned because the phone numbers are not an exact match.
+        NoCustomerId := 0;
+        LibraryAssert.AreEqual(NoCustomerId, CustomerId, 'A non-exact phone match must not be treated as an existing customer.');
+    end;
+
+    [Test]
+    [HandlerFunctions('HttpClientHandler')]
+    procedure UnitTestFindIdByPhoneReturnsIdForExactMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+    begin
+        // [SCENARIO] A spaced phone number matches a Shopify customer whose normalized phone number is identical.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer whose normalized phone equals the requested one.
+        ResponseContent := CustomerPhoneSearchResponse(ShopifyCustomerId(), '+4545454545');
+
+        // [WHEN] Searching by the spaced phone number '+45 4545 4545'.
+        CustomerId := CustomerApi.FindIdByPhone('+45 4545 4545');
+
+        // [THEN] The matching customer id is returned.
+        LibraryAssert.AreEqual(ShopifyCustomerId(), CustomerId, 'An exact phone match should return the customer id.');
+    end;
+
+    [Test]
+    [HandlerFunctions('HttpClientHandler')]
+    procedure UnitTestFindIdByEmailIgnoresNonExactMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+        NoCustomerId: BigInteger;
+    begin
+        // [SCENARIO] An e-mail search must not accept a Shopify customer whose e-mail differs from the requested one.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer with a different e-mail address.
+        ResponseContent := CustomerEMailSearchResponse(ShopifyCustomerId(), 'other@contoso.com');
+
+        // [WHEN] Searching by e-mail 'p1@contoso.com'.
+        CustomerId := CustomerApi.FindIdByEmail('p1@contoso.com');
+
+        // [THEN] No customer id is returned because the e-mail addresses are not an exact match.
+        NoCustomerId := 0;
+        LibraryAssert.AreEqual(NoCustomerId, CustomerId, 'A non-exact e-mail match must not be treated as an existing customer.');
+    end;
+
+    [Test]
+    [HandlerFunctions('HttpClientHandler')]
+    procedure UnitTestFindIdByEmailReturnsIdForExactMatch()
+    var
+        CustomerApi: Codeunit "Shpfy Customer API";
+        CustomerId: BigInteger;
+    begin
+        // [SCENARIO] An e-mail search matches a Shopify customer with the same e-mail address, ignoring casing.
+        Initialize();
+        CustomerApi.SetShop(Shop);
+
+        // [GIVEN] Shopify returns a customer with the same e-mail address in a different casing.
+        ResponseContent := CustomerEMailSearchResponse(ShopifyCustomerId(), 'P1@Contoso.com');
+
+        // [WHEN] Searching by e-mail 'p1@contoso.com'.
+        CustomerId := CustomerApi.FindIdByEmail('p1@contoso.com');
+
+        // [THEN] The matching customer id is returned.
+        LibraryAssert.AreEqual(ShopifyCustomerId(), CustomerId, 'An exact e-mail match should return the customer id.');
+    end;
+
+    local procedure CustomerPhoneSearchResponse(Id: BigInteger; PhoneNo: Text): Text
+    begin
+        exit(StrSubstNo(CustomerSearchResponseTok, Id, StrSubstNo(DefaultPhoneNumberNodeTok, PhoneNo)));
+    end;
+
+    local procedure ShopifyCustomerId(): BigInteger
+    var
+        Id: BigInteger;
+    begin
+        // A realistic Shopify customer id does not fit in an Integer, so it is parsed into a BigInteger.
+        Evaluate(Id, '9324520669439');
+        exit(Id);
+    end;
+
+    local procedure CustomerEMailSearchResponse(Id: BigInteger; EMail: Text): Text
+    begin
+        exit(StrSubstNo(CustomerSearchResponseTok, Id, StrSubstNo(DefaultEMailAddressNodeTok, EMail)));
+    end;
+
+    local procedure Initialize()
+    var
+        AccessToken: SecretText;
+    begin
+        if IsInitialized then
+            exit;
+        IsInitialized := true;
+        Shop := InitializeTest.CreateShop();
+        AccessToken := Any.AlphanumericText(20);
+        InitializeTest.RegisterAccessTokenForShop(Shop.GetStoreName(), AccessToken);
+        Commit();
+    end;
+
+    [HttpClientHandler]
+    internal procedure HttpClientHandler(Request: TestHttpRequestMessage; var Response: TestHttpResponseMessage): Boolean
+    begin
+        if not InitializeTest.VerifyRequestUrl(Request.Path, Shop."Shopify URL") then
+            exit(true);
+
+        Response.Content.WriteFrom(ResponseContent);
+        exit(false);
     end;
 }

--- a/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Customers/ShpfyCustomerAPITest.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 139589 "Shpfy Customer API Test"
         Shop: Record "Shpfy Shop";
         LibraryAssert: Codeunit "Library Assert";
         InitializeTest: Codeunit "Shpfy Initialize Test";
+        CommunicationMgt: Codeunit "Shpfy Communication Mgt.";
         Any: Codeunit Any;
         ResponseContent: Text;
         IsInitialized: Boolean;
@@ -240,6 +241,9 @@ codeunit 139589 "Shpfy Customer API Test"
             exit;
         IsInitialized := true;
         Shop := InitializeTest.CreateShop();
+        // CreateShop enables the legacy IsTestInProgress mock path; disable it so the app performs a real
+        // HttpClient call that the [HttpClientHandler] below can intercept.
+        CommunicationMgt.SetTestInProgress(false);
         AccessToken := Any.AlphanumericText(20);
         InitializeTest.RegisterAccessTokenForShop(Shop.GetStoreName(), AccessToken);
         Commit();


### PR DESCRIPTION
## Summary
Backport of bug #646794 to `releases/28.x`.

Fixes [AB#647743](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647743)

Original PR: microsoft/BCApps#10256

## Note on conflict resolution
`releases/28.x` predates the migration of the Shopify GraphQL queries to external `.resources/**/*.graphql` files, so the fix was adapted to that branch's older architecture:

- The query changes (return `defaultEmailAddress` / `defaultPhoneNumber`, expected cost `3` → `4`) were applied to the `Shpfy GQL FindCustByEMail` / `Shpfy GQL FindCustByPhone` codeunits instead of the non-existent `.graphql` resource files.
- The code uses the 28.x enum names `FindCustomerIdByEMail` / `FindCustomerIdByPhone` (renamed to `Customers_*` on `main`).

The exact-match verification, the `FormatPhoneNo` helper, and the HTTP-mocked tests are identical to the original fix.




