### PR TITLE
[Master] [Expense Agent] Bug 639921 Confirm before closing Expense User Card without Employee No.

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
@@ -260,7 +260,7 @@ page 6949 "Expense User"
     var
         NoFieldVisible: Boolean;
         IsCreateEmployeeVisible: Boolean;
-        CloseWithoutEmployeeNoQst: Label '%1 is blank. Do you want to close the card without linking an %1?', Comment = '%1 = Employee No. field caption';
+        CloseWithoutEmployeeNoQst: Label '%1 is blank. The expense user will not be linked to an employee.\\Are you sure you want to exit?', Comment = '%1 = Employee No. field caption';
 
     local procedure SetCodeFieldVisible()
     var

--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.ExpenseAgent;
 
 using Microsoft.Projects.Resources.Resource;
+using System.Utilities;
 
 page 6949 "Expense User"
 {
@@ -236,6 +237,15 @@ page 6949 "Expense User"
         exit(Rec.ConfirmApproverReassignment());
     end;
 
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    var
+        ConfirmManagement: Codeunit "Confirm Management";
+    begin
+        if Rec."Employee No." = '' then
+            if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(CloseWithoutEmployeeNoQst, Rec.FieldCaption("Employee No.")), true) then
+                exit(false);
+    end;
+
     trigger OnOpenPage()
     begin
         SetCodeFieldVisible();
@@ -250,6 +260,7 @@ page 6949 "Expense User"
     var
         NoFieldVisible: Boolean;
         IsCreateEmployeeVisible: Boolean;
+        CloseWithoutEmployeeNoQst: Label '%1 is blank. Do you want to close the card without linking an %1?', Comment = '%1 = Employee No. field caption';
 
     local procedure SetCodeFieldVisible()
     var

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseTestII.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseTestII.Codeunit.al
@@ -2534,6 +2534,7 @@ codeunit 148309 "Expense Test II"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
     procedure EmployeeIsNotCreatedFromExpenseUserWhenNameIsEmpty()
     var
         ExpenseUser: Record "Expense User";
@@ -2563,6 +2564,7 @@ codeunit 148309 "Expense Test II"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
     procedure EmployeeIsNotCreatedFromExpenseUserWhenEmailIsEmpty()
     var
         ExpenseUser: Record "Expense User";


### PR DESCRIPTION
Fixes [AB#639921](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/639921)

Issue: On the Expense User card (page 6949) the mandatory Employee No. field could be left blank and the card closed anyway. The card closed silently and the expense user was saved without being linked to an employee — no warning and no confirmation — so an unlinked expense user could be created unintentionally.

Cause: Employee No. was only flagged as mandatory for display (ShowMandatory); the page had no OnQueryClosePage guard. Nothing intercepted the close action while the field was empty, so the record was committed with a blank Employee No.

Solution: Added an OnQueryClosePage trigger on page 6949 that uses Codeunit "Confirm Management". When Employee No. is blank the user is prompted "Employee No. is blank. The expense user will not be linked to an employee. Are you sure you want to exit?"; choosing No cancels the close and keeps the card open. Added [HandlerFunctions('ConfirmHandlerYes')] to the two tests that close the card with a blank Employee No. (EmployeeIsNotCreatedFromExpenseUserWhenNameIsEmpty, ...WhenEmailIsEmpty) so they still assert the mandatory-field errors.
