### PR TITLE
Add AI variant caption experiment for New from PDF action

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Extensions/PAPurchaseInvoiceList.PageExt.al
+++ b/src/Apps/W1/PayablesAgent/app/Extensions/PAPurchaseInvoiceList.PageExt.al
@@ -20,11 +20,22 @@ pageextension 3309 "PA Purchase Invoice List" extends "Purchase Invoices"
                 Caption = 'New from PDF';
                 Image = Sparkle;
                 ToolTip = 'Upload a PDF invoice to create a purchase invoice with agent assistance.';
-                Visible = IsAgentActionVisible;
+                Visible = IsAgentActionVisible and not IsNewInvoiceAIVariant;
                 trigger OnAction()
                 begin
-                    UploadInvoiceWithAgent();
-                    ShowTaskPaneForLatestAgentTask();
+                    RunNewInvoiceAction(false);
+                end;
+            }
+            action(PANewInvoiceAIVariant)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Draft from PDF with AI';
+                Image = Sparkle;
+                ToolTip = 'Upload a PDF invoice to create a purchase invoice with agent assistance.';
+                Visible = IsAgentActionVisible and IsNewInvoiceAIVariant;
+                trigger OnAction()
+                begin
+                    RunNewInvoiceAction(true);
                 end;
             }
         }
@@ -36,17 +47,31 @@ pageextension 3309 "PA Purchase Invoice List" extends "Purchase Invoices"
                 Caption = 'New from PDF';
                 Image = Sparkle;
                 ToolTip = 'Upload a PDF invoice to create a purchase invoice with agent assistance.';
-                Visible = IsAgentActionVisible;
+                Visible = IsAgentActionVisible and not IsNewInvoiceAIVariant;
                 trigger OnAction()
                 begin
-                    UploadInvoiceWithAgent();
-                    ShowTaskPaneForLatestAgentTask();
+                    RunNewInvoiceAction(false);
+                end;
+            }
+            action(PANewInvoicePromptingAIVariant)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Draft from PDF with AI';
+                Image = Sparkle;
+                ToolTip = 'Upload a PDF invoice to create a purchase invoice with agent assistance.';
+                Visible = IsAgentActionVisible and IsNewInvoiceAIVariant;
+                trigger OnAction()
+                begin
+                    RunNewInvoiceAction(true);
                 end;
             }
         }
         addlast(Category_New)
         {
             actionref(PANewInvoice_Promoted; PANewInvoice)
+            {
+            }
+            actionref(PANewInvoiceAIVariant_Promoted; PANewInvoiceAIVariant)
             {
             }
         }
@@ -58,9 +83,16 @@ pageextension 3309 "PA Purchase Invoice List" extends "Purchase Invoices"
     trigger OnOpenPage()
     begin
         IsAgentActionVisible := PayablesAgentSetup.CanShowAgentActions();
+        IsNewInvoiceAIVariant := PayablesAgentSetup.IsNewInvoiceAIVariant();
     end;
 
-    local procedure UploadInvoiceWithAgent()
+    local procedure RunNewInvoiceAction(UseAIVariant: Boolean)
+    begin
+        UploadInvoiceWithAgent(UseAIVariant);
+        ShowTaskPaneForLatestAgentTask();
+    end;
+
+    local procedure UploadInvoiceWithAgent(UseAIVariant: Boolean)
     var
         PayablesAgent: Codeunit "Payables Agent";
         PATrialGuide: Page "PA Trial Guide";
@@ -78,7 +110,10 @@ pageextension 3309 "PA Purchase Invoice List" extends "Purchase Invoices"
         AgentExistInEnvironment := PayablesAgent.PayablesAgentExistsAcrossAllCompanies();
         PayablesAgentSetup.EnsureAgentActivated(AlreadyActivated);
         PayablesAgentSetup.ImportInvoiceFile(FileName, InStream);
-        Session.LogMessage('0000SEJ', NewWithAgentTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, PayablesAgent.GetCustomDimensions());
+        if UseAIVariant then
+            Session.LogMessage('0000V8J', NewInvoiceAIVariantTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, PayablesAgent.GetCustomDimensions())
+        else
+            Session.LogMessage('0000SEJ', NewWithAgentTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, PayablesAgent.GetCustomDimensions());
 
         if AgentExistInEnvironment then
             exit;
@@ -109,7 +144,9 @@ pageextension 3309 "PA Purchase Invoice List" extends "Purchase Invoices"
     var
         PayablesAgentSetup: Codeunit "Payables Agent Setup";
         IsAgentActionVisible: Boolean;
+        IsNewInvoiceAIVariant: Boolean;
         SelectFileLbl: Label 'Select file';
         PdfFileFilterLbl: Label 'PDF Files (*.pdf)|*.pdf';
         NewWithAgentTok: Label 'User uploaded invoice via New with agent action.', Locked = true;
+        NewInvoiceAIVariantTok: Label 'User uploaded invoice via Draft from PDF with AI action.', Locked = true;
 }

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Codeunit.al
@@ -278,6 +278,16 @@ codeunit 3307 "Payables Agent Setup"
     end;
 
     /// <summary>
+    /// Returns true when the tenant is assigned the "Draft from PDF with AI" caption variant, false for the "New from PDF" control.
+    /// </summary>
+    internal procedure IsNewInvoiceAIVariant(): Boolean
+    var
+        FeatureConfiguration: Codeunit "Feature Configuration";
+    begin
+        exit(FeatureConfiguration.GetConfiguration(NewInvoiceAIVariantTok) = NewInvoiceAIVariantTreatmentTok);
+    end;
+
+    /// <summary>
     /// Reconciles the agent's persisted instructions with the current experiment configuration.
     /// The agent instructions are set once (at creation/upgrade), but tenant-level ECS experiments can change
     /// independently; this reapplies the instructions when the configuration that produced them has drifted.
@@ -821,4 +831,6 @@ codeunit 3307 "Payables Agent Setup"
         UnableToConfigureAgentInstructionsErr: Label 'Unable to configure agent instructions.';
         AgentDrivenLineMatchingTok: Label 'PAAgentDrivenLineMatching', Locked = true;
         AgentDrivenTreatmentTok: Label 'agent_driven', Locked = true;
+        NewInvoiceAIVariantTok: Label 'PADraftFromPdfCaption', Locked = true;
+        NewInvoiceAIVariantTreatmentTok: Label 'AI_variant', Locked = true;
 }


### PR DESCRIPTION
## What & why

Runs an A/B experiment on the "New from PDF" action caption on the Purchase Invoices list. Half of tenants keep the current "New from PDF" caption (control) and half get "Draft from PDF with AI" (variant), assigned by an ECS feature flag. The goal is to see if a clearer, AI-forward label gets more people to try the action and turn on the Payables Agent. Each variant fires its own telemetry event so we can compare how many tenants click each version over the run.

Fixes [AB#641681](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641681)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Payables Agent app locally, no new analyzer warnings.
- Clicking control logs the existing event, clicking the variant logs the new variant event, so clicks can be attributed per caption.
- No unit tests added. The change is a caption swap driven by an existing ECS resolver pattern and telemetry, there is no new business logic to cover. The visibility split reuses the same gate as the current action.

## Risk & compatibility

- Feature flag: the new AI variant only shows when ECS returns the treatment value for key `PADraftFromPdfCaption`. If the key is unset or the value does not match, everyone stays on the control caption, so the safe default is current behavior.
- Telemetry: adds one new event for the variant click. The variant event tag is still a placeholder and must be filled by expand-telemetrytags before merge.
- New caption string needs translating in all shipped locales since the experiment runs globally.





