### PR TITLE
[Subcontracting] (Bug: 638998) Add extensibility to Subcontracting app for IT partner migration

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcCreateSubCReturnOrder.Report.al
@@ -127,6 +127,7 @@ report 20502 "Subc. Create SubCReturnOrder"
             TransferHeader."Trsf.-from Country/Region Code" := Vendor."Country/Region Code";
 
             TransferHeader.Modify();
+            OnAfterInsertTransferHeader(TransferHeader, Vendor);
             LineNo := 0;
         end else begin
             TransferLine.SetRange("Document No.", TransferHeader."No.");
@@ -262,7 +263,13 @@ report 20502 "Subc. Create SubCReturnOrder"
     local procedure ShowDocument()
     var
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeShowDocument(TransferHeader, IsHandled);
+        if IsHandled then
+            exit;
+
         Commit(); // Used for following call of Transfer Pages
 
         SubcPurchFactboxMgmt.ShowTransferOrdersAndReturnOrder("Purchase Line", true, true);
@@ -416,5 +423,15 @@ report 20502 "Subc. Create SubCReturnOrder"
         TransferLineToCheck.SetRange("Transfer WIP Item", true);
         TransferLineToCheck.SetRange("Subc. Return Order", true);
         exit(not TransferLineToCheck.IsEmpty());
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterInsertTransferHeader(var TransferHeader: Record "Transfer Header"; Vendor: Record Vendor)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeShowDocument(var TransferHeader: Record "Transfer Header"; var IsHandled: Boolean)
+    begin
     end;
 }

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcontractorPrice.Table.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcontractorPrice.Table.al
@@ -12,7 +12,6 @@ using Microsoft.Purchases.Vendor;
 
 table 20500 "Subcontractor Price"
 {
-    AllowInCustomizations = AsReadOnly;
     Caption = 'Subcontractor Price';
     DataClassification = CustomerContent;
     DrillDownPageId = "Subcontractor Prices";

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -158,7 +158,9 @@ report 20501 "Subc. Create Transf. Order"
             TransferHeader."Transfer-to County" := Vendor.County;
             TransferHeader."Trsf.-from Country/Region Code" := Vendor."Country/Region Code";
 
+            OnInsertTransferHeaderOnBeforeModify(TransferHeader, Vendor, "Purchase Header");
             TransferHeader.Modify();
+            OnAfterInsertTransferHeader(TransferHeader, Vendor);
             LineNo := 0;
         end else begin
             TransferLine.SetRange("Document No.", TransferHeader."No.");
@@ -178,6 +180,7 @@ report 20501 "Subc. Create Transf. Order"
         PurchaseLine.SetFilter("Prod. Order No.", '<>''''');
         PurchaseLine.SetFilter("Prod. Order Line No.", '<>0');
         PurchaseLine.SetFilter("Operation No.", '<>0');
+        OnCheckTransferCreatedOnAfterPurchaseLineSetFilters(PurchaseLine, "Purchase Header");
         if PurchaseLine.FindSet() then
             repeat
                 if HandleComponentsForPurchLine(PurchaseLine, false) then
@@ -223,6 +226,7 @@ report 20501 "Subc. Create Transf. Order"
         ProdOrderComponent.SetRange("Routing Link Code", ProdOrderRoutingLine."Routing Link Code");
         ProdOrderComponent.SetRange("Subc. Purchase Order Filter", PurchaseLine."Document No.");
         ProdOrderComponent.SetRange("Component Supply Method", ProdOrderComponent."Component Supply Method"::"Transfer to Vendor");
+        OnHandleComponentsForPurchLineOnAfterProdOrderComponentSetFilters(ProdOrderComponent, PurchaseLine);
         if ProdOrderComponent.FindSet() then
             repeat
                 Item.SetLoadFields("Rounding Precision", "Order Tracking Policy");
@@ -292,6 +296,8 @@ report 20501 "Subc. Create Transf. Order"
                         ProdOrderComponent.Modify();
 
                         SubcTransferManagement.CreateReservEntryForTransferReceiptToProdOrderComp(TransferLine, ProdOrderComponent);
+
+                        OnAfterInsertTransferLine(TransferHeader, TransferLine, PurchaseLine, ProdOrderComponent);
                     end else
                         exit(true);
             until ProdOrderComponent.Next() = 0;
@@ -302,7 +308,13 @@ report 20501 "Subc. Create Transf. Order"
     local procedure ShowDocument()
     var
         SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeShowDocument(TransferHeader, IsHandled);
+        if IsHandled then
+            exit;
+
         Commit(); // Used for following call of Transfer Pages
         SubcPurchFactboxMgmt.ShowTransferOrdersFromPurchaseOrder("Purchase Header", false);
     end;
@@ -441,6 +453,8 @@ report 20501 "Subc. Create Transf. Order"
         TransferLine."Prev. Operation No." := WIPPreviousOperationNo;
 
         TransferLine.Modify();
+
+        OnAfterInsertWIPTransferLine(TransferHeader, TransferLine, PurchaseLine, ProdOrderLine, ProdOrderRoutingLine);
     end;
 
     local procedure GetWIPTransferFromLocations(ProdOrderLine: Record "Prod. Order Line"; ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var WIPSourceLocationList: List of [Code[10]]; var WIPSourceQtyDict: Dictionary of [Code[10], Decimal]; var WIPPreviousOperationNoDict: Dictionary of [Code[10], Code[10]]; PurchLineQtyBase: Decimal)
@@ -648,5 +662,40 @@ report 20501 "Subc. Create Transf. Order"
         SubcontractorWIPLedgerEntry.SetRange("In Transit", false);
         SubcontractorWIPLedgerEntry.CalcSums("Quantity (Base)");
         exit(SubcontractorWIPLedgerEntry."Quantity (Base)");
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnInsertTransferHeaderOnBeforeModify(var TransferHeader: Record "Transfer Header"; Vendor: Record Vendor; PurchaseHeader: Record "Purchase Header")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterInsertTransferHeader(var TransferHeader: Record "Transfer Header"; Vendor: Record Vendor)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterInsertTransferLine(var TransferHeader: Record "Transfer Header"; var TransferLine: Record "Transfer Line"; PurchaseLine: Record "Purchase Line"; var ProdOrderComponent: Record "Prod. Order Component")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterInsertWIPTransferLine(var TransferHeader: Record "Transfer Header"; var TransferLine: Record "Transfer Line"; PurchaseLine: Record "Purchase Line"; ProdOrderLine: Record "Prod. Order Line"; ProdOrderRoutingLine: Record "Prod. Order Routing Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCheckTransferCreatedOnAfterPurchaseLineSetFilters(var PurchaseLine: Record "Purchase Line"; PurchaseHeader: Record "Purchase Header")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnHandleComponentsForPurchLineOnAfterProdOrderComponentSetFilters(var ProdOrderComponent: Record "Prod. Order Component"; PurchaseLine: Record "Purchase Line")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeShowDocument(var TransferHeader: Record "Transfer Header"; var IsHandled: Boolean)
+    begin
     end;
 }


### PR DESCRIPTION
## What & why

The new W1 **Subcontracting** app was missing extensibility points that Italian partners depend on when migrating from the legacy IT BaseApp subcontracting objects. This adds those extension points and removes a redundant customization restriction:

- **Subcontractor Price table** — removed the redundant `AllowInCustomizations` property. The previous `AsReadOnly` value is behaviorally equivalent to the current default (`ToBeClassified`), which already allows page customizations; the deprecated `Always` value is intentionally avoided.
- **Subc. Create Transf. Order report** — added integration events mirroring legacy report 12152 (header pre-modify / after-insert, component transfer line insert, WIP transfer line insert, set-filter hooks, and before-show-document with `IsHandled`).
- **Subc. Create SubCReturnOrder report** — added `OnAfterInsertTransferHeader` and `OnBeforeShowDocument` integration events, matching legacy report 12153.

Event placement was chosen for clean semantics (e.g. `OnAfterInsertTransferHeader` fires once per newly created header), and all new events use `[IntegrationEvent(false, false)]` consistent with the app's existing convention.

## Linked work

[AB#638998](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638998)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Changes cross-checked against the legacy IT NAV objects (`releases/28.x`, reports 12152 / 12153) to confirm event parity by behavior, since object names/IDs differ in the new app.
- A local build could not be completed in this environment because the available Base Application symbols predate commit `cf0e1a5107` (which added a 4th parameter to `OnAfterOpenForRecRef`), producing an unrelated AL0282 against stale symbols. The changed objects are additive (new integration events + property removal) and were reviewed for signature/import correctness.
- No tests added: the changes only publish new integration events and remove a redundant property; there is no new runtime behavior to assert beyond event emission.

## Risk & compatibility

- **Low risk / additive.** New integration events do not alter existing control flow. The `OnBeforeShowDocument` event guards with `IsHandled` and defaults to the original behavior.
- **Customization behavior unchanged** by the table property removal: `AsReadOnly` and the default `ToBeClassified` both allow fields as read-only source expressions in page customizations.
- Event placement / `IncludeSender` differs slightly from legacy (cleaner semantics, `IncludeSender = false`); this was a deliberate choice and may require a subscriber rebind for partners porting from the legacy objects — expected given the object IDs changed.





