### PR TITLE
[29.x] - [Bug 647893] Bug 647272: [Expense Agent] Unwanted caption in expense report FactBox

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportFactBox.Page.al
@@ -8,7 +8,7 @@ page 7098 "Expense Report FactBox"
 {
     PageType = CardPart;
     SourceTable = "Expense Report Header";
-    Caption = 'Expense Report FactBox';
+    Caption = 'Expense Report';
 
     layout
     {

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReportFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReportFactBox.Page.al
@@ -8,7 +8,7 @@ page 7094 "Posted Expense Report FactBox"
 {
     PageType = CardPart;
     SourceTable = "Posted Expense Report Header";
-    Caption = 'Posted Expense Report FactBox';
+    Caption = 'Posted Expense Report';
     Editable = false;
 
     layout


### PR DESCRIPTION
## Description
Change the Expense Report FactBox caption to `Expense Report` and the Posted Expense Report FactBox caption to `Posted Expense Report`, removing the unwanted technical caption.

Fixes [AB#647893](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647893)

## Backport
Backport of #10438 to `releases/29.x`.

Cherry-picked with `git cherry-pick -x`:
- 17a9dfbffb17166e90fef66e5fafaf9de8f2865b

Applied cleanly with no conflicts.

### Note on source PR state
The source PR #10438 was still open at the time of backporting. If it changes before merge, this backport must be refreshed.


