### PR TITLE
[Slice 626305] [Excise Tax][VENDOR] Improving Excise Duty Calculation — calculation type foundation

### DIFF
--- a/src/Apps/W1/ExciseTaxes/app/src/enum/ExciseDutyCalculationType.Enum.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/enum/ExciseDutyCalculationType.Enum.al
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.ExciseTaxes;
+
+enum 7415 "Excise Duty Calculation Type"
+{
+    Extensible = true;
+
+    value(0; Specific)
+    {
+        Caption = 'Specific';
+    }
+    value(1; "Ad Valorem")
+    {
+        Caption = 'Ad Valorem';
+    }
+    value(2; Hybrid)
+    {
+        Caption = 'Hybrid';
+    }
+}

--- a/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxItemFARates.Page.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxItemFARates.Page.al
@@ -38,6 +38,14 @@ page 7412 "Excise Tax Item/FA Rates"
                 {
                     ToolTip = 'Specifies the excise duty.';
                 }
+                field("Calculation Type"; Rec."Calculation Type")
+                {
+                    ToolTip = 'Specifies whether the excise duty is calculated as a specific amount per unit, ad valorem (a percentage of value), or a hybrid of both.';
+                }
+                field("Ad Valorem %"; Rec."Ad Valorem %")
+                {
+                    ToolTip = 'Specifies the percentage of value used when the calculation type is Ad Valorem or Hybrid.';
+                }
                 field("Effective From Date"; Rec."Effective From Date")
                 {
                     ToolTip = 'Specifies when this excise duty becomes effective.';

--- a/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxItemFARate.Table.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxItemFARate.Table.al
@@ -67,6 +67,22 @@ table 7413 "Excise Tax Item/FA Rate"
         {
             Caption = 'Description';
         }
+        field(8; "Calculation Type"; Enum "Excise Duty Calculation Type")
+        {
+            Caption = 'Calculation Type';
+
+            trigger OnValidate()
+            begin
+                if "Calculation Type" = "Calculation Type"::Specific then
+                    "Ad Valorem %" := 0;
+            end;
+        }
+        field(9; "Ad Valorem %"; Decimal)
+        {
+            Caption = 'Ad Valorem %';
+            DecimalPlaces = 2 : 5;
+            MinValue = 0;
+        }
     }
 
     keys


### PR DESCRIPTION


Introduces the data-model foundation for specific / ad valorem / hybrid excise duty:
- New enum "Excise Duty Calculation Type" (Specific, Ad Valorem, Hybrid).
- New fields on "Excise Tax Item/FA Rate": "Calculation Type" (defaults to Specific,
  so existing rates keep current behavior) and "Ad Valorem %".
- Fields surfaced on the "Excise Duty Rates" page.

Next: wire the calculation logic in "Excise Tax Calculation" to apply ad valorem/hybrid.

