### PR TITLE
Re-enable SCM Inventory Costing IV ACY tests (AB#642681, AB#642682)

### DIFF
--- a/src/DisabledTests/Tests-SCM-Costing/Tests-SCM-Costing.DisabledTest.json
+++ b/src/DisabledTests/Tests-SCM-Costing/Tests-SCM-Costing.DisabledTest.json
@@ -534,17 +534,5 @@
     "codeunitName": "SCM Costing Batch",
     "method": "PurchasePostingDoesNotPropagateACYToSourceCurrencyOnGLEntry",
     "bug": "RU: shared W1 test fails under RU base-app behavior in the merged RU build; runs+passes for W1/other countries. Disabled globally (low value, RU pipeline enablement)."
-  },
-  {
-    "codeunitId": 137289,
-    "codeunitName": "SCM Inventory Costing IV",
-    "method": "AdjustCostForDifferentCurrencyExchangeRate",
-    "bug": "RU: #9071 (b477d1fe9c) regresses ACY balancing in RU Purch.-Post -> G/L inconsistency. Shared W1 test, fails only in RU. Mirrors NAV App/DisabledTests/SCMInventoryCostingIV.DisabledTest.json (PR 250996, 2026-07-17)."
-  },
-  {
-    "codeunitId": 137289,
-    "codeunitName": "SCM Inventory Costing IV",
-    "method": "PostPurchOrderWithDiffCurrencyExchangeRate",
-    "bug": "RU: #9071 (b477d1fe9c) regresses ACY balancing in RU Purch.-Post -> G/L inconsistency. Shared W1 test, fails only in RU. Mirrors NAV App/DisabledTests/SCMInventoryCostingIV.DisabledTest.json (PR 250996, 2026-07-17)."
   }
 ]


### PR DESCRIPTION
## What & why

Re-enables two SCM ACY purchase-posting tests that were disabled during the BCApps uptake (NAV PR 250996).

- Codeunit 137289 "SCM Inventory Costing IV" -> `AdjustCostForDifferentCurrencyExchangeRate` ([AB#642681](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642681))
- Codeunit 137289 "SCM Inventory Costing IV" -> `PostPurchOrderWithDiffCurrencyExchangeRate` ([AB#642682](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642682))

Both failed with a G/L Entry inconsistency in `Purch.-Post.FinalizePosting` when posting with an additional reporting currency (ACY). The regression was introduced by #9071 (b477d1fe9c) in `Gen. Jnl.-Post Line`.CreateGLEntryBalAcc and has since been fixed by #10214 (37f845fe08), which restores source-currency balancing. The tests now pass, so their entries are removed from `Tests-SCM-Costing.DisabledTest.json`.

## Linked work

Fixes [AB#642681](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642681)
Fixes [AB#642682](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642682)

## How I validated this

- The culprit/fix chain was verified via git blame/history.
- The remaining `SCM Costing Batch` test (137402) is intentionally left disabled.



