### PR TITLE
[Slice 626292] [Excise Tax][VENDOR] Bonded Locations for Excise Calculations — foundation

### DIFF
--- a/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseLocationCardExt.PageExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseLocationCardExt.PageExt.al
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.ExciseTaxes;
+
+using Microsoft.Inventory.Location;
+
+pageextension 7420 "Excise Location Card Ext" extends "Location Card"
+{
+    layout
+    {
+        addlast(General)
+        {
+            field(Bonded; Rec.Bonded)
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies that this is a bonded location. Goods held in bond are not subject to excise duty until they are released from the bonded location.';
+            }
+        }
+    }
+}

--- a/src/Apps/W1/ExciseTaxes/app/src/tableextension/ExciseLocationExt.TableExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/tableextension/ExciseLocationExt.TableExt.al
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.ExciseTaxes;
+
+using Microsoft.Inventory.Location;
+
+tableextension 7420 "Excise Location Ext" extends Location
+{
+    fields
+    {
+        field(7412; Bonded; Boolean)
+        {
+            Caption = 'Bonded';
+            DataClassification = CustomerContent;
+        }
+    }
+}


### PR DESCRIPTION
Description: [AB#626292](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626292) — adds a Bonded flag to Location (+ Location Card). Goods in bond aren't dutied until released. 2 files.

