### PR TITLE
[28.4] Classify E-Document sales table data sensitivity

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -10,6 +10,7 @@ using Microsoft.eServices.EDocument.OrderMatch;
 using Microsoft.EServices.EDocument.Processing;
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
+using Microsoft.eServices.EDocument.Processing.Import.Sales;
 using Microsoft.eServices.EDocument.Processing.Interfaces;
 using Microsoft.eServices.EDocument.Processing.Message;
 using Microsoft.eServices.EDocument.Service.Participant;
@@ -528,6 +529,8 @@ codeunit 6103 "E-Document Subscribers"
 #pragma warning restore AL0432
 #endif
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc Sample Purch. Inv File");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Sales Header");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Sales Line");
     end;
 
 


### PR DESCRIPTION
## Why

The 28.4 backport of the PEPPOL EDI receive path introduced the E-Document Sales Header and E-Document Sales Line tables without the companion data-sensitivity registration from #9105. NAV test codeunit 135153 therefore fails with `Field 2 of Table 6153 has Data Sensitivity Unclassified`, blocking the BCApps uptake into NAV 28.4.

This backports the established fix from commit 34101c1c88bb9cada8c115345fa3d40235e54ff7.

## Summary

- **Imported** the sales-import namespace used by the new E-Document tables.
- **Classified** all fields on E-Document Sales Header and E-Document Sales Line as Normal in evaluation-company sensitivity data.
- **Reused** the existing `ClassifyDataSensitivity` subscriber and existing NAV regression test coverage.

[AB#647510](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647510)
