### PR TITLE
Fix app-baseline storage account selection to use the target branch

### DIFF
--- a/.github/actions/RunAutomation/UpdateAppBaselines/run.ps1
+++ b/.github/actions/RunAutomation/UpdateAppBaselines/run.ps1
@@ -9,7 +9,7 @@ Install-Module -Name BcContainerHelper -AllowPrerelease -Force
 Import-Module BcContainerHelper -DisableNameChecking
 Import-Module $PSScriptRoot\..\..\..\..\build\scripts\EnlistmentHelperFunctions.psm1
 
-$newVersion = Update-PackageVersion -PackageName "AppBaselines-BCArtifacts"
+$newVersion = Update-PackageVersion -PackageName "AppBaselines-BCArtifacts" -Branch $runParameters.TargetBranch
 
 $result = @{
     'Files' = @()

--- a/build/scripts/EnlistmentHelperFunctions.psm1
+++ b/build/scripts/EnlistmentHelperFunctions.psm1
@@ -207,13 +207,19 @@ function Set-ConfigValue() {
     For example, if the repo version is 1.2, the function will look for the latest version of the package that has major.minor = 1.2.
 .Parameter PackageName
     The name of the package
+.Parameter Branch
+    The branch the package version is being updated for (e.g. "main" or "releases/28.0").
+    Used to decide which storage account to use for BCArtifacts baselines. When not provided,
+    it falls back to Get-CurrentBranch.
 .Returns
     The latest version of the package
 #>
 function Get-PackageLatestVersion() {
     param(
         [Parameter(Mandatory=$true)]
-        [string] $PackageName
+        [string] $PackageName,
+        [Parameter(Mandatory=$false)]
+        [string] $Branch
     )
 
     $package = Get-ConfigValue -Key $PackageName -ConfigType Packages
@@ -246,7 +252,15 @@ function Get-PackageLatestVersion() {
                 }
             }
 
-            $currentBranch = Get-CurrentBranch
+            # Determine the branch this update is running for. The automation is triggered from a
+            # single workflow (running on 'main') that updates every release branch via a matrix, so
+            # Get-CurrentBranch (which returns $GITHUB_REF_NAME) reports 'main' for every job and
+            # cannot be used to pick the storage account. Prefer the explicit target branch passed in
+            # by the automation and only fall back to Get-CurrentBranch when it is not available.
+            $currentBranch = $Branch
+            if (-not $currentBranch) {
+                $currentBranch = Get-CurrentBranch
+            }
             Write-Host "Current branch: $currentBranch"
             $storageAccountOrder = @("bcartifacts", "bcinsider")
             if($currentBranch -eq "main") {
@@ -397,13 +411,18 @@ function Update-BCArtifactVersion {
     Updates the version of a package in the Packages config file to the latest version available.
 .Parameter PackageName
     The name of the package to update
+.Parameter Branch
+    The branch the package version is being updated for (e.g. "main" or "releases/28.0").
+    Forwarded to Get-PackageLatestVersion to select the correct BCArtifacts baseline storage account.
 .Returns
     The new version of the package, if it was updated
 #>
 function Update-PackageVersion
 (
     [Parameter(Mandatory=$true)]
-    [string] $PackageName
+    [string] $PackageName,
+    [Parameter(Mandatory=$false)]
+    [string] $Branch
 )
 {
     $currentPackage = Get-ConfigValue -Key $PackageName -ConfigType Packages
@@ -421,7 +440,7 @@ function Update-PackageVersion
         return $null
     }
 
-    $latestVersion = Get-PackageLatestVersion -PackageName $PackageName
+    $latestVersion = Get-PackageLatestVersion -PackageName $PackageName -Branch $Branch
     Write-Host "Latest $PackageName version found: $latestVersion"
 
     $result = $null


### PR DESCRIPTION
## What & why

The scheduled **Update Package Versions** workflow ([run 32816561886](https://github.com/microsoft/BCApps/actions/runs/32816561886)) started picking wrong app-baseline versions (e.g. `28.0` resolved baseline `27.11.53876.0` instead of `≤ 27.5`), and most matrix jobs failed with `No artifact found for version <minor>`. Re-runs failed identically, so this is a **deterministic code regression** — not a transient artifact-feed issue.

### Root cause

`UpdatePackageVersions.yaml` is triggered on `main` (schedule / `workflow_dispatch`) and updates every release branch through a matrix. Each job checks out its release branch and passes it as `targetBranch`, but `$GITHUB_REF_NAME` stays `main` for all jobs.

PR #10300 changed `Get-CurrentBranch` to return `$GITHUB_REF_NAME` (needed for strict-mode detection). As a side effect, `Get-PackageLatestVersion` — which uses `Get-CurrentBranch` to choose the baseline storage account — began seeing `main` for **every** matrix job:

```powershell
$currentBranch = Get-CurrentBranch          # "main" for every job
if ($currentBranch -eq "main") { $storageAccountOrder = @("bcinsider") }
```

So every job queried the **bcinsider** (insider) feed only. bcinsider holds only high insider minors (e.g. 27.8–27.11, 28.2–28.5), which is why `.0`/dev branches silently resolved to an insider build and exact previous-minor branches failed outright. Every failing **and** "passing" job logged `Current branch: main` + `Platformurl: …bcinsider…`, confirming the diagnosis.

### Impact (from the failing run)

| Branch | Baseline looked up | bcinsider result | Outcome |
|---|---|---|---|
| `28.0` (`.0` → `27`) | `27` | `27.11.53876.0` | ❌ silently wrong (should be ≤ 27.5) |
| `27.0` (`.0` → `26`) | `26` | `26.17.53905.0` | ❌ silently wrong |
| `28.3` | `28.2` | `28.2.51133.0` | ❌ silently wrong (insider build) |
| `27.4` | `27.3` | none | ❌ `No artifact found` |
| `28.1` / `28.2` | `28.0` / `28.1` | none | ❌ `No artifact found` |
| `26.4` / `26.5` / `27.2` / `27.x` | `26.3` / `26.4` / `27.1` / `27.5` | none | ❌ `No artifact found` |
| `main` | — | bcinsider | ✅ correct (intended) |

Note the wrong "successful" values all end in a `.0` revision — the hallmark of insider builds, versus real sandbox revisions like `.53931`.

### Fix

Thread the automation's real `TargetBranch` (already provided by the `RunAutomation` action as `$runParameters.TargetBranch`) through `Update-PackageVersion` into `Get-PackageLatestVersion`, and use it to select the storage account, falling back to `Get-CurrentBranch` when not supplied. This restores the pre-regression behavior:

- release branches → `bcartifacts` first (so `28.0` resolves `27` against bcartifacts's 27.0–27.5 → `27.5.x`);
- `main` → `bcinsider` only (unchanged, intended);
- other callers (no `-Branch`) → fall back to `Get-CurrentBranch`.

`Get-CurrentBranch` itself is left untouched so the strict-mode detection fix from #10300 is preserved.

## Testing

- Both modified scripts parse without errors.
- Verified the storage-account decision for `releases/28.0`, `releases/27.4`, `releases/26.4` → `[bcartifacts, bcinsider]`; `main` → `[bcinsider]`; empty → `Get-CurrentBranch` fallback.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>


[AB#647772](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647772)

