### PR TITLE
[Bug 646559] Make E-Doc attachment tests CZ-compatible

### DIFF
--- a/src/Apps/W1/EnforcedDigitalVouchers/test/src/EDocAttachmentTests.Codeunit.al
+++ b/src/Apps/W1/EnforcedDigitalVouchers/test/src/EDocAttachmentTests.Codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.Test.EServices.EDocument;
 using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration;
 using Microsoft.eServices.EDocument.Test;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
@@ -283,8 +284,15 @@ codeunit 139649 "E-Doc. Attachment Tests"
     end;
 
     local procedure Initialize()
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"E-Doc. Attachment Tests");
+
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
+        GeneralLedgerSetup.Modify(false);
+
         if IsInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"E-Doc. Attachment Tests");

--- a/src/Apps/W1/EnforcedDigitalVouchers/test/src/EDocAttachmentTests.Codeunit.al
+++ b/src/Apps/W1/EnforcedDigitalVouchers/test/src/EDocAttachmentTests.Codeunit.al
@@ -290,8 +290,10 @@ codeunit 139649 "E-Doc. Attachment Tests"
         LibraryTestInitialize.OnTestInitialize(Codeunit::"E-Doc. Attachment Tests");
 
         GeneralLedgerSetup.Get();
-        GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
-        GeneralLedgerSetup.Modify(false);
+        if GeneralLedgerSetup."VAT Reporting Date Usage" <> GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled then begin
+            GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
+            GeneralLedgerSetup.Modify(false);
+        end;
 
         if IsInitialized then
             exit;


### PR DESCRIPTION
## Why

CZ posting validates that the VAT reporting date belongs to an existing VAT period. The E-Document attachment tests did not isolate themselves from this country-specific validation, so they failed before reaching their intended posting and attachment assertions.

## Summary

- **Disabled** VAT reporting date usage during E-Document attachment test initialization.
- **Kept** the W1 tests independent of CZ-specific test libraries while allowing them to run in CZ uptake builds.

Fixes [AB#646559](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646559)


