### PR TITLE
Bug 611704: Align Tax Transaction Value ID assignment with G/L Entry pattern

### DIFF
--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxDocumentGLPosting.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-PostingHandler/src/PostingManagement/codeunit/TaxDocumentGLPosting.Codeunit.al
@@ -70,7 +70,7 @@ codeunit 20341 "Tax Document GL Posting"
                 ToTaxTransactionValue.Init();
                 ToTaxTransactionValue := FromTaxTransactionValue;
                 ToTaxTransactionValue."Tax Record ID" := ToRecID;
-                ToTaxTransactionValue.ID := 0;
+                ToTaxTransactionValue.ID := ToTaxTransactionValue.GetNextID();
                 ToTaxTransactionValue.Insert();
             until FromTaxTransactionValue.Next() = 0;
     end;

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TransactionValue/table/TaxTransactionValue.Table.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TransactionValue/table/TaxTransactionValue.Table.al
@@ -7,6 +7,7 @@ namespace Microsoft.Finance.TaxEngine.TaxTypeHandler;
 using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.TaxEngine.Core;
+using Microsoft.Foundation.NoSeries;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Purchases.Archive;
 using Microsoft.Purchases.Document;
@@ -153,6 +154,14 @@ table 20261 "Tax Transaction Value"
         {
         }
     }
+
+    procedure GetNextID(): Integer
+    var
+        SequenceNoMgt: Codeunit "Sequence No. Mgt.";
+    begin
+        exit(SequenceNoMgt.GetNextSeqNo(Database::"Tax Transaction Value"));
+    end;
+
     procedure GetAttributeColumName(): Text
     var
         TaxAttribute: Record "Tax Attribute";

--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-UseCaseBuilder/src/UseCase/codeunit/TaxRateComputation.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-UseCaseBuilder/src/UseCase/codeunit/TaxRateComputation.Codeunit.al
@@ -204,6 +204,7 @@ codeunit 20291 "Tax Rate Computation"
         TaxTransactionValue."Value Type" := TransactionValueType;
         TaxTransactionValue."Tax Type" := TaxType;
         TaxTransactionValue."Value ID" := ID;
+        TaxTransactionValue.ID := TaxTransactionValue.GetNextID();
         TaxTransactionValue.Insert();
     end;
 


### PR DESCRIPTION
[AB#611704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611704)
[Slice 611704](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/611704): [Repair Item][IN] Change "Tax Transaction Value".ID to be BigInteger


### Issue
The **ID** field on the Tax Transaction Value table (20261) is assigned solely via SQL IDENTITY (`AutoIncrement`). Due to high churn (delete + re-insert on every tax recompute) and non-transactional IDENTITY consumption (numbers burned on Posting Preview and rollbacks), the ID column overflowed, producing *"Arithmetic overflow error converting IDENTITY to data type int"* ([AB#611704](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611704)).

### Cause
ID generation depended only on the database IDENTITY column — there was no application-managed sequence and no alignment with the platform's standard ledger-entry numbering pattern used by G/L Entry.

### Solution
Introduced G/L Entry–style ID assignment:
- **TaxTransactionValue.Table.al** — added a new `GetNextID()` procedure that returns the next number from `Sequence No. Mgt.`, mirroring G/L Entry's `GetNextEntryNo()`. The field is left unchanged (`Integer`, `AutoIncrement = true`) — no schema/breaking change.
- **TaxRateComputation** & **TaxDocumentGLPosting** — assign `ID := GetNextID()` before `Insert()`.

**Tested:** Purchase Invoice posting completes successfully with no errors.


