### PR TITLE
Temporarily suppress AS0072 (ObsoleteTag 29.0) on 10 Base App elements for v30 prep

### DIFF
--- a/src/Apps/DE/EDocumentDE/app/src/EDocumentServiceDE.TableExt.al
+++ b/src/Apps/DE/EDocumentDE/app/src/EDocumentServiceDE.TableExt.al
@@ -24,7 +24,9 @@ tableextension 13915 "E-Document Service DE" extends "E-Document Service"
             ObsoleteState = Pending;
 #endif
             ObsoleteReason = 'Buyer Reference is resolved automatically via priority chain: Document field > Customer E-Invoice Routing No. > Your Reference.';
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
         }
 #pragma warning restore AL0432
 #pragma warning restore AS0105

--- a/src/Apps/W1/EDocument/App/src/Logging/EDocumentLog.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Logging/EDocumentLog.Table.al
@@ -58,7 +58,9 @@ table 6124 "E-Document Log"
             ObsoleteReason = 'Replaced by Service Integration V2.';
 #if CLEAN26
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '26.0';
@@ -114,7 +116,9 @@ table 6124 "E-Document Log"
             ObsoleteReason = 'Replaced by Key4.';
 #if CLEAN26
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '26.0';

--- a/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderMatch.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/OrderMatching/EDocOrderMatch.Table.al
@@ -41,7 +41,9 @@ table 6164 "E-Doc. Order Match"
             ObsoleteReason = 'This field has been replaced by the Precise Quantity field.';
 #if CLEAN26
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '26.0';

--- a/src/Apps/W1/EDocument/App/src/Service/EDocumentService.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Service/EDocumentService.Table.al
@@ -42,7 +42,9 @@ table 6103 "E-Document Service"
             ObsoleteReason = 'Use Service Integration V2 integration enum instead';
 #if CLEAN26
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '26.0';

--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Tables/ExpenseUser.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Tables/ExpenseUser.Table.al
@@ -180,7 +180,9 @@ table 6923 "Expense User"
             ObsoleteState = Pending;
 #endif
             ObsoleteReason = 'Replaced by Welcome Email Status, which also tracks queued and failed sends.';
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
         }
 #endif
         field(55; "Welcome Email Sent At"; DateTime)

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
@@ -130,7 +130,9 @@ table 6930 "Expense Agent Setup"
 #else
             ObsoleteState = Pending;
 #endif
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
             ObsoleteReason = 'This field is no longer required and will be removed in a future release.';
             ToolTip = 'Specifies how amounts are rounded: nearest, up, or down.';
         }

--- a/src/Apps/W1/SalesOrderAgent/app/src/RoleCenter/SOAKPI.Table.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/RoleCenter/SOAKPI.Table.al
@@ -23,7 +23,9 @@ table 4593 "SOA KPI"
 #else
     ObsoleteState = Removed;
     ObsoleteReason = 'Replaced by table SOA KPI Summary for multi-agent KPI tracking.';
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
     ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
 
     fields

--- a/src/Apps/W1/SalesOrderAgent/app/src/RoleCenter/SOAKPI.Table.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/RoleCenter/SOAKPI.Table.al
@@ -17,7 +17,9 @@ table 4593 "SOA KPI"
 #if not CLEAN29
     ObsoleteState = Pending;
     ObsoleteReason = 'Replaced by table SOA KPI Summary for multi-agent KPI tracking.';
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
     ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
     ObsoleteState = Removed;
     ObsoleteReason = 'Replaced by table SOA KPI Summary for multi-agent KPI tracking.';

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -901,7 +901,9 @@ table 30102 "Shpfy Shop"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Apps/W1/Subscription Billing/App/Base/Table Extensions/GeneralLedgerSetup.TableExt.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Table Extensions/GeneralLedgerSetup.TableExt.al
@@ -16,7 +16,9 @@ tableextension 8051 "General Ledger Setup" extends "General Ledger Setup"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
             DataClassification = CustomerContent;
             Caption = 'Dimension Code for Customer Subscription Contract';

--- a/src/Apps/W1/Subscription Billing/App/ContractAnalysis/SubContrAnalysisEntry.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/ContractAnalysis/SubContrAnalysisEntry.Table.al
@@ -287,7 +287,9 @@ table 8019 "Sub. Contr. Analysis Entry"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Apps/W1/Subscription Billing/App/Overdue Service Commitments/Tables/OverdueSubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Overdue Service Commitments/Tables/OverdueSubscriptionLine.Table.al
@@ -63,7 +63,9 @@ table 8007 "Overdue Subscription Line"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
             TableRelation = Item;
         }

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -587,7 +587,9 @@ table 8059 "Subscription Line"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Objects/Tables/SubscriptionHeader.Table.al
@@ -331,7 +331,9 @@ table 8057 "Subscription Header"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
 
         }

--- a/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Tables/UsageDataBilling.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Usage Based Billing/Tables/UsageDataBilling.Table.al
@@ -114,7 +114,9 @@ table 8006 "Usage Data Billing"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
             ObsoleteReason = 'No longer needed as the time component is not relevant for processing of usage data.';
         }
@@ -132,7 +134,9 @@ table 8006 "Usage Data Billing"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
             ObsoleteReason = 'No longer needed as the time component is not relevant for processing of usage data.';
         }
@@ -152,7 +156,9 @@ table 8006 "Usage Data Billing"
             ObsoleteTag = '26.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
             ObsoleteReason = 'No longer needed as the time component is not relevant for processing of usage data.';
         }

--- a/src/Apps/W1/Sustainability/app/src/ExciseTax/SustExciseJnlLine.Table.al
+++ b/src/Apps/W1/Sustainability/app/src/ExciseTax/SustExciseJnlLine.Table.al
@@ -91,7 +91,9 @@ table 6240 "Sust. Excise Jnl. Line"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
         field(9; "Account Name"; Text[100])
@@ -104,7 +106,9 @@ table 6240 "Sust. Excise Jnl. Line"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
         field(10; "Account Category"; Code[20])
@@ -118,7 +122,9 @@ table 6240 "Sust. Excise Jnl. Line"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
         field(11; "Account Subcategory"; Code[20])
@@ -131,7 +137,9 @@ table 6240 "Sust. Excise Jnl. Line"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Apps/W1/Sustainability/app/src/ExciseTax/SustExciseTaxesTransLog.Table.al
+++ b/src/Apps/W1/Sustainability/app/src/ExciseTax/SustExciseTaxesTransLog.Table.al
@@ -77,7 +77,9 @@ table 6241 "Sust. Excise Taxes Trans. Log"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
         field(17; "Account Name"; Text[100])
@@ -90,7 +92,9 @@ table 6241 "Sust. Excise Taxes Trans. Log"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
         field(18; "Account Category"; Code[20])
@@ -104,7 +108,9 @@ table 6241 "Sust. Excise Taxes Trans. Log"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
         field(19; "Account Subcategory"; Code[20])
@@ -117,7 +123,9 @@ table 6241 "Sust. Excise Taxes Trans. Log"
             ObsoleteTag = '28.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/APAC/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -347,7 +347,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/APAC/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -574,7 +574,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/BE/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/CH/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/CH/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/DACH/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/ES/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -346,7 +346,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/ES/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -574,7 +574,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/FI/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/FI/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/GB/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -348,7 +348,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/GB/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/IS/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/IS/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/IT/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/IT/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/IT/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -574,7 +574,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/NA/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/NA/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/NL/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/NL/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/NO/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/NO/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -577,7 +577,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/RU/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -353,7 +353,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/RU/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -579,7 +579,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/SE/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/BufferICInboxTransaction.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/BufferICInboxTransaction.Table.al
@@ -48,7 +48,9 @@ table 610 "Buffer IC Inbox Transaction"
             ObsoleteTag = '27.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/HandledICInboxTrans.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/HandledICInboxTrans.Table.al
@@ -51,7 +51,9 @@ table 420 "Handled IC Inbox Trans."
             ObsoleteTag = '27.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransaction.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransaction.Table.al
@@ -53,7 +53,9 @@ table 418 "IC Inbox Transaction"
             ObsoleteTag = '27.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/Outbox/HandledICOutboxTrans.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/Outbox/HandledICOutboxTrans.Table.al
@@ -56,7 +56,9 @@ table 416 "Handled IC Outbox Trans."
             ObsoleteTag = '27.0';
 #else
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/W1/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Setup/PurchasesPayablesSetup.Table.al
@@ -345,7 +345,9 @@ table 312 "Purchases & Payables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/W1/BaseApp/Sales/Reminder/Automation/History/ReminderActionLog.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/Automation/History/ReminderActionLog.Table.al
@@ -61,7 +61,9 @@ table 6752 "Reminder Action Log"
 #else
             ObsoleteState = Removed;
             ObsoleteReason = 'This field is obsolete and should not be used.';
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderAttachmentText.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderAttachmentText.Table.al
@@ -70,7 +70,9 @@ table 502 "Reminder Attachment Text"
 #else
             ObsoleteReason = 'To support the use of multiple lines, this is replaced by Reminder Attachment Text Line table.';
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif
@@ -100,7 +102,9 @@ table 502 "Reminder Attachment Text"
 #else
             ObsoleteReason = 'To support the use of multiple lines, this is replaced by Reminder Attachment Text Line table.';
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #endif
         }
 #endif

--- a/src/Layers/W1/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Setup/SalesReceivablesSetup.Table.al
@@ -573,7 +573,9 @@ table 311 "Sales & Receivables Setup"
             ObsoleteReason = 'Discontinued function';
 #if CLEAN27
             ObsoleteState = Removed;
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #else
             ObsoleteState = Pending;
             ObsoleteTag = '27.0';

--- a/src/Layers/W1/BaseApp/System/ChangeLog/ChangeLogEntry.Table.al
+++ b/src/Layers/W1/BaseApp/System/ChangeLog/ChangeLogEntry.Table.al
@@ -171,7 +171,9 @@ table 405 "Change Log Entry"
         {
             Enabled = false;
             ObsoleteReason = 'The key is disabled because Notification Message Id is not used for record retrieval.';
+#pragma warning disable AS0072 // Bug 647877: temporary v30 suppression, restore ObsoleteTag to 30.0
             ObsoleteTag = '29.0';
+#pragma warning restore AS0072
 #if not CLEAN29
             ObsoleteState = Pending;
 #else


### PR DESCRIPTION
## Context

The bump to app version 30.0 makes AppSourceCop rule **AS0072** require `ObsoleteTag = '30.0'`. Elements that still carry `ObsoleteTag = '29.0'` fail the clean compile with:

> error AS0072: The Obsolete Tag 29.0 in `<element>` is not allowed. Expected tag for this branch: 30.0.

This is a **temporary** unblock. The ObsoleteTag values are intentionally **not** changed here — the permanent remediation (restoring correct tags / obsoletion cleanup) is tracked by **ADO Bug 647877**.

[AB#646622](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646622)

## Scope

Two parts:

### 1. W1 Base Application (10 elements + country propagation)
Wrapped 10 Base App elements, then ran `Invoke-Miapp` to propagate the two country-replicated setup tables (`Purchases & Payables Setup`, `Sales & Receivables Setup`) to all country layers.

- `System/ChangeLog/ChangeLogEntry.Table.al` — key `Key4`
- `Finance/Intercompany/**` — field `Source Type` (Buffer IC Inbox, Handled IC Inbox, IC Inbox, Handled IC Outbox)
- `Purchases/Setup/PurchasesPayablesSetup.Table.al` / `Sales/Setup/SalesReceivablesSetup.Table.al` — field `Create Item from Item No.`
- `Sales/Reminder/TermsAndLevels/ReminderAttachmentText.Table.al` — fields `Beginning Line`, `Ending Line`
- `Sales/Reminder/Automation/History/ReminderActionLog.Table.al` — field `Total Errors`

### 2. W1 apps (24 locations across 6 apps)
The `(Clean)` builds also compile the pending/removed obsolete branches of elements that still carry `29.0`, failing every country clean build. Wrapped each:

- **E-Document Core** — `EDocumentService.Table.al` field `Service Integration`; `EDocumentLog.Table.al` field `Service Integration` + key `Key3`; `EDocOrderMatch.Table.al` field `Quantity`
- **Expense Agent (Preview)** — `ExpenseUser.Table.al` field `Welcome Email Sent`; `ExpenseAgentSetup.Table.al` field `Expense Report Rounding Type`
- **Sales Order Agent** — `SOAKPI.Table.al` table `SOA KPI`
- **Shopify Connector** — `ShpfyShop.Table.al` field `Items Mapped to Products`
- **Subscription Billing** — `UsageDataBilling.Table.al` fields `Charge Start Time` / `Charge End Time` / `Charged Period (Hours)`; `Item No.` in `OverdueSubscriptionLine`, `SubscriptionHeader`, `SubscriptionLine`; `SubContrAnalysisEntry.Table.al` field `Service Object Item No.`; `GeneralLedgerSetup.TableExt.al` field `Dimension Code Cust. Contr.`
- **Sustainability** — `Account No.` / `Account Name` / `Account Category` / `Account Subcategory` in both `SustExciseTaxesTransLog.Table.al` and `SustExciseJnlLine.Table.al`

Each is wrapped with `#pragma warning disable/restore AS0072 // Bug 647877 ...` around only the `ObsoleteTag = '29.0'` line, matching the repo's existing AS0074 house style. Pragmas are balanced.

## Follow-up

Revert all suppressions as part of **ADO Bug 647877** (permanent fix: restore correct `ObsoleteTag` / complete obsoletion cleanup).





