### PR TITLE
[29.x] - [Bug 647874] Slice 638097: [Expense Agent] Enable simple interim approval scenario

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ApproverViewAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ApproverViewAPI.Page.al
@@ -50,7 +50,7 @@ page 6969 "Approver View API"
                     EntityName = 'expenseReport';
                     EntitySetName = 'expenseReports';
                     SubPageLink = "Pending Approval By" = field("No."),
-                                    Status = const("Pending Approval");
+                                    Status = filter("Pending Approval" | "Interim Approved");
                 }
             }
         }

--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
@@ -163,6 +163,26 @@ page 6928 "Expense Reports API"
                     Caption = 'Approver Comment';
                     Editable = false;
                 }
+                field(finalApproverNo; Rec."Final Approver No.")
+                {
+                    Caption = 'Final Approver No.';
+                    Editable = false;
+                }
+                field(finalApproverName; Rec."Final Approver Name")
+                {
+                    Caption = 'Final Approver Name';
+                    Editable = false;
+                }
+                field(interimApproverNo; Rec."Interim Approver No.")
+                {
+                    Caption = 'Interim Approver No.';
+                    Editable = false;
+                }
+                field(interimApproverName; Rec."Interim Approver Name")
+                {
+                    Caption = 'Interim Approver Name';
+                    Editable = false;
+                }
                 field(reimbursementCurrencyCode; ReimbursementCurrencyCodeDisplay)
                 {
                     Caption = 'Reimbursement Currency Code';
@@ -472,6 +492,17 @@ page 6928 "Expense Reports API"
             EAKPITrack.UpdateExpenseReportLineEntry(ExpenseReportLine);
         end else
             Error(ExpenseNotFoundErr, ExpenseId);
+
+        ActionContext.SetObjectType(ObjectType::Page);
+        ActionContext.SetObjectId(Page::"Expense Reports API");
+        ActionContext.AddEntityKey(Rec.FieldNo(SystemId), Rec.SystemId);
+        ActionContext.SetResultCode(WebServiceActionResultCode::Updated);
+    end;
+
+    [ServiceEnabled]
+    procedure AssignInterimApprover(var ActionContext: WebServiceActionContext; InterimApproverExpenseUserNo: Code[20]; ActorExpenseUserNo: Code[20])
+    begin
+        Rec.AssignInterimApprover(InterimApproverExpenseUserNo, ActorExpenseUserNo);
 
         ActionContext.SetObjectType(ObjectType::Page);
         ActionContext.SetObjectId(Page::"Expense Reports API");

--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Enums/ExpenseActivityEventType.Enum.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Enums/ExpenseActivityEventType.Enum.al
@@ -50,6 +50,14 @@ enum 6922 "Expense Activity Event Type"
     {
         Caption = 'Reopened by approver';
     }
+    value(23; InterimApproverAssigned)
+    {
+        Caption = 'Interim approver assigned';
+    }
+    value(24; InterimApproved)
+    {
+        Caption = 'Interim approved';
+    }
     value(30; CommentAdded)
     {
         Caption = 'Comment added';

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -27,6 +27,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         InterimApproverRequiredErr: Label 'Select an interim approver from the available approvers.';
         InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 %3.', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
         InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
+        ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
         InterimApproverAssignedCommentTxt: Label 'Interim approver set to %1 (%2).', Locked = true;
 
     procedure ProcessAction(var ExpenseReportHeader: Record "Expense Report Header"; ActionType: Enum "Expense Approval Action")
@@ -176,6 +177,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ExpenseReportHeader.TestApprovalPending();
         CheckApproverPermissions(ExpenseReportHeader);
         ApproverExpenseUserNo := GetExpenseUserNo();
+        CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+        CheckActorIsActiveApprover(ExpenseReportHeader, ApproverExpenseUserNo);
 
         SetApprovalStatusInExpenseReport(ExpenseReportHeader, ExpenseReportHeader.Status::Rejected, ApproverExpenseUserNo, CopyStr(UserId(), 1, 50));
         LogExpenseReportRejected(ExpenseReportHeader, ApproverExpenseUserNo, '');
@@ -190,6 +193,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
 
         ExpenseUser.Get(ApproverExpenseUserNo);
         CheckApproverPermissions(ExpenseUser);
+        CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+        CheckActorIsActiveApprover(ExpenseReportHeader, ApproverExpenseUserNo);
 
         UpdateApproverComment(ExpenseReportHeader, RejectReason);
         SetApprovalStatusInExpenseReport(ExpenseReportHeader, ExpenseReportHeader.Status::Rejected, ApproverExpenseUserNo, ExpenseUser."User Id For Approvals");
@@ -207,6 +212,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         CheckApproverPermissions(ExpenseReportHeader);
         ApproverExpenseUserNo := GetExpenseUserNo();
         CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+        CheckActorIsActiveApprover(ExpenseReportHeader, ApproverExpenseUserNo);
 
         if ShouldRouteToFinalApprover(ExpenseReportHeader) then begin
             RouteToFinalApprover(ExpenseReportHeader, ApproverExpenseUserNo);
@@ -227,6 +233,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ExpenseUser.Get(ApproverExpenseUserNo);
         CheckApproverPermissions(ExpenseUser);
         CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+        CheckActorIsActiveApprover(ExpenseReportHeader, ApproverExpenseUserNo);
 
         if ShouldRouteToFinalApprover(ExpenseReportHeader) then begin
             RouteToFinalApprover(ExpenseReportHeader, ApproverExpenseUserNo);
@@ -351,6 +358,18 @@ codeunit 6901 "Expense Report Approval Mgmt"
 
         if ActingApproverExpenseUserNo = ExpenseReportHeader."Interim Approver No." then
             Error(InterimApproverCannotFinalizeErr, ExpenseReportHeader.FieldCaption("Interim Approver No."), ExpenseReportHeader."Interim Approver No.");
+    end;
+
+    local procedure CheckActorIsActiveApprover(ExpenseReportHeader: Record "Expense Report Header"; ActingApproverExpenseUserNo: Code[20])
+    begin
+        if ExpenseReportHeader."Interim Approver No." = '' then
+            exit;
+
+        if ActingApproverExpenseUserNo = '' then
+            exit;
+
+        if ActingApproverExpenseUserNo <> ExpenseReportHeader."Approver Expense User No." then
+            Error(ActorNotActiveApproverErr, ExpenseReportHeader."Approver Expense User No.");
     end;
 
     local procedure SetApprovalStatusInExpenseReport(var ExpenseReportHeader: Record "Expense Report Header"; ExpenseReportStatus: Enum "Expense Report Status"; ApproverExpenseUserNo: Code[20]; ApproverUserId: Code[50])

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -22,6 +22,12 @@ codeunit 6901 "Expense Report Approval Mgmt"
         NotAuthorizedToRecallExpReportErr: Label 'Only the original submitter or a user with %1 can recall a submitted expense report.', Comment = '%1 = User Setup field caption';
         ApproverMustBeEnabledInExpenseUserErr: Label '%1 must be enabled to approve or reject expense reports in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
         UserIdForApprovalMustNotBeBlankInExpenseUserErr: Label '%1 must not be blank in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
+        InterimApproverAgentRequiredErr: Label 'An interim approver can only be assigned when the agent is enabled in %1.', Comment = '%1 = Expense Agent Setup table caption';
+        InterimApproverStatusErr: Label 'You can only assign an interim approver while the expense report is %1.', Comment = '%1 = Pending Approval status caption';
+        InterimApproverRequiredErr: Label 'Select an interim approver from the available approvers.';
+        InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 %3.', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
+        InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
+        InterimApproverAssignedCommentTxt: Label 'Interim approver set to %1 (%2).', Locked = true;
 
     procedure ProcessAction(var ExpenseReportHeader: Record "Expense Report Header"; ActionType: Enum "Expense Approval Action")
     begin
@@ -59,10 +65,10 @@ codeunit 6901 "Expense Report Approval Mgmt"
             ActionType::Submit:
                 exit(ExpenseReportHeader.Status = ExpenseReportHeader.Status::Released);
             ActionType::"Reopen Submitted":
-                exit((ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Pending Approval") or (ExpenseReportHeader.Status = ExpenseReportHeader.Status::Rejected));
+                exit((ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Pending Approval") or (ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Interim Approved") or (ExpenseReportHeader.Status = ExpenseReportHeader.Status::Rejected));
             ActionType::Reject,
             ActionType::Approve:
-                exit(ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Pending Approval");
+                exit((ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Pending Approval") or (ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Interim Approved"));
             ActionType::"Reopen Approved":
                 exit((ExpenseReportHeader.Status = ExpenseReportHeader.Status::Approved) or (ExpenseReportHeader.Status = ExpenseReportHeader.Status::Rejected));
         end;
@@ -99,6 +105,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ExpenseReportHeader.TestApprovalStatus();
 
         ExpenseReportHeader.UpdateApproverID();
+        ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
+        RouteToInterimIfAssigned(ExpenseReportHeader);
 
         SetApprovalStatusToPendingApprovalInExpenseReport(ExpenseReportHeader, SubmitterExpenseUserNo, ExpenseUser."User Id For Approvals");
         LogExpenseReportSubmission(ExpenseReportHeader, SubmitterExpenseUserNo, IsResubmission);
@@ -113,7 +121,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         if ExpenseReportHeader.Status = ExpenseReportHeader.Status::Open then
             exit;
 
-        IsRecall := ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Pending Approval";
+        IsRecall := ExpenseReportHeader.Status in [ExpenseReportHeader.Status::"Pending Approval", ExpenseReportHeader.Status::"Interim Approved"];
         if IsRecall then begin
             RecallActorRole := GetRecallActorRole(ExpenseReportHeader);
             SubmitterExpenseUserNo := ExpenseReportHeader."Submitter Expense User No.";
@@ -146,6 +154,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
     )
     begin
         ExpenseReportHeader.UpdateApproverID();
+        ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
+        RouteToInterimIfAssigned(ExpenseReportHeader);
         ExpenseReportHeader.Status := ExpenseReportHeader.Status::"Pending Approval";
         ExpenseReportHeader.Modify(true);
         LogExpenseReportEvent(
@@ -163,7 +173,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         if ExpenseReportHeader.Status = ExpenseReportHeader.Status::Rejected then
             exit;
 
-        ExpenseReportHeader.TestField(Status, ExpenseReportHeader.Status::"Pending Approval");
+        ExpenseReportHeader.TestApprovalPending();
         CheckApproverPermissions(ExpenseReportHeader);
         ApproverExpenseUserNo := GetExpenseUserNo();
 
@@ -193,9 +203,15 @@ codeunit 6901 "Expense Report Approval Mgmt"
         if ExpenseReportHeader.Status = ExpenseReportHeader.Status::Approved then
             exit;
 
-        ExpenseReportHeader.TestField(Status, ExpenseReportHeader.Status::"Pending Approval");
+        ExpenseReportHeader.TestApprovalPending();
         CheckApproverPermissions(ExpenseReportHeader);
         ApproverExpenseUserNo := GetExpenseUserNo();
+        CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+
+        if ShouldRouteToFinalApprover(ExpenseReportHeader) then begin
+            RouteToFinalApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+            exit;
+        end;
 
         SetApprovalStatusInExpenseReport(ExpenseReportHeader, ExpenseReportHeader.Status::Approved, ApproverExpenseUserNo, CopyStr(UserId(), 1, 50));
         LogExpenseReportApproved(ExpenseReportHeader, ApproverExpenseUserNo);
@@ -210,9 +226,131 @@ codeunit 6901 "Expense Report Approval Mgmt"
 
         ExpenseUser.Get(ApproverExpenseUserNo);
         CheckApproverPermissions(ExpenseUser);
+        CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+
+        if ShouldRouteToFinalApprover(ExpenseReportHeader) then begin
+            RouteToFinalApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+            exit;
+        end;
 
         SetApprovalStatusInExpenseReport(ExpenseReportHeader, ExpenseReportHeader.Status::Approved, ApproverExpenseUserNo, ExpenseUser."User Id For Approvals");
         LogExpenseReportApproved(ExpenseReportHeader, ApproverExpenseUserNo);
+    end;
+
+    internal procedure AssignInterimApprover(var ExpenseReportHeader: Record "Expense Report Header"; NewApproverExpenseUserNo: Code[20]; ActorExpenseUserNo: Code[20])
+    var
+        InterimApprover: Record "Expense User";
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        ExpenseAgentSetup.GetRecordOnce();
+        if not ExpenseAgentSetup."Enable Agent" then
+            Error(InterimApproverAgentRequiredErr, ExpenseAgentSetup.TableCaption());
+
+        if ExpenseReportHeader.Status <> ExpenseReportHeader.Status::"Pending Approval" then
+            Error(InterimApproverStatusErr, Format(ExpenseReportHeader.Status::"Pending Approval"));
+
+        if NewApproverExpenseUserNo = '' then
+            Error(InterimApproverRequiredErr);
+
+        if NewApproverExpenseUserNo = ExpenseReportHeader."Expense User No." then
+            Error(InterimApproverConflictErr, ExpenseReportHeader.FieldCaption("Interim Approver No."), ExpenseReportHeader.FieldCaption("Expense User No."), ExpenseReportHeader."Expense User No.");
+
+        if NewApproverExpenseUserNo = ExpenseReportHeader."Final Approver No." then
+            Error(InterimApproverConflictErr, ExpenseReportHeader.FieldCaption("Interim Approver No."), ExpenseReportHeader.FieldCaption("Final Approver No."), ExpenseReportHeader."Final Approver No.");
+
+        InterimApprover.Get(NewApproverExpenseUserNo);
+        CheckApproverPermissions(InterimApprover);
+
+        SetInterimApproverInExpenseReport(ExpenseReportHeader, InterimApprover);
+        LogInterimApproverAssigned(ExpenseReportHeader, InterimApprover, ActorExpenseUserNo);
+    end;
+
+    local procedure SetInterimApproverInExpenseReport(var ExpenseReportHeader: Record "Expense Report Header"; InterimApprover: Record "Expense User")
+    begin
+        ExpenseReportHeader."Interim Approver No." := InterimApprover."No.";
+        ExpenseReportHeader."Approver Expense User No." := InterimApprover."No.";
+        ExpenseReportHeader."Approver Expense User ID" := InterimApprover."User Id For Approvals";
+        ExpenseReportHeader.Modify(true);
+    end;
+
+    local procedure LogInterimApproverAssigned(ExpenseReportHeader: Record "Expense Report Header"; InterimApprover: Record "Expense User"; ActorExpenseUserNo: Code[20])
+    var
+        ExpenseActivityLogMgt: Codeunit "Expense Activity Log Mgt.";
+        LogComment: Text;
+    begin
+        LogComment := StrSubstNo(InterimApproverAssignedCommentTxt, InterimApprover."No.", InterimApprover.Name);
+        if ActorExpenseUserNo <> '' then
+            LogExpenseReportEvent(
+                ExpenseReportHeader,
+                Enum::"Expense Activity Event Type"::InterimApproverAssigned,
+                Enum::"Expense Activity Actor Role"::Submitter,
+                ActorExpenseUserNo,
+                LogComment)
+        else
+            ExpenseActivityLogMgt.LogExpenseReportEventByBCUser(
+                ExpenseReportHeader,
+                Enum::"Expense Activity Event Type"::InterimApproverAssigned,
+                Enum::"Expense Activity Actor Role"::Submitter,
+                LogComment);
+    end;
+
+    // Restarts the two-stage flow at a still-assigned interim on resubmit or reopen (no-op when no interim is set).
+    local procedure RouteToInterimIfAssigned(var ExpenseReportHeader: Record "Expense Report Header")
+    var
+        InterimApprover: Record "Expense User";
+    begin
+        if ExpenseReportHeader."Interim Approver No." = '' then
+            exit;
+
+        if ExpenseReportHeader."Interim Approver No." = ExpenseReportHeader."Final Approver No." then
+            exit;
+
+        InterimApprover.Get(ExpenseReportHeader."Interim Approver No.");
+        ExpenseReportHeader."Approver Expense User No." := InterimApprover."No.";
+        ExpenseReportHeader."Approver Expense User ID" := InterimApprover."User Id For Approvals";
+    end;
+
+    local procedure ShouldRouteToFinalApprover(ExpenseReportHeader: Record "Expense Report Header"): Boolean
+    begin
+        exit(
+            (ExpenseReportHeader."Interim Approver No." <> '') and
+            (ExpenseReportHeader."Approver Expense User No." = ExpenseReportHeader."Interim Approver No.") and
+            (ExpenseReportHeader."Final Approver No." <> '') and
+            (ExpenseReportHeader."Final Approver No." <> ExpenseReportHeader."Interim Approver No."));
+    end;
+
+    local procedure RouteToFinalApprover(var ExpenseReportHeader: Record "Expense Report Header"; InterimApproverExpenseUserNo: Code[20])
+    var
+        FinalApprover: Record "Expense User";
+    begin
+        FinalApprover.Get(ExpenseReportHeader."Final Approver No.");
+        ExpenseReportHeader.Status := ExpenseReportHeader.Status::"Interim Approved";
+        ExpenseReportHeader."Approver Expense User No." := FinalApprover."No.";
+        ExpenseReportHeader."Approver Expense User ID" := FinalApprover."User Id For Approvals";
+        ExpenseReportHeader.Modify(true);
+        LogInterimApproved(ExpenseReportHeader, InterimApproverExpenseUserNo);
+    end;
+
+    local procedure LogInterimApproved(ExpenseReportHeader: Record "Expense Report Header"; InterimApproverExpenseUserNo: Code[20])
+    begin
+        LogExpenseReportEvent(
+            ExpenseReportHeader,
+            Enum::"Expense Activity Event Type"::InterimApproved,
+            Enum::"Expense Activity Actor Role"::Approver,
+            InterimApproverExpenseUserNo,
+            '');
+    end;
+
+    local procedure CheckActorIsNotInterimApprover(ExpenseReportHeader: Record "Expense Report Header"; ActingApproverExpenseUserNo: Code[20])
+    begin
+        if ExpenseReportHeader.Status <> ExpenseReportHeader.Status::"Interim Approved" then
+            exit;
+
+        if ActingApproverExpenseUserNo = '' then
+            exit;
+
+        if ActingApproverExpenseUserNo = ExpenseReportHeader."Interim Approver No." then
+            Error(InterimApproverCannotFinalizeErr, ExpenseReportHeader.FieldCaption("Interim Approver No."), ExpenseReportHeader."Interim Approver No.");
     end;
 
     local procedure SetApprovalStatusInExpenseReport(var ExpenseReportHeader: Record "Expense Report Header"; ExpenseReportStatus: Enum "Expense Report Status"; ApproverExpenseUserNo: Code[20]; ApproverUserId: Code[50])

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -29,7 +29,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
         ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
         InterimApproverActorErr: Label 'Only the expense report owner %1 can assign an interim approver.', Comment = '%1 = Expense User No. of the report owner';
-        InterimApproverAssignedCommentTxt: Label 'Interim approver set to %1 (%2).', Locked = true;
+        InterimApproverAssignedCommentTxt: Label 'Interim approver set to %1 (%2).', Comment = '%1 = Interim Approver No., %2 = Interim Approver Name';
 
     procedure ProcessAction(var ExpenseReportHeader: Record "Expense Report Header"; ActionType: Enum "Expense Approval Action")
     begin

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -25,9 +25,10 @@ codeunit 6901 "Expense Report Approval Mgmt"
         InterimApproverAgentRequiredErr: Label 'An interim approver can only be assigned when the agent is enabled in %1.', Comment = '%1 = Expense Agent Setup table caption';
         InterimApproverStatusErr: Label 'You can only assign an interim approver while the expense report is %1.', Comment = '%1 = Pending Approval status caption';
         InterimApproverRequiredErr: Label 'Select an interim approver from the available approvers.';
-        InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 %3.', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
+        InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 (value: %3).', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
         InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
         ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
+        InterimApproverActorErr: Label 'Only the expense report owner %1 can assign an interim approver.', Comment = '%1 = Expense User No. of the report owner';
         InterimApproverAssignedCommentTxt: Label 'Interim approver set to %1 (%2).', Locked = true;
 
     procedure ProcessAction(var ExpenseReportHeader: Record "Expense Report Header"; ActionType: Enum "Expense Approval Action")
@@ -88,6 +89,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ExpenseReportHeader.TestApprovalStatus();
 
         ExpenseReportHeader.UpdateApproverID();
+        ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
+        RouteToInterimIfAssigned(ExpenseReportHeader);
 
         SetApprovalStatusToPendingApprovalInExpenseReport(ExpenseReportHeader, ExpenseUser."No.", ExpenseUser."User Id For Approvals");
         LogExpenseReportSubmission(ExpenseReportHeader, ExpenseUser."No.", IsResubmission);
@@ -265,6 +268,9 @@ codeunit 6901 "Expense Report Approval Mgmt"
         if NewApproverExpenseUserNo = ExpenseReportHeader."Final Approver No." then
             Error(InterimApproverConflictErr, ExpenseReportHeader.FieldCaption("Interim Approver No."), ExpenseReportHeader.FieldCaption("Final Approver No."), ExpenseReportHeader."Final Approver No.");
 
+        if (ActorExpenseUserNo <> '') and (ActorExpenseUserNo <> ExpenseReportHeader."Expense User No.") then
+            Error(InterimApproverActorErr, ExpenseReportHeader."Expense User No.");
+
         InterimApprover.Get(NewApproverExpenseUserNo);
         CheckApproverPermissions(InterimApprover);
 
@@ -301,6 +307,11 @@ codeunit 6901 "Expense Report Approval Mgmt"
                 LogComment);
     end;
 
+    local procedure IsApproverEligible(ExpenseUser: Record "Expense User"): Boolean
+    begin
+        exit(ExpenseUser."Can Approve" and (ExpenseUser."User Id For Approvals" <> ''));
+    end;
+
     // Restarts the two-stage flow at a still-assigned interim on resubmit or reopen (no-op when no interim is set).
     local procedure RouteToInterimIfAssigned(var ExpenseReportHeader: Record "Expense Report Header")
     var
@@ -313,6 +324,9 @@ codeunit 6901 "Expense Report Approval Mgmt"
             exit;
 
         InterimApprover.Get(ExpenseReportHeader."Interim Approver No.");
+        if not IsApproverEligible(InterimApprover) then
+            exit; // interim no longer qualifies; leave the final approver as the active approver
+
         ExpenseReportHeader."Approver Expense User No." := InterimApprover."No.";
         ExpenseReportHeader."Approver Expense User ID" := InterimApprover."User Id For Approvals";
     end;
@@ -331,6 +345,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         FinalApprover: Record "Expense User";
     begin
         FinalApprover.Get(ExpenseReportHeader."Final Approver No.");
+        CheckApproverPermissions(FinalApprover);
         ExpenseReportHeader.Status := ExpenseReportHeader.Status::"Interim Approved";
         ExpenseReportHeader."Approver Expense User No." := FinalApprover."No.";
         ExpenseReportHeader."Approver Expense User ID" := FinalApprover."User Id For Approvals";

--- a/src/Apps/W1/ExpenseAgent/app/src/Common/Enums/ExpenseReportStatus.Enum.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Common/Enums/ExpenseReportStatus.Enum.al
@@ -16,4 +16,5 @@ enum 6910 "Expense Report Status"
     value(4; Rejected) { Caption = 'Rejected'; }
     value(5; "Processed for Payment") { Caption = 'Processed for Payment'; }
     value(6; Completed) { Caption = 'Completed'; }
+    value(7; "Interim Approved") { Caption = 'Interim Approved'; }
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Expense/Pages/AccountantExpenseReports.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Expense/Pages/AccountantExpenseReports.Page.al
@@ -128,7 +128,7 @@ page 7091 "Accountant Expense Reports"
                     Caption = 'Approve';
                     Image = Approve;
                     ToolTip = 'Approve the selected expense report.';
-                    Enabled = Rec.Status = Rec.Status::"Pending Approval";
+                    Enabled = (Rec.Status = Rec.Status::"Pending Approval") or (Rec.Status = Rec.Status::"Interim Approved");
 
                     trigger OnAction()
                     var
@@ -145,7 +145,7 @@ page 7091 "Accountant Expense Reports"
                     Caption = 'Reject';
                     Image = Reject;
                     ToolTip = 'Reject the selected expense report.';
-                    Enabled = Rec.Status = Rec.Status::"Pending Approval";
+                    Enabled = (Rec.Status = Rec.Status::"Pending Approval") or (Rec.Status = Rec.Status::"Interim Approved");
 
                     trigger OnAction()
                     var
@@ -253,6 +253,8 @@ page 7091 "Accountant Expense Reports"
             Rec.Status::Released:
                 StatusStyleExpr := 'Favorable';
             Rec.Status::"Pending Approval":
+                StatusStyleExpr := 'Attention';
+            Rec.Status::"Interim Approved":
                 StatusStyleExpr := 'Attention';
             Rec.Status::Approved:
                 StatusStyleExpr := 'Strong';

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Codeunits/ReleaseExpReportDocument.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Codeunits/ReleaseExpReportDocument.Codeunit.al
@@ -142,7 +142,7 @@ codeunit 6984 "Release Exp. Report Document"
 
     local procedure CheckReopenStatus(ExpReportHeader: Record "Expense Report Header")
     begin
-        if ExpReportHeader.Status = ExpReportHeader.Status::"Pending Approval" then
+        if ExpReportHeader.Status in [ExpReportHeader.Status::"Pending Approval", ExpReportHeader.Status::"Interim Approved"] then
             Error(ApprovalProcessMustBeCancelledErr);
     end;
 
@@ -222,7 +222,7 @@ codeunit 6984 "Release Exp. Report Document"
     var
         ExpenseReportLine: Record "Expense Report Line";
     begin
-        ExpReportHeader.TestField(Status, ExpReportHeader.Status::"Pending Approval");
+        ExpReportHeader.TestApprovalPending();
         ExpReportHeader.TestField("Expense User No.");
 
         CheckExpenseReportLines(ExpenseReportLine, ExpReportHeader);
@@ -253,7 +253,7 @@ codeunit 6984 "Release Exp. Report Document"
 
     local procedure CheckRejectedStatus(var ExpReportHeader: Record "Expense Report Header")
     begin
-        ExpReportHeader.TestField(Status, ExpReportHeader.Status::"Pending Approval");
+        ExpReportHeader.TestApprovalPending();
         ExpReportHeader.TestField("Expense User No.");
     end;
 

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
@@ -646,6 +646,9 @@ page 6910 "Expense Report"
                 actionref(ReopenSubmitted_Promoted; ReopenSubmitted)
                 {
                 }
+                actionref(AssignInterimApprover_Promoted; "Assign Interim Approver")
+                {
+                }
             }
             group(Category_Expense)
             {

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
@@ -121,6 +121,22 @@ page 6910 "Expense Report"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+                field("Final Approver No."; Rec."Final Approver No.")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies the final approver for the expense report, prepopulated from the expense user''s approver.';
+                    Importance = Additional;
+                    Editable = false;
+                    Visible = AgentEnabled;
+                }
+                field("Interim Approver No."; Rec."Interim Approver No.")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies the optional interim approver who approves before the final approver.';
+                    Importance = Additional;
+                    Editable = false;
+                    Visible = AgentEnabled;
+                }
                 group("Approver Comment")
                 {
                     Caption = 'Approver Comment';
@@ -436,6 +452,20 @@ page 6910 "Expense Report"
                         ReopenSubmittedExpenseReport();
                     end;
                 }
+                action("Assign Interim Approver")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Assign Interim Approver';
+                    Image = UserSetup;
+                    ToolTip = 'Assign an optional interim approver who approves before the final approver.';
+                    Visible = AgentEnabled;
+                    Enabled = Rec.Status = Rec.Status::"Pending Approval";
+
+                    trigger OnAction()
+                    begin
+                        AssignInterimApproverExpenseReport();
+                    end;
+                }
             }
         }
         area(Navigation)
@@ -693,6 +723,7 @@ page 6910 "Expense Report"
         ApproverComment: Text;
         AllowVATReclaim: Boolean;
         ApprovalActionsEnabled: Boolean;
+        AgentEnabled: Boolean;
 
     protected var
         SubmitEnabled: Boolean;
@@ -711,6 +742,7 @@ page 6910 "Expense Report"
 
         ExpenseAgentSetup.GetRecordOnce();
         AllowVATReclaim := ExpenseAgentSetup."Allow VAT Reclaim";
+        AgentEnabled := ExpenseAgentSetup."Enable Agent";
         ApprovalActionsEnabled := ExpenseAgentSetup."Enable Agent" and ApproveEnabled and (Rec."Approver Expense User ID" = UserId());
     end;
 
@@ -754,6 +786,24 @@ page 6910 "Expense Report"
     begin
         if ExpenseReportApprovalMgt.ConfirmAction(RefActionType::"Reopen Submitted") then
             Process(RefActionType::"Reopen Submitted");
+    end;
+
+    local procedure AssignInterimApproverExpenseReport()
+    var
+        ExpenseUserInterimApprover: Record "Expense User";
+        ExpenseUsers: Page "Expense Users";
+    begin
+        ExpenseUserInterimApprover.SetRange("Can Approve", true);
+        ExpenseUserInterimApprover.SetFilter("No.", '<>%1', Rec."Expense User No.");
+
+        ExpenseUsers.LookupMode(true);
+        ExpenseUsers.SetTableView(ExpenseUserInterimApprover);
+        if ExpenseUsers.RunModal() <> Action::LookupOK then
+            exit;
+
+        ExpenseUsers.GetRecord(ExpenseUserInterimApprover);
+        Rec.AssignInterimApprover(ExpenseUserInterimApprover."No.");
+        CurrPage.Update(false);
     end;
 
     local procedure ProcessApprovalAction(ActionType: Enum "Expense Approval Action")

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
@@ -70,6 +70,8 @@ table 6906 "Expense Report Header"
                     Rec.Validate("Approver Expense User No.", '');
                     Rec.Validate("Approver Expense User ID", '');
                     Rec.Validate("Spend Request No.", '');
+                    Rec."Final Approver No." := GetFinalApproverNo(Rec."Expense User No.");
+                    Rec."Interim Approver No." := '';
                 end;
 
                 Rec.CreateDimFromDefaultDim(Rec.FieldNo("Expense User No."));
@@ -503,6 +505,38 @@ table 6906 "Expense Report Header"
             CalcFormula = sum("Expense Report Line VAT Spec."."Reclaim VAT Amount (LCY)" where("Document No." = field("No."), "Reclaim Status" = const(Approved)));
             ToolTip = 'Specifies the total VAT amount approved for reclaim across all VAT specification lines of this expense report, in local currency.';
         }
+        field(68; "Final Approver No."; Code[20])
+        {
+            Caption = 'Final Approver No.';
+            ToolTip = 'Specifies the expense user who gives final approval. Prepopulated from the expense user''s approver.';
+            DataClassification = EndUserIdentifiableInformation;
+            Editable = false;
+            TableRelation = "Expense User"."No." where("Can Approve" = const(true));
+        }
+        field(69; "Final Approver Name"; Text[100])
+        {
+            Caption = 'Final Approver Name';
+            ToolTip = 'Specifies the name of the final approver.';
+            Editable = false;
+            FieldClass = FlowField;
+            CalcFormula = lookup("Expense User".Name where("No." = field("Final Approver No.")));
+        }
+        field(70; "Interim Approver No."; Code[20])
+        {
+            Caption = 'Interim Approver No.';
+            ToolTip = 'Specifies an optional interim approver who must approve before the final approver.';
+            DataClassification = EndUserIdentifiableInformation;
+            Editable = false;
+            TableRelation = "Expense User"."No." where("Can Approve" = const(true));
+        }
+        field(71; "Interim Approver Name"; Text[100])
+        {
+            Caption = 'Interim Approver Name';
+            ToolTip = 'Specifies the name of the interim approver.';
+            Editable = false;
+            FieldClass = FlowField;
+            CalcFormula = lookup("Expense User".Name where("No." = field("Interim Approver No.")));
+        }
         field(100; "Spend Request No."; Code[20])
         {
             Caption = 'Spend Request No.';
@@ -609,6 +643,7 @@ table 6906 "Expense Report Header"
         DimChangeQst: Label 'You may have changed a dimension.\\Do you want to update the lines?';
         DoYouWantToKeepExistingDimensionsQst: Label 'This will change the dimension specified on the document. Do you want to recalculate/update dimensions?';
         InvalidApprovalStatusErr: Label 'Status must be Released or Rejected for Expense Report No. %1.', Comment = '%1 - Expense Report No.';
+        NotPendingApprovalErr: Label 'Status must be Pending Approval or Interim Approved for Expense Report No. %1.', Comment = '%1 - Expense Report No.';
         ExpenseUserIsConfiguredForDifferentEmployeeWhenApprovalIsEnabledErr: Label '%1 must be %2 to select this %3 %4.', Comment = '%1 = Field Caption, %2 = User Id, %3 = Table Caption, %4 = Field Value';
         ExpenseApprovalSetupNotExistErr: Label '%1 does not exist for %2 %3.', Comment = '%1 = Table Caption, %2 = Field Caption, %3 = Field Value';
         ExpenseUserSetupNotExistErr: Label '%1 does not exist for %2.', Comment = '%1 = Table Caption, %2 = Field Value';
@@ -1161,6 +1196,41 @@ table 6906 "Expense Report Header"
     begin
         if not (Rec.Status in [Rec.Status::Released, Rec.Status::Rejected]) then
             Error(InvalidApprovalStatusErr, Rec."No.");
+    end;
+
+    internal procedure TestApprovalPending()
+    begin
+        if not (Rec.Status in [Rec.Status::"Pending Approval", Rec.Status::"Interim Approved"]) then
+            Error(NotPendingApprovalErr, Rec."No.");
+    end;
+
+    /// <summary>
+    /// Assigns an optional interim approver who must approve before the final approver.
+    /// </summary>
+    procedure AssignInterimApprover(NewApproverExpenseUserNo: Code[20])
+    begin
+        AssignInterimApprover(NewApproverExpenseUserNo, '');
+    end;
+
+    internal procedure AssignInterimApprover(NewApproverExpenseUserNo: Code[20]; ActorExpenseUserNo: Code[20])
+    var
+        ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
+    begin
+        ExpenseReportApprovalMgmt.AssignInterimApprover(Rec, NewApproverExpenseUserNo, ActorExpenseUserNo);
+    end;
+
+    local procedure GetFinalApproverNo(ExpenseUserNo: Code[20]): Code[20]
+    var
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+    begin
+        if ExpenseUserNo = '' then
+            exit('');
+
+        if ExpenseApprovalSetup.Get(ExpenseUserNo) and (ExpenseApprovalSetup."Approver No." <> '') then
+            exit(ExpenseApprovalSetup."Approver No.");
+
+        ExpenseAgentSetup.GetRecordOnce();
+        exit(ExpenseAgentSetup."Default Approver No.");
     end;
 
     local procedure GetExpenseApproverUser(var ExpenseUser: Record "Expense User")

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
@@ -1,0 +1,526 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Test.ExpenseAgent;
+
+using Microsoft.ExpenseAgent;
+using Microsoft.HumanResources.Employee;
+using System.Security.AccessControl;
+using System.Security.User;
+using System.TestLibraries.Environment;
+using System.TestLibraries.Utilities;
+
+codeunit 148346 "Expense Interim Approval Test"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    TestPermissions = Disabled;
+
+    trigger OnRun()
+    begin
+        // [FEATURE] [Approval] [Interim Approval] [Expense Report]
+    end;
+
+    var
+        Assert: Codeunit Assert;
+        LibraryExpense: Codeunit "Library - Expense";
+        LibraryRandom: Codeunit "Library - Random";
+        LibraryWorkflow: Codeunit "Library - Workflow";
+        LibraryJobQueue: Codeunit "Library - Job Queue";
+        LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        LibraryDocumentApprovals: Codeunit "Library - Document Approvals";
+        ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
+        IsInitialized: Boolean;
+        InterimApproverAgentRequiredErr: Label 'An interim approver can only be assigned when the agent is enabled in %1.', Comment = '%1 = Expense Agent Setup table caption';
+        InterimApproverStatusErr: Label 'You can only assign an interim approver while the expense report is %1.', Comment = '%1 = Pending Approval status caption';
+        InterimApproverRequiredErr: Label 'Select an interim approver from the available approvers.';
+        InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 %3.', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
+        InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure FinalApproverPrepopulatedFromExpenseUser()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] The Final Approver is prepopulated on the expense report header from the expense user's approver.
+        Initialize();
+
+        // [GIVEN] Agent is enabled and a submitter whose designated approver is the final approver.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+
+        // [WHEN] An expense report is created for the submitter.
+        CreateAndReleaseExpenseReport(Submitter, ExpenseReportHeader);
+
+        // [THEN] The Final Approver No. is prepopulated with the submitter's approver and no interim approver is set.
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        ExpenseReportHeader.TestField("Final Approver No.", FinalApprover."No.");
+        ExpenseReportHeader.TestField("Interim Approver No.", '');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverRoutesReportThroughFinalApprover()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] With an interim approver assigned, the report goes Pending Approval -> Interim Approved -> Approved.
+        Initialize();
+
+        // [GIVEN] Agent is enabled, a submitter, an interim and a final approver, and a submitted expense report.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+
+        // [THEN] The report is Pending Approval with the final approver as active approver.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Pending Approval");
+        VerifyActiveApprover(ExpenseReportHeader, FinalApprover);
+
+        // [WHEN] The submitter assigns an interim approver.
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [THEN] The interim approver becomes the active approver, status stays Pending Approval.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Pending Approval");
+        VerifyInterimApprover(ExpenseReportHeader, InterimApprover."No.");
+        VerifyActiveApprover(ExpenseReportHeader, InterimApprover);
+
+        // [WHEN] The interim approver approves.
+        ExpenseReportHeader.PerformManualApproved(InterimApprover."No.", true);
+
+        // [THEN] The report moves to Interim Approved and is routed to the final approver.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Interim Approved");
+        VerifyActiveApprover(ExpenseReportHeader, FinalApprover);
+
+        // [WHEN] The final approver approves.
+        ExpenseReportHeader.PerformManualApproved(FinalApprover."No.", true);
+
+        // [THEN] The report is Approved.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Approved);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ReportWithoutInterimGoesStraightToApproved()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] Without an interim approver, the report goes Pending Approval -> Approved in a single step.
+        Initialize();
+
+        // [GIVEN] Agent is enabled and a submitted expense report with no interim approver.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Pending Approval");
+
+        // [WHEN] The final approver approves.
+        ExpenseReportHeader.PerformManualApproved(FinalApprover."No.", true);
+
+        // [THEN] The report is Approved without passing through Interim Approved.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Approved);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure AssignInterimApproverRequiresApprover()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] Assigning a blank interim approver is rejected.
+        Initialize();
+
+        // [GIVEN] Agent is enabled and a submitted expense report.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+
+        // [WHEN] A blank interim approver is assigned.
+        asserterror ExpenseReportHeader.AssignInterimApprover('', Submitter."No.");
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(InterimApproverRequiredErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverCannotBeSubmitter()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] The interim approver cannot be the same as the expense user (submitter).
+        Initialize();
+
+        // [GIVEN] Agent is enabled and a submitted expense report.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+
+        // [WHEN] The submitter is assigned as interim approver.
+        asserterror ExpenseReportHeader.AssignInterimApprover(Submitter."No.", Submitter."No.");
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(
+            StrSubstNo(
+                InterimApproverConflictErr,
+                ExpenseReportHeader.FieldCaption("Interim Approver No."),
+                ExpenseReportHeader.FieldCaption("Expense User No."),
+                ExpenseReportHeader."Expense User No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverCannotBeFinalApprover()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] The interim approver cannot be the same as the final approver.
+        Initialize();
+
+        // [GIVEN] Agent is enabled and a submitted expense report.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+
+        // [WHEN] The final approver is assigned as interim approver.
+        asserterror ExpenseReportHeader.AssignInterimApprover(FinalApprover."No.", Submitter."No.");
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(
+            StrSubstNo(
+                InterimApproverConflictErr,
+                ExpenseReportHeader.FieldCaption("Interim Approver No."),
+                ExpenseReportHeader.FieldCaption("Final Approver No."),
+                ExpenseReportHeader."Final Approver No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure AssignInterimApproverRequiresAgentEnabled()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] An interim approver can only be assigned when the agent is enabled.
+        Initialize();
+
+        // [GIVEN] A submitted expense report created while agent was enabled.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+
+        // [GIVEN] Agent is disabled.
+        EnableAgent(false);
+
+        // [WHEN] An interim approver is assigned.
+        asserterror ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(StrSubstNo(InterimApproverAgentRequiredErr, ExpenseAgentSetup.TableCaption()));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure AssignInterimApproverRequiresPendingApproval()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] An interim approver can only be assigned while the report is Pending Approval.
+        Initialize();
+
+        // [GIVEN] Agent is enabled and a released (not submitted) expense report.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateAndReleaseExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+
+        // [WHEN] An interim approver is assigned before submission.
+        asserterror ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(StrSubstNo(InterimApproverStatusErr, Format(ExpenseReportHeader.Status::"Pending Approval")));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverCannotGiveFinalApproval()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] The interim approver cannot complete the final approval of a report they already interim-approved.
+        Initialize();
+
+        // [GIVEN] A report that has been interim approved and is now routed to the final approver.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+        ExpenseReportHeader.PerformManualApproved(InterimApprover."No.", true);
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Interim Approved");
+
+        // [WHEN] The interim approver tries to give the final approval.
+        asserterror ExpenseReportHeader.PerformManualApproved(InterimApprover."No.", true);
+
+        // [THEN] An error is raised.
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        Assert.ExpectedError(
+            StrSubstNo(
+                InterimApproverCannotFinalizeErr,
+                ExpenseReportHeader.FieldCaption("Interim Approver No."),
+                ExpenseReportHeader."Interim Approver No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ResubmitAfterRejectRoutesBackToInterim()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] After an interim approver rejects, resubmitting routes the report back to the interim approver.
+        Initialize();
+
+        // [GIVEN] A submitted report with an interim approver assigned.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [WHEN] The interim approver rejects the report.
+        ExpenseReportHeader.PerformManualRejected(InterimApprover."No.", 'Rejected by interim approver.');
+
+        // [THEN] The report is Rejected.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Rejected);
+
+        // [WHEN] The report is resubmitted.
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is Pending Approval again and routed back to the interim approver.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Pending Approval");
+        VerifyInterimApprover(ExpenseReportHeader, InterimApprover."No.");
+        VerifyActiveApprover(ExpenseReportHeader, InterimApprover);
+    end;
+
+    local procedure Initialize()
+    var
+        UserSetup: Record "User Setup";
+        User: Record User;
+        LibraryERMCountryData: Codeunit "Library - ERM Country Data";
+    begin
+        LibraryTestInitialize.OnTestInitialize(Codeunit::"Expense Interim Approval Test");
+        LibraryVariableStorage.Clear();
+        EnableSaaS(false);
+        LibraryERMCountryData.CreateVATData();
+        LibraryERMCountryData.UpdateGeneralPostingSetup();
+        LibraryERMCountryData.UpdateVATPostingSetup();
+        LibraryERMCountryData.UpdateJournalTemplMandatory(false);
+        LibraryExpense.SetupNumberSeriesInExpenseMgmt();
+        LibraryExpense.InitializeExpenseSourceCode();
+        LibraryExpense.UpdateUseRulesInAgentSetup(true);
+        LibraryExpense.CleanUpBeforeTesting();
+        LibraryExpense.CleanTransactionalData();
+        LibraryWorkflow.DisableAllWorkflows();
+        UserSetup.DeleteAll();
+        // Remove test-created users to stay within the CI license user cap; keep the current session user.
+        User.SetFilter("User Security ID", '<>%1', UserSecurityId());
+        User.DeleteAll();
+        if IsInitialized then
+            exit;
+
+        LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Expense Interim Approval Test");
+        IsInitialized := true;
+        BindSubscription(LibraryJobQueue);
+        LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"Expense Interim Approval Test");
+    end;
+
+    local procedure CreateInterimApprovalSetup(var Submitter: Record "Expense User"; var InterimApprover: Record "Expense User"; var FinalApprover: Record "Expense User")
+    var
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+    begin
+        CreateSubmitterExpenseUser(Submitter);
+        CreateApproverExpenseUser(InterimApprover);
+        CreateApproverExpenseUser(FinalApprover);
+        // The submitter's designated approver is the final approver, so the Final Approver No. prepopulates to it.
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Submitter."No.", FinalApprover."No.");
+    end;
+
+    local procedure CreateSubmitterExpenseUser(var ExpenseUser: Record "Expense User")
+    var
+        UserSetup: Record "User Setup";
+        UserEmail: Text[80];
+    begin
+        LibraryDocumentApprovals.CreateMockupUserSetup(UserSetup);
+        UserEmail := GenerateUniqueEmail();
+        CreateAndUpdateUserWithEmail(UserSetup."User ID", UserEmail);
+
+        LibraryExpense.CreateExpenseUser(ExpenseUser);
+        ExpenseUser.Validate("E-mail", UserEmail);
+        ExpenseUser.Validate("Entra Id", CreateGuid());
+        ExpenseUser.Modify();
+    end;
+
+    local procedure CreateApproverExpenseUser(var ExpenseUser: Record "Expense User")
+    var
+        UserSetup: Record "User Setup";
+        UserEmail: Text[80];
+    begin
+        LibraryDocumentApprovals.CreateMockupUserSetup(UserSetup);
+        UserEmail := GenerateUniqueEmail();
+        CreateAndUpdateUserWithEmail(UserSetup."User ID", UserEmail);
+
+        LibraryExpense.CreateExpenseUser(ExpenseUser);
+        ExpenseUser.Validate("E-mail", UserEmail);
+        ExpenseUser.Validate("Can Approve", true);
+        ExpenseUser.Validate("Entra Id", CreateGuid());
+        ExpenseUser.Modify();
+    end;
+
+    local procedure CreateSubmittedExpenseReport(Submitter: Record "Expense User"; var ExpenseReportHeader: Record "Expense Report Header")
+    begin
+        CreateAndReleaseExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.PerformManualPendingApproval(Submitter."No.");
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+    end;
+
+    local procedure CreateAndReleaseExpenseReport(Submitter: Record "Expense User"; var ExpenseReportHeader: Record "Expense Report Header")
+    var
+        Expense: Record Expense;
+        CreateExpenseReport: Codeunit "Create Expense Report";
+        ReleaseExpenseDocument: Codeunit "Release Expense Document";
+        ReleaseExpenseReportDocument: Codeunit "Release Exp. Report Document";
+    begin
+        CreateExpense(Expense, Submitter, LibraryRandom.RandIntInRange(5000, 10000));
+        ReleaseExpenseDocument.PerformManualCheckAndRelease(Expense);
+
+        LibraryExpense.CreateExpenseReport(ExpenseReportHeader, Submitter."No.", Expense."Currency Code", Expense."VAT Bus. Posting Group");
+        CreateExpenseReport.AddExpensesToReport(ExpenseReportHeader);
+        ReleaseExpenseReportDocument.PerformManualCheckAndRelease(ExpenseReportHeader);
+    end;
+
+    local procedure CreateExpense(var Expense: Record Expense; ExpenseUser: Record "Expense User"; Amount: Decimal)
+    var
+        ExpenseCategory: Record "Expense Category";
+    begin
+        LibraryExpense.CreateExpenseCategory(ExpenseCategory, ExpenseCategory."Reimbursement Type"::"Employee Paid", ExpenseCategory."Expense Detail Required"::" ");
+        LibraryExpense.CreateExpense(Expense, ExpenseUser."No.", ExpenseCategory.Code, '', '', true, '', Amount);
+        UpdateExpenseAccountInEmployeePostingGroup(ExpenseUser, ExpenseCategory.Code);
+    end;
+
+    local procedure UpdateExpenseAccountInEmployeePostingGroup(ExpenseUser: Record "Expense User"; CategoryCode: Code[20])
+    var
+        ExpenseCategory: Record "Expense Category";
+        Employee: Record Employee;
+    begin
+        ExpenseCategory.Get(CategoryCode);
+        Employee.Get(ExpenseUser."Employee No.");
+        LibraryExpense.UpdateExpenseAccountInEmployeePostingGroup(Employee."Employee Posting Group");
+    end;
+
+    local procedure EnableAgent(Enable: Boolean)
+    var
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        ExpenseAgentSetup.GetRecordOnce();
+        ExpenseAgentSetup."Enable Agent" := Enable;
+        ExpenseAgentSetup.Modify(true);
+    end;
+
+    local procedure CreateAndUpdateUserWithEmail(UserName: Code[50]; UserEmail: Text[80])
+    var
+        User: Record User;
+    begin
+        User.SetRange("User Name", UserName);
+        if User.FindFirst() then begin
+            User."Authentication Email" := UserEmail;
+            User.Modify();
+        end else begin
+            User.Init();
+            User."User Security ID" := CreateGuid();
+            User."User Name" := UserName;
+            User."Authentication Email" := UserEmail;
+            User.Insert(true);
+        end;
+    end;
+
+    local procedure GenerateUniqueEmail(): Text[80]
+    begin
+        // A globally unique authentication email to avoid duplicate authentication email collisions across tests.
+        exit(CopyStr(DelChr(LowerCase(Format(CreateGuid())), '=', '{}-') + '@test.local', 1, 80));
+    end;
+
+    local procedure VerifyStatus(var ExpenseReportHeader: Record "Expense Report Header"; ExpectedStatus: Enum "Expense Report Status")
+    begin
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        ExpenseReportHeader.TestField(Status, ExpectedStatus);
+    end;
+
+    local procedure VerifyActiveApprover(var ExpenseReportHeader: Record "Expense Report Header"; Approver: Record "Expense User")
+    begin
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        ExpenseReportHeader.TestField("Approver Expense User No.", Approver."No.");
+        ExpenseReportHeader.TestField("Approver Expense User ID", Approver."User Id For Approvals");
+    end;
+
+    local procedure VerifyInterimApprover(var ExpenseReportHeader: Record "Expense Report Header"; ExpectedInterimNo: Code[20])
+    begin
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        ExpenseReportHeader.TestField("Interim Approver No.", ExpectedInterimNo);
+    end;
+
+    local procedure EnableSaaS(IsSaaS: Boolean)
+    var
+        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
+    begin
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(IsSaaS);
+    end;
+
+    [ModalPageHandler]
+    procedure ExpensesModalPageHandler(var Expenses: TestPage Expenses)
+    begin
+        Expenses.OK().Invoke();
+    end;
+}

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
@@ -38,6 +38,7 @@ codeunit 148346 "Expense Interim Approval Test"
         InterimApproverRequiredErr: Label 'Select an interim approver from the available approvers.';
         InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 %3.', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
         InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
+        ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
 
     [Test]
     [HandlerFunctions('ExpensesModalPageHandler')]
@@ -308,6 +309,93 @@ codeunit 148346 "Expense Interim Approval Test"
                 InterimApproverCannotFinalizeErr,
                 ExpenseReportHeader.FieldCaption("Interim Approver No."),
                 ExpenseReportHeader."Interim Approver No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverCannotRejectAfterInterimApproval()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] The interim approver cannot reject a report they already interim-approved.
+        Initialize();
+
+        // [GIVEN] A report that has been interim approved and is now routed to the final approver.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+        ExpenseReportHeader.PerformManualApproved(InterimApprover."No.", true);
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Interim Approved");
+
+        // [WHEN] The interim approver tries to reject the report.
+        asserterror ExpenseReportHeader.PerformManualRejected(InterimApprover."No.", 'Rejected by interim approver.');
+
+        // [THEN] An error is raised.
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+        Assert.ExpectedError(
+            StrSubstNo(
+                InterimApproverCannotFinalizeErr,
+                ExpenseReportHeader.FieldCaption("Interim Approver No."),
+                ExpenseReportHeader."Interim Approver No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure FinalApproverCannotApproveWhileInterimPending()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] While the report waits for interim approval, an approver other than the interim approver cannot approve it.
+        Initialize();
+
+        // [GIVEN] A submitted report with an interim approver assigned and awaiting interim approval.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+        VerifyActiveApprover(ExpenseReportHeader, InterimApprover);
+
+        // [WHEN] The final approver tries to approve before the interim approver has acted.
+        asserterror ExpenseReportHeader.PerformManualApproved(FinalApprover."No.", true);
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(StrSubstNo(ActorNotActiveApproverErr, InterimApprover."No."));
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure FinalApproverCannotRejectWhileInterimPending()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 638097] While the report waits for interim approval, an approver other than the interim approver cannot reject it.
+        Initialize();
+
+        // [GIVEN] A submitted report with an interim approver assigned and awaiting interim approval.
+        EnableAgent(true);
+        CreateInterimApprovalSetup(Submitter, InterimApprover, FinalApprover);
+        CreateSubmittedExpenseReport(Submitter, ExpenseReportHeader);
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+        VerifyActiveApprover(ExpenseReportHeader, InterimApprover);
+
+        // [WHEN] The final approver tries to reject before the interim approver has acted.
+        asserterror ExpenseReportHeader.PerformManualRejected(FinalApprover."No.", 'Rejected by final approver.');
+
+        // [THEN] An error is raised.
+        Assert.ExpectedError(StrSubstNo(ActorNotActiveApproverErr, InterimApprover."No."));
     end;
 
     [Test]

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
@@ -36,7 +36,7 @@ codeunit 148346 "Expense Interim Approval Test"
         InterimApproverAgentRequiredErr: Label 'An interim approver can only be assigned when the agent is enabled in %1.', Comment = '%1 = Expense Agent Setup table caption';
         InterimApproverStatusErr: Label 'You can only assign an interim approver while the expense report is %1.', Comment = '%1 = Pending Approval status caption';
         InterimApproverRequiredErr: Label 'Select an interim approver from the available approvers.';
-        InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 %3.', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
+        InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 (value: %3).', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
         InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
         ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
 


### PR DESCRIPTION
the backport description (Description + Fixes [AB#647874](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647874) + Backport/cherry-pick SHAs), mirroring #10643



