### PR TITLE
[29.x] Slice 425446: Payment Journal Batch Total

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -323,7 +323,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -335,7 +335,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -346,7 +346,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -357,7 +357,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2134,16 +2134,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2462,11 +2461,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -323,6 +323,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -334,6 +335,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -344,6 +346,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -354,6 +357,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -726,6 +730,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1913,6 +1931,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1995,12 +2014,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2106,7 +2128,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2425,6 +2462,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/APAC/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/APAC/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -45,6 +45,8 @@ codeunit 134920 "ERM General Journal UT"
         RecurringFrequencyNotClearedErr: Label 'The recurring frequency should be cleared.';
         YearlyRecurringFrequencyTok: Label '1Y', Locked = true;
         RecurringFrequencyNotLocalizedErr: Label 'The recurring frequency should be displayed using the localized date formula tokens.';
+        WrongBatchTotalErr: Label 'Wrong Batch Total on the Payment Journal page.';
+        BatchTotalNotShownErr: Label 'Batch Total must be shown.';
         IsInitialized: Boolean;
 
     [Test]
@@ -6297,6 +6299,177 @@ codeunit 134920 "ERM General Journal UT"
           GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), 0);
         GenJournalLine.Validate("Document No.", LibraryUtility.GenerateGUID());
         GenJournalLine.Modify(true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalShowsSumOfLineAmounts()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        ExpectedBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page shows the total amount that is selected for payment in the batch.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is the sum of "Amount (LCY)" of the three lines
+        Assert.AreEqual(ExpectedBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalIsZeroForEmptyBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is zero when the batch has no lines.
+        Initialize();
+
+        // [GIVEN] Payment journal batch without lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is 0
+        Assert.AreEqual(0, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenLineAmountIsValidated()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        InitialBatchTotal: Decimal;
+        OldAmount: Decimal;
+        NewAmount: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is recalculated when the Amount of a line is changed.
+        Initialize();
+
+        // [GIVEN] Payment Journal page opened on a batch with two payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        InitialBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+        PaymentJournal.First();
+        OldAmount := PaymentJournal.Amount.AsDecimal();
+        NewAmount := OldAmount - LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [WHEN] Amount is changed on the first line
+        PaymentJournal.Amount.SetValue(NewAmount);
+
+        // [THEN] Batch Total is updated without leaving the line
+        Assert.AreEqual(
+          InitialBatchTotal - OldAmount + NewAmount, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenBatchIsChanged()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalBatch2: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        SecondBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page only covers the lines of the selected batch.
+        Initialize();
+
+        // [GIVEN] Two payment journal batches with lines, in the same template
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch2, GenJournalTemplate.Name);
+        SecondBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch2, 3);
+
+        // [GIVEN] Payment Journal page opened on the first batch
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [WHEN] Batch Name is changed to the second batch
+        PaymentJournal.CurrentJnlBatchName.SetValue(GenJournalBatch2.Name);
+
+        // [THEN] Batch Total is the total of the second batch only
+        Assert.AreEqual(SecondBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CalcBatchTotalReturnsSumOfAmountLCYOfFilteredLines()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
+        ExpectedBatchTotal: Decimal;
+        BatchTotal: Decimal;
+        ShowBatchTotal: Boolean;
+    begin
+        // [FEATURE] [Payment] [Batch Total] [UT]
+        // [SCENARIO 425446] CalcBatchTotal returns the sum of "Amount (LCY)" of the lines that the filters apply to.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        GenJournalLine.SetRange("Journal Template Name", GenJournalBatch."Journal Template Name");
+        GenJournalLine.SetRange("Journal Batch Name", GenJournalBatch.Name);
+
+        // [WHEN] CalcBatchTotal is called for the filtered lines
+        GenJnlManagement.CalcBatchTotal(GenJournalLine, BatchTotal, ShowBatchTotal);
+
+        // [THEN] The total of the batch is returned and can be shown
+        Assert.IsTrue(ShowBatchTotal, BatchTotalNotShownErr);
+        Assert.AreEqual(ExpectedBatchTotal, BatchTotal, WrongBatchTotalErr);
+    end;
+
+    local procedure CreatePaymentJournalLines(GenJournalTemplate: Record "Gen. Journal Template"; GenJournalBatch: Record "Gen. Journal Batch"; NoOfLines: Integer) TotalAmountLCY: Decimal
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorNo: Code[20];
+        i: Integer;
+    begin
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        for i := 1 to NoOfLines do begin
+            LibraryERM.CreateGeneralJnlLine2(
+              GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, GenJournalLine."Document Type"::Payment,
+              GenJournalLine."Account Type"::Vendor, VendorNo, -LibraryRandom.RandDecInRange(100, 1000, 2));
+            TotalAmountLCY += GenJournalLine."Amount (LCY)";
+        end;
     end;
 
     local procedure Initialize()

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -306,7 +306,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -318,7 +318,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -329,7 +329,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -340,7 +340,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2234,16 +2234,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2573,11 +2572,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -306,6 +306,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -317,6 +318,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -327,6 +329,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -337,6 +340,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -680,6 +684,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -2003,6 +2021,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -2091,12 +2110,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2206,7 +2228,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2536,6 +2573,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/CH/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -45,6 +45,8 @@ codeunit 134920 "ERM General Journal UT"
         RecurringFrequencyNotClearedErr: Label 'The recurring frequency should be cleared.';
         YearlyRecurringFrequencyTok: Label '1Y', Locked = true;
         RecurringFrequencyNotLocalizedErr: Label 'The recurring frequency should be displayed using the localized date formula tokens.';
+        WrongBatchTotalErr: Label 'Wrong Batch Total on the Payment Journal page.';
+        BatchTotalNotShownErr: Label 'Batch Total must be shown.';
         IsInitialized: Boolean;
 
     [Test]
@@ -6100,6 +6102,177 @@ codeunit 134920 "ERM General Journal UT"
           GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), 0);
         GenJournalLine.Validate("Document No.", LibraryUtility.GenerateGUID());
         GenJournalLine.Modify(true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalShowsSumOfLineAmounts()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        ExpectedBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page shows the total amount that is selected for payment in the batch.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is the sum of "Amount (LCY)" of the three lines
+        Assert.AreEqual(ExpectedBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalIsZeroForEmptyBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is zero when the batch has no lines.
+        Initialize();
+
+        // [GIVEN] Payment journal batch without lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is 0
+        Assert.AreEqual(0, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenLineAmountIsValidated()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        InitialBatchTotal: Decimal;
+        OldAmount: Decimal;
+        NewAmount: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is recalculated when the Amount of a line is changed.
+        Initialize();
+
+        // [GIVEN] Payment Journal page opened on a batch with two payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        InitialBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+        PaymentJournal.First();
+        OldAmount := PaymentJournal.Amount.AsDecimal();
+        NewAmount := OldAmount - LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [WHEN] Amount is changed on the first line
+        PaymentJournal.Amount.SetValue(NewAmount);
+
+        // [THEN] Batch Total is updated without leaving the line
+        Assert.AreEqual(
+          InitialBatchTotal - OldAmount + NewAmount, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenBatchIsChanged()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalBatch2: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        SecondBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page only covers the lines of the selected batch.
+        Initialize();
+
+        // [GIVEN] Two payment journal batches with lines, in the same template
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch2, GenJournalTemplate.Name);
+        SecondBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch2, 3);
+
+        // [GIVEN] Payment Journal page opened on the first batch
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [WHEN] Batch Name is changed to the second batch
+        PaymentJournal.CurrentJnlBatchName.SetValue(GenJournalBatch2.Name);
+
+        // [THEN] Batch Total is the total of the second batch only
+        Assert.AreEqual(SecondBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CalcBatchTotalReturnsSumOfAmountLCYOfFilteredLines()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
+        ExpectedBatchTotal: Decimal;
+        BatchTotal: Decimal;
+        ShowBatchTotal: Boolean;
+    begin
+        // [FEATURE] [Payment] [Batch Total] [UT]
+        // [SCENARIO 425446] CalcBatchTotal returns the sum of "Amount (LCY)" of the lines that the filters apply to.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        GenJournalLine.SetRange("Journal Template Name", GenJournalBatch."Journal Template Name");
+        GenJournalLine.SetRange("Journal Batch Name", GenJournalBatch.Name);
+
+        // [WHEN] CalcBatchTotal is called for the filtered lines
+        GenJnlManagement.CalcBatchTotal(GenJournalLine, BatchTotal, ShowBatchTotal);
+
+        // [THEN] The total of the batch is returned and can be shown
+        Assert.IsTrue(ShowBatchTotal, BatchTotalNotShownErr);
+        Assert.AreEqual(ExpectedBatchTotal, BatchTotal, WrongBatchTotalErr);
+    end;
+
+    local procedure CreatePaymentJournalLines(GenJournalTemplate: Record "Gen. Journal Template"; GenJournalBatch: Record "Gen. Journal Batch"; NoOfLines: Integer) TotalAmountLCY: Decimal
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorNo: Code[20];
+        i: Integer;
+    begin
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        for i := 1 to NoOfLines do begin
+            LibraryERM.CreateGeneralJnlLine2(
+              GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, GenJournalLine."Document Type"::Payment,
+              GenJournalLine."Account Type"::Vendor, VendorNo, -LibraryRandom.RandDecInRange(100, 1000, 2));
+            TotalAmountLCY += GenJournalLine."Amount (LCY)";
+        end;
     end;
 
     local procedure Initialize()

--- a/src/Layers/CZ/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/CZ/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -45,6 +45,8 @@ codeunit 134920 "ERM General Journal UT"
         RecurringFrequencyNotClearedErr: Label 'The recurring frequency should be cleared.';
         YearlyRecurringFrequencyTok: Label '1Y', Locked = true;
         RecurringFrequencyNotLocalizedErr: Label 'The recurring frequency should be displayed using the localized date formula tokens.';
+        WrongBatchTotalErr: Label 'Wrong Batch Total on the Payment Journal page.';
+        BatchTotalNotShownErr: Label 'Batch Total must be shown.';
         IsInitialized: Boolean;
 
     [Test]
@@ -6296,6 +6298,177 @@ codeunit 134920 "ERM General Journal UT"
           GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), 0);
         GenJournalLine.Validate("Document No.", LibraryUtility.GenerateGUID());
         GenJournalLine.Modify(true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalShowsSumOfLineAmounts()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        ExpectedBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page shows the total amount that is selected for payment in the batch.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is the sum of "Amount (LCY)" of the three lines
+        Assert.AreEqual(ExpectedBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalIsZeroForEmptyBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is zero when the batch has no lines.
+        Initialize();
+
+        // [GIVEN] Payment journal batch without lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is 0
+        Assert.AreEqual(0, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenLineAmountIsValidated()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        InitialBatchTotal: Decimal;
+        OldAmount: Decimal;
+        NewAmount: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is recalculated when the Amount of a line is changed.
+        Initialize();
+
+        // [GIVEN] Payment Journal page opened on a batch with two payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        InitialBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+        PaymentJournal.First();
+        OldAmount := PaymentJournal.Amount.AsDecimal();
+        NewAmount := OldAmount - LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [WHEN] Amount is changed on the first line
+        PaymentJournal.Amount.SetValue(NewAmount);
+
+        // [THEN] Batch Total is updated without leaving the line
+        Assert.AreEqual(
+          InitialBatchTotal - OldAmount + NewAmount, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenBatchIsChanged()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalBatch2: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        SecondBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page only covers the lines of the selected batch.
+        Initialize();
+
+        // [GIVEN] Two payment journal batches with lines, in the same template
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch2, GenJournalTemplate.Name);
+        SecondBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch2, 3);
+
+        // [GIVEN] Payment Journal page opened on the first batch
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [WHEN] Batch Name is changed to the second batch
+        PaymentJournal.CurrentJnlBatchName.SetValue(GenJournalBatch2.Name);
+
+        // [THEN] Batch Total is the total of the second batch only
+        Assert.AreEqual(SecondBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CalcBatchTotalReturnsSumOfAmountLCYOfFilteredLines()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
+        ExpectedBatchTotal: Decimal;
+        BatchTotal: Decimal;
+        ShowBatchTotal: Boolean;
+    begin
+        // [FEATURE] [Payment] [Batch Total] [UT]
+        // [SCENARIO 425446] CalcBatchTotal returns the sum of "Amount (LCY)" of the lines that the filters apply to.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        GenJournalLine.SetRange("Journal Template Name", GenJournalBatch."Journal Template Name");
+        GenJournalLine.SetRange("Journal Batch Name", GenJournalBatch.Name);
+
+        // [WHEN] CalcBatchTotal is called for the filtered lines
+        GenJnlManagement.CalcBatchTotal(GenJournalLine, BatchTotal, ShowBatchTotal);
+
+        // [THEN] The total of the batch is returned and can be shown
+        Assert.IsTrue(ShowBatchTotal, BatchTotalNotShownErr);
+        Assert.AreEqual(ExpectedBatchTotal, BatchTotal, WrongBatchTotalErr);
+    end;
+
+    local procedure CreatePaymentJournalLines(GenJournalTemplate: Record "Gen. Journal Template"; GenJournalBatch: Record "Gen. Journal Batch"; NoOfLines: Integer) TotalAmountLCY: Decimal
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorNo: Code[20];
+        i: Integer;
+    begin
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        for i := 1 to NoOfLines do begin
+            LibraryERM.CreateGeneralJnlLine2(
+              GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, GenJournalLine."Document Type"::Payment,
+              GenJournalLine."Account Type"::Vendor, VendorNo, -LibraryRandom.RandDecInRange(100, 1000, 2));
+            TotalAmountLCY += GenJournalLine."Amount (LCY)";
+        end;
     end;
 
     local procedure Initialize()

--- a/src/Layers/DACH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/DACH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,7 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -304,7 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -315,7 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -326,7 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -1985,16 +1985,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2313,11 +2312,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/DACH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/DACH/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,6 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -303,6 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -313,6 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -323,6 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -661,6 +665,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1762,6 +1780,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1846,12 +1865,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -1957,7 +1979,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2276,6 +2313,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
@@ -617,6 +617,22 @@ codeunit 230 GenJnlManagement
         OnAfterCalcBalance(GenJnlLine);
     end;
 
+    procedure CalcBatchTotal(var GenJnlLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var ShowBatchTotal: Boolean)
+    var
+        [SecurityFiltering(SecurityFilter::Filtered)]
+        TotalGenJnlLine: Record "Gen. Journal Line";
+    begin
+        BatchTotal := 0;
+        ShowBatchTotal := not (CurrentClientType in [CLIENTTYPE::SOAP, CLIENTTYPE::OData, CLIENTTYPE::ODataV4, CLIENTTYPE::Api]);
+        if not ShowBatchTotal then
+            exit;
+
+        TotalGenJnlLine.CopyFilters(GenJnlLine);
+        OnCalcBatchTotalOnAfterCopyFilters(TotalGenJnlLine);
+        TotalGenJnlLine.CalcSums("Amount (LCY)");
+        BatchTotal := TotalGenJnlLine."Amount (LCY)";
+    end;
+
     /// <summary>
     /// Generates unique journal template names by checking for conflicts and incrementing names when needed.
     /// Ensures new template names are unique while maintaining meaningful naming based on template type.
@@ -920,6 +936,11 @@ codeunit 230 GenJnlManagement
     /// <param name="TempGenJournalLine">Temporary journal line record with copied filters that can be modified.</param>
     [IntegrationEvent(false, false)]
     local procedure OnCalcBalanceOnAfterCopyFilters(var TempGenJournalLine: Record "Gen. Journal Line" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcBatchTotalOnAfterCopyFilters(var GenJournalLine: Record "Gen. Journal Line")
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
@@ -628,7 +628,6 @@ codeunit 230 GenJnlManagement
             exit;
 
         TotalGenJnlLine.CopyFilters(GenJnlLine);
-        OnCalcBatchTotalOnAfterCopyFilters(TotalGenJnlLine);
         TotalGenJnlLine.CalcSums("Amount (LCY)");
         BatchTotal := TotalGenJnlLine."Amount (LCY)";
     end;
@@ -936,11 +935,6 @@ codeunit 230 GenJnlManagement
     /// <param name="TempGenJournalLine">Temporary journal line record with copied filters that can be modified.</param>
     [IntegrationEvent(false, false)]
     local procedure OnCalcBalanceOnAfterCopyFilters(var TempGenJournalLine: Record "Gen. Journal Line" temporary)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnCalcBatchTotalOnAfterCopyFilters(var GenJournalLine: Record "Gen. Journal Line")
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -304,7 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -316,7 +316,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -327,7 +327,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -338,7 +338,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2106,16 +2106,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2434,11 +2433,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -304,6 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -315,6 +316,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -325,6 +327,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -335,6 +338,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -751,6 +755,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1886,6 +1904,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1966,12 +1985,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2078,7 +2100,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2397,6 +2434,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/ES/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -45,6 +45,8 @@ codeunit 134920 "ERM General Journal UT"
         RecurringFrequencyNotClearedErr: Label 'The recurring frequency should be cleared.';
         YearlyRecurringFrequencyTok: Label '1Y', Locked = true;
         RecurringFrequencyNotLocalizedErr: Label 'The recurring frequency should be displayed using the localized date formula tokens.';
+        WrongBatchTotalErr: Label 'Wrong Batch Total on the Payment Journal page.';
+        BatchTotalNotShownErr: Label 'Batch Total must be shown.';
         IsInitialized: Boolean;
 
     [Test]
@@ -6325,6 +6327,177 @@ codeunit 134920 "ERM General Journal UT"
           GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), 0);
         GenJournalLine.Validate("Document No.", LibraryUtility.GenerateGUID());
         GenJournalLine.Modify(true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalShowsSumOfLineAmounts()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        ExpectedBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page shows the total amount that is selected for payment in the batch.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is the sum of "Amount (LCY)" of the three lines
+        Assert.AreEqual(ExpectedBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalIsZeroForEmptyBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is zero when the batch has no lines.
+        Initialize();
+
+        // [GIVEN] Payment journal batch without lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is 0
+        Assert.AreEqual(0, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenLineAmountIsValidated()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        InitialBatchTotal: Decimal;
+        OldAmount: Decimal;
+        NewAmount: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is recalculated when the Amount of a line is changed.
+        Initialize();
+
+        // [GIVEN] Payment Journal page opened on a batch with two payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        InitialBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+        PaymentJournal.First();
+        OldAmount := PaymentJournal.Amount.AsDecimal();
+        NewAmount := OldAmount - LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [WHEN] Amount is changed on the first line
+        PaymentJournal.Amount.SetValue(NewAmount);
+
+        // [THEN] Batch Total is updated without leaving the line
+        Assert.AreEqual(
+          InitialBatchTotal - OldAmount + NewAmount, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenBatchIsChanged()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalBatch2: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        SecondBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page only covers the lines of the selected batch.
+        Initialize();
+
+        // [GIVEN] Two payment journal batches with lines, in the same template
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch2, GenJournalTemplate.Name);
+        SecondBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch2, 3);
+
+        // [GIVEN] Payment Journal page opened on the first batch
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [WHEN] Batch Name is changed to the second batch
+        PaymentJournal.CurrentJnlBatchName.SetValue(GenJournalBatch2.Name);
+
+        // [THEN] Batch Total is the total of the second batch only
+        Assert.AreEqual(SecondBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CalcBatchTotalReturnsSumOfAmountLCYOfFilteredLines()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
+        ExpectedBatchTotal: Decimal;
+        BatchTotal: Decimal;
+        ShowBatchTotal: Boolean;
+    begin
+        // [FEATURE] [Payment] [Batch Total] [UT]
+        // [SCENARIO 425446] CalcBatchTotal returns the sum of "Amount (LCY)" of the lines that the filters apply to.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        GenJournalLine.SetRange("Journal Template Name", GenJournalBatch."Journal Template Name");
+        GenJournalLine.SetRange("Journal Batch Name", GenJournalBatch.Name);
+
+        // [WHEN] CalcBatchTotal is called for the filtered lines
+        GenJnlManagement.CalcBatchTotal(GenJournalLine, BatchTotal, ShowBatchTotal);
+
+        // [THEN] The total of the batch is returned and can be shown
+        Assert.IsTrue(ShowBatchTotal, BatchTotalNotShownErr);
+        Assert.AreEqual(ExpectedBatchTotal, BatchTotal, WrongBatchTotalErr);
+    end;
+
+    local procedure CreatePaymentJournalLines(GenJournalTemplate: Record "Gen. Journal Template"; GenJournalBatch: Record "Gen. Journal Batch"; NoOfLines: Integer) TotalAmountLCY: Decimal
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorNo: Code[20];
+        i: Integer;
+    begin
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        for i := 1 to NoOfLines do begin
+            LibraryERM.CreateGeneralJnlLine2(
+              GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, GenJournalLine."Document Type"::Payment,
+              GenJournalLine."Account Type"::Vendor, VendorNo, -LibraryRandom.RandDecInRange(100, 1000, 2));
+            TotalAmountLCY += GenJournalLine."Amount (LCY)";
+        end;
     end;
 
     local procedure Initialize()

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,7 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -304,7 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -315,7 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -326,7 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -1983,16 +1983,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2311,11 +2310,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,6 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -303,6 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -313,6 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -323,6 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -673,6 +677,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1765,6 +1783,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1844,12 +1863,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -1955,7 +1977,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2274,6 +2311,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,7 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -304,7 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -315,7 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -326,7 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2005,16 +2005,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2333,11 +2332,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/GB/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,6 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -303,6 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -313,6 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -323,6 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -661,6 +665,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1787,6 +1805,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1866,12 +1885,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -1977,7 +1999,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2296,6 +2333,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -358,7 +358,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -370,7 +370,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -381,7 +381,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -392,7 +392,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2056,16 +2056,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2384,11 +2383,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -358,6 +358,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -369,6 +370,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -379,6 +381,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -389,6 +392,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -727,6 +731,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1836,6 +1854,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1915,12 +1934,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2028,7 +2050,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2347,6 +2384,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/IT/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -45,6 +45,8 @@ codeunit 134920 "ERM General Journal UT"
         RecurringFrequencyNotClearedErr: Label 'The recurring frequency should be cleared.';
         YearlyRecurringFrequencyTok: Label '1Y', Locked = true;
         RecurringFrequencyNotLocalizedErr: Label 'The recurring frequency should be displayed using the localized date formula tokens.';
+        WrongBatchTotalErr: Label 'Wrong Batch Total on the Payment Journal page.';
+        BatchTotalNotShownErr: Label 'Batch Total must be shown.';
         IsInitialized: Boolean;
 
     [Test]
@@ -6296,6 +6298,177 @@ codeunit 134920 "ERM General Journal UT"
           GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), 0);
         GenJournalLine.Validate("Document No.", LibraryUtility.GenerateGUID());
         GenJournalLine.Modify(true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalShowsSumOfLineAmounts()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        ExpectedBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page shows the total amount that is selected for payment in the batch.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is the sum of "Amount (LCY)" of the three lines
+        Assert.AreEqual(ExpectedBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalIsZeroForEmptyBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is zero when the batch has no lines.
+        Initialize();
+
+        // [GIVEN] Payment journal batch without lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is 0
+        Assert.AreEqual(0, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenLineAmountIsValidated()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        InitialBatchTotal: Decimal;
+        OldAmount: Decimal;
+        NewAmount: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is recalculated when the Amount of a line is changed.
+        Initialize();
+
+        // [GIVEN] Payment Journal page opened on a batch with two payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        InitialBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+        PaymentJournal.First();
+        OldAmount := PaymentJournal.Amount.AsDecimal();
+        NewAmount := OldAmount - LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [WHEN] Amount is changed on the first line
+        PaymentJournal.Amount.SetValue(NewAmount);
+
+        // [THEN] Batch Total is updated without leaving the line
+        Assert.AreEqual(
+          InitialBatchTotal - OldAmount + NewAmount, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenBatchIsChanged()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalBatch2: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        SecondBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page only covers the lines of the selected batch.
+        Initialize();
+
+        // [GIVEN] Two payment journal batches with lines, in the same template
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch2, GenJournalTemplate.Name);
+        SecondBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch2, 3);
+
+        // [GIVEN] Payment Journal page opened on the first batch
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [WHEN] Batch Name is changed to the second batch
+        PaymentJournal.CurrentJnlBatchName.SetValue(GenJournalBatch2.Name);
+
+        // [THEN] Batch Total is the total of the second batch only
+        Assert.AreEqual(SecondBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CalcBatchTotalReturnsSumOfAmountLCYOfFilteredLines()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
+        ExpectedBatchTotal: Decimal;
+        BatchTotal: Decimal;
+        ShowBatchTotal: Boolean;
+    begin
+        // [FEATURE] [Payment] [Batch Total] [UT]
+        // [SCENARIO 425446] CalcBatchTotal returns the sum of "Amount (LCY)" of the lines that the filters apply to.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        GenJournalLine.SetRange("Journal Template Name", GenJournalBatch."Journal Template Name");
+        GenJournalLine.SetRange("Journal Batch Name", GenJournalBatch.Name);
+
+        // [WHEN] CalcBatchTotal is called for the filtered lines
+        GenJnlManagement.CalcBatchTotal(GenJournalLine, BatchTotal, ShowBatchTotal);
+
+        // [THEN] The total of the batch is returned and can be shown
+        Assert.IsTrue(ShowBatchTotal, BatchTotalNotShownErr);
+        Assert.AreEqual(ExpectedBatchTotal, BatchTotal, WrongBatchTotalErr);
+    end;
+
+    local procedure CreatePaymentJournalLines(GenJournalTemplate: Record "Gen. Journal Template"; GenJournalBatch: Record "Gen. Journal Batch"; NoOfLines: Integer) TotalAmountLCY: Decimal
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorNo: Code[20];
+        i: Integer;
+    begin
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        for i := 1 to NoOfLines do begin
+            LibraryERM.CreateGeneralJnlLine2(
+              GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, GenJournalLine."Document Type"::Payment,
+              GenJournalLine."Account Type"::Vendor, VendorNo, -LibraryRandom.RandDecInRange(100, 1000, 2));
+            TotalAmountLCY += GenJournalLine."Amount (LCY)";
+        end;
     end;
 
     local procedure Initialize()

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -298,7 +298,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -310,7 +310,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -321,7 +321,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -332,7 +332,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2189,16 +2189,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2612,11 +2611,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -298,6 +298,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -309,6 +310,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -319,6 +321,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -329,6 +332,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -746,6 +750,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1949,6 +1967,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -2039,12 +2058,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2161,7 +2183,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2575,6 +2612,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
@@ -712,6 +712,22 @@ codeunit 230 GenJnlManagement
             InsertCBGStatement(GenJnlTemplate);
     end;
 
+    procedure CalcBatchTotal(var GenJnlLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var ShowBatchTotal: Boolean)
+    var
+        [SecurityFiltering(SecurityFilter::Filtered)]
+        TotalGenJnlLine: Record "Gen. Journal Line";
+    begin
+        BatchTotal := 0;
+        ShowBatchTotal := not (CurrentClientType in [CLIENTTYPE::SOAP, CLIENTTYPE::OData, CLIENTTYPE::ODataV4, CLIENTTYPE::Api]);
+        if not ShowBatchTotal then
+            exit;
+
+        TotalGenJnlLine.CopyFilters(GenJnlLine);
+        OnCalcBatchTotalOnAfterCopyFilters(TotalGenJnlLine);
+        TotalGenJnlLine.CalcSums("Amount (LCY)");
+        BatchTotal := TotalGenJnlLine."Amount (LCY)";
+    end;
+
     /// <summary>
     /// Generates unique journal template names by checking for conflicts and incrementing names when needed.
     /// Ensures new template names are unique while maintaining meaningful naming based on template type.
@@ -1015,6 +1031,11 @@ codeunit 230 GenJnlManagement
     /// <param name="TempGenJournalLine">Temporary journal line record with copied filters that can be modified.</param>
     [IntegrationEvent(false, false)]
     local procedure OnCalcBalanceOnAfterCopyFilters(var TempGenJournalLine: Record "Gen. Journal Line" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcBatchTotalOnAfterCopyFilters(var GenJournalLine: Record "Gen. Journal Line")
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
@@ -723,7 +723,6 @@ codeunit 230 GenJnlManagement
             exit;
 
         TotalGenJnlLine.CopyFilters(GenJnlLine);
-        OnCalcBatchTotalOnAfterCopyFilters(TotalGenJnlLine);
         TotalGenJnlLine.CalcSums("Amount (LCY)");
         BatchTotal := TotalGenJnlLine."Amount (LCY)";
     end;
@@ -1031,11 +1030,6 @@ codeunit 230 GenJnlManagement
     /// <param name="TempGenJournalLine">Temporary journal line record with copied filters that can be modified.</param>
     [IntegrationEvent(false, false)]
     local procedure OnCalcBalanceOnAfterCopyFilters(var TempGenJournalLine: Record "Gen. Journal Line" temporary)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnCalcBatchTotalOnAfterCopyFilters(var GenJournalLine: Record "Gen. Journal Line")
     begin
     end;
 

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -300,6 +300,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -311,6 +312,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -321,6 +323,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -331,6 +334,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -687,6 +691,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1918,6 +1936,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1999,12 +2018,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2110,7 +2132,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2434,6 +2471,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -300,7 +300,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -312,7 +312,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -323,7 +323,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -334,7 +334,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2138,16 +2138,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2471,11 +2470,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -319,7 +319,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -331,7 +331,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -342,7 +342,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -353,7 +353,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -2118,16 +2118,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2446,11 +2445,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -319,6 +319,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -330,6 +331,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -340,6 +342,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -350,6 +353,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -698,6 +702,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1900,6 +1918,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1979,12 +1998,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -2090,7 +2112,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2409,6 +2446,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
@@ -617,6 +617,22 @@ codeunit 230 GenJnlManagement
         OnAfterCalcBalance(GenJnlLine);
     end;
 
+    procedure CalcBatchTotal(var GenJnlLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var ShowBatchTotal: Boolean)
+    var
+        [SecurityFiltering(SecurityFilter::Filtered)]
+        TotalGenJnlLine: Record "Gen. Journal Line";
+    begin
+        BatchTotal := 0;
+        ShowBatchTotal := not (CurrentClientType in [CLIENTTYPE::SOAP, CLIENTTYPE::OData, CLIENTTYPE::ODataV4, CLIENTTYPE::Api]);
+        if not ShowBatchTotal then
+            exit;
+
+        TotalGenJnlLine.CopyFilters(GenJnlLine);
+        OnCalcBatchTotalOnAfterCopyFilters(TotalGenJnlLine);
+        TotalGenJnlLine.CalcSums("Amount (LCY)");
+        BatchTotal := TotalGenJnlLine."Amount (LCY)";
+    end;
+
     /// <summary>
     /// Generates unique journal template names by checking for conflicts and incrementing names when needed.
     /// Ensures new template names are unique while maintaining meaningful naming based on template type.
@@ -920,6 +936,11 @@ codeunit 230 GenJnlManagement
     /// <param name="TempGenJournalLine">Temporary journal line record with copied filters that can be modified.</param>
     [IntegrationEvent(false, false)]
     local procedure OnCalcBalanceOnAfterCopyFilters(var TempGenJournalLine: Record "Gen. Journal Line" temporary)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCalcBatchTotalOnAfterCopyFilters(var GenJournalLine: Record "Gen. Journal Line")
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/GenJnlManagement.Codeunit.al
@@ -628,7 +628,6 @@ codeunit 230 GenJnlManagement
             exit;
 
         TotalGenJnlLine.CopyFilters(GenJnlLine);
-        OnCalcBatchTotalOnAfterCopyFilters(TotalGenJnlLine);
         TotalGenJnlLine.CalcSums("Amount (LCY)");
         BatchTotal := TotalGenJnlLine."Amount (LCY)";
     end;
@@ -936,11 +935,6 @@ codeunit 230 GenJnlManagement
     /// <param name="TempGenJournalLine">Temporary journal line record with copied filters that can be modified.</param>
     [IntegrationEvent(false, false)]
     local procedure OnCalcBalanceOnAfterCopyFilters(var TempGenJournalLine: Record "Gen. Journal Line" temporary)
-    begin
-    end;
-
-    [IntegrationEvent(false, false)]
-    local procedure OnCalcBatchTotalOnAfterCopyFilters(var GenJournalLine: Record "Gen. Journal Line")
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,7 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -304,7 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -315,7 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -326,7 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
-                        UpdateBalance();
+                        UpdateBatchTotalAfterAmountChange();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -1971,16 +1971,15 @@ page 256 "Payment Journal"
     end;
 
     local procedure UpdateBatchTotal()
-    var
-        IsHandled: Boolean;
     begin
-        IsHandled := false;
-        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
-        if IsHandled then
-            exit;
-
         GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
         BatchTotalVisible := ShowBatchTotal;
+    end;
+
+    local procedure UpdateBatchTotalAfterAmountChange()
+    begin
+        CurrPage.SaveRecord();
+        UpdateBatchTotal();
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2299,11 +2298,6 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
-    begin
-    end;
-
-    [IntegrationEvent(true, false)]
-    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Journal/PaymentJournal.Page.al
@@ -292,6 +292,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Amount (LCY)"; Rec."Amount (LCY)")
@@ -303,6 +304,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Debit Amount"; Rec."Debit Amount")
@@ -313,6 +315,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("Credit Amount"; Rec."Credit Amount")
@@ -323,6 +326,7 @@ page 256 "Payment Journal"
                     trigger OnValidate()
                     begin
                         CheckAmountMatchedToAppliedLines();
+                        UpdateBalance();
                     end;
                 }
                 field("VAT Amount"; Rec."VAT Amount")
@@ -661,6 +665,20 @@ page 256 "Payment Journal"
                             Editable = false;
                             ToolTip = 'Specifies the total balance in the payment journal.';
                             Visible = TotalBalanceVisible;
+                        }
+                    }
+                    group("Batch Total")
+                    {
+                        Caption = 'Batch Total (LCY)';
+                        field(BatchTotal; BatchTotal)
+                        {
+                            ApplicationArea = All;
+                            AutoFormatType = 1;
+                            AutoFormatExpression = '';
+                            Caption = 'Batch Total (LCY)';
+                            Editable = false;
+                            ToolTip = 'Specifies the total amount, in local currency, of the lines that are shown in the journal. Use this to see how much is selected for payment before you post the journal.';
+                            Visible = BatchTotalVisible;
                         }
                     }
                 }
@@ -1753,6 +1771,7 @@ page 256 "Payment Journal"
     begin
         TotalBalanceVisible := true;
         BalanceVisible := true;
+        BatchTotalVisible := true;
         AmountVisible := true;
         GeneralLedgerSetup.Get();
         IsPowerAutomatePrivacyNoticeApproved := PrivacyNotice.GetPrivacyNoticeApprovalState(FlowServiceManagement.GetPowerAutomatePrivacyNoticeId()) = "Privacy Notice Approval State"::Agreed;
@@ -1832,12 +1851,15 @@ page 256 "Payment Journal"
         GenJnlLineApprovalStatus: Text[20];
         Balance: Decimal;
         TotalBalance: Decimal;
+        BatchTotal: Decimal;
         NumberOfRecords: Integer;
         ShowBalance: Boolean;
         ShowTotalBalance: Boolean;
+        ShowBatchTotal: Boolean;
         HasPmtFileErr: Boolean;
         BalanceVisible: Boolean;
         TotalBalanceVisible: Boolean;
+        BatchTotalVisible: Boolean;
         IsPostingGroupEditable: Boolean;
         StyleTxt: Text;
         OverdueWarningText: Text;
@@ -1943,7 +1965,22 @@ page 256 "Payment Journal"
         if ShowTotalBalance then
             NumberOfRecords := Rec.Count();
 
+        UpdateBatchTotal();
+
         OnAfterUpdateBalance(TotalBalanceVisible);
+    end;
+
+    local procedure UpdateBatchTotal()
+    var
+        IsHandled: Boolean;
+    begin
+        IsHandled := false;
+        OnBeforeUpdateBatchTotal(Rec, BatchTotal, BatchTotalVisible, IsHandled);
+        if IsHandled then
+            exit;
+
+        GenJnlManagement.CalcBatchTotal(Rec, BatchTotal, ShowBatchTotal);
+        BatchTotalVisible := ShowBatchTotal;
     end;
 
     local procedure EnableApplyEntriesAction()
@@ -2262,6 +2299,11 @@ page 256 "Payment Journal"
     /// <param name="IsHandled">Set to true to skip standard balance update logic.</param>
     [IntegrationEvent(true, false)]
     local procedure OnBeforeUpdateBalance(var GenJournalLine: Record "Gen. Journal Line"; xGenJournalLine: Record "Gen. Journal Line"; var Balance: Decimal; var TotalBalance: Decimal; var ShowBalance: Boolean; var ShowTotalBalance: Boolean; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    local procedure OnBeforeUpdateBatchTotal(var GenJournalLine: Record "Gen. Journal Line"; var BatchTotal: Decimal; var BatchTotalVisible: Boolean; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/W1/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -45,6 +45,8 @@ codeunit 134920 "ERM General Journal UT"
         RecurringFrequencyNotClearedErr: Label 'The recurring frequency should be cleared.';
         YearlyRecurringFrequencyTok: Label '1Y', Locked = true;
         RecurringFrequencyNotLocalizedErr: Label 'The recurring frequency should be displayed using the localized date formula tokens.';
+        WrongBatchTotalErr: Label 'Wrong Batch Total on the Payment Journal page.';
+        BatchTotalNotShownErr: Label 'Batch Total must be shown.';
         IsInitialized: Boolean;
 
     [Test]
@@ -6296,6 +6298,177 @@ codeunit 134920 "ERM General Journal UT"
           GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), 0);
         GenJournalLine.Validate("Document No.", LibraryUtility.GenerateGUID());
         GenJournalLine.Modify(true);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalShowsSumOfLineAmounts()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        ExpectedBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page shows the total amount that is selected for payment in the batch.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is the sum of "Amount (LCY)" of the three lines
+        Assert.AreEqual(ExpectedBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalIsZeroForEmptyBatch()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is zero when the batch has no lines.
+        Initialize();
+
+        // [GIVEN] Payment journal batch without lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+
+        // [WHEN] Payment Journal page is opened on the batch
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [THEN] Batch Total is 0
+        Assert.AreEqual(0, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenLineAmountIsValidated()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        InitialBatchTotal: Decimal;
+        OldAmount: Decimal;
+        NewAmount: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page is recalculated when the Amount of a line is changed.
+        Initialize();
+
+        // [GIVEN] Payment Journal page opened on a batch with two payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        InitialBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+        PaymentJournal.First();
+        OldAmount := PaymentJournal.Amount.AsDecimal();
+        NewAmount := OldAmount - LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [WHEN] Amount is changed on the first line
+        PaymentJournal.Amount.SetValue(NewAmount);
+
+        // [THEN] Batch Total is updated without leaving the line
+        Assert.AreEqual(
+          InitialBatchTotal - OldAmount + NewAmount, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure PaymentJournalBatchTotalUpdatedWhenBatchIsChanged()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalBatch2: Record "Gen. Journal Batch";
+        GeneralJournalBatches: TestPage "General Journal Batches";
+        PaymentJournal: TestPage "Payment Journal";
+        SecondBatchTotal: Decimal;
+    begin
+        // [FEATURE] [Payment] [Batch Total]
+        // [SCENARIO 425446] Batch Total on the Payment Journal page only covers the lines of the selected batch.
+        Initialize();
+
+        // [GIVEN] Two payment journal batches with lines, in the same template
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 2);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch2, GenJournalTemplate.Name);
+        SecondBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch2, 3);
+
+        // [GIVEN] Payment Journal page opened on the first batch
+        PrepareGeneralJournalBatchesPage(GeneralJournalBatches, GenJournalBatch);
+        RunEditJournalActionOnPaymentJournalPage(PaymentJournal, GeneralJournalBatches);
+
+        // [WHEN] Batch Name is changed to the second batch
+        PaymentJournal.CurrentJnlBatchName.SetValue(GenJournalBatch2.Name);
+
+        // [THEN] Batch Total is the total of the second batch only
+        Assert.AreEqual(SecondBatchTotal, PaymentJournal.BatchTotal.AsDecimal(), WrongBatchTotalErr);
+
+        PaymentJournal.Close();
+        GeneralJournalBatches.Close();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CalcBatchTotalReturnsSumOfAmountLCYOfFilteredLines()
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: Record "Gen. Journal Line";
+        ExpectedBatchTotal: Decimal;
+        BatchTotal: Decimal;
+        ShowBatchTotal: Boolean;
+    begin
+        // [FEATURE] [Payment] [Batch Total] [UT]
+        // [SCENARIO 425446] CalcBatchTotal returns the sum of "Amount (LCY)" of the lines that the filters apply to.
+        Initialize();
+
+        // [GIVEN] Payment journal batch with three payment lines
+        CreateGenJournalTemplateBatchPayment(GenJournalTemplate, GenJournalBatch);
+        ExpectedBatchTotal := CreatePaymentJournalLines(GenJournalTemplate, GenJournalBatch, 3);
+        GenJournalLine.SetRange("Journal Template Name", GenJournalBatch."Journal Template Name");
+        GenJournalLine.SetRange("Journal Batch Name", GenJournalBatch.Name);
+
+        // [WHEN] CalcBatchTotal is called for the filtered lines
+        GenJnlManagement.CalcBatchTotal(GenJournalLine, BatchTotal, ShowBatchTotal);
+
+        // [THEN] The total of the batch is returned and can be shown
+        Assert.IsTrue(ShowBatchTotal, BatchTotalNotShownErr);
+        Assert.AreEqual(ExpectedBatchTotal, BatchTotal, WrongBatchTotalErr);
+    end;
+
+    local procedure CreatePaymentJournalLines(GenJournalTemplate: Record "Gen. Journal Template"; GenJournalBatch: Record "Gen. Journal Batch"; NoOfLines: Integer) TotalAmountLCY: Decimal
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorNo: Code[20];
+        i: Integer;
+    begin
+        VendorNo := LibraryPurchase.CreateVendorNo();
+        for i := 1 to NoOfLines do begin
+            LibraryERM.CreateGeneralJnlLine2(
+              GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, GenJournalLine."Document Type"::Payment,
+              GenJournalLine."Account Type"::Vendor, VendorNo, -LibraryRandom.RandDecInRange(100, 1000, 2));
+            TotalAmountLCY += GenJournalLine."Amount (LCY)";
+        end;
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
## What & why

Cherry-picks #10538 to `releases/29.x`.

Adds a Batch Total to the Payment Journal so users can see the total amount selected for payment before posting the journal.

## Linked work

Fixes [AB#647899](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647899)

Original PR: #10538

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Cherry-picked both commits from #10538 onto the latest `upstream/releases/29.x` without conflicts.
- Verified the resulting 20-file patch is byte-for-byte equivalent to the source PR patch.
- Ran `git diff --check upstream/releases/29.x..HEAD`; no errors were reported.
- The original PR includes unit-test updates for W1 and affected localizations. Local AL compilation was not run because Docker and BCContainerHelper are unavailable in this environment; repository CI will provide the build validation.

## Risk & compatibility

This is a direct backport of #10538. The main compatibility risk is differences between `main` and `releases/29.x`; the cherry-pick applied cleanly and retained an identical patch.


