### PR TITLE
Route BaseApp/Projects to SCM in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,7 +68,7 @@
 /src/Layers/*/BaseApp/OtherCapabilities/ @microsoft/d365-bc-integrations
 /src/Layers/*/BaseApp/Permissions/ @microsoft/d365-bc-integrations
 /src/Layers/*/BaseApp/Pricing/ @microsoft/d365-bc-scm
-/src/Layers/*/BaseApp/Projects/ @microsoft/d365-bc-finance-1
+/src/Layers/*/BaseApp/Projects/ @microsoft/d365-bc-scm
 /src/Layers/*/BaseApp/Purchases/ @microsoft/d365-bc-scm
 /src/Layers/*/BaseApp/RoleCenters/ @microsoft/d365-bc-integrations
 /src/Layers/*/BaseApp/Sales/ @microsoft/d365-bc-scm


### PR DESCRIPTION
Routes `src/Layers/*/BaseApp/Projects/` to SCM instead of Finance.

### Problem

Projects/Jobs is owned by **SCM**, but `CODEOWNERS` routed it to **Finance**. Projects PRs requested review from the wrong team, and the owning team was never notified.

Worse, the same PR carried two contradictory owners: the triage agent labelled it `Team: SCM` while `CODEOWNERS` requested `@microsoft/d365-bc-finance-1`.

Example — #10361 ("Line Discount Amount Rounding Discrepancy When Transferring Project Planning Lines to Sales Invoice"):

| | |
|---|---|
| Triage label | `Team: SCM` |
| Reviewers requested | D365 BC Finance, D365 BC Integrations |
| SCM requested? | No |

### Cause

`CODEOWNERS` mirrors `baseAppAreaRules` in `ownership-rules.js` (BCAppsTriage). That table was corrected to `Projects: 'SCM'` — Projects/Jobs is an SCM sub-area in the ownership matrix, and `subAreaToTeam['Projects']` already said SCM, so the folder tier contradicted the matrix tier. The correction was confirmed by human triage corrections on #9559 (Blocked check on Job Bill-to Customer) and #9462 (project WIP calculation), both relabelled Finance → SCM.

`CODEOWNERS` was generated before that correction and never regenerated. This is drift, not a disagreement about who owns Projects.

### Change

```diff
-/src/Layers/*/BaseApp/Projects/ @microsoft/d365-bc-finance-1
+/src/Layers/*/BaseApp/Projects/ @microsoft/d365-bc-scm
```

Affects 404 files under `src/Layers/*/BaseApp/Projects/` (359 W1, 30 NA, remainder small localization layers).

### Validation

Audited all 31 `/src/Layers/*/BaseApp/<Area>/` lines against the current `baseAppAreaRules`:

- before: 1 line disagreed (this one)
- after: 0 disagreements

So this was the only drifted area line.

### Note on existing PRs

GitHub computes reviewer requests when a PR is opened and does not recompute them when `CODEOWNERS` changes, so PRs opened before this merges keep their original reviewers. (#10361 also still shows D365 BC Integrations, from a rule already removed in #10491, for the same reason.) Both clear on the next PR touching these paths.

### Follow-up

The generator that produces `CODEOWNERS` from `ownership-rules.js` isn't checked in, so `CODEOWNERS` can't be regenerated when ownership rules change and nothing detects divergence. This bug is the first drift it caused. Tracked in [AB#647927](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647927) — committing the generator plus a CI check that regenerates and compares would prevent recurrence.

Fixes [AB#647927](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647927)



