### PR TITLE
[Bug 646558] Stabilize remittance advice tests in CZ

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocRemitAdviceTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocRemitAdviceTest.Codeunit.al
@@ -6,6 +6,7 @@ using Microsoft.eServices.EDocument.RemittanceAdvice;
 using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Finance.GeneralLedger.Posting;
 using Microsoft.Finance.GeneralLedger.Preview;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Inventory.Item;
@@ -596,6 +597,7 @@ codeunit 139547 "E-Doc. Remit. Advice Test"
     var
         EDocument: Record "E-Document";
         EDocumentServiceStatus: Record "E-Document Service Status";
+        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
         LibraryVariableStorage.Clear();
         Clear(EDocImplState);
@@ -611,6 +613,12 @@ codeunit 139547 "E-Doc. Remit. Advice Test"
 
         if BindSubscription(LibraryJobQueue) then;
         LibraryJobQueue.SetDoNotHandleCodeunitJobQueueEnqueueEvent(true);
+
+        GeneralLedgerSetup.Get();
+        if GeneralLedgerSetup."VAT Reporting Date Usage" <> GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled then begin
+            GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
+            GeneralLedgerSetup.Modify(false);
+        end;
 
         EDocumentService.DeleteAll();
 


### PR DESCRIPTION
## Why

The E-Document remittance advice tests fail in the CZ extension test run because the CZ localization enables VAT reporting dates. The shared test setup posts purchase invoices without normalizing this localization-specific setting, so the tests fail during posting before they exercise remittance advice behavior.

## Summary

- **Disabled** VAT reporting date usage during one-time remittance advice test initialization.
- **Aligned** the setup with other E-Document test suites that normalize VAT reporting dates for cross-localization execution.
- **Stabilized** codeunit 139547 so its tests can run under the CZ extension stack.

Fixes [AB#646558](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646558)




