### PR TITLE
[Main] [ALL-E] "Item tracking is defined for item 1000 in the Requisition Line. You must delete the existing item tracking before modifying or deleting the Requisition line" err when creating a Purchase Order from a Sales Order including DROP Shipment Bug 643358

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Requisition/OrderPlanningMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Requisition/OrderPlanningMgt.Codeunit.al
@@ -196,10 +196,10 @@ codeunit 5522 "Order Planning Mgt."
         OnInsertDemandLinesOnAfterReqLineInsert(ReqLine, TempUnplannedDemand);
         if Item."No." <> TempUnplannedDemand."Item No." then
             Item.Get(TempUnplannedDemand."Item No.");
-        if Item."Item Tracking Code" <> '' then
-            OnInsertDemandLinesOnCopyItemTracking(ReqLine, TempUnplannedDemand);
         if ReqLine.Quantity > 0 then
             PlanningLineMgt.Calculate(ReqLine, 1, true, true, 0);
+        if Item."Item Tracking Code" <> '' then
+            OnInsertDemandLinesOnCopyItemTracking(ReqLine, TempUnplannedDemand);
         ReqLine.Find('+');
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesLinePlanning.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesLinePlanning.Codeunit.al
@@ -68,8 +68,8 @@ codeunit 99000850 "Sales Line-Planning"
     begin
         if UnplannedDemand."Demand Type" = UnplannedDemand."Demand Type"::Sales then begin
             SalesLine.Get(UnplannedDemand."Demand SubType", UnplannedDemand."Demand Order No.", UnplannedDemand."Demand Line No.");
-            // Use new overload to set Reservation status instead of default Prospect to match Calculate Plan behavior
-            ItemTrackingManagement.CopyItemTracking(SalesLine.RowID1(), RequisitionLine.RowID1(), true);
+            if not SalesLine."Drop Shipment" then
+                ItemTrackingManagement.CopyItemTracking(SalesLine.RowID1(), RequisitionLine.RowID1(), true);
         end;
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesLinePlanning.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesLinePlanning.Codeunit.al
@@ -68,8 +68,7 @@ codeunit 99000850 "Sales Line-Planning"
     begin
         if UnplannedDemand."Demand Type" = UnplannedDemand."Demand Type"::Sales then begin
             SalesLine.Get(UnplannedDemand."Demand SubType", UnplannedDemand."Demand Order No.", UnplannedDemand."Demand Line No.");
-            if not SalesLine."Drop Shipment" then
-                ItemTrackingManagement.CopyItemTracking(SalesLine.RowID1(), RequisitionLine.RowID1(), true);
+            ItemTrackingManagement.CopyItemTracking(SalesLine.RowID1(), RequisitionLine.RowID1(), true);
         end;
     end;
 

--- a/src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningIII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Planning/SCMOrderPlanningIII.Codeunit.al
@@ -32,6 +32,7 @@ codeunit 137088 "SCM Order Planning - III"
         NotificationLifecycleMgt: Codeunit "Notification Lifecycle Mgt.";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibraryRandom: Codeunit "Library - Random";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
         VerifyOnGlobal: Option RequisitionLine,Orders;
         DemandTypeGlobal: Option Sales,Production;
         GlobalChildItemNo: Code[20];
@@ -1566,6 +1567,49 @@ codeunit 137088 "SCM Order Planning - III"
         // [THEN] A new purchase order for "B" is successfully created.
         FindPurchaseDocumentByItemNo(PurchaseHeader, PurchaseLine, Item2."No.");
         PurchaseHeader.TestField("Buy-from Vendor No.", Item2."Vendor No.");
+    end;
+
+    [Test]
+    procedure CreatePurchaseOrderFromDropShipmentSalesOrderWithLotTracking()
+    var
+        Item: Record Item;
+        Location: Record Location;
+        Purchasing: Record Purchasing;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        LotNo: Code[50];
+        Quantity: Decimal;
+    begin
+        // [SCENARIO 647806] Create a purchase order from a drop shipment sales order with lot tracking.
+        Initialize();
+        LotNo := LibraryUtility.GenerateGUID();
+        Quantity := LibraryRandom.RandInt(10);
+
+        // [GIVEN] A lot-tracked item with a vendor and a drop shipment sales order line with item tracking.
+        LibraryItemTracking.CreateLotItem(Item);
+        Item.Validate("Vendor No.", LibraryPurchase.CreateVendorNo());
+        Item.Modify(true);
+        LibraryWarehouse.CreateLocation(Location);
+        LibraryPurchase.CreateDropShipmentPurchasingCode(Purchasing);
+        CreateSalesOrderWithPurchasingCode(SalesHeader, SalesLine, Item."No.", Purchasing.Code);
+        SalesLine.Validate("Location Code", Location.Code);
+        SalesLine.Validate(Quantity, Quantity);
+        SalesLine.Modify(true);
+        LibraryItemTracking.CreateSalesOrderItemTracking(ReservationEntry, SalesLine, '', LotNo, Quantity);
+
+        // [WHEN] Create a purchase order from the sales order.
+        CreatePurchaseOrderFromSalesOrder(SalesHeader."No.", true);
+
+        // [THEN] The purchase order is created with the lot tracking from the sales line.
+        FindPurchaseDocumentByItemNo(PurchaseHeader, PurchaseLine, Item."No.");
+        ReservationEntry.SetSourceFilter(
+            Database::"Purchase Line", PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.", true);
+        ReservationEntry.SetSourceFilter('', 0);
+        ReservationEntry.SetRange("Lot No.", LotNo);
+        Assert.RecordIsNotEmpty(ReservationEntry);
     end;
 
     [Test]


### PR DESCRIPTION
[Bug 648695](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648695): [Master] [ALL-E] "Item tracking is defined for item 1000 in the Requisition Line. You must delete the existing item tracking before modifying or deleting the Requisition line" when creating a Purchase Order from a Sales Order including DROP Shipment

Fixes [AB#648695](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648695)








