### PR TITLE
[29.0] Backport #10562: Install Subcontracting by default in new online environments

### DIFF
--- a/build/groups.json
+++ b/build/groups.json
@@ -2959,24 +2959,19 @@
     "name": "Subcontracting",
     "groups": [
       {
-        "name": "AllExtensions",
-        "doNotInstall": true
+        "name": "AllExtensions"
       },
       {
-        "name": "Financials",
-        "doNotInstall": true
+        "name": "Financials"
       },
       {
-        "name": "FinancialsExtensions",
-        "doNotInstall": true
+        "name": "FinancialsExtensions"
       },
       {
-        "name": "OnPrem",
-        "doNotInstall": true
+        "name": "OnPrem"
       },
       {
-        "name": "OnPremExtensions",
-        "doNotInstall": true
+        "name": "OnPremExtensions"
       }
     ]
   },
@@ -2984,24 +2979,19 @@
     "name": "Subcontracting-Tests",
     "groups": [
       {
-        "name": "AllExtensions",
-        "doNotInstall": true
+        "name": "AllExtensions"
       },
       {
-        "name": "Financials",
-        "doNotInstall": true
+        "name": "Financials"
       },
       {
-        "name": "FinancialsExtensions",
-        "doNotInstall": true
+        "name": "FinancialsExtensions"
       },
       {
-        "name": "OnPrem",
-        "doNotInstall": true
+        "name": "OnPrem"
       },
       {
-        "name": "OnPremExtensions",
-        "doNotInstall": true
+        "name": "OnPremExtensions"
       }
     ]
   },

--- a/build/projects.json
+++ b/build/projects.json
@@ -3708,7 +3708,6 @@
       "dvdFolder": "Applications\\Subcontracting\\Source",
       "supportedCountries": "All",
       "installOnEnvironmentUpdate": false,
-      "skipInstallOnPrem": true,
       "hasTranslations": true,
       "runStaticCodeAnalysis": true,
       "logLevel": "warning",


### PR DESCRIPTION
## What & why

Backports #10562 to eleases/29.0 so Subcontracting and its test app are installed by default in new online environments while remaining excluded from environment updates.

## Linked work

- Source PR: #10562
- [AB#647211](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647211)

## Validation

- Confirmed the effective patch matches #10562 exactly.
- Parsed uild/groups.json and uild/projects.json successfully.
- git diff --check passes.

## Risk & compatibility

Limited to Subcontracting installation metadata in the 29.0 release branch.

