### PR TITLE
[28.4] Fix E-Document registration number vendor test setup

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
@@ -21,7 +21,6 @@ codeunit 139799 "E-Doc. Helper Test"
         Assert: Codeunit "Assert";
         LibraryEDoc: Codeunit "Library - E-Document";
         LibraryLowerPermission: Codeunit "Library - Lower Permissions";
-        LibraryPurchase: Codeunit "Library - Purchase";
         MultipleVendorsWithRegistrationNoErr: Label 'Multiple vendors match the registration number on the electronic document.';
 
     trigger OnRun()
@@ -69,7 +68,7 @@ codeunit 139799 "E-Doc. Helper Test"
         // [FEATURE] [AI test]
         // [SCENARIO 646793] A vendor can be resolved by Registration No. when other identifiers are unavailable.
         RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
-        LibraryPurchase.CreateVendor(Vendor);
+        CreateVendorForLookup(Vendor);
         Vendor."Use Reg. No. in E-Document" := true;
         Vendor."Registration Number" := RegistrationNo;
         Vendor.Modify();
@@ -88,7 +87,7 @@ codeunit 139799 "E-Doc. Helper Test"
         // [FEATURE] [AI test]
         // [SCENARIO 646793] Registration No. matching requires explicit vendor setup.
         RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
-        LibraryPurchase.CreateVendor(Vendor);
+        CreateVendorForLookup(Vendor);
         Vendor."Registration Number" := RegistrationNo;
         Vendor.Modify();
 
@@ -106,11 +105,11 @@ codeunit 139799 "E-Doc. Helper Test"
         // [FEATURE] [AI test]
         // [SCENARIO 646793] Vendor matching fails when a registration number identifies multiple vendors.
         RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
-        LibraryPurchase.CreateVendor(Vendor[1]);
+        CreateVendorForLookup(Vendor[1]);
         Vendor[1]."Use Reg. No. in E-Document" := true;
         Vendor[1]."Registration Number" := RegistrationNo;
         Vendor[1].Modify();
-        LibraryPurchase.CreateVendor(Vendor[2]);
+        CreateVendorForLookup(Vendor[2]);
         Vendor[2]."Use Reg. No. in E-Document" := true;
         Vendor[2]."Registration Number" := RegistrationNo;
         Vendor[2].Modify();
@@ -197,6 +196,15 @@ codeunit 139799 "E-Doc. Helper Test"
 
         // Cleanup
         EDocument.Delete();
+    end;
+
+    local procedure CreateVendorForLookup(var Vendor: Record Vendor)
+    var
+        LibraryUtility: Codeunit "Library - Utility";
+    begin
+        Vendor.Init();
+        Vendor."No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(Vendor."No."));
+        Vendor.Insert();
     end;
 
 }


### PR DESCRIPTION
## Why

The E-Document registration number vendor tests use `LibraryPurchase.CreateVendor`, which requires existing VAT posting setup. The IT extension test database has no VAT Business Posting Group, causing all three tests to fail before exercising registration number matching.

## Summary

- **Replaced** full vendor creation with a lightweight lookup vendor helper.
- **Removed** the tests' dependency on VAT posting setup data.

Fixes
[AB#647510](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647510)

