### PR TITLE
Fix decimal tax rates for Polish region

### DIFF
--- a/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TaxType/rate/codeunit/TaxSetupMatrixMgmt.Codeunit.al
+++ b/src/Apps/W1/INTaxEngine/app/TaxEngine-TaxTypeHandler/src/TaxType/rate/codeunit/TaxSetupMatrixMgmt.Codeunit.al
@@ -346,9 +346,9 @@ codeunit 20233 "Tax Setup Matrix Mgmt."
                         Evaluate(TaxRateValue."Date Value", Value);
                 TaxRateSetup.Type::Decimal:
                     if IsRange then
-                        Evaluate(TaxRateValue."Decimal Value To", Value)
+                        TaxRateValue."Decimal Value To" := ScriptDataTypeMgmt.Text2Number(Value)
                     else
-                        Evaluate(TaxRateValue."Decimal Value", Value);
+                        TaxRateValue."Decimal Value" := ScriptDataTypeMgmt.Text2Number(Value);
             end;
     end;
 
@@ -407,7 +407,7 @@ codeunit 20233 "Tax Setup Matrix Mgmt."
         case TaxRateSetup.Type of
             TaxRateSetup.Type::Decimal, TaxRateSetup.Type::Integer:
                 begin
-                    Evaluate(DecimalValue, TaxConfigurationValue.Value);
+                    DecimalValue := ScriptDataTypeMgmt.Text2Number(TaxConfigurationValue.Value);
                     if DecimalValue < 0 then
                         Error(ValueCannotBeLessThanZeroErr, TaxConfigurationValue."Column Name");
 
@@ -416,7 +416,8 @@ codeunit 20233 "Tax Setup Matrix Mgmt."
                         TaxRateSetup."Column Type"::"Range From and Range To",
                         TaxRateSetup."Column Type"::"Range To"]
                     then
-                        if Evaluate(DecimalValue2, TaxConfigurationValue."Value To") then begin
+                        if TaxConfigurationValue."Value To" <> '' then begin
+                            DecimalValue2 := ScriptDataTypeMgmt.Text2Number(TaxConfigurationValue."Value To");
                             if DecimalValue2 < 0 then
                                 Error(ValueCannotBeLessThanZeroErr, TaxConfigurationValue."Column Name");
 


### PR DESCRIPTION
[AB#647127](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647127)
[Bug 647127](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647127): [BC-IN]Value cannot be evaluated to Decimal type when Region is set to Polish in IN Localization


Issue:  
When the Business Central region is set to Polish (`pl-PL`), entering a decimal value on the Tax Rates page results in the error: `The value "10.4" can't be evaluated into type Decimal.`

Cause:  
The localized input was converted to an invariant XML value using a period as the decimal separator, such as `10.4`. The Tax Setup Matrix validation subsequently parsed this invariant value using the locale-sensitive `Evaluate` method, which expects a comma under the Polish regional format.

Solution:  
Replaced locale-sensitive decimal parsing with the existing XML-aware `ScriptDataTypeMgmt.Text2Number` method. This is now used when validating tax-rate values and updating decimal range fields, ensuring invariant XML decimal values are handled consistently across regional formats.




