### PR TITLE
[29.0] [Reminders] Complete the communication texts model uptake

### DIFF
--- a/src/Apps/GB/GovTalk/test/src/RegularTests/UTREPPurchaseSalesGovTalk.Codeunit.al
+++ b/src/Apps/GB/GovTalk/test/src/RegularTests/UTREPPurchaseSalesGovTalk.Codeunit.al
@@ -5,7 +5,6 @@
 namespace Microsoft.Finance.VAT.GovTalk;
 
 using Microsoft.Finance.VAT.Reporting;
-using System.Environment.Configuration;
 using System.TestLibraries.Utilities;
 
 codeunit 144035 "UT REP Purchase Sales GovTalk"
@@ -81,21 +80,10 @@ codeunit 144035 "UT REP Purchase Sales GovTalk"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryVariableStorage.Clear();
         DeleteObjectOptionsIfNeeded();
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
     end;
 
     local procedure DeleteObjectOptionsIfNeeded()
@@ -113,4 +101,3 @@ codeunit 144035 "UT REP Purchase Sales GovTalk"
     end;
 #endif
 }
-

--- a/src/Apps/GB/ReportsGB/test/src/Codeunits/UTREPPurchaseSales.Codeunit.al
+++ b/src/Apps/GB/ReportsGB/test/src/Codeunits/UTREPPurchaseSales.Codeunit.al
@@ -2,7 +2,6 @@ namespace Microsoft.Finance.FinancialReports;
 
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
-using System.Environment.Configuration;
 using System.TestLibraries.Utilities;
 
 codeunit 144015 "UT REP Purchase & Sales"
@@ -65,21 +64,10 @@ codeunit 144015 "UT REP Purchase & Sales"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryVariableStorage.Clear();
         DeleteObjectOptionsIfNeeded();
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
     end;
 
     local procedure CreatePostedPurchaseInvoiceWithMultipleLine(var PurchInvLine: Record "Purch. Inv. Line")
@@ -174,4 +162,3 @@ codeunit 144015 "UT REP Purchase & Sales"
         LibraryReportValidation.DeleteObjectOptions(CurrentSaveValuesId);
     end;
 }
-

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Sales/1.Setup Data/CreateReminderText.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Sales/1.Setup Data/CreateReminderText.Codeunit.al
@@ -5,6 +5,7 @@
 
 namespace Microsoft.DemoData.Sales;
 
+using Microsoft.DemoTool;
 using Microsoft.DemoTool.Helpers;
 using Microsoft.Sales.Reminder;
 
@@ -15,21 +16,37 @@ codeunit 5268 "Create Reminder Text"
 
     trigger OnRun()
     var
+        ContosoCoffeeDemoDataSetup: Record "Contoso Coffee Demo Data Setup";
         CreateReminderTerms: Codeunit "Create Reminder Terms";
         CreateReminderLevel: Codeunit "Create Reminder Level";
+        ContosoLanguage: Codeunit "Contoso Language";
         ContosoReminder: Codeunit "Contoso Reminder";
+        LanguageCode: Code[10];
     begin
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel1(), Enum::"Reminder Text Position"::Ending, 10000, DomesticPmtReminderLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel2(), Enum::"Reminder Text Position"::Ending, 10000, BalanceLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel2(), Enum::"Reminder Text Position"::Ending, 20000, AccountAgencyLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel3(), Enum::"Reminder Text Position"::Ending, 20000, ReminderLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel3(), Enum::"Reminder Text Position"::Ending, 30000, AccountAttorneyLbl);
+        ContosoCoffeeDemoDataSetup.Get();
+        LanguageCode := ContosoLanguage.GetLanguageCode(ContosoCoffeeDemoDataSetup."Country/Region Code");
 
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Foreign(), CreateReminderLevel.DomesticLevel1(), Enum::"Reminder Text Position"::Ending, 30000, DomesticPmtReminderLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Foreign(), CreateReminderLevel.DomesticLevel2(), Enum::"Reminder Text Position"::Ending, 30000, BalanceLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Foreign(), CreateReminderLevel.DomesticLevel2(), Enum::"Reminder Text Position"::Ending, 40000, AccountAgencyLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Foreign(), CreateReminderLevel.DomesticLevel3(), Enum::"Reminder Text Position"::Ending, 40000, ReminderLbl);
-        ContosoReminder.InsertReminderText(CreateReminderTerms.Foreign(), CreateReminderLevel.DomesticLevel3(), Enum::"Reminder Text Position"::Ending, 50000, AccountAttorneyLbl);
+        InsertReminderCommunication(ContosoReminder, CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel1(), LanguageCode, DomesticPmtReminderLbl, '', EmailBodyLevel1Lbl);
+        InsertReminderCommunication(ContosoReminder, CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel2(), LanguageCode, BalanceLbl, AccountAgencyLbl, EmailBodyLevel2Lbl);
+        InsertReminderCommunication(ContosoReminder, CreateReminderTerms.Domestic(), CreateReminderLevel.DomesticLevel3(), LanguageCode, ReminderLbl, AccountAttorneyLbl, EmailBodyLevel3Lbl);
+
+        InsertReminderCommunication(ContosoReminder, CreateReminderTerms.Foreign(), CreateReminderLevel.ForeignLevel1(), LanguageCode, DomesticPmtReminderLbl, '', EmailBodyLevel1Lbl);
+        InsertReminderCommunication(ContosoReminder, CreateReminderTerms.Foreign(), CreateReminderLevel.ForeignLevel2(), LanguageCode, BalanceLbl, AccountAgencyLbl, EmailBodyLevel2Lbl);
+        InsertReminderCommunication(ContosoReminder, CreateReminderTerms.Foreign(), CreateReminderLevel.ForeignLevel3(), LanguageCode, ReminderLbl, AccountAttorneyLbl, EmailBodyLevel3Lbl);
+    end;
+
+    local procedure InsertReminderCommunication(var ContosoReminder: Codeunit "Contoso Reminder"; ReminderTermsCode: Code[10]; ReminderLevelNo: Integer; LanguageCode: Code[10]; FirstEndingLine: Text[100]; SecondEndingLine: Text[100]; EmailBody: Text)
+    var
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
+        ReminderGuid: Guid;
+    begin
+        ReminderGuid := CreateGuid();
+        ContosoReminder.InsertReminderAttachText(ReminderGuid, ReminderTermsCode, ReminderLevelNo, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", AttachmentFileNameLbl, '', '', FirstEndingLine);
+        ReminderLevel.Get(ReminderTermsCode, ReminderLevelNo);
+        ReminderGuid := ReminderLevel."Reminder Attachment Text";
+        ContosoReminder.InsertReminderAttachTextLine(ReminderGuid, LanguageCode, ReminderAttachmentTextLine.Position::"Ending Line", 20000, SecondEndingLine);
+        ContosoReminder.InsertReminderEmailText(ReminderTermsCode, ReminderLevelNo, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", EmailSubjectLbl, EmailGreetingLbl, EmailBody, EmailClosingLbl);
     end;
 
     var
@@ -38,4 +55,11 @@ codeunit 5268 "Create Reminder Text"
         AccountAgencyLbl: Label 'your account will be sent to a collection agency.', MaxLength = 100;
         ReminderLbl: Label 'This is reminder number %8.', MaxLength = 100, Comment = '%8 No. of Reminders';
         AccountAttorneyLbl: Label 'Your account has now been sent to our attorney.', MaxLength = 100;
+        AttachmentFileNameLbl: Label 'Reminder', MaxLength = 100;
+        EmailSubjectLbl: Label 'Issued Reminder', MaxLength = 128;
+        EmailGreetingLbl: Label 'Dear Customer,', MaxLength = 128;
+        EmailClosingLbl: Label 'Sincerely,', MaxLength = 128;
+        EmailBodyLevel1Lbl: Label 'Please remit your payment as soon as possible. The payment was due on %1. If you have already made the payment, please disregard this email. Thank you for your business.', Comment = '%1 = Due date';
+        EmailBodyLevel2Lbl: Label 'This is a second reminder that a payment due on %1 remains unpaid. Please remit payment to avoid further fees and charges. If you have already made the payment, please disregard this email.', Comment = '%1 = Due date';
+        EmailBodyLevel3Lbl: Label 'This is reminder number %8. The payment due on %1 remains unpaid and your account has now been sent to our attorney.', Comment = '%1 = Due date, %8 = Reminder level';
 }

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/Contoso Helpers/ContosoReminder.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoTool/Contoso Helpers/ContosoReminder.Codeunit.al
@@ -10,8 +10,9 @@ codeunit 5694 "Contoso Reminder"
 {
     InherentEntitlements = X;
     InherentPermissions = X;
-    Permissions = tabledata "Reminder Attachment Text" = ri,
-                    tabledata "Reminder Email Text" = ri,
+    Permissions = tabledata "Reminder Attachment Text" = rim,
+                    tabledata "Reminder Attachment Text Line" = rim,
+                    tabledata "Reminder Email Text" = rim,
                     tabledata "Reminder Text" = rim,
                     tabledata "Reminder Level" = rim,
                     tabledata "Reminder Terms" = rim,
@@ -174,31 +175,56 @@ codeunit 5694 "Contoso Reminder"
         ReminderEmailText: Record "Reminder Email Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
+        ReminderEmailTextId: Guid;
     begin
-        ReminderEmailText.Validate(ID, CreateGuid());
-        ReminderEmailText.Validate("Language Code", LanguageCode);
-        ReminderEmailText.Validate("Source Type", SourceType);
-        ReminderEmailText.Validate(Subject, Subject);
-        ReminderEmailText.Validate(Greeting, Greeting);
-        ReminderEmailText.Validate(Closing, Closing);
-        ReminderEmailText.Insert(true);
-
+        ReminderEmailTextId := CreateGuid();
         case SourceType of
             SourceType::"Reminder Level":
                 begin
                     ReminderLevel.Get(ReminderTermsCode, ReminderLevelNo);
-                    if IsNullGuid(ReminderLevel."Reminder Email Text") then begin
-                        ReminderLevel.Validate("Reminder Email Text", ReminderEmailText.ID);
-                        ReminderLevel.Modify(true);
-                    end;
+                    if not IsNullGuid(ReminderLevel."Reminder Email Text") then
+                        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
                 end;
             SourceType::"Reminder Term":
                 begin
                     ReminderTerms.Get(ReminderTermsCode);
-                    if IsNullGuid(ReminderTerms."Reminder Email Text") then begin
-                        ReminderTerms.Validate("Reminder Email Text", ReminderEmailText.ID);
-                        ReminderTerms.Modify(true);
-                    end;
+                    if not IsNullGuid(ReminderTerms."Reminder Email Text") then
+                        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+                end;
+        end;
+
+        if ReminderEmailText.Get(ReminderEmailTextId, LanguageCode) then begin
+            if not OverwriteData then
+                exit(ReminderEmailText);
+
+            ReminderEmailText.Validate("Source Type", SourceType);
+            ReminderEmailText.Validate(Subject, Subject);
+            ReminderEmailText.Validate(Greeting, Greeting);
+            ReminderEmailText.Validate(Closing, Closing);
+            ReminderEmailText.Modify(true);
+        end else begin
+            ReminderEmailText.Init();
+            ReminderEmailText.Validate(ID, ReminderEmailTextId);
+            ReminderEmailText.Validate("Language Code", LanguageCode);
+            ReminderEmailText.Validate("Source Type", SourceType);
+            ReminderEmailText.Validate(Subject, Subject);
+            ReminderEmailText.Validate(Greeting, Greeting);
+            ReminderEmailText.Validate(Closing, Closing);
+            ReminderEmailText.Insert(true);
+        end;
+
+        ReminderEmailText.SetBodyText(BodyText);
+
+        case SourceType of
+            SourceType::"Reminder Level":
+                if IsNullGuid(ReminderLevel."Reminder Email Text") then begin
+                    ReminderLevel.Validate("Reminder Email Text", ReminderEmailText.ID);
+                    ReminderLevel.Modify(true);
+                end;
+            SourceType::"Reminder Term":
+                if IsNullGuid(ReminderTerms."Reminder Email Text") then begin
+                    ReminderTerms.Validate("Reminder Email Text", ReminderEmailText.ID);
+                    ReminderTerms.Modify(true);
                 end;
         end;
         exit(ReminderEmailText);
@@ -207,34 +233,86 @@ codeunit 5694 "Contoso Reminder"
     procedure InsertReminderAttachText(ReminderGuid: Guid; ReminderTermsCode: Code[10]; ReminderLevelNo: Integer; LanguageCode: Code[10]; SourceType: Enum "Reminder Text Source Type"; FileName: Text[100]; BeginningLine: Text[100]; InlineFeeDescription: Text[100]; EndingLine: Text[100])
     var
         ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
+        ReminderAttachmentTextId: Guid;
     begin
-        ReminderAttachmentText.Validate(Id, ReminderGuid);
-        ReminderAttachmentText.Validate("Language Code", LanguageCode);
-        ReminderAttachmentText.Validate("Source Type", SourceType);
-        ReminderAttachmentText.Validate("File Name", FileName);
-        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
-        ReminderAttachmentText.Insert(true);
-
+        ReminderAttachmentTextId := ReminderGuid;
         case SourceType of
             SourceType::"Reminder Level":
                 begin
                     ReminderLevel.Get(ReminderTermsCode, ReminderLevelNo);
-                    if IsNullGuid(ReminderLevel."Reminder Attachment Text") then begin
-                        ReminderLevel.Validate("Reminder Attachment Text", ReminderAttachmentText.Id);
-                        ReminderLevel.Modify(true);
-                    end;
+                    if not IsNullGuid(ReminderLevel."Reminder Attachment Text") then
+                        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
                 end;
             SourceType::"Reminder Term":
                 begin
                     ReminderTerms.Get(ReminderTermsCode);
-                    if IsNullGuid(ReminderTerms."Reminder Attachment Text") then begin
-                        ReminderTerms.Validate("Reminder Attachment Text", ReminderAttachmentText.Id);
-                        ReminderTerms.Modify(true);
-                    end;
+                    if not IsNullGuid(ReminderTerms."Reminder Attachment Text") then
+                        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
                 end;
         end;
+
+        if ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode) then begin
+            if OverwriteData then begin
+                ReminderAttachmentText.Validate("Source Type", SourceType);
+                ReminderAttachmentText.Validate("File Name", FileName);
+                ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+                ReminderAttachmentText.Modify(true);
+            end;
+        end else begin
+            ReminderAttachmentText.Init();
+            ReminderAttachmentText.Validate(Id, ReminderAttachmentTextId);
+            ReminderAttachmentText.Validate("Language Code", LanguageCode);
+            ReminderAttachmentText.Validate("Source Type", SourceType);
+            ReminderAttachmentText.Validate("File Name", FileName);
+            ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+            ReminderAttachmentText.Insert(true);
+        end;
+
+        if BeginningLine <> '' then
+            InsertReminderAttachTextLine(ReminderAttachmentTextId, LanguageCode, ReminderAttachmentTextLine.Position::"Beginning Line", 10000, BeginningLine);
+        if EndingLine <> '' then
+            InsertReminderAttachTextLine(ReminderAttachmentTextId, LanguageCode, ReminderAttachmentTextLine.Position::"Ending Line", 10000, EndingLine);
+
+        case SourceType of
+            SourceType::"Reminder Level":
+                if IsNullGuid(ReminderLevel."Reminder Attachment Text") then begin
+                    ReminderLevel.Validate("Reminder Attachment Text", ReminderAttachmentTextId);
+                    ReminderLevel.Modify(true);
+                end;
+            SourceType::"Reminder Term":
+                if IsNullGuid(ReminderTerms."Reminder Attachment Text") then begin
+                    ReminderTerms.Validate("Reminder Attachment Text", ReminderAttachmentTextId);
+                    ReminderTerms.Modify(true);
+                end;
+        end;
+    end;
+
+    procedure InsertReminderAttachTextLine(ReminderGuid: Guid; LanguageCode: Code[10]; Position: Option "Beginning Line","Ending Line"; LineNo: Integer; Text: Text[100])
+    var
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+    begin
+        if Text = '' then
+            exit;
+
+        if ReminderAttachmentTextLine.Get(ReminderGuid, LanguageCode, Position, LineNo) then begin
+            if not OverwriteData then
+                exit;
+
+            ReminderAttachmentTextLine.Validate(Text, Text);
+            ReminderAttachmentTextLine.Modify(true);
+            exit;
+        end;
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderGuid);
+        ReminderAttachmentTextLine.Validate("Language Code", LanguageCode);
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo);
+        ReminderAttachmentTextLine.Validate(Text, Text);
+        ReminderAttachmentTextLine.Insert(true);
     end;
 
     procedure InsertReminderText(ReminderTermsCode: Code[10]; ReminderLevel: Integer; Position: Enum "Reminder Text Position"; LineNo: Integer; Text: Text[100])

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/ContosoReminderTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/ContosoReminderTest.Codeunit.al
@@ -1,0 +1,113 @@
+namespace Microsoft.Test.DemoTool;
+
+using Microsoft.DemoTool.Helpers;
+using Microsoft.Sales.Reminder;
+
+codeunit 148450 "Contoso Reminder Test"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ReminderHelperStoresCommunicationText()
+    var
+        ReminderTerms: Record "Reminder Terms";
+        ReminderLevel: Record "Reminder Level";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderEmailText: Record "Reminder Email Text";
+        ContosoReminder: Codeunit "Contoso Reminder";
+        LanguageCode: Code[10];
+        ReminderGuid: Guid;
+    begin
+        LanguageCode := GetLanguageCode();
+        ContosoReminder.SetOverwriteData(true);
+        ContosoReminder.InsertReminderTerms('CTEST', 'Contoso reminder test');
+        ContosoReminder.InsertReminderLevel('CTEST', 1, '<2D>', 0, '<7D>');
+
+        ReminderGuid := CreateGuid();
+        ContosoReminder.InsertReminderAttachText(
+            ReminderGuid, 'CTEST', 1, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level",
+            'Reminder', 'Beginning text', 'Inline fee', 'Ending text');
+        ContosoReminder.InsertReminderEmailText(
+            'CTEST', 1, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level",
+            'Subject', 'Greeting', 'Body text', 'Closing');
+
+        ReminderLevel.Get('CTEST', 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", LanguageCode);
+        Assert.AreEqual('Inline fee', ReminderAttachmentText."Inline Fee Description", 'The inline fee description was not stored.');
+
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", LanguageCode);
+        ReminderAttachmentTextLine.SetRange(Position, ReminderAttachmentTextLine.Position::"Beginning Line");
+        ReminderAttachmentTextLine.FindFirst();
+        Assert.AreEqual('Beginning text', ReminderAttachmentTextLine.Text, 'The attachment beginning line was not stored.');
+        ReminderAttachmentTextLine.SetRange(Position, ReminderAttachmentTextLine.Position::"Ending Line");
+        ReminderAttachmentTextLine.FindFirst();
+        Assert.AreEqual('Ending text', ReminderAttachmentTextLine.Text, 'The attachment ending line was not stored.');
+
+        ReminderEmailText.Get(ReminderLevel."Reminder Email Text", LanguageCode);
+        Assert.AreEqual('Body text', ReminderEmailText.GetBodyText(), 'The reminder email body was not stored.');
+
+        ReminderEmailText.Delete(true);
+        ReminderAttachmentText.Delete(true);
+        ReminderLevel.Delete(true);
+        ReminderTerms.Get('CTEST');
+        ReminderTerms.Delete(true);
+    end;
+
+    [Test]
+    procedure ReminderHelperCompletesExistingAttachmentText()
+    var
+        ReminderTerms: Record "Reminder Terms";
+        ReminderLevel: Record "Reminder Level";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ContosoReminder: Codeunit "Contoso Reminder";
+        LanguageCode: Code[10];
+        ReminderGuid: Guid;
+    begin
+        LanguageCode := GetLanguageCode();
+        ContosoReminder.SetOverwriteData(false);
+        ContosoReminder.InsertReminderTerms('CTEST2', 'Contoso reminder rerun test');
+        ContosoReminder.InsertReminderLevel('CTEST2', 1, '<2D>', 0, '<7D>');
+
+        ReminderGuid := CreateGuid();
+        ReminderAttachmentText.Init();
+        ReminderAttachmentText.Validate(Id, ReminderGuid);
+        ReminderAttachmentText.Validate("Language Code", LanguageCode);
+        ReminderAttachmentText.Validate("Source Type", Enum::"Reminder Text Source Type"::"Reminder Level");
+        ReminderAttachmentText.Insert(true);
+        ReminderLevel.Get('CTEST2', 1);
+        ReminderLevel.Validate("Reminder Attachment Text", ReminderGuid);
+        ReminderLevel.Modify(true);
+
+        ContosoReminder.InsertReminderAttachText(
+            ReminderGuid, 'CTEST2', 1, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level",
+            'Reminder', 'Beginning text', 'Inline fee', 'Ending text');
+
+        ReminderAttachmentTextLine.Get(ReminderGuid, LanguageCode, ReminderAttachmentTextLine.Position::"Beginning Line", 10000);
+        Assert.AreEqual('Beginning text', ReminderAttachmentTextLine.Text, 'The missing attachment beginning line was not added.');
+        ReminderAttachmentTextLine.Get(ReminderGuid, LanguageCode, ReminderAttachmentTextLine.Position::"Ending Line", 10000);
+        Assert.AreEqual('Ending text', ReminderAttachmentTextLine.Text, 'The missing attachment ending line was not added.');
+
+        ReminderAttachmentTextLine.SetRange(Id, ReminderGuid);
+        ReminderAttachmentTextLine.DeleteAll(true);
+        ReminderAttachmentText.Delete(true);
+        ReminderLevel.Delete(true);
+        ReminderTerms.Get('CTEST2');
+        ReminderTerms.Delete(true);
+    end;
+
+    local procedure GetLanguageCode(): Code[10]
+    var
+        ContosoLanguage: Codeunit "Contoso Language";
+    begin
+        ContosoLanguage.SetOverwriteData(false);
+        ContosoLanguage.InsertLanguage('ENU', 'English');
+        exit('ENU');
+    end;
+}

--- a/src/Apps/W1/HybridBC14/app/src/Migration/Setup/BC14ReminderTextMigrator.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/app/src/Migration/Setup/BC14ReminderTextMigrator.Codeunit.al
@@ -6,6 +6,7 @@
 namespace Microsoft.DataMigration.BC14Reimplementation;
 
 using Microsoft.Sales.Reminder;
+using System.Globalization;
 
 codeunit 46927 "BC14 Reminder Text Migrator" implements "BC14 Migrator"
 {
@@ -18,6 +19,7 @@ codeunit 46927 "BC14 Reminder Text Migrator" implements "BC14 Migrator"
 
     var
         MigratorNameLbl: Label 'Reminder Text Migrator';
+        ReminderAttachmentFileNameLbl: Label 'Reminder', MaxLength = 100;
 
     procedure GetDisplayName(): Text[250]
     begin
@@ -83,6 +85,7 @@ codeunit 46927 "BC14 Reminder Text Migrator" implements "BC14 Migrator"
         end;
 
         OnAfterMigrateReminderText(BC14ReminderText, ReminderText);
+        MigrateReminderAttachmentText(ReminderText);
     end;
 
     local procedure TransferFields(BC14ReminderText: Record "BC14 Reminder Text"; var ReminderText: Record "Reminder Text")
@@ -100,6 +103,70 @@ codeunit 46927 "BC14 Reminder Text Migrator" implements "BC14 Migrator"
         OnTransferReminderTextCustomFields(BC14ReminderText, ReminderText);
     end;
 
+    local procedure MigrateReminderAttachmentText(ReminderText: Record "Reminder Text")
+    var
+        ReminderLevel: Record "Reminder Level";
+        Language: Record Language;
+        LanguageCodeunit: Codeunit Language;
+        DefaultLanguageCode: Code[10];
+    begin
+        if not ReminderLevel.Get(ReminderText."Reminder Terms Code", ReminderText."Reminder Level") then
+            exit;
+
+        DefaultLanguageCode := LanguageCodeunit.GetLanguageCode(LanguageCodeunit.GetDefaultApplicationLanguageId());
+        if Language.FindSet() then
+            repeat
+                MigrateReminderAttachmentTextForLanguage(ReminderText, ReminderLevel, Language.Code);
+            until Language.Next() = 0;
+
+        if not Language.Get(DefaultLanguageCode) then
+            MigrateReminderAttachmentTextForLanguage(ReminderText, ReminderLevel, DefaultLanguageCode);
+    end;
+
+    local procedure MigrateReminderAttachmentTextForLanguage(ReminderText: Record "Reminder Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        AttachmentTextId: Guid;
+        LinePosition: Option "Beginning Line","Ending Line";
+    begin
+        AttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(AttachmentTextId) then
+            AttachmentTextId := CreateGuid();
+
+        if not ReminderAttachmentText.Get(AttachmentTextId, LanguageCode) then begin
+            ReminderAttachmentText.Init();
+            ReminderAttachmentText.Validate(Id, AttachmentTextId);
+            ReminderAttachmentText.Validate("Language Code", LanguageCode);
+            ReminderAttachmentText.Validate("Source Type", Enum::"Reminder Text Source Type"::"Reminder Level");
+            ReminderAttachmentText.Validate("File Name", ReminderAttachmentFileNameLbl);
+            ReminderAttachmentText.Insert();
+        end;
+
+        if IsNullGuid(ReminderLevel."Reminder Attachment Text") then begin
+            ReminderLevel.Validate("Reminder Attachment Text", AttachmentTextId);
+            ReminderLevel.Modify();
+        end;
+
+        if ReminderText.Position = ReminderText.Position::Beginning then
+            LinePosition := ReminderAttachmentTextLine.Position::"Beginning Line"
+        else
+            LinePosition := ReminderAttachmentTextLine.Position::"Ending Line";
+
+        if ReminderAttachmentTextLine.Get(AttachmentTextId, LanguageCode, LinePosition, ReminderText."Line No.") then begin
+            ReminderAttachmentTextLine.Validate(Text, ReminderText.Text);
+            ReminderAttachmentTextLine.Modify();
+        end else begin
+            ReminderAttachmentTextLine.Init();
+            ReminderAttachmentTextLine.Validate(Id, AttachmentTextId);
+            ReminderAttachmentTextLine.Validate("Language Code", LanguageCode);
+            ReminderAttachmentTextLine.Validate(Position, LinePosition);
+            ReminderAttachmentTextLine.Validate("Line No.", ReminderText."Line No.");
+            ReminderAttachmentTextLine.Validate(Text, ReminderText.Text);
+            ReminderAttachmentTextLine.Insert();
+        end;
+    end;
+
     [IntegrationEvent(false, false)]
     local procedure OnMigrateReminderText(BC14ReminderText: Record "BC14 Reminder Text"; var IsMigrated: Boolean)
     begin
@@ -115,4 +182,3 @@ codeunit 46927 "BC14 Reminder Text Migrator" implements "BC14 Migrator"
     begin
     end;
 }
-

--- a/src/Apps/W1/HybridBC14/test/src/migrators/BC14MigratorCSVTests.Codeunit.al
+++ b/src/Apps/W1/HybridBC14/test/src/migrators/BC14MigratorCSVTests.Codeunit.al
@@ -49,6 +49,47 @@ codeunit 148912 "BC14 Migrator CSV Tests"
         RecordNotFoundLbl: Label 'Expected %1 %2 was not migrated.', Comment = '%1 = entity name, %2 = key';
         CountMismatchLbl: Label 'Number of migrated %1 does not match expected.', Comment = '%1 = entity name';
 
+    [Test]
+    procedure TestMigrateReminderText_CreatesDefaultLanguageWhenOtherLanguagesExist()
+    var
+        BC14ReminderText: Record "BC14 Reminder Text";
+        ReminderTerms: Record "Reminder Terms";
+        ReminderLevel: Record "Reminder Level";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        Language: Record Language;
+        BC14ReminderTextMigrator: Codeunit "BC14 Reminder Text Migrator";
+        LanguageCodeunit: Codeunit Language;
+        LibraryERM: Codeunit "Library - ERM";
+        DefaultLanguageCode: Code[10];
+    begin
+        // [GIVEN] A language exists, but the default application language does not.
+        Language.DeleteAll();
+        Language.Init();
+        Language.Validate(Code, 'OTHER');
+        Language.Insert(true);
+        DefaultLanguageCode := LanguageCodeunit.GetLanguageCode(LanguageCodeunit.GetDefaultApplicationLanguageId());
+        LibraryERM.CreateReminderTermsAndLevel(ReminderTerms, ReminderLevel);
+
+        BC14ReminderText."Reminder Terms Code" := ReminderTerms.Code;
+        BC14ReminderText."Reminder Level" := ReminderLevel."No.";
+        BC14ReminderText.Position := BC14ReminderText.Position::Ending;
+        BC14ReminderText."Line No." := 10000;
+        BC14ReminderText.Text := 'Migrated reminder text';
+
+        // [WHEN] The legacy reminder text is migrated.
+        BC14ReminderTextMigrator.MigrateReminderText(BC14ReminderText);
+
+        // [THEN] Communication text is created for the runtime fallback language.
+        ReminderLevel.Get(ReminderTerms.Code, ReminderLevel."No.");
+        Assert.IsTrue(
+            ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", DefaultLanguageCode),
+            'Reminder attachment text was not created for the default application language.');
+        ReminderAttachmentTextLine.Get(
+            ReminderAttachmentText.Id, DefaultLanguageCode, ReminderAttachmentTextLine.Position::"Ending Line", BC14ReminderText."Line No.");
+        Assert.AreEqual(BC14ReminderText.Text, ReminderAttachmentTextLine.Text, 'The migrated reminder text does not match.');
+    end;
+
     // ====================================================================
     // Customer
     // ====================================================================

--- a/src/Layers/APAC/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/APAC/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1638,7 +1638,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/APAC/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/APAC/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -17,12 +17,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -616,52 +614,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -867,37 +822,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/APAC/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/APAC/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -602,7 +602,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/AT/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/AT/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1439,7 +1439,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/AT/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/AT/DemoTool/InterfaceBasisData.Codeunit.al
@@ -42,7 +42,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -55,7 +55,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -931,4 +930,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/AT/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/AT/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1277,6 +1277,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3122,4 +3222,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/AU/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/AU/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1635,7 +1635,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/AU/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/AU/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 202; // Number of calls to RunCodeunit
+        MaxSteps := 201; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -929,4 +928,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/BE/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/BE/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1522,7 +1522,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/BE/BaseApp/Sales/Reminder/ReminderHeader.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Reminder/ReminderHeader.Table.al
@@ -784,7 +784,6 @@ table 295 "Reminder Header"
         CustPostingGr: Record "Customer Posting Group";
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         FinChrgTerms: Record "Finance Charge Terms";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
@@ -807,7 +806,6 @@ table 295 "Reminder Header"
         PrintReminderQst: Label 'Do you want to print reminder %1?', Comment = '%1 = Reminder No.';
         DeleteExistingLinesTxt: Label 'This change will cause the existing lines to be deleted for this reminder.\\';
         ContinueTxt: Label 'Do you want to continue?';
-        NotEnoughSpaceForTextErr: Label 'There is not enough space to insert the text.';
         GapInNumberSeriesIfDeleteTxt: Label 'Deleting this document will cause a gap in the number series for reminders. ';
         CreateEmptyReminderTxt: Label 'An empty reminder %1 will be created to fill this gap in the number series.\\', Comment = '%1 = Reminder No.';
         UnexpectedLineTypeErr: Label 'Unexpected line type %1 in reminder %2', Comment = '%1 = Line Type, %2 = Reminder No.';
@@ -980,6 +978,7 @@ table 295 "Reminder Header"
 
                     NextLineNo := NextLineNo + LineSpacing;
                     ReminderLine.Init();
+                    ReminderLine."Reminder No." := "No.";
                     ReminderLine."Line No." := NextLineNo;
                     ReminderLine.Type := ReminderLine.Type::"G/L Account";
                     TestField("Customer Posting Group");
@@ -1059,33 +1058,12 @@ table 295 "Reminder Header"
         ReminderLevel.SetRange("No.", 1, ReminderHeader."Reminder Level");
         OnInsertBeginTextsOnAfterReminderLevelSetFilters(ReminderLevel, ReminderHeader);
         if ReminderLevel.FindLast() then
-            if ReminderCommunication.NewReminderCommunicationEnabled() then
-                ReminderCommunication.InsertBeginningText(ReminderHeader, ReminderLevel, ReminderLine)
-            else begin
-                ReminderText.Reset();
-                ReminderText.SetRange("Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-                ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-                ReminderText.SetRange(Position, ReminderText.Position::Beginning);
-                OnInsertBeginTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-                ReminderLine.Reset();
-                ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-                ReminderLine."Reminder No." := ReminderHeader."No.";
-                if ReminderLine.Find('-') then begin
-                    LineSpacing := ReminderLine."Line No." div (ReminderText.Count + 2);
-                    if LineSpacing = 0 then
-                        Error(NotEnoughSpaceForTextErr);
-                end else
-                    LineSpacing := 10000;
-                NextLineNo := 0;
-                InsertTextLines(ReminderHeader);
-            end;
+            ReminderCommunication.InsertBeginningText(ReminderHeader, ReminderLevel, ReminderLine);
     end;
 
     local procedure InsertEndTexts(var ReminderHeader: Record "Reminder Header")
     var
         ReminderCommunication: Codeunit "Reminder Communication";
-        ReminderLine2: Record "Reminder Line";
         IsHandled: Boolean;
     begin
         IsHandled := false;
@@ -1097,46 +1075,7 @@ table 295 "Reminder Header"
         ReminderLevel.SetRange("No.", 1, ReminderHeader."Reminder Level");
         OnInsertEndTextsOnAfterReminderLevelSetFilters(ReminderLevel, ReminderHeader);
         if ReminderLevel.FindLast() then
-            if ReminderCommunication.NewReminderCommunicationEnabled() then
-                ReminderCommunication.InsertEndingText(ReminderHeader, ReminderLevel, ReminderLine)
-            else begin
-                ReminderText.SetRange(
-                  "Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-                ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-                ReminderText.SetRange(Position, ReminderText.Position::Ending);
-                OnInsertEndTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-                ReminderLine.Reset();
-                ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-                ReminderLine.SetFilter(
-                  "Line Type", '%1|%2|%3',
-                  ReminderLine."Line Type"::"Reminder Line",
-                  ReminderLine."Line Type"::"Additional Fee",
-                  ReminderLine."Line Type"::Rounding);
-                OnInsertEndTextsOnAfterReminderLineSetFilters(ReminderLine, ReminderHeader);
-                if ReminderLine.FindLast() then
-                    NextLineNo := ReminderLine."Line No."
-                else
-                    NextLineNo := 0;
-                ReminderLine.SetRange("Line Type");
-                ReminderLine2 := ReminderLine;
-                ReminderLine2.CopyFilters(ReminderLine);
-                ReminderLine2.SetFilter("Line Type", '<>%1', ReminderLine2."Line Type"::"Line Fee");
-                if ReminderLine2.Next() <> 0 then begin
-                    LineSpacing :=
-                      (ReminderLine2."Line No." - ReminderLine."Line No.") div
-                      (ReminderText.Count + 2);
-                    if LineSpacing = 0 then
-                        Error(NotEnoughSpaceForTextErr);
-                end else
-                    LineSpacing := 10000;
-                InsertTextLines(ReminderHeader);
-            end;
-    end;
-
-    local procedure InsertTextLines(var ReminderHeader: Record "Reminder Header")
-    begin
-        InsertTextLines(ReminderHeader, ReminderText, NextLineNo, LineSpacing);
+            ReminderCommunication.InsertEndingText(ReminderHeader, ReminderLevel, ReminderLine);
     end;
 
     /// <summary>
@@ -1783,10 +1722,13 @@ table 295 "Reminder Header"
     /// </summary>
     /// <param name="ReminderLine">The reminder line record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertEndTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertEndTextsOnAfterReminderLineSetFilters(var ReminderLine: Record "Reminder Line"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after setting filters on reminder level during InsertEndTexts processing.
@@ -1931,20 +1873,26 @@ table 295 "Reminder Header"
     /// </summary>
     /// <param name="ReminderText">The reminder text record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertBeginTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertBeginTextsOnAfterReminderTextSetFilters(var ReminderText: Record "Reminder Text"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after setting filters on reminder text during InsertEndTexts processing.
     /// </summary>
     /// <param name="ReminderText">The reminder text record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertEndTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertEndTextsOnAfterReminderTextSetFilters(var ReminderText: Record "Reminder Text"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after calculating the additional fee during InsertLines processing.

--- a/src/Layers/BE/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/BE/DemoTool/InterfaceBasisData.Codeunit.al
@@ -45,7 +45,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -58,7 +58,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -938,4 +937,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/BE/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/BE/DemoTool/InterfaceTrialData.Codeunit.al
@@ -57,7 +57,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -188,4 +187,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/BE/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/BE/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1277,6 +1277,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3151,4 +3251,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/BE/Tests/Local/TestEnterpriseNoandBranch.Codeunit.al
+++ b/src/Layers/BE/Tests/Local/TestEnterpriseNoandBranch.Codeunit.al
@@ -1422,20 +1422,9 @@ codeunit 144025 "Test Enterprise No and Branch"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibrarySetupStorage.Restore();
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;

--- a/src/Layers/CA/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/CA/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 202; // Number of calls to RunCodeunit
+        MaxSteps := 201; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");

--- a/src/Layers/CA/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/CA/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");

--- a/src/Layers/CA/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/CA/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -324,6 +310,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -351,7 +338,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -547,6 +535,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -564,8 +553,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -587,8 +576,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -602,7 +594,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -637,8 +632,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -652,7 +650,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1473,6 +1474,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1488,8 +1490,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2533,8 +2535,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2546,15 +2546,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2576,10 +2567,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2744,16 +2731,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2762,8 +2750,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2771,6 +2757,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2878,25 +2869,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3132,4 +3104,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/CH/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/CH/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1393,7 +1393,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/CH/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/CH/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -554,7 +554,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/CH/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/CH/DemoTool/InterfaceBasisData.Codeunit.al
@@ -45,7 +45,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -58,7 +58,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -951,4 +950,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/CH/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/CH/DemoTool/InterfaceTrialData.Codeunit.al
@@ -54,7 +54,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -181,4 +180,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/CH/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/CH/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1275,6 +1275,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3119,4 +3219,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/CZ/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/CZ/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -928,4 +927,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/CZ/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/CZ/DemoTool/InterfaceTrialData.Codeunit.al
@@ -58,7 +58,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -187,4 +186,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/CZ/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/CZ/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1277,6 +1277,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3122,4 +3222,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/CZ/Tests/ERM-Finance/ERMFinancialReportsII.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM-Finance/ERMFinancialReportsII.Codeunit.al
@@ -44,6 +44,7 @@
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         OriginalWorkdate: Date;
         ExchRateWasAdjustedTxt: Label 'One or more currency exchange rates have been adjusted.';
         GenJnlTemplateNameTok: Label 'JnlTemplateName_GenJnlBatch';
@@ -58,6 +59,7 @@
         TestReportDifferentCustomerSameDocumentErr: Label '%1 posted on %2, must be separated by an empty line';
         IsInitialized: Boolean;
         InvoiceOutOfBalanceErr: Label 'Invoice %1 is out of balance by %2.';
+        RemitPaymentTxt: Label 'Please remit your payment %7', Comment = '%7 = Amount due';
         DateOutOfBalanceErr: Label 'As of %1, the lines are out of balance by %2.';
         TotalOutOfBalanceErr: Label 'The total of the lines is out of balance by%1.';
         NotAllowedPostingDateErr: Label 'The Posting Date is not within your range of allowed posting dates.';
@@ -829,7 +831,7 @@
     begin
         // [SCENARIO 122513] Reminder Report doesn't print Not Due documents when run with "Show Not Due Amounts" = FALSE
         Initialize();
-        CustomerNo := CreateCustomer();
+        CustomerNo := CreateCustomerWithReminderAttachmentText();
 
         // [GIVEN] Posted invoice with "Posting Date" = WorkDate() + 2 Month
         CreateAndPostGenJournalLineWithDate(GenJournalLine, CalcDate('<2M>', WorkDate()), CustomerNo, LibraryRandom.RandDec(1000, 2));  // Using Random value for Amount.
@@ -1700,8 +1702,6 @@
     local procedure Initialize()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Financial Reports II");
@@ -1715,15 +1715,6 @@
         if OriginalWorkdate = 0D then
             OriginalWorkdate := WorkDate();
         WorkDate := OriginalWorkdate;
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -1909,6 +1900,28 @@
         ReminderLevel.FindFirst();
         LibrarySales.CreateCustomer(Customer);
         Customer.Validate("Reminder Terms Code", ReminderLevel."Reminder Terms Code");
+        Customer.Validate("Fin. Charge Terms Code", CreateFinanceChargeTerms());
+        Customer.Modify(true);
+        exit(Customer."No.");
+    end;
+
+    local procedure CreateCustomerWithReminderAttachmentText(): Code[20]
+    var
+        Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
+        ReminderTerms: Record "Reminder Terms";
+    begin
+        LibraryERM.CreateReminderTermsAndLevel(ReminderTerms, ReminderLevel);
+        ReminderLevel.Validate("Additional Fee (LCY)", LibraryRandom.RandInt(10));
+        ReminderLevel.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", RemitPaymentTxt);
+
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
         Customer.Validate("Fin. Charge Terms Code", CreateFinanceChargeTerms());
         Customer.Modify(true);
         exit(Customer."No.");
@@ -2307,16 +2320,18 @@
     local procedure GetRemitPaymentsMsg(IssuedReminderNo: Code[20]; Amount: Decimal): Text
     var
         IssuedReminderHeader: Record "Issued Reminder Header";
-        ReminderText: Record "Reminder Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
         Text: Text;
     begin
         IssuedReminderHeader.Get(IssuedReminderNo);
-        ReminderText.SetRange("Reminder Terms Code", IssuedReminderHeader."Reminder Terms Code");
-        ReminderText.SetRange("Reminder Level", 1);
-        ReminderText.SetRange(Position, 1);
-        ReminderText.FindFirst();
+        ReminderLevel.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level");
+        ReminderAttachmentTextLine.SetRange(Id, ReminderLevel."Reminder Attachment Text");
+        ReminderAttachmentTextLine.SetRange("Language Code", Language.GetUserLanguageCode());
+        ReminderAttachmentTextLine.SetRange(Position, ReminderAttachmentTextLine.Position::"Ending Line");
+        ReminderAttachmentTextLine.FindFirst();
         // Replace '%7' with '%1'
-        Text := ConvertStr(ReminderText.Text, '7', '1');
+        Text := ConvertStr(ReminderAttachmentTextLine.Text, '7', '1');
         exit(StrSubstNo(Text, Amount));
     end;
 

--- a/src/Layers/DACH/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/DACH/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1472,7 +1472,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/DACH/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/DACH/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -18,12 +18,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -671,52 +669,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -922,37 +877,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/DACH/Tests/Local/ERMExcelReportsDACH.Codeunit.al
+++ b/src/Layers/DACH/Tests/Local/ERMExcelReportsDACH.Codeunit.al
@@ -21,44 +21,45 @@ codeunit 142082 "ERM Excel Reports DACH"
     [Scope('OnPrem')]
     procedure ReminderTestReportTestEndingAndBeginningTexts()
     var
-        ReminderTextBeginning: array[2] of Record "Reminder Text";
-        ReminderTextEnding: array[2] of Record "Reminder Text";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLineBeginning: array[2] of Record "Reminder Attachment Text Line";
+        ReminderAttachmentTextLineEnding: array[2] of Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderHeader: Record "Reminder Header";
+        ReminderLevel: Record "Reminder Level";
         ReminderTestReport: Report "Reminder - Test";
+        Language: Codeunit Language;
     begin
         // [FEATURE] [Reminder]
         // [SCENARIO 364318] All the lines of Reminder's beginning and Ending text should be printed in "Reminder - Test" Report
         Initialize();
         // [GIVEN] Reminder with 2 lines of beginning and 2 lines of ending texts
         CreateReminderHeader(ReminderHeader);
+        ReminderLevel.Get(ReminderHeader."Reminder Terms Code", ReminderHeader."Reminder Level");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
 
-        LibraryERM.CreateReminderText(
-          ReminderTextBeginning[1],
-          ReminderHeader."Reminder Terms Code",
-          ReminderHeader."Reminder Level",
-          ReminderTextBeginning[1].Position::Beginning,
+        LibraryERM.CreateReminderAttachmentTextLine(
+          ReminderAttachmentTextLineBeginning[1],
+          ReminderAttachmentText,
+          ReminderAttachmentTextLineBeginning[1].Position::"Beginning Line",
           LibraryUtility.GenerateGUID());
-        LibraryERM.CreateReminderText(
-          ReminderTextBeginning[2],
-          ReminderHeader."Reminder Terms Code",
-          ReminderHeader."Reminder Level",
-          ReminderTextBeginning[2].Position::Beginning,
+        LibraryERM.CreateReminderAttachmentTextLine(
+          ReminderAttachmentTextLineBeginning[2],
+          ReminderAttachmentText,
+          ReminderAttachmentTextLineBeginning[2].Position::"Beginning Line",
           LibraryUtility.GenerateGUID());
 
         LibraryERM.CreateReminderLine(ReminderLine, ReminderHeader."No.", ReminderLine.Type::"G/L Account");
 
-        LibraryERM.CreateReminderText(
-          ReminderTextEnding[1],
-          ReminderHeader."Reminder Terms Code",
-          ReminderHeader."Reminder Level",
-          ReminderTextEnding[1].Position::Ending,
+        LibraryERM.CreateReminderAttachmentTextLine(
+          ReminderAttachmentTextLineEnding[1],
+          ReminderAttachmentText,
+          ReminderAttachmentTextLineEnding[1].Position::"Ending Line",
           LibraryUtility.GenerateGUID());
-        LibraryERM.CreateReminderText(
-          ReminderTextEnding[2],
-          ReminderHeader."Reminder Terms Code",
-          ReminderHeader."Reminder Level",
-          ReminderTextEnding[2].Position::Ending,
+        LibraryERM.CreateReminderAttachmentTextLine(
+          ReminderAttachmentTextLineEnding[2],
+          ReminderAttachmentText,
+          ReminderAttachmentTextLineEnding[2].Position::"Ending Line",
           LibraryUtility.GenerateGUID());
 
         ReminderHeader.InsertLines();
@@ -71,22 +72,11 @@ codeunit 142082 "ERM Excel Reports DACH"
 
         // [THEN] Both beginning text lines are printed in column 2 of lines 23 and 24
         // [THEN] Both ending text lines are printed in column 2 of lines 28 and 29
-        ValidateReminderTexts(ReminderTextBeginning, ReminderTextEnding);
+        ValidateReminderTexts(ReminderAttachmentTextLineBeginning, ReminderAttachmentTextLineEnding);
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         Commit();
         Clear(LibraryReportValidation);
     end;
@@ -113,7 +103,7 @@ codeunit 142082 "ERM Excel Reports DACH"
         ReminderHeader.Modify();
     end;
 
-    local procedure ValidateReminderTexts(ReminderTextBeginning: array[2] of Record "Reminder Text"; ReminderTextEnding: array[2] of Record "Reminder Text")
+    local procedure ValidateReminderTexts(ReminderTextBeginning: array[2] of Record "Reminder Attachment Text Line"; ReminderTextEnding: array[2] of Record "Reminder Attachment Text Line")
     var
         ExcelSheetNo: Integer;
     begin
@@ -138,4 +128,3 @@ codeunit 142082 "ERM Excel Reports DACH"
           WrongCellValueTxt + ' ' + Format(29) + ';' + Format(2));
     end;
 }
-

--- a/src/Layers/DACH/Tests/Local/UTREPReminder.Codeunit.al
+++ b/src/Layers/DACH/Tests/Local/UTREPReminder.Codeunit.al
@@ -187,18 +187,7 @@ codeunit 142074 "UT REP Reminder"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         LibraryVariableStorage.Clear();
     end;
 

--- a/src/Layers/DE/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/DE/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1419,7 +1419,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/DE/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/DE/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 211; // Number of calls to RunCodeunit
+        MaxSteps := 210; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -938,4 +937,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/DE/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/DE/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -184,4 +183,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/DK/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/DK/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -179,4 +178,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/ES/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/ES/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1716,7 +1716,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/ES/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -19,11 +19,9 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -799,52 +797,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -1030,37 +985,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/ES/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -582,16 +582,9 @@ table 296 "Reminder Line"
                         ReminderHeader."Posting Date"));
 
                     Description := '';
-                    if (Amount <> 0) then begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
-                        else
-                            if (ReminderLevel."Add. Fee per Line Description" <> '') then
-                                Description :=
-                                    StrSubstNo(
-                                        ReminderLevel."Add. Fee per Line Description", "Reminder No.", "No. of Reminders", "Document Date",
-                                        "Posting Date", "No.", Amount, "Applies-to Document Type", "Applies-to Document No.", ReminderLevel."No.");
-                    end else
+                    if (Amount <> 0) then
+                        Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
+                    else
                         if GLAcc.Get("No.") then
                             Description := GLAcc.Name;
                 end;

--- a/src/Layers/ES/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/ES/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -556,7 +556,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/ES/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/ES/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 208; // Number of calls to RunCodeunit
+        MaxSteps := 207; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -56,7 +56,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -951,4 +950,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/ES/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/ES/DemoTool/InterfaceTrialData.Codeunit.al
@@ -55,7 +55,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Area");
@@ -183,4 +182,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/ES/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/ES/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1278,6 +1278,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3149,4 +3249,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/ES/Tests/Rapid Start/ERMRSWizardWorksheet.Codeunit.al
+++ b/src/Layers/ES/Tests/Rapid Start/ERMRSWizardWorksheet.Codeunit.al
@@ -382,9 +382,11 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         CheckPage(DATABASE::"Customer Posting Group", PAGE::"Customer Posting Groups");
         CheckPage(DATABASE::"Payment Terms", PAGE::"Payment Terms");
         CheckPage(DATABASE::"Payment Method", PAGE::"Payment Methods");
-        CheckPage(DATABASE::"Reminder Terms", PAGE::"Reminder Terms");
-        CheckPage(DATABASE::"Reminder Level", PAGE::"Reminder Levels");
+        CheckPage(DATABASE::"Reminder Terms", PAGE::"Reminder Terms List");
+        CheckPage(DATABASE::"Reminder Level", PAGE::"Reminder Level Setup");
+#if not CLEAN29
         CheckPage(DATABASE::"Reminder Text", PAGE::"Reminder Text");
+#endif
         CheckPage(DATABASE::"Finance Charge Terms", PAGE::"Finance Charge Terms");
         CheckPage(DATABASE::"Shipment Method", PAGE::"Shipment Methods");
         CheckPage(DATABASE::"Shipping Agent", PAGE::"Shipping Agents");
@@ -517,7 +519,7 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         CheckPage(DATABASE::"Cash Flow Manual Revenue", PAGE::"Cash Flow Manual Revenues");
         CheckPage(DATABASE::"IC Partner", PAGE::"IC Partner List");
         CheckPage(DATABASE::"Base Calendar", PAGE::"Base Calendar List");
-        CheckPage(DATABASE::"Finance Charge Text", PAGE::"Reminder Text");
+        CheckPage(DATABASE::"Finance Charge Text", PAGE::"Finance Charge Text");
         CheckPage(DATABASE::"Currency for Fin. Charge Terms", PAGE::"Currencies for Fin. Chrg Terms");
         CheckPage(DATABASE::"Currency for Reminder Level", PAGE::"Currencies for Reminder Level");
         CheckPage(DATABASE::"Currency Exchange Rate", PAGE::"Currency Exchange Rates");
@@ -3397,4 +3399,3 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         ConfigPackageRecords.Field3.AssertEquals(LibraryVariableStorage.DequeueText());
     end;
 }
-

--- a/src/Layers/FI/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/FI/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1429,7 +1429,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/FI/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/FI/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -18,12 +18,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -683,52 +681,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -933,37 +888,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/FI/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -582,16 +582,9 @@ table 296 "Reminder Line"
                         ReminderHeader."Posting Date"));
 
                     Description := '';
-                    if (Amount <> 0) then begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
-                        else
-                            if (ReminderLevel."Add. Fee per Line Description" <> '') then
-                                Description :=
-                                    StrSubstNo(
-                                        ReminderLevel."Add. Fee per Line Description", "Reminder No.", "No. of Reminders", "Document Date",
-                                        "Posting Date", "No.", Amount, "Applies-to Document Type", "Applies-to Document No.", ReminderLevel."No.");
-                    end else
+                    if (Amount <> 0) then
+                        Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
+                    else
                         if GLAcc.Get("No.") then
                             Description := GLAcc.Name;
                 end;

--- a/src/Layers/FI/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/FI/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -574,7 +574,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/FI/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/FI/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 203; // Number of calls to RunCodeunit
+        MaxSteps := 202; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -927,4 +926,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/FI/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/FI/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -290,6 +276,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -317,7 +304,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -513,6 +501,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -530,8 +519,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -553,8 +542,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -568,7 +560,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -603,8 +598,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -618,7 +616,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1441,6 +1442,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1456,8 +1458,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2553,8 +2555,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2566,15 +2566,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2594,10 +2585,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2761,16 +2748,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2779,8 +2767,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2788,6 +2774,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2895,25 +2886,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3162,4 +3134,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/FI/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
+++ b/src/Layers/FI/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
@@ -183,14 +183,14 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     [Scope('OnPrem')]
     procedure PrintServiceInvoiceTextonInvoiceTranslated()
     var
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         AddFeePerLine: Decimal;
         CustomerNo: Code[20];
         InvoiceNo: Code[20];
+        LanguageCode: Code[10];
         ReminderTermsCode: Code[10];
     begin
         // [SCENARIO 107048] A service invoice report contains translated Add. Fee Note
-        // as selected Reminder Terms contain Translated text on Report and Customer Country is set to use specific lang.
+        // as selected Reminder Terms contain attachment text in the customer's language.
         Initialize();
         SetupRefNumOnSalesAndReceivablesSetup(RefNoNoSeriesCode, true);
 
@@ -198,8 +198,9 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         // defined in other language and Customer Language set to that language
         AddFeePerLine := LibraryRandom.RandDec(1000, 2);
         CreateCustomerWithReminderTermsAddFeePerLine(CustomerNo, ReminderTermsCode, true, '', AddFeePerLine);
-        CreateReminderTermsTranslationEntry(ReminderTermsTranslation, ReminderTermsCode);
-        UpdateCustomerLangCode(CustomerNo, ReminderTermsTranslation."Language Code");
+        LanguageCode := LibraryERM.GetAnyLanguageDifferentFromCurrent();
+        CreateReminderTermsInlineFeeText(ReminderTermsCode, LanguageCode);
+        UpdateCustomerLangCode(CustomerNo, LanguageCode);
 
         // [GIVEN] A posted service invoice for customer with Reminder Term = X
         InvoiceNo := PostServiceInvoice(CustomerNo, WorkDate());
@@ -207,9 +208,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         // [WHEN] The invoice is printed
         ExportServiceInvoice(CustomerNo);
 
-        // [THEN] The Add. Fee per Line note on report is printed on language defined in Reminder Terms Translation table
-        ValidateInvoiceAddFeePerLine(
-          ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', ReminderTermsTranslation."Language Code");
+        // [THEN] The Add. Fee per Line note on report is printed in the customer's language
+        ValidateInvoiceAddFeePerLine(ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', LanguageCode);
     end;
 
     local procedure Initialize()
@@ -303,14 +303,16 @@ codeunit 134993 "Reminder - Line Fee on Reports"
 
     local procedure CreateReminderTerms(PostLineFee: Boolean; PostInterest: Boolean; PostAddFee: Boolean): Code[10]
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderTerms: Record "Reminder Terms";
     begin
         LibraryERM.CreateReminderTerms(ReminderTerms);
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
         exit(ReminderTerms.Code)
     end;
 
@@ -327,8 +329,6 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -338,17 +338,14 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Modify(true);
     end;
 
-    local procedure CreateReminderTermsTranslationEntry(var ReminderTermsTranslation: Record "Reminder Terms Translation"; ReminderTermsCode: Code[10])
+    local procedure CreateReminderTermsInlineFeeText(ReminderTermsCode: Code[10]; LanguageCode: Code[10])
     var
-        Language: Record Language;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderTerms: Record "Reminder Terms";
     begin
-        Language.FindFirst();
-        ReminderTermsTranslation.Init();
-        ReminderTermsTranslation.Validate("Reminder Terms Code", ReminderTermsCode);
-        ReminderTermsTranslation.Validate("Language Code", Language.Code);
-        ReminderTermsTranslation.Insert(true);
-        ReminderTermsTranslation.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
-        ReminderTermsTranslation.Modify(true);
+        ReminderTerms.Get(ReminderTermsCode);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, LanguageCode);
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
     end;
 
     local procedure CreateRefNumberSeries(StartingNo: Code[20]): Code[10]
@@ -442,9 +439,9 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         ElementExpectedValue: Text;
         MarginalPerc: Decimal;
         TextOnReportExpected: Text[150];
@@ -469,12 +466,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
             CurrencyCode := GeneralLedgerSetup."LCY Code";
         end;
 
-        // expected result
-        if LanguageCode <> Language.GetUserLanguageCode() then begin
-            ReminderTermsTranslation.Get(ReminderTerms.Code, LanguageCode);
-            TextOnReportExpected := ReminderTermsTranslation."Note About Line Fee on Report"
-        end else
-            TextOnReportExpected := ReminderTerms."Note About Line Fee on Report";
+        ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode);
+        TextOnReportExpected := ReminderAttachmentText."Inline Fee Description";
 
         ElementExpectedValue := StrSubstNo(TextOnReportExpected, Format(AddFeePerLine, 0, 9),
             CurrencyCode, AddFeeDueDate, Format(MarginalPerc, 0, 9));

--- a/src/Layers/FI/Tests/Local/CompanyFieldReportTest.Codeunit.al
+++ b/src/Layers/FI/Tests/Local/CompanyFieldReportTest.Codeunit.al
@@ -27,21 +27,11 @@ codeunit 144010 "Company Field Report Test"
     local procedure Initialize()
     var
         SalesAndReceivablesSetup: Record "Sales & Receivables Setup";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibrarySales.SetCreditWarningsToNoWarnings();
         LibrarySales.SetStockoutWarning(false);
         LibraryVariableStorage.Clear();
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         LibraryReportDataset.Reset();
         CompanyInformation.FindFirst();

--- a/src/Layers/FR/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/FR/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1603,7 +1603,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/FR/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/FR/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -18,12 +18,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -689,52 +687,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -949,37 +904,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/FR/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/FR/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 202; // Number of calls to RunCodeunit
+        MaxSteps := 201; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -929,4 +928,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/FR/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/FR/DemoTool/InterfaceTrialData.Codeunit.al
@@ -55,7 +55,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -183,4 +182,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/FR/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
@@ -15,7 +15,6 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         LibrarySales: Codeunit "Library - Sales";
         LibraryService: Codeunit "Library - Service";
         LibraryReportDataset: Codeunit "Library - Report Dataset";
-        LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         IsInitialized: Boolean;
@@ -177,22 +176,23 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     [Scope('OnPrem')]
     procedure PrintServiceInvoiceTextonInvoiceTranslated()
     var
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         AddFeePerLine: Decimal;
         CustomerNo: Code[20];
         InvoiceNo: Code[20];
+        LanguageCode: Code[10];
         ReminderTermsCode: Code[10];
     begin
         // [SCENARIO 107048] A service invoice report contains translated Add. Fee Note
-        // as selected Reminder Terms contain Translated text on Report and Customer Country is set to use specific lang.
+        // as selected Reminder Terms contain attachment text in the customer's language.
         Initialize();
 
         // [GIVEN] A Reminder Term X, with level 1 with Add. Fee per Line = A, where A > 0, with Text on Report
         // defined in other language and Customer Language set to that language
         AddFeePerLine := LibraryRandom.RandDec(1000, 2);
         CreateCustomerWithReminderTermsAddFeePerLine(CustomerNo, ReminderTermsCode, true, '', AddFeePerLine);
-        CreateReminderTermsTranslationEntry(ReminderTermsTranslation, ReminderTermsCode);
-        UpdateCustomerLangCode(CustomerNo, ReminderTermsTranslation."Language Code");
+        LanguageCode := LibraryERM.GetAnyLanguageDifferentFromCurrent();
+        CreateReminderTermsInlineFeeText(ReminderTermsCode, LanguageCode);
+        UpdateCustomerLangCode(CustomerNo, LanguageCode);
 
         // [GIVEN] A posted service invoice for customer with Reminder Term = X
         InvoiceNo := PostServiceInvoice(CustomerNo, WorkDate());
@@ -200,9 +200,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         // [WHEN] The invoice is printed
         ExportServiceInvoice(CustomerNo);
 
-        // [THEN] The Add. Fee per Line note on report is printed on language defined in Reminder Terms Translation table
-        ValidateInvoiceAddFeePerLine(
-          ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', ReminderTermsTranslation."Language Code");
+        // [THEN] The Add. Fee per Line note on report is printed in the customer's language
+        ValidateInvoiceAddFeePerLine(ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', LanguageCode);
     end;
 
     local procedure Initialize()
@@ -295,14 +294,16 @@ codeunit 134993 "Reminder - Line Fee on Reports"
 
     local procedure CreateReminderTerms(PostLineFee: Boolean; PostInterest: Boolean; PostAddFee: Boolean): Code[10]
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderTerms: Record "Reminder Terms";
     begin
         LibraryERM.CreateReminderTerms(ReminderTerms);
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
         exit(ReminderTerms.Code)
     end;
 
@@ -319,8 +320,6 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -330,17 +329,14 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Modify(true);
     end;
 
-    local procedure CreateReminderTermsTranslationEntry(var ReminderTermsTranslation: Record "Reminder Terms Translation"; ReminderTermsCode: Code[10])
+    local procedure CreateReminderTermsInlineFeeText(ReminderTermsCode: Code[10]; LanguageCode: Code[10])
     var
-        Language: Record Language;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderTerms: Record "Reminder Terms";
     begin
-        Language.FindFirst();
-        ReminderTermsTranslation.Init();
-        ReminderTermsTranslation.Validate("Reminder Terms Code", ReminderTermsCode);
-        ReminderTermsTranslation.Validate("Language Code", Language.Code);
-        ReminderTermsTranslation.Insert(true);
-        ReminderTermsTranslation.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
-        ReminderTermsTranslation.Modify(true);
+        ReminderTerms.Get(ReminderTermsCode);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, LanguageCode);
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
     end;
 
     local procedure ExportServiceInvoice(CustomerNo: Code[20])
@@ -409,9 +405,9 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         ElementExpectedValue: Text;
         MarginalPerc: Decimal;
         TextOnReportExpected: Text[150];
@@ -436,12 +432,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
             CurrencyCode := GeneralLedgerSetup."LCY Code";
         end;
 
-        // expected result
-        if LanguageCode <> Language.GetUserLanguageCode() then begin
-            ReminderTermsTranslation.Get(ReminderTerms.Code, LanguageCode);
-            TextOnReportExpected := ReminderTermsTranslation."Note About Line Fee on Report"
-        end else
-            TextOnReportExpected := ReminderTerms."Note About Line Fee on Report";
+        ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode);
+        TextOnReportExpected := ReminderAttachmentText."Inline Fee Description";
 
         ElementExpectedValue := StrSubstNo(TextOnReportExpected, Format(AddFeePerLine, 0, 9),
             CurrencyCode, AddFeeDueDate, Format(MarginalPerc, 0, 9));

--- a/src/Layers/FR/Tests/Rapid Start/ERMRSWizardWorksheet.Codeunit.al
+++ b/src/Layers/FR/Tests/Rapid Start/ERMRSWizardWorksheet.Codeunit.al
@@ -382,9 +382,11 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         CheckPage(DATABASE::"Customer Posting Group", PAGE::"Customer Posting Groups");
         CheckPage(DATABASE::"Payment Terms", PAGE::"Payment Terms");
         CheckPage(DATABASE::"Payment Method", PAGE::"Payment Methods");
-        CheckPage(DATABASE::"Reminder Terms", PAGE::"Reminder Terms");
-        CheckPage(DATABASE::"Reminder Level", PAGE::"Reminder Levels");
+        CheckPage(DATABASE::"Reminder Terms", PAGE::"Reminder Terms List");
+        CheckPage(DATABASE::"Reminder Level", PAGE::"Reminder Level Setup");
+#if not CLEAN29
         CheckPage(DATABASE::"Reminder Text", PAGE::"Reminder Text");
+#endif
         CheckPage(DATABASE::"Finance Charge Terms", PAGE::"Finance Charge Terms");
         CheckPage(DATABASE::"Shipment Method", PAGE::"Shipment Methods");
         CheckPage(DATABASE::"Shipping Agent", PAGE::"Shipping Agents");
@@ -517,7 +519,7 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         CheckPage(DATABASE::"Cash Flow Manual Revenue", PAGE::"Cash Flow Manual Revenues");
         CheckPage(DATABASE::"IC Partner", PAGE::"IC Partner List");
         CheckPage(DATABASE::"Base Calendar", PAGE::"Base Calendar List");
-        CheckPage(DATABASE::"Finance Charge Text", PAGE::"Reminder Text");
+        CheckPage(DATABASE::"Finance Charge Text", PAGE::"Finance Charge Text");
         CheckPage(DATABASE::"Currency for Fin. Charge Terms", PAGE::"Currencies for Fin. Chrg Terms");
         CheckPage(DATABASE::"Currency for Reminder Level", PAGE::"Currencies for Reminder Level");
         CheckPage(DATABASE::"Currency Exchange Rate", PAGE::"Currency Exchange Rates");
@@ -3397,4 +3399,3 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         ConfigPackageRecords.Field3.AssertEquals(LibraryVariableStorage.DequeueText());
     end;
 }
-

--- a/src/Layers/GB/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/GB/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1405,7 +1405,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/GB/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/GB/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -18,12 +18,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -891,52 +889,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -1169,37 +1124,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/GB/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -582,16 +582,9 @@ table 296 "Reminder Line"
                         ReminderHeader."Posting Date"));
 
                     Description := '';
-                    if (Amount <> 0) then begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
-                        else
-                            if (ReminderLevel."Add. Fee per Line Description" <> '') then
-                                Description :=
-                                    StrSubstNo(
-                                        ReminderLevel."Add. Fee per Line Description", "Reminder No.", "No. of Reminders", "Document Date",
-                                        "Posting Date", "No.", Amount, "Applies-to Document Type", "Applies-to Document No.", ReminderLevel."No.");
-                    end else
+                    if (Amount <> 0) then
+                        Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
+                    else
                         if GLAcc.Get("No.") then
                             Description := GLAcc.Name;
                 end;

--- a/src/Layers/GB/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/GB/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -572,7 +572,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/GB/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/GB/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -926,4 +925,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/GB/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/GB/DemoTool/InterfaceTrialData.Codeunit.al
@@ -55,7 +55,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -180,4 +179,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/GB/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/GB/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1285,6 +1285,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3129,4 +3229,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/GB/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/GB/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -335,6 +321,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -362,7 +349,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -563,6 +551,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -580,8 +569,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -603,8 +592,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -618,7 +610,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -653,8 +648,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -668,7 +666,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1507,6 +1508,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1522,8 +1524,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2647,8 +2649,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2660,15 +2660,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2687,10 +2678,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2854,16 +2841,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2872,8 +2860,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2881,6 +2867,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2988,25 +2979,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3269,4 +3241,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/GB/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/GB/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
@@ -948,9 +948,6 @@ codeunit 134979 "Reminder Automation Tests"
         // [SCENARIO 609485] When using Transfer Texts from the old reminder term text to the new customer communications the used language is not considered
         Initialize();
 
-        // [GIVEN] Disable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', false);
-
         // [GIVEN] Set Region and Global Language to Dutch (Netherlands)
         // Save old company region so we can restore it in tear down
         CompanyInfo.Get();
@@ -966,9 +963,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         // [GIVEN] Create reminder term with levels
         CreateReminderTerm(ReminderTerms);
-
-        // [GIVEN] Enable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', true);
 
         // [WHEN] Page Reminder Term Invoke Action Transfer Texts 
         ReminderTermList.OpenEdit();
@@ -1307,15 +1301,11 @@ codeunit 134979 "Reminder Automation Tests"
         ReminderLevel: Record "Reminder Level";
         ReminderAttachmentText: Record "Reminder Attachment Text";
     begin
-        ReminderAttachmentText.Id := CreateGuid();
-        ReminderAttachmentText."Language Code" := LanguageCode;
-        ReminderAttachmentText."File Name" := CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name"));
-        ReminderAttachmentText.Insert();
-
         ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
         ReminderLevel.FindFirst();
-        ReminderLevel."Reminder Attachment Text" := ReminderAttachmentText.Id;
-        ReminderLevel.Modify();
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, LanguageCode);
+        ReminderAttachmentText.Validate("File Name", CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name")));
+        ReminderAttachmentText.Modify(true);
 
         LibraryVariableStorage.Enqueue(ReminderAttachmentText."File Name" + '.pdf');
     end;
@@ -1666,19 +1656,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         ReportSelections.FindEmailAttachmentUsageForCust(ReportUsage, CustomerNo, TempReportSelections);
         ReportSelections.SendEmailToCust(ReportUsage.AsInteger(), Document, '', '', true, CustomerNo);
-    end;
-
-    local procedure CheckFeatureReminderTermsCommunicationTexts(FeatureKeyCode: Code[100]; Enable: Boolean)
-    var
-        FeatureKey: Record "Feature Key";
-    begin
-        FeatureKey.Get(FeatureKeyCode);
-        if Enable then
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::"All Users")
-        else
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::None);
-
-        FeatureKey.Modify(true);
     end;
 
     local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)

--- a/src/Layers/GB/Tests/Local/UTREPPurchaseSales.Codeunit.al
+++ b/src/Layers/GB/Tests/Local/UTREPPurchaseSales.Codeunit.al
@@ -468,21 +468,10 @@ codeunit 144052 "UT REP Purchase & Sales"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryVariableStorage.Clear();
         DeleteObjectOptionsIfNeeded();
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
     end;
 
     local procedure CreateCustomer(): Code[20]

--- a/src/Layers/IN/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/IN/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
 
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
@@ -55,7 +55,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -966,4 +965,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/IN/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/IN/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -212,4 +211,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/IS/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/IS/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1425,7 +1425,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/IS/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/IS/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -594,7 +594,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/IT/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/IT/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1499,7 +1499,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/IT/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/IT/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -590,7 +590,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/IT/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/IT/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 215; // Number of calls to RunCodeunit
+        MaxSteps := 214; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -55,7 +55,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -944,4 +943,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/IT/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/IT/DemoTool/InterfaceTrialData.Codeunit.al
@@ -57,7 +57,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -186,4 +185,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/IT/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/IT/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1318,6 +1318,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3355,4 +3455,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/IT/Tests/ERM-Finance/ERMRemindersGracePeriod.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ERMRemindersGracePeriod.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 134376 "ERM Reminders - Grace Period"
         LibraryERM: Codeunit "Library - ERM";
         LibrarySales: Codeunit "Library - Sales";
         LibraryRandom: Codeunit "Library - Random";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         AmountErr: Label '%1 must be equal to %2 in %3.';
         RemainingAmount4Txt: Label 'Remaining Amount %4';
@@ -643,7 +644,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
     procedure ReminderWhenOneInvoiceGraceExpiredOneInvoiceGraceNotExpired()
     var
         ReminderTerms: Record "Reminder Terms";
-        ReminderLevel: Record "Reminder Level";
         ReminderLine: Record "Reminder Line";
         CustomerNo: Code[20];
         ReminderNo: Code[20];
@@ -658,16 +658,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
         LibraryERM.CreateReminderTerms(ReminderTerms);
         AddFeePerLine := LibraryRandom.RandDecInRange(2, 4, 2);
         CreateReminderLevelWithText(ReminderTerms.Code, 10, 0, AddFeePerLine, RemainingAmount4Txt);
-
-        // [GIVEN] Reminder Levels have a description text.
-        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
-        if not ReminderLevel.IsEmpty() then begin
-            ReminderLevel.FindSet();
-            repeat
-                ReminderLevel."Add. Fee per Line Description" := ReminderTerms.Code;
-                ReminderLevel.Modify(true);
-            until ReminderLevel.Next() = 0;
-        end;
 
         // [GIVEN] Customer with given Reminder Terms.
         // [GIVEN] Posted Sales Invoice "I1" with "Due Date" = 01-09-2021 and Amount = "A1". Grace Period expires after 11-09-2021.
@@ -707,7 +697,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
     procedure ReminderWhenTwoInvoicesGraceExpired()
     var
         ReminderTerms: Record "Reminder Terms";
-        ReminderLevel: Record "Reminder Level";
         ReminderLine: Record "Reminder Line";
         CustomerNo: Code[20];
         ReminderNo: Code[20];
@@ -722,16 +711,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
         LibraryERM.CreateReminderTerms(ReminderTerms);
         AddFeePerLine := LibraryRandom.RandDecInRange(2, 4, 2);
         CreateReminderLevelWithText(ReminderTerms.Code, 10, 0, AddFeePerLine, RemainingAmount4Txt);
-
-        // [GIVEN] Reminder Levels have a description text.
-        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
-        if not ReminderLevel.IsEmpty() then begin
-            ReminderLevel.FindSet();
-            repeat
-                ReminderLevel."Add. Fee per Line Description" := ReminderTerms.Code;
-                ReminderLevel.Modify(true);
-            until ReminderLevel.Next() = 0;
-        end;
 
         // [GIVEN] Customer with given Reminder Terms.
         // [GIVEN] Posted Sales Invoice "I1" with "Due Date" = 01-09-2021 and Amount = "A1". Grace Period expires after 11-09-2021.
@@ -768,19 +747,9 @@ codeunit 134376 "ERM Reminders - Grace Period"
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reminders - Grace Period");
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         if IsInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(CODEUNIT::"ERM Reminders - Grace Period");
@@ -797,10 +766,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
         IsInitialized := true;
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"ERM Reminders - Grace Period");
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure AddDueDateCalcOnReminderLevel(ReminderTermsCode: Code[10])
@@ -997,8 +962,9 @@ codeunit 134376 "ERM Reminders - Grace Period"
 
     local procedure CreateReminderLevelWithText(ReminderTermsCode: Code[10]; GracePeriod: Integer; AdditionalFee: Decimal; AddFeePerLine: Decimal; ReminderEndingText: Text[100])
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(ReminderLevel."Grace Period", '<' + Format(GracePeriod) + 'D>');
@@ -1006,7 +972,10 @@ codeunit 134376 "ERM Reminders - Grace Period"
         ReminderLevel.Validate("Add. Fee per Line Amount (LCY)", AddFeePerLine);
         ReminderLevel.Modify(true);
 
-        LibraryERM.CreateReminderText(ReminderText, ReminderTermsCode, ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, ReminderTermsCode);
     end;
 
     local procedure CreateReminderTerms(): Code[10]
@@ -1286,4 +1255,3 @@ codeunit 134376 "ERM Reminders - Grace Period"
         ReminderLine.TestField(Amount, AmountValue);
     end;
 }
-

--- a/src/Layers/IT/Tests/ERM-Finance/ERMSuggestReminder.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ERMSuggestReminder.Codeunit.al
@@ -16,8 +16,9 @@
         LibrarySales: Codeunit "Library - Sales";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryRandom: Codeunit "Library - Random";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
-        ReminderCaptionTxt: Label 'Reminder Text - %1 %2 Beginning', Comment = '%1=Reminder Terms Code;%2=Reminder Level';
+        ReminderLevelCommunicationCaptionTxt: Label 'Reminder Level Communication - %1 ∙ %2', Comment = '%1 = Reminder Terms Code, %2 = Reminder Level No.';
         CaptionErr: Label 'Page Captions must match.';
         ReminderLineExistErr: Label 'Reminder Line must not exist.';
 
@@ -35,6 +36,45 @@
 
         // Verify: Verify the Creation of Reminder Lines.
         VerifyReminderLine(ReminderHeaderNo);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SuggestReminderUsesTermsAttachmentTextWhenLevelTextIsMissing()
+    var
+        Customer: Record Customer;
+        ReminderTerms: Record "Reminder Terms";
+        ReminderLevel: Record "Reminder Level";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLine: Record "Reminder Line";
+        CustomerNo: Code[20];
+        ReminderNo: Code[20];
+        BeginningText: Text[100];
+        EndingText: Text[100];
+    begin
+        Initialize();
+        CustomerNo := CreateCustomer();
+        Customer.Get(CustomerNo);
+        ReminderTerms.Get(Customer."Reminder Terms Code");
+        FindReminderLevel(ReminderLevel, ReminderTerms.Code);
+        Assert.IsTrue(IsNullGuid(ReminderLevel."Reminder Attachment Text"), 'The reminder level must not have attachment text.');
+        BeginningText := CopyStr(LibraryRandom.RandText(MaxStrLen(BeginningText)), 1, MaxStrLen(BeginningText));
+        EndingText := CopyStr(LibraryRandom.RandText(MaxStrLen(EndingText)), 1, MaxStrLen(EndingText));
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Beginning Line", BeginningText);
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", EndingText);
+
+        ReminderNo := CreateAndSuggestReminderLine(LibraryRandom.RandInt(10), CustomerNo);
+
+        Assert.IsTrue(
+            ReminderTextLineExists(ReminderNo, ReminderLine."Line Type"::"Beginning Text", BeginningText),
+            'The terms-level beginning text was not added to the reminder.');
+        Assert.IsTrue(
+            ReminderTextLineExists(ReminderNo, ReminderLine."Line Type"::"Ending Text", EndingText),
+            'The terms-level ending text was not added to the reminder.');
     end;
 
     [Test]
@@ -68,33 +108,44 @@
     [Scope('OnPrem')]
     procedure ReminderTextPageCaption()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderEmailText: Record "Reminder Email Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
-        ReminderText: Record "Reminder Text";
-        ReminderLevels: TestPage "Reminder Levels";
-        ReminderTextPage: TestPage "Reminder Text";
+        ReminderLevelCommunication: TestPage "Reminder Level Communication";
+        ReminderTermsSetup: TestPage "Reminder Terms Setup";
         ReminderTermsCode: Code[10];
         BeginningText: Text[100];
     begin
-        // Check Reminder Text Page's caption updated according to Reminder Terms.
+        // Check Reminder Level Communication Page's caption.
 
-        // Setup: Create Reminder Terms with Reminder Level and Beginning Text.
+        // Setup: Create Reminder Terms with Reminder Level and Beginning Attachment Text.
         Initialize();
         ReminderTermsCode := CreateReminderTerms(true);
         BeginningText := ReminderTermsCode + Format(LibraryRandom.RandInt(10));  // Create any Beginning Text using Random.
+        ReminderTerms.Get(ReminderTermsCode);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderEmailText(ReminderEmailText, ReminderTerms, Language.GetUserLanguageCode());
         FindReminderLevel(ReminderLevel, ReminderTermsCode);
-        LibraryERM.CreateReminderText(ReminderText, ReminderTermsCode, ReminderLevel."No.",
-          ReminderText.Position::Beginning, BeginningText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Beginning Line", BeginningText);
+        LibraryERM.CreateReminderEmailText(ReminderEmailText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderEmailTextBody(ReminderEmailText, BeginningText);
 
-        // Open Reminder Text Page from Reminder Levels Page.
-        OpenReminderTextPage(ReminderLevels, ReminderTermsCode, ReminderLevel."No.");
-        ReminderTextPage.Trap();
+        // Open Reminder Terms Setup Page from Reminder Terms List.
+        OpenReminderTermsSetupPage(ReminderTermsSetup, ReminderTermsCode, ReminderLevel."No.");
+        ReminderLevelCommunication.Trap();
 
-        // Exercise: Invoke Reminder Text Page.
-        ReminderLevels.BeginningText.Invoke();
+        // Exercise: Invoke Reminder Level Communication Page.
+        ReminderTermsSetup.ReminderLevelSetup.CustomerCommunications.Invoke();
 
-        // Verify: Verify page caption for Reminder Text Page.
-        Assert.AreEqual(StrSubstNo(ReminderCaptionTxt, ReminderTermsCode, ReminderLevel."No."), ReminderTextPage.Caption, CaptionErr);
+        // Verify: Verify page caption for Reminder Level Communication Page.
+        Assert.AreEqual(
+            StrSubstNo(ReminderLevelCommunicationCaptionTxt, ReminderTermsCode, ReminderLevel."No."),
+            ReminderLevelCommunication.Caption,
+            CaptionErr);
 
         // Tear Down: Delete Reminder Terms created earlier.
         ReminderTerms.Get(ReminderTermsCode);
@@ -192,18 +243,8 @@
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Suggest Reminder");
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         if IsInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(CODEUNIT::"ERM Suggest Reminder");
@@ -347,15 +388,15 @@
         ReminderLevel.FindFirst();
     end;
 
-    local procedure OpenReminderTextPage(var ReminderLevels: TestPage "Reminder Levels"; "Code": Code[10]; No: Integer)
+    local procedure OpenReminderTermsSetupPage(var ReminderTermsSetup: TestPage "Reminder Terms Setup"; "Code": Code[10]; No: Integer)
     var
-        ReminderTerms: TestPage "Reminder Terms";
+        ReminderTermsList: TestPage "Reminder Terms List";
     begin
-        ReminderTerms.OpenEdit();
-        ReminderTerms.FILTER.SetFilter(Code, Code);
-        ReminderLevels.Trap();
-        ReminderTerms."&Levels".Invoke();
-        ReminderLevels.FILTER.SetFilter("No.", Format(No));
+        ReminderTermsList.OpenView();
+        ReminderTermsList.FILTER.SetFilter(Code, Code);
+        ReminderTermsSetup.Trap();
+        ReminderTermsList.Edit().Invoke();
+        ReminderTermsSetup.ReminderLevelSetup.FILTER.SetFilter("No.", Format(No));
     end;
 
     local procedure VerifyReminderLine(ReminderNo: Code[20])
@@ -364,5 +405,20 @@
     begin
         ReminderLine.SetRange("Reminder No.", ReminderNo);
         ReminderLine.FindFirst();
+    end;
+
+    local procedure ReminderTextLineExists(ReminderNo: Code[20]; LineType: Enum "Reminder Line Type"; ExpectedText: Text[100]): Boolean
+    var
+        ReminderLine: Record "Reminder Line";
+    begin
+        ReminderLine.SetRange("Reminder No.", ReminderNo);
+        ReminderLine.SetRange("Line Type", LineType);
+        if ReminderLine.FindSet() then
+            repeat
+                if ReminderLine.Description = ExpectedText then
+                    exit(true);
+            until ReminderLine.Next() = 0;
+
+        exit(false);
     end;
 }

--- a/src/Layers/IT/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -324,6 +310,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -351,7 +338,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -547,6 +535,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -564,8 +553,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -587,8 +576,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -602,7 +594,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -637,8 +632,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -652,7 +650,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1470,6 +1471,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1485,8 +1487,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2582,8 +2584,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2595,15 +2595,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2623,10 +2614,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2790,16 +2777,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2808,8 +2796,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2817,6 +2803,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2924,25 +2915,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3193,4 +3165,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/IT/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
@@ -948,9 +948,6 @@ codeunit 134979 "Reminder Automation Tests"
         // [SCENARIO 609485] When using Transfer Texts from the old reminder term text to the new customer communications the used language is not considered
         Initialize();
 
-        // [GIVEN] Disable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', false);
-
         // [GIVEN] Set Region and Global Language to Dutch (Netherlands)
         // Save old company region so we can restore it in tear down
         CompanyInfo.Get();
@@ -966,9 +963,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         // [GIVEN] Create reminder term with levels
         CreateReminderTerm(ReminderTerms);
-
-        // [GIVEN] Enable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', true);
 
         // [WHEN] Page Reminder Term Invoke Action Transfer Texts 
         ReminderTermList.OpenEdit();
@@ -1307,15 +1301,11 @@ codeunit 134979 "Reminder Automation Tests"
         ReminderLevel: Record "Reminder Level";
         ReminderAttachmentText: Record "Reminder Attachment Text";
     begin
-        ReminderAttachmentText.Id := CreateGuid();
-        ReminderAttachmentText."Language Code" := LanguageCode;
-        ReminderAttachmentText."File Name" := CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name"));
-        ReminderAttachmentText.Insert();
-
         ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
         ReminderLevel.FindFirst();
-        ReminderLevel."Reminder Attachment Text" := ReminderAttachmentText.Id;
-        ReminderLevel.Modify();
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, LanguageCode);
+        ReminderAttachmentText.Validate("File Name", CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name")));
+        ReminderAttachmentText.Modify(true);
 
         LibraryVariableStorage.Enqueue(ReminderAttachmentText."File Name" + '.pdf');
     end;
@@ -1669,19 +1659,6 @@ codeunit 134979 "Reminder Automation Tests"
         ReportSelections.SendEmailToCust(ReportUsage.AsInteger(), Document, '', '', true, CustomerNo);
     end;
 
-    local procedure CheckFeatureReminderTermsCommunicationTexts(FeatureKeyCode: Code[100]; Enable: Boolean)
-    var
-        FeatureKey: Record "Feature Key";
-    begin
-        FeatureKey.Get(FeatureKeyCode);
-        if Enable then
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::"All Users")
-        else
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::None);
-
-        FeatureKey.Modify(true);
-    end;
-
     local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)
     var
         Item: Record Item;
@@ -1704,6 +1681,7 @@ codeunit 134979 "Reminder Automation Tests"
 
         for I := 1 to NumberOfEntries do begin
             LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, Customer."No.");
+            SalesHeader.SetHideValidationDialog(true);
             SalesHeader.Validate("Posting Date", PostingDate);
             SalesHeader.Validate("Due Date", PostingDate);
             SalesHeader.Validate("Document Date", PostingDate);

--- a/src/Layers/MX/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/MX/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");

--- a/src/Layers/MX/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/MX/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1295,6 +1295,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3183,4 +3283,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/MX/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/MX/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -324,6 +310,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -351,7 +338,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -547,6 +535,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -564,8 +553,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -587,8 +576,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -602,7 +594,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -637,8 +632,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -652,7 +650,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1466,6 +1467,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1481,8 +1483,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2526,8 +2528,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2539,15 +2539,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2568,10 +2559,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2735,16 +2722,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2753,8 +2741,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2762,6 +2748,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2869,25 +2860,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3123,4 +3095,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/NA/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/NA/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1591,7 +1591,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = BasicMX;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/NA/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -17,12 +17,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -622,52 +620,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -876,37 +831,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/NA/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/NA/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");

--- a/src/Layers/NA/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/NA/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");

--- a/src/Layers/NA/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/NA/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1295,6 +1295,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3177,4 +3277,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/NA/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
@@ -808,9 +808,6 @@ codeunit 134979 "Reminder Automation Tests"
         // [SCENARIO 609485] When using Transfer Texts from the old reminder term text to the new customer communications the used language is not considered
         Initialize();
 
-        // [GIVEN] Disable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', false);
-
         // [GIVEN] Set Region and Global Language to Dutch (Netherlands)
         // Save old company region so we can restore it in tear down
         CompanyInfo.Get();
@@ -826,9 +823,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         // [GIVEN] Create reminder term with levels
         CreateReminderTerm(ReminderTerms);
-
-        // [GIVEN] Enable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', true);
 
         // [WHEN] Page Reminder Term Invoke Action Transfer Texts 
         ReminderTermList.OpenEdit();
@@ -1167,15 +1161,11 @@ codeunit 134979 "Reminder Automation Tests"
         ReminderLevel: Record "Reminder Level";
         ReminderAttachmentText: Record "Reminder Attachment Text";
     begin
-        ReminderAttachmentText.Id := CreateGuid();
-        ReminderAttachmentText."Language Code" := LanguageCode;
-        ReminderAttachmentText."File Name" := CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name"));
-        ReminderAttachmentText.Insert();
-
         ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
         ReminderLevel.FindFirst();
-        ReminderLevel."Reminder Attachment Text" := ReminderAttachmentText.Id;
-        ReminderLevel.Modify();
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, LanguageCode);
+        ReminderAttachmentText.Validate("File Name", CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name")));
+        ReminderAttachmentText.Modify(true);
 
         LibraryVariableStorage.Enqueue(ReminderAttachmentText."File Name" + '.pdf');
     end;
@@ -1525,19 +1515,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         ReportSelections.FindEmailAttachmentUsageForCust(ReportUsage, CustomerNo, TempReportSelections);
         ReportSelections.SendEmailToCust(ReportUsage.AsInteger(), Document, '', '', true, CustomerNo);
-    end;
-
-    local procedure CheckFeatureReminderTermsCommunicationTexts(FeatureKeyCode: Code[100]; Enable: Boolean)
-    var
-        FeatureKey: Record "Feature Key";
-    begin
-        FeatureKey.Get(FeatureKeyCode);
-        if Enable then
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::"All Users")
-        else
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::None);
-
-        FeatureKey.Modify(true);
     end;
 
     local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)

--- a/src/Layers/NA/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
@@ -18,7 +18,6 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         LibrarySales: Codeunit "Library - Sales";
         LibraryService: Codeunit "Library - Service";
         LibraryReportDataset: Codeunit "Library - Report Dataset";
-        LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         IsInitialized: Boolean;
@@ -151,22 +150,23 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     [Scope('OnPrem')]
     procedure PrintServiceInvoiceTextonInvoiceTranslated()
     var
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         AddFeePerLine: Decimal;
         CustomerNo: Code[20];
         InvoiceNo: Code[20];
+        LanguageCode: Code[10];
         ReminderTermsCode: Code[10];
     begin
         // [SCENARIO 107048] A service invoice report contains translated Add. Fee Note
-        // as selected Reminder Terms contain Translated text on Report and Customer Country is set to use specific lang.
+        // as selected Reminder Terms contain attachment text in the customer's language.
         Initialize();
 
         // [GIVEN] A Reminder Term X, with level 1 with Add. Fee per Line = A, where A > 0, with Text on Report
         // defined in other language and Customer Language set to that language
         AddFeePerLine := LibraryRandom.RandDec(1000, 2);
         CreateCustomerWithReminderTermsAddFeePerLine(CustomerNo, ReminderTermsCode, true, '', AddFeePerLine);
-        CreateReminderTermsTranslationEntry(ReminderTermsTranslation, ReminderTermsCode);
-        UpdateCustomerLangCode(CustomerNo, ReminderTermsTranslation."Language Code");
+        LanguageCode := LibraryERM.GetAnyLanguageDifferentFromCurrent();
+        CreateReminderTermsInlineFeeText(ReminderTermsCode, LanguageCode);
+        UpdateCustomerLangCode(CustomerNo, LanguageCode);
 
         // [GIVEN] A posted service invoice for customer with Reminder Term = X
         InvoiceNo := PostServiceInvoice(CustomerNo, WorkDate());
@@ -174,9 +174,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         // [WHEN] The invoice is printed
         ExportServiceInvoice(CustomerNo);
 
-        // [THEN] The Add. Fee per Line note on report is printed on language defined in Reminder Terms Translation table
-        ValidateInvoiceAddFeePerLine(
-          ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', ReminderTermsTranslation."Language Code");
+        // [THEN] The Add. Fee per Line note on report is printed in the customer's language
+        ValidateInvoiceAddFeePerLine(ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', LanguageCode);
     end;
 
     local procedure Initialize()
@@ -271,14 +270,16 @@ codeunit 134993 "Reminder - Line Fee on Reports"
 
     local procedure CreateReminderTerms(PostLineFee: Boolean; PostInterest: Boolean; PostAddFee: Boolean): Code[10]
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderTerms: Record "Reminder Terms";
     begin
         LibraryERM.CreateReminderTerms(ReminderTerms);
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
         exit(ReminderTerms.Code)
     end;
 
@@ -295,8 +296,6 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -306,17 +305,14 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Modify(true);
     end;
 
-    local procedure CreateReminderTermsTranslationEntry(var ReminderTermsTranslation: Record "Reminder Terms Translation"; ReminderTermsCode: Code[10])
+    local procedure CreateReminderTermsInlineFeeText(ReminderTermsCode: Code[10]; LanguageCode: Code[10])
     var
-        Language: Record Language;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderTerms: Record "Reminder Terms";
     begin
-        Language.FindFirst();
-        ReminderTermsTranslation.Init();
-        ReminderTermsTranslation.Validate("Reminder Terms Code", ReminderTermsCode);
-        ReminderTermsTranslation.Validate("Language Code", Language.Code);
-        ReminderTermsTranslation.Insert(true);
-        ReminderTermsTranslation.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
-        ReminderTermsTranslation.Modify(true);
+        ReminderTerms.Get(ReminderTermsCode);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, LanguageCode);
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
     end;
 
     local procedure ExportServiceInvoice(CustomerNo: Code[20])
@@ -369,9 +365,9 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         ElementExpectedValue: Text;
         MarginalPerc: Decimal;
         TextOnReportExpected: Text[150];
@@ -396,12 +392,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
             CurrencyCode := GeneralLedgerSetup."LCY Code";
         end;
 
-        // expected result
-        if LanguageCode <> Language.GetUserLanguageCode() then begin
-            ReminderTermsTranslation.Get(ReminderTerms.Code, LanguageCode);
-            TextOnReportExpected := ReminderTermsTranslation."Note About Line Fee on Report"
-        end else
-            TextOnReportExpected := ReminderTerms."Note About Line Fee on Report";
+        ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode);
+        TextOnReportExpected := ReminderAttachmentText."Inline Fee Description";
 
         ElementExpectedValue := StrSubstNo(TextOnReportExpected, Format(AddFeePerLine, 0, 9),
             CurrencyCode, AddFeeDueDate, Format(MarginalPerc, 0, 9));

--- a/src/Layers/NL/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/NL/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1496,7 +1496,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/NL/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/NL/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -183,4 +182,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/NO/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/NO/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1517,7 +1517,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/NO/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -18,13 +18,11 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using Microsoft.Utilities;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -684,52 +682,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -936,37 +891,6 @@ report 117 Reminder
                       8, "Issued Reminder Header"."No.", 0, 0, DATABASE::Customer, "Issued Reminder Header"."Customer No.",
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
     end;
 
     var

--- a/src/Layers/NO/BaseApp/Sales/Reminder/ReminderHeader.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/ReminderHeader.Table.al
@@ -841,7 +841,6 @@ table 295 "Reminder Header"
         CustPostingGr: Record "Customer Posting Group";
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         FinChrgTerms: Record "Finance Charge Terms";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
@@ -870,7 +869,6 @@ table 295 "Reminder Header"
         PrintReminderQst: Label 'Do you want to print reminder %1?', Comment = '%1 = Reminder No.';
         DeleteExistingLinesTxt: Label 'This change will cause the existing lines to be deleted for this reminder.\\';
         ContinueTxt: Label 'Do you want to continue?';
-        NotEnoughSpaceForTextErr: Label 'There is not enough space to insert the text.';
         GapInNumberSeriesIfDeleteTxt: Label 'Deleting this document will cause a gap in the number series for reminders. ';
         CreateEmptyReminderTxt: Label 'An empty reminder %1 will be created to fill this gap in the number series.\\', Comment = '%1 = Reminder No.';
         UnexpectedLineTypeErr: Label 'Unexpected line type %1 in reminder %2', Comment = '%1 = Line Type, %2 = Reminder No.';
@@ -1125,33 +1123,12 @@ table 295 "Reminder Header"
         ReminderLevel.SetRange("No.", 1, ReminderHeader."Reminder Level");
         OnInsertBeginTextsOnAfterReminderLevelSetFilters(ReminderLevel, ReminderHeader);
         if ReminderLevel.FindLast() then
-            if ReminderCommunication.NewReminderCommunicationEnabled() then
-                ReminderCommunication.InsertBeginningText(ReminderHeader, ReminderLevel, ReminderLine)
-            else begin
-                ReminderText.Reset();
-                ReminderText.SetRange("Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-                ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-                ReminderText.SetRange(Position, ReminderText.Position::Beginning);
-                OnInsertBeginTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-                ReminderLine.Reset();
-                ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-                ReminderLine."Reminder No." := ReminderHeader."No.";
-                if ReminderLine.Find('-') then begin
-                    LineSpacing := ReminderLine."Line No." div (ReminderText.Count + 2);
-                    if LineSpacing = 0 then
-                        Error(NotEnoughSpaceForTextErr);
-                end else
-                    LineSpacing := 10000;
-                NextLineNo := 0;
-                InsertTextLines(ReminderHeader);
-            end;
+            ReminderCommunication.InsertBeginningText(ReminderHeader, ReminderLevel, ReminderLine);
     end;
 
     local procedure InsertEndTexts(var ReminderHeader: Record "Reminder Header")
     var
         ReminderCommunication: Codeunit "Reminder Communication";
-        ReminderLine2: Record "Reminder Line";
         IsHandled: Boolean;
     begin
         IsHandled := false;
@@ -1163,46 +1140,7 @@ table 295 "Reminder Header"
         ReminderLevel.SetRange("No.", 1, ReminderHeader."Reminder Level");
         OnInsertEndTextsOnAfterReminderLevelSetFilters(ReminderLevel, ReminderHeader);
         if ReminderLevel.FindLast() then
-            if ReminderCommunication.NewReminderCommunicationEnabled() then
-                ReminderCommunication.InsertEndingText(ReminderHeader, ReminderLevel, ReminderLine)
-            else begin
-                ReminderText.SetRange(
-                  "Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-                ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-                ReminderText.SetRange(Position, ReminderText.Position::Ending);
-                OnInsertEndTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-                ReminderLine.Reset();
-                ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-                ReminderLine.SetFilter(
-                  "Line Type", '%1|%2|%3',
-                  ReminderLine."Line Type"::"Reminder Line",
-                  ReminderLine."Line Type"::"Additional Fee",
-                  ReminderLine."Line Type"::Rounding);
-                OnInsertEndTextsOnAfterReminderLineSetFilters(ReminderLine, ReminderHeader);
-                if ReminderLine.FindLast() then
-                    NextLineNo := ReminderLine."Line No."
-                else
-                    NextLineNo := 0;
-                ReminderLine.SetRange("Line Type");
-                ReminderLine2 := ReminderLine;
-                ReminderLine2.CopyFilters(ReminderLine);
-                ReminderLine2.SetFilter("Line Type", '<>%1', ReminderLine2."Line Type"::"Line Fee");
-                if ReminderLine2.Next() <> 0 then begin
-                    LineSpacing :=
-                      (ReminderLine2."Line No." - ReminderLine."Line No.") div
-                      (ReminderText.Count + 2);
-                    if LineSpacing = 0 then
-                        Error(NotEnoughSpaceForTextErr);
-                end else
-                    LineSpacing := 10000;
-                InsertTextLines(ReminderHeader);
-            end;
-    end;
-
-    local procedure InsertTextLines(var ReminderHeader: Record "Reminder Header")
-    begin
-        InsertTextLines(ReminderHeader, ReminderText, NextLineNo, LineSpacing);
+            ReminderCommunication.InsertEndingText(ReminderHeader, ReminderLevel, ReminderLine);
     end;
 
     /// <summary>
@@ -1236,6 +1174,7 @@ table 295 "Reminder Header"
             repeat
                 NextLineNo := NextLineNo + LineSpacing;
                 ReminderLine.Init();
+                ReminderLine."Reminder No." := "No.";
                 ReminderLine."Line No." := NextLineNo;
                 ReminderLine.Type := ReminderLine.Type::" ";
                 ReminderLine.Description :=
@@ -1880,10 +1819,13 @@ table 295 "Reminder Header"
     /// </summary>
     /// <param name="ReminderLine">The reminder line record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertEndTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertEndTextsOnAfterReminderLineSetFilters(var ReminderLine: Record "Reminder Line"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after setting filters on reminder level during InsertEndTexts processing.
@@ -2028,20 +1970,26 @@ table 295 "Reminder Header"
     /// </summary>
     /// <param name="ReminderText">The reminder text record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertBeginTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertBeginTextsOnAfterReminderTextSetFilters(var ReminderText: Record "Reminder Text"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after setting filters on reminder text during InsertEndTexts processing.
     /// </summary>
     /// <param name="ReminderText">The reminder text record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertEndTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertEndTextsOnAfterReminderTextSetFilters(var ReminderText: Record "Reminder Text"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after calculating the additional fee during InsertLines processing.

--- a/src/Layers/NO/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -591,16 +591,9 @@ table 296 "Reminder Line"
                         ReminderHeader."Posting Date"));
 
                     Description := '';
-                    if (Amount <> 0) then begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
-                        else
-                            if (ReminderLevel."Add. Fee per Line Description" <> '') then
-                                Description :=
-                                    StrSubstNo(
-                                        ReminderLevel."Add. Fee per Line Description", "Reminder No.", "No. of Reminders", "Document Date",
-                                        "Posting Date", "No.", Amount, "Applies-to Document Type", "Applies-to Document No.", ReminderLevel."No.");
-                    end else
+                    if (Amount <> 0) then
+                        Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
+                    else
                         if GLAcc.Get("No.") then
                             Description := GLAcc.Name;
                 end;

--- a/src/Layers/NO/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/NO/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -619,7 +619,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/NO/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/NO/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -939,4 +938,3 @@
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/NO/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/NO/DemoTool/InterfaceTrialData.Codeunit.al
@@ -55,7 +55,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -183,4 +182,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/NO/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/NO/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1277,6 +1277,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3136,4 +3236,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/NO/Tests/ERM-Finance/ERMFinancialReportsII.Codeunit.al
+++ b/src/Layers/NO/Tests/ERM-Finance/ERMFinancialReportsII.Codeunit.al
@@ -44,6 +44,7 @@
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         OriginalWorkdate: Date;
         ExchRateWasAdjustedTxt: Label 'One or more currency exchange rates have been adjusted.';
         GenJnlTemplateNameTok: Label 'JnlTemplateName_GenJnlBatch';
@@ -58,6 +59,7 @@
         TestReportDifferentCustomerSameDocumentErr: Label '%1 posted on %2, must be separated by an empty line';
         IsInitialized: Boolean;
         InvoiceOutOfBalanceErr: Label 'Invoice %1 is out of balance by %2.';
+        RemitPaymentTxt: Label 'Please remit your payment %7', Comment = '%7 = Amount due';
         DateOutOfBalanceErr: Label 'As of %1, the lines are out of balance by %2.';
         TotalOutOfBalanceErr: Label 'The total of the lines is out of balance by%1.';
         NotAllowedPostingDateErr: Label 'The Posting Date is not within your range of allowed posting dates.';
@@ -828,7 +830,7 @@
     begin
         // [SCENARIO 122513] Reminder Report doesn't print Not Due documents when run with "Show Not Due Amounts" = FALSE
         Initialize();
-        CustomerNo := CreateCustomer();
+        CustomerNo := CreateCustomerWithReminderAttachmentText();
 
         // [GIVEN] Posted invoice with "Posting Date" = WorkDate() + 2 Month
         CreateAndPostGenJournalLineWithDate(GenJournalLine, CalcDate('<2M>', WorkDate()), CustomerNo, LibraryRandom.RandDec(1000, 2));  // Using Random value for Amount.
@@ -1699,8 +1701,6 @@
     local procedure Initialize()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Financial Reports II");
@@ -1714,15 +1714,6 @@
         if OriginalWorkdate = 0D then
             OriginalWorkdate := WorkDate();
         WorkDate := OriginalWorkdate;
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -1908,6 +1899,28 @@
         ReminderLevel.FindFirst();
         LibrarySales.CreateCustomer(Customer);
         Customer.Validate("Reminder Terms Code", ReminderLevel."Reminder Terms Code");
+        Customer.Validate("Fin. Charge Terms Code", CreateFinanceChargeTerms());
+        Customer.Modify(true);
+        exit(Customer."No.");
+    end;
+
+    local procedure CreateCustomerWithReminderAttachmentText(): Code[20]
+    var
+        Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
+        ReminderTerms: Record "Reminder Terms";
+    begin
+        LibraryERM.CreateReminderTermsAndLevel(ReminderTerms, ReminderLevel);
+        ReminderLevel.Validate("Additional Fee (LCY)", LibraryRandom.RandInt(10));
+        ReminderLevel.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", RemitPaymentTxt);
+
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
         Customer.Validate("Fin. Charge Terms Code", CreateFinanceChargeTerms());
         Customer.Modify(true);
         exit(Customer."No.");
@@ -2306,16 +2319,18 @@
     local procedure GetRemitPaymentsMsg(IssuedReminderNo: Code[20]; Amount: Decimal): Text
     var
         IssuedReminderHeader: Record "Issued Reminder Header";
-        ReminderText: Record "Reminder Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
         Text: Text;
     begin
         IssuedReminderHeader.Get(IssuedReminderNo);
-        ReminderText.SetRange("Reminder Terms Code", IssuedReminderHeader."Reminder Terms Code");
-        ReminderText.SetRange("Reminder Level", 1);
-        ReminderText.SetRange(Position, 1);
-        ReminderText.FindFirst();
+        ReminderLevel.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level");
+        ReminderAttachmentTextLine.SetRange(Id, ReminderLevel."Reminder Attachment Text");
+        ReminderAttachmentTextLine.SetRange("Language Code", Language.GetUserLanguageCode());
+        ReminderAttachmentTextLine.SetRange(Position, ReminderAttachmentTextLine.Position::"Ending Line");
+        ReminderAttachmentTextLine.FindFirst();
         // Replace '%7' with '%1'
-        Text := ConvertStr(ReminderText.Text, '7', '1');
+        Text := ConvertStr(ReminderAttachmentTextLine.Text, '7', '1');
         exit(StrSubstNo(Text, Amount));
     end;
 

--- a/src/Layers/NZ/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/NZ/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 201; // Number of calls to RunCodeunit
+        MaxSteps := 200; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -927,4 +926,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/RU/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/RU/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1848,7 +1848,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/RU/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/RU/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -711,7 +711,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")

--- a/src/Layers/RU/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/RU/DemoTool/InterfaceBasisData.Codeunit.al
@@ -64,7 +64,7 @@
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -77,7 +77,6 @@
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -1241,4 +1240,3 @@
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/RU/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/RU/DemoTool/InterfaceTrialData.Codeunit.al
@@ -62,7 +62,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -198,4 +197,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/RU/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/RU/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1285,6 +1285,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3371,4 +3471,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/RU/Tests/ERM-Finance/ERMIssuedReminderAddnlFee.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMIssuedReminderAddnlFee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         AmountError: Label 'Additional Fee Amount must be %1 for Issued Reminder No: %2.';
         ReminderEndingText: Label 'Balance %7';
@@ -75,9 +76,10 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     procedure CreateSalesInvoiceAndReminder()
     var
         Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         DueDate: Date;
         DocumentDate: Date;
     begin
@@ -87,8 +89,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         CreateCustomer(Customer, '');
         ReminderLevel.SetRange("Reminder Terms Code", Customer."Reminder Terms Code");
         ReminderLevel.FindFirst();
-        LibraryERM.CreateReminderText(
-          ReminderText, Customer."Reminder Terms Code", ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
 
         // Exercise: Post Sales Invoice and Create Reminder.
         DueDate := CreateAndPostSalesInvoice(Customer."No.", '');
@@ -172,9 +175,10 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     procedure UpdateReminderText()
     var
         Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderHeader: Record "Reminder Header";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
     begin
         // Check the functionality of Report Update Reminder Text.
 
@@ -182,8 +186,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         Initialize();
         CreateCustomer(Customer, '');
         GetReminderLevel(ReminderLevel, Customer."Reminder Terms Code");
-        LibraryERM.CreateReminderText(
-          ReminderText, Customer."Reminder Terms Code", ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
         ReminderLevelNo := ReminderLevel."No.";  // Assign global variable.
         CreateReminder(
           Customer."No.",
@@ -592,8 +597,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     procedure VerifyEmailOnReminderPageWhenCustomerHasNoContacts()
     var
         Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         ReminderHeader: Record "Reminder Header";
         ReminderPage: TestPage Reminder;
         CustomerCard: TestPage "Customer Card";
@@ -618,9 +624,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         // [GIVEN] Create Reminder Level with Random Grace Period and Random Additional Fee.
         ReminderLevel.SetRange("Reminder Terms Code", Customer."Reminder Terms Code");
         ReminderLevel.FindFirst();
-        LibraryERM.CreateReminderText(
-            ReminderText, Customer."Reminder Terms Code",
-            ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
 
         // [WHEN] Post Sales Invoice and Create Reminder.
         DueDate := CreateAndPostSalesInvoice(Customer."No.", '');
@@ -702,23 +708,12 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         DocumentNoVisibility: Codeunit DocumentNoVisibility;
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Issued Reminder Addnl Fee");
         // Clear global variable.
         Clear(ReminderLevelNo);
         DocumentNoVisibility.ClearState();
         LibraryVariableStorage.Clear();
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -1153,4 +1148,3 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         BatchCancelIssuedReminders.OK().Invoke();
     end;
 }
-

--- a/src/Layers/RU/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -294,6 +280,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -321,7 +308,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -517,6 +505,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -534,8 +523,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -557,8 +546,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -572,7 +564,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -607,8 +602,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -622,7 +620,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1445,6 +1446,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1460,8 +1462,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2559,8 +2561,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader: Record "Reminder Header";
         VATPostingSetup: Record "VAT Posting Setup";
         GLAccount: Record "G/L Account";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2573,14 +2573,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2606,10 +2598,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2773,16 +2761,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2791,8 +2780,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2800,6 +2787,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2907,25 +2899,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3170,4 +3143,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/RU/Tests/Integration-Internal/MailServiceTest.Codeunit.al
+++ b/src/Layers/RU/Tests/Integration-Internal/MailServiceTest.Codeunit.al
@@ -356,8 +356,6 @@ codeunit 139111 "Mail Service Test"
     local procedure Initialize()
     var
         CompanyInformation: Record "Company Information";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryEmail: Codeunit "Library - Email";
         LibraryLowerPermissions: Codeunit "Library - Lower Permissions";
     begin
@@ -365,14 +363,6 @@ codeunit 139111 "Mail Service Test"
         LibraryEmail.SetUpEmailAccount();
         BindActiveDirectoryMockEvents();
         LibraryVariableStorage.Clear();
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if not IsInitialized then begin
             IsInitialized := true;

--- a/src/Layers/SE/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/SE/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1391,7 +1391,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/SE/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/SE/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 203; // Number of calls to RunCodeunit
+        MaxSteps := 202; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -928,4 +927,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/SE/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/SE/DemoTool/InterfaceTrialData.Codeunit.al
@@ -57,7 +57,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -187,4 +186,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/SE/Tests/Local/SECustomerReports.Codeunit.al
+++ b/src/Layers/SE/Tests/Local/SECustomerReports.Codeunit.al
@@ -100,18 +100,7 @@ codeunit 144026 "SE Customer Reports"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         Clear(LibraryReportValidation);
         LibraryVariableStorage.Clear();
 

--- a/src/Layers/US/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/US/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");

--- a/src/Layers/US/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/US/DemoTool/InterfaceTrialData.Codeunit.al
@@ -56,7 +56,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");

--- a/src/Layers/US/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/US/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -324,6 +310,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -351,7 +338,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -547,6 +535,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -564,8 +553,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -587,8 +576,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -602,7 +594,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -637,8 +632,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -652,7 +650,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1473,6 +1474,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1488,8 +1490,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2533,8 +2535,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2546,15 +2546,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2575,10 +2566,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Reminder - Add. Line fee");
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
     end;
 
     local procedure ResetDocumentValueRange()
@@ -2743,16 +2730,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2761,8 +2749,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2770,6 +2756,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2877,25 +2868,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3131,4 +3103,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/RoleCenters/FinanceManagerRoleCenter.Page.al
@@ -1404,7 +1404,7 @@ page 8901 "Finance Manager Role Center"
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Reminder Terms';
-                        RunObject = page "Reminder Terms";
+                        RunObject = page "Reminder Terms List";
                         Tooltip = 'Open the Reminder Terms page.';
                     }
                     action("Finance Charge Terms")

--- a/src/Layers/W1/BaseApp/Sales/Reminder/LineFeeNoteonReportHist.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/LineFeeNoteonReportHist.Table.al
@@ -16,6 +16,7 @@ table 1053 "Line Fee Note on Report Hist."
 {
     Caption = 'Line Fee Note on Report Hist.';
     Permissions = TableData "Line Fee Note on Report Hist." = rimd,
+                  tabledata "Reminder Attachment Text" = R,
                   tabledata "Reminder Terms" = R;
     DataClassification = CustomerContent;
 
@@ -116,6 +117,11 @@ table 1053 "Line Fee Note on Report Hist."
         LineFeeNoteOnReportHist: Record "Line Fee Note on Report Hist.";
     begin
         if LineFeeNoteOnReport <> '' then begin
+            if LineFeeNoteOnReportHist.Get(
+                CustLedgerEntryNo, DueDate, LanguageCode, ReminderLevel."Reminder Terms Code", ReminderLevel."No.")
+            then
+                exit;
+
             LineFeeNoteOnReportHist.Init();
             LineFeeNoteOnReportHist."Cust. Ledger Entry No" := CustLedgerEntryNo;
             LineFeeNoteOnReportHist."Due Date" := DueDate;
@@ -127,37 +133,49 @@ table 1053 "Line Fee Note on Report Hist."
         end;
     end;
 
-    local procedure InsertTransLineFeeNoteOnReport(CustLedgerEntry: Record "Cust. Ledger Entry"; ReminderTerms: Record "Reminder Terms"; ReminderLevel: Record "Reminder Level"; DueDate: Date)
+    local procedure InsertAttachmentLineFeeNotesOnReport(CustLedgerEntry: Record "Cust. Ledger Entry"; ReminderTerms: Record "Reminder Terms"; ReminderLevel: Record "Reminder Level"; DueDate: Date)
     var
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
-        Language: Codeunit Language;
-        AddTextOnReport: Text[200];
-        AddTextOnReportDefault: Text[200];
-        DefaultLanguageCode: Code[10];
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderLevelAttachmentText: Record "Reminder Attachment Text";
+        LineFeeNoteOnReport: Text[200];
     begin
-        // insert default language
-        if ReminderTerms."Note About Line Fee on Report" <> '' then begin
-            DefaultLanguageCode := Language.GetUserLanguageCode();
-            if not ReminderTermsTranslation.Get(ReminderTerms.Code, DefaultLanguageCode) then begin
-                AddTextOnReportDefault := GetLineFeeNoteOnReport(CustLedgerEntry, ReminderLevel,
-                    ReminderTerms."Note About Line Fee on Report", DueDate);
-                InsertRec(ReminderLevel, CustLedgerEntry."Entry No.", DueDate, Language.GetUserLanguageCode(), AddTextOnReportDefault);
-            end;
+        if not IsNullGuid(ReminderLevel."Reminder Attachment Text") then begin
+            ReminderAttachmentText.SetRange(Id, ReminderLevel."Reminder Attachment Text");
+            if ReminderAttachmentText.FindSet() then
+                repeat
+                    if ReminderAttachmentText."Inline Fee Description" <> '' then begin
+                        LineFeeNoteOnReport :=
+                            GetLineFeeNoteOnReport(CustLedgerEntry, ReminderLevel, ReminderAttachmentText."Inline Fee Description", DueDate);
+                        InsertRec(ReminderLevel,
+                            CustLedgerEntry."Entry No.",
+                            DueDate,
+                            ReminderAttachmentText."Language Code",
+                            LineFeeNoteOnReport);
+                    end;
+                until ReminderAttachmentText.Next() = 0;
         end;
 
-        // insert Reminder Terms Translation records
-        ReminderTermsTranslation.SetRange("Reminder Terms Code", ReminderLevel."Reminder Terms Code");
-        if ReminderTermsTranslation.FindSet() then
-            repeat
-                AddTextOnReport :=
-                  GetLineFeeNoteOnReport(CustLedgerEntry, ReminderLevel, ReminderTermsTranslation."Note About Line Fee on Report", DueDate);
-                InsertRec(ReminderLevel,
-                  CustLedgerEntry."Entry No.",
-                  DueDate,
-                  ReminderTermsTranslation."Language Code",
-                  AddTextOnReport);
+        if IsNullGuid(ReminderTerms."Reminder Attachment Text") then
+            exit;
 
-            until ReminderTermsTranslation.Next() = 0;
+        ReminderAttachmentText.Reset();
+        ReminderAttachmentText.SetRange(Id, ReminderTerms."Reminder Attachment Text");
+        ReminderAttachmentText.SetFilter("Inline Fee Description", '<>%1', '');
+        if ReminderAttachmentText.FindSet() then
+            repeat
+                if IsNullGuid(ReminderLevel."Reminder Attachment Text") or
+                   not ReminderLevelAttachmentText.Get(
+                       ReminderLevel."Reminder Attachment Text", ReminderAttachmentText."Language Code")
+                then begin
+                    LineFeeNoteOnReport :=
+                        GetLineFeeNoteOnReport(CustLedgerEntry, ReminderLevel, ReminderAttachmentText."Inline Fee Description", DueDate);
+                    InsertRec(ReminderLevel,
+                        CustLedgerEntry."Entry No.",
+                        DueDate,
+                        ReminderAttachmentText."Language Code",
+                        LineFeeNoteOnReport);
+                end;
+            until ReminderAttachmentText.Next() = 0;
     end;
 
     /// <summary>
@@ -184,12 +202,11 @@ table 1053 "Line Fee Note on Report Hist."
         ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
         if ReminderLevel.FindSet() then begin
             DueDate := CalcDate(ReminderLevel."Grace Period", CustLedgerEntry."Due Date");
-            InsertTransLineFeeNoteOnReport(CustLedgerEntry, ReminderTerms, ReminderLevel, DueDate);
+            InsertAttachmentLineFeeNotesOnReport(CustLedgerEntry, ReminderTerms, ReminderLevel, DueDate);
             while ReminderLevel.Next() <> 0 do begin
                 DueDate := CalcDate(ReminderLevel."Grace Period", DueDate);
-                InsertTransLineFeeNoteOnReport(CustLedgerEntry, ReminderTerms, ReminderLevel, DueDate);
+                InsertAttachmentLineFeeNotesOnReport(CustLedgerEntry, ReminderTerms, ReminderLevel, DueDate);
             end;
         end;
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Sales/Reminder/Reminder.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/Reminder.Report.al
@@ -18,12 +18,10 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Sales.Customer;
-using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using Microsoft.Sales.Setup;
 using System.Email;
 using System.Globalization;
-using System.Text;
 using System.Utilities;
 
 report 117 Reminder
@@ -671,52 +669,9 @@ report 117 Reminder
 
                     trigger OnPreDataItem()
                     var
-                        FinanceChargeTerms: Record "Finance Charge Terms";
-                        ReminderEmailText: Record "Reminder Email Text";
-                        AutoFormat: Codeunit "Auto Format";
                         ReminderCommunication: Codeunit "Reminder Communication";
-                        AutoFormatType: Enum "Auto Format";
-                        EmailTextInStream: InStream;
-                        EmailTextLine: Text;
                     begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT)
-                        else begin
-                            AmtDueTxt := '';
-                            BodyTxt := '';
-                            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-                            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-                            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-                            if Format("Issued Reminder Header"."Due Date") <> '' then
-                                AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), "Issued Reminder Header"."Due Date");
-
-                            if GetEmailTextInStream(EmailTextInStream, "Issued Reminder Header") then begin
-                                AmtDueTxt := '';
-                                BodyTxt := '';
-                                if "Issued Reminder Header"."Fin. Charge Terms Code" <> '' then
-                                    FinanceChargeTerms.Get("Issued Reminder Header"."Fin. Charge Terms Code");
-
-                                while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                                    BodyTxt += EmailTextLine;
-
-                                BodyTxt := StrSubstNo(
-                                    BodyTxt,
-                                    "Issued Reminder Header"."Document Date",
-                                    "Issued Reminder Header"."Due Date",
-                                    FinanceChargeTerms."Interest Rate",
-                                    Format("Issued Reminder Header"."Remaining Amount", 0,
-                                        AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Interest Amount",
-                                    "Issued Reminder Header"."Additional Fee",
-                                    Format(NNC_TotalInclVAT, 0, AutoFormat.ResolveAutoFormat(AutoFormatType::AmountFormat, "Issued Reminder Header"."Currency Code")),
-                                    "Issued Reminder Header"."Reminder Level",
-                                    "Issued Reminder Header"."Currency Code",
-                                    "Issued Reminder Header"."Posting Date",
-                                    CompanyInfo.Name,
-                                    "Issued Reminder Header"."Add. Fee per Line");
-                            end else
-                                BodyTxt := ReminderEmailText.GetBodyLbl();
-                        end;
+                        ReminderCommunication.PopulateEmailText("Issued Reminder Header", CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
                         OnLetterTextOnPreDataItemOnAfterSetAmtDueTxt("Issued Reminder Header", AmtDueTxt, GreetingTxt, BodyTxt, ClosingTxt, DescriptionTxt);
                     end;
                 }
@@ -922,38 +877,6 @@ report 117 Reminder
                       '', '', "Issued Reminder Header".GetLogInteractionDescription(), '');
                 until "Issued Reminder Header".Next() = 0;
     end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
-    end;
-
 
     var
 #pragma warning disable AA0074

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderHeader.Table.al
@@ -779,7 +779,6 @@ table 295 "Reminder Header"
         CustPostingGr: Record "Customer Posting Group";
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         FinChrgTerms: Record "Finance Charge Terms";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
@@ -802,7 +801,6 @@ table 295 "Reminder Header"
         PrintReminderQst: Label 'Do you want to print reminder %1?', Comment = '%1 = Reminder No.';
         DeleteExistingLinesTxt: Label 'This change will cause the existing lines to be deleted for this reminder.\\';
         ContinueTxt: Label 'Do you want to continue?';
-        NotEnoughSpaceForTextErr: Label 'There is not enough space to insert the text.';
         GapInNumberSeriesIfDeleteTxt: Label 'Deleting this document will cause a gap in the number series for reminders. ';
         CreateEmptyReminderTxt: Label 'An empty reminder %1 will be created to fill this gap in the number series.\\', Comment = '%1 = Reminder No.';
         UnexpectedLineTypeErr: Label 'Unexpected line type %1 in reminder %2', Comment = '%1 = Line Type, %2 = Reminder No.';
@@ -1054,33 +1052,12 @@ table 295 "Reminder Header"
         ReminderLevel.SetRange("No.", 1, ReminderHeader."Reminder Level");
         OnInsertBeginTextsOnAfterReminderLevelSetFilters(ReminderLevel, ReminderHeader);
         if ReminderLevel.FindLast() then
-            if ReminderCommunication.NewReminderCommunicationEnabled() then
-                ReminderCommunication.InsertBeginningText(ReminderHeader, ReminderLevel, ReminderLine)
-            else begin
-                ReminderText.Reset();
-                ReminderText.SetRange("Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-                ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-                ReminderText.SetRange(Position, ReminderText.Position::Beginning);
-                OnInsertBeginTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-                ReminderLine.Reset();
-                ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-                ReminderLine."Reminder No." := ReminderHeader."No.";
-                if ReminderLine.Find('-') then begin
-                    LineSpacing := ReminderLine."Line No." div (ReminderText.Count + 2);
-                    if LineSpacing = 0 then
-                        Error(NotEnoughSpaceForTextErr);
-                end else
-                    LineSpacing := 10000;
-                NextLineNo := 0;
-                InsertTextLines(ReminderHeader);
-            end;
+            ReminderCommunication.InsertBeginningText(ReminderHeader, ReminderLevel, ReminderLine);
     end;
 
     local procedure InsertEndTexts(var ReminderHeader: Record "Reminder Header")
     var
         ReminderCommunication: Codeunit "Reminder Communication";
-        ReminderLine2: Record "Reminder Line";
         IsHandled: Boolean;
     begin
         IsHandled := false;
@@ -1092,46 +1069,7 @@ table 295 "Reminder Header"
         ReminderLevel.SetRange("No.", 1, ReminderHeader."Reminder Level");
         OnInsertEndTextsOnAfterReminderLevelSetFilters(ReminderLevel, ReminderHeader);
         if ReminderLevel.FindLast() then
-            if ReminderCommunication.NewReminderCommunicationEnabled() then
-                ReminderCommunication.InsertEndingText(ReminderHeader, ReminderLevel, ReminderLine)
-            else begin
-                ReminderText.SetRange(
-                  "Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-                ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-                ReminderText.SetRange(Position, ReminderText.Position::Ending);
-                OnInsertEndTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-                ReminderLine.Reset();
-                ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-                ReminderLine.SetFilter(
-                  "Line Type", '%1|%2|%3',
-                  ReminderLine."Line Type"::"Reminder Line",
-                  ReminderLine."Line Type"::"Additional Fee",
-                  ReminderLine."Line Type"::Rounding);
-                OnInsertEndTextsOnAfterReminderLineSetFilters(ReminderLine, ReminderHeader);
-                if ReminderLine.FindLast() then
-                    NextLineNo := ReminderLine."Line No."
-                else
-                    NextLineNo := 0;
-                ReminderLine.SetRange("Line Type");
-                ReminderLine2 := ReminderLine;
-                ReminderLine2.CopyFilters(ReminderLine);
-                ReminderLine2.SetFilter("Line Type", '<>%1', ReminderLine2."Line Type"::"Line Fee");
-                if ReminderLine2.Next() <> 0 then begin
-                    LineSpacing :=
-                      (ReminderLine2."Line No." - ReminderLine."Line No.") div
-                      (ReminderText.Count + 2);
-                    if LineSpacing = 0 then
-                        Error(NotEnoughSpaceForTextErr);
-                end else
-                    LineSpacing := 10000;
-                InsertTextLines(ReminderHeader);
-            end;
-    end;
-
-    local procedure InsertTextLines(var ReminderHeader: Record "Reminder Header")
-    begin
-        InsertTextLines(ReminderHeader, ReminderText, NextLineNo, LineSpacing);
+            ReminderCommunication.InsertEndingText(ReminderHeader, ReminderLevel, ReminderLine);
     end;
 
     /// <summary>
@@ -1279,6 +1217,7 @@ table 295 "Reminder Header"
 
         NextLineNo := NextLineNo + LineSpacing;
         ReminderLine.Init();
+        ReminderLine."Reminder No." := "No.";
         ReminderLine."Line No." := NextLineNo;
         ReminderLine."Line Type" := LineType;
         OnInsertBlankLineOnBeforeReminderLineInsert(ReminderLine);
@@ -1778,10 +1717,13 @@ table 295 "Reminder Header"
     /// </summary>
     /// <param name="ReminderLine">The reminder line record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertEndTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertEndTextsOnAfterReminderLineSetFilters(var ReminderLine: Record "Reminder Line"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after setting filters on reminder level during InsertEndTexts processing.
@@ -1926,20 +1868,26 @@ table 295 "Reminder Header"
     /// </summary>
     /// <param name="ReminderText">The reminder text record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertBeginTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertBeginTextsOnAfterReminderTextSetFilters(var ReminderText: Record "Reminder Text"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after setting filters on reminder text during InsertEndTexts processing.
     /// </summary>
     /// <param name="ReminderText">The reminder text record with filters.</param>
     /// <param name="ReminderHeader">The reminder header record.</param>
+#if not CLEAN29
+    [Obsolete('The legacy Reminder Text flow is no longer used. Use OnBeforeInsertEndTexts instead.', '29.0')]
     [IntegrationEvent(false, false)]
     internal procedure OnInsertEndTextsOnAfterReminderTextSetFilters(var ReminderText: Record "Reminder Text"; ReminderHeader: Record "Reminder Header")
     begin
     end;
+#endif
 
     /// <summary>
     /// Raised after calculating the additional fee during InsertLines processing.

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLevel.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLevel.Table.al
@@ -13,8 +13,10 @@ table 293 "Reminder Level"
 {
     Caption = 'Reminder Level';
     DataCaptionFields = "Reminder Terms Code", "No.";
+#if not CLEAN29
     DrillDownPageID = "Reminder Levels";
     LookupPageID = "Reminder Levels";
+#endif
     DataClassification = CustomerContent;
 
     fields
@@ -261,4 +263,3 @@ table 293 "Reminder Level"
         end;
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLevels.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLevels.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 ﻿// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -15,6 +16,9 @@ page 432 "Reminder Levels"
     DataCaptionFields = "Reminder Terms Code";
     PageType = List;
     SourceTable = "Reminder Level";
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Use page 1896 "Reminder Level Setup" instead.';
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -241,4 +245,4 @@ page 432 "Reminder Levels"
         end;
     end;
 }
-
+#endif

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLine.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderLine.Table.al
@@ -582,16 +582,9 @@ table 296 "Reminder Line"
                         ReminderHeader."Posting Date"));
 
                     Description := '';
-                    if (Amount <> 0) then begin
-                        if ReminderCommunication.NewReminderCommunicationEnabled() then
-                            Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
-                        else
-                            if (ReminderLevel."Add. Fee per Line Description" <> '') then
-                                Description :=
-                                    StrSubstNo(
-                                        ReminderLevel."Add. Fee per Line Description", "Reminder No.", "No. of Reminders", "Document Date",
-                                        "Posting Date", "No.", Amount, "Applies-to Document Type", "Applies-to Document No.", ReminderLevel."No.");
-                    end else
+                    if (Amount <> 0) then
+                        Description := ReminderCommunication.FindDescriptionForLineFee(ReminderLevel, CustLedgEntry, Rec, GLAcc)
+                    else
                         if GLAcc.Get("No.") then
                             Description := GLAcc.Name;
                 end;

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderTerms.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderTerms.Page.al
@@ -1,10 +1,9 @@
+#if not CLEAN29
 ﻿// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Reminder;
-
-using System.Telemetry;
 
 /// <summary>
 /// Displays and manages reminder terms configurations including posting options and fee settings.
@@ -15,11 +14,10 @@ page 431 "Reminder Terms"
     Caption = 'Reminder Terms';
     PageType = List;
     SourceTable = "Reminder Terms";
-#if not CLEAN27
-    UsageCategory = Administration;
-#else
     UsageCategory = None;
-#endif
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Use page 837 "Reminder Terms List" instead.';
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -118,24 +116,11 @@ page 431 "Reminder Terms"
     }
 
     trigger OnOpenPage()
-    var
-        ReminderCommunication: Codeunit "Reminder Communication";
-        FeatureTelemetry: Codeunit "Feature Telemetry";
     begin
         if CurrPage.LookupMode() then
             exit;
-        FeatureTelemetry.LogUptake('0000LAY', 'Reminder', Enum::"Feature Uptake Status"::Discovered);
-        if ReminderCommunication.NewReminderCommunicationEnabled() then begin
-            Page.Run(Page::"Reminder Terms List");
-            Error('');
-        end;
-    end;
-
-    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
-    var
-        FeatureTelemetry: Codeunit "Feature Telemetry";
-    begin
-        FeatureTelemetry.LogUptake('0000LAZ', 'Reminder', Enum::"Feature Uptake Status"::"Set up");
+        Page.Run(Page::"Reminder Terms List");
+        Error('');
     end;
 }
-
+#endif

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderTermsTranslation.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderTermsTranslation.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 ﻿// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ page 1052 "Reminder Terms Translation"
     Caption = 'Reminder Terms Translation';
     DataCaptionExpression = PageCaptionText;
     SourceTable = "Reminder Terms Translation";
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Use page 1897 "Reminder Term Communication" instead.';
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -49,4 +53,4 @@ page 1052 "Reminder Terms Translation"
     var
         PageCaptionText: Text;
 }
-
+#endif

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderTermsTranslation.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderTermsTranslation.Table.al
@@ -12,8 +12,10 @@ using System.Globalization;
 table 1052 "Reminder Terms Translation"
 {
     Caption = 'Reminder Terms Translation';
+#if not CLEAN29
     DrillDownPageID = "Reminder Terms Translation";
     LookupPageID = "Reminder Terms Translation";
+#endif
     DataClassification = CustomerContent;
 
     fields
@@ -59,4 +61,3 @@ table 1052 "Reminder Terms Translation"
     {
     }
 }
-

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderText.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderText.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN29
 ﻿// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -17,6 +18,9 @@ page 433 "Reminder Text"
     PageType = List;
     SaveValues = true;
     SourceTable = "Reminder Text";
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Use page 835 "Reminder Level Communication" instead.';
+    ObsoleteTag = '29.0';
 
     layout
     {
@@ -73,4 +77,4 @@ page 433 "Reminder Text"
     var
         PageCaptionVariable: Text[250];
 }
-
+#endif

--- a/src/Layers/W1/BaseApp/Sales/Reminder/ReminderText.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/ReminderText.Table.al
@@ -10,8 +10,10 @@ namespace Microsoft.Sales.Reminder;
 table 294 "Reminder Text"
 {
     Caption = 'Reminder Text';
+#if not CLEAN29
     DrillDownPageID = "Reminder Text";
     LookupPageID = "Reminder Text";
+#endif
     DataClassification = CustomerContent;
 
     fields
@@ -89,4 +91,3 @@ table 294 "Reminder Text"
     var
         ReminderLevel: Record "Reminder Level";
 }
-

--- a/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderCommunication.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderCommunication.Codeunit.al
@@ -11,9 +11,6 @@ using Microsoft.Sales.Customer;
 using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.Receivables;
 using System.EMail;
-#if not CLEAN27
-using System.Environment.Configuration;
-#endif
 using System.Globalization;
 using System.Reflection;
 using System.Text;
@@ -24,20 +21,6 @@ using System.Utilities;
 /// </summary>
 codeunit 1890 "Reminder Communication"
 {
-
-    internal procedure NewReminderCommunicationEnabled(): Boolean
-#if not CLEAN27
-    var
-        FeatureManagementFacade: Codeunit "Feature Management Facade";
-#endif
-    begin
-#if not CLEAN27
-        exit(FeatureManagementFacade.IsEnabled(FeatureIdTok));
-#else
-    exit(true);
-#endif
-    end;
-
     /// <summary>
     /// Finds the description text for a line fee based on reminder level and customer language settings.
     /// </summary>
@@ -53,21 +36,17 @@ codeunit 1890 "Reminder Communication"
         LanguageCode: Code[10];
         Result: Text[100];
     begin
-        if NewReminderCommunicationEnabled() then begin
-            LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(CustLedgerEntry."Customer No.");
+        LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(CustLedgerEntry."Customer No.");
 
-            // Check if there is a reminder attachment text for the Reminder Level
-            if ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", LanguageCode) then
+        // Check if there is a reminder attachment text for the Reminder Level
+        if TryGetReminderAttachmentText(ReminderLevel."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then
+            Result := SubstituteInlineFeeDescription(ReminderAttachmentText."Inline Fee Description", ReminderLevel, ReminderLine)
+        else begin
+            // If there are no reminder attachment text for the language, check the Reminder Terms attachment text
+            ReminderTerms.Get(ReminderLevel."Reminder Terms Code");
+            if TryGetReminderAttachmentText(ReminderTerms."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then
                 Result := SubstituteInlineFeeDescription(ReminderAttachmentText."Inline Fee Description", ReminderLevel, ReminderLine)
-            else begin
-                // If there are no reminder attachment text for the language, check the Reminder Terms attachment text
-                ReminderTerms.Get(ReminderLevel."Reminder Terms Code");
-                if ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode) then
-                    Result := SubstituteInlineFeeDescription(ReminderAttachmentText."Inline Fee Description", ReminderLevel, ReminderLine)
-            end;
-        end
-        else
-            Result := SubstituteInlineFeeDescription(ReminderLevel."Add. Fee per Line Description", ReminderLevel, ReminderLine);
+        end;
 
         if Result = '' then
             if GLAccount.Get(ReminderLine."No.") then
@@ -88,29 +67,22 @@ codeunit 1890 "Reminder Communication"
         LineSpacing, NextLineNo : Integer;
         LanguageCode: Code[10];
     begin
-        if NewReminderCommunicationEnabled() then begin
-            LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(ReminderHeader."Customer No.");
-            ReminderLine.Reset();
-            ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-            ReminderLine."Reminder No." := ReminderHeader."No.";
+        LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(ReminderHeader."Customer No.");
+        ReminderLine.Reset();
+        ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
+        ReminderLine."Reminder No." := ReminderHeader."No.";
 
-            if ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", LanguageCode) then begin
+        if TryGetReminderAttachmentText(ReminderLevel."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then begin
+            LineSpacing := CalculateLineSpacingForBeginningText(ReminderLine, ReminderAttachmentText);
+            ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Beginning Text", NextLineNo, LineSpacing);
+        end
+        else begin
+            ReminderTerms.Get(ReminderLevel."Reminder Terms Code");
+            if TryGetReminderAttachmentText(ReminderTerms."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then begin
                 LineSpacing := CalculateLineSpacingForBeginningText(ReminderLine, ReminderAttachmentText);
-                ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Beginning Text", NextLineNo, LineSpacing);
-            end
-            else begin
-                ReminderTerms.Get(ReminderLevel."Reminder Terms Code");
-                if ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode) then begin
-                    LineSpacing := CalculateLineSpacingForBeginningText(ReminderLine, ReminderAttachmentText);
-                    ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Beginning Text", NextLineNo, LineSpacing)
-                end;
+                ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Beginning Text", NextLineNo, LineSpacing)
             end;
         end;
-
-#if not CLEAN27
-        if not NewReminderCommunicationEnabled() then
-            IntroduceBeginningTextFromReminderText(ReminderHeader, ReminderLevel, ReminderLine);
-#endif
     end;
 
     /// <summary>
@@ -127,111 +99,36 @@ codeunit 1890 "Reminder Communication"
         LanguageCode: Code[10];
         LineSpacing, NextLineNo : Integer;
     begin
-        if NewReminderCommunicationEnabled() then begin
-            LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(ReminderHeader."Customer No.");
-            ReminderLine.Reset();
-            ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-            ReminderLine.SetFilter(
-              "Line Type", '%1|%2|%3',
-              ReminderLine."Line Type"::"Reminder Line",
-              ReminderLine."Line Type"::"Additional Fee",
-              ReminderLine."Line Type"::Rounding);
-
-            if ReminderLine.FindLast() then
-                NextLineNo := ReminderLine."Line No."
-            else
-                NextLineNo := 0;
-
-            ReminderLine.SetRange("Line Type");
-            ReminderLine2 := ReminderLine;
-            ReminderLine2.CopyFilters(ReminderLine);
-            ReminderLine2.SetFilter("Line Type", '<>%1', ReminderLine2."Line Type"::"Line Fee");
-
-            if ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", LanguageCode) then begin
-                LineSpacing := CalculateLineSpacingForEndingText(ReminderLine, ReminderLine2, ReminderAttachmentText);
-                ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Ending Text", NextLineNo, LineSpacing);
-            end
-            else begin
-                ReminderTerms.Get(ReminderLevel."Reminder Terms Code");
-                if ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode) then begin
-                    LineSpacing := CalculateLineSpacingForEndingText(ReminderLine, ReminderLine2, ReminderAttachmentText);
-                    ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Ending Text", NextLineNo, LineSpacing);
-                end;
-            end;
-        end;
-
-#if not CLEAN27
-        if not NewReminderCommunicationEnabled() then
-            IntroduceEndingTextFromReminderText(ReminderHeader, ReminderLevel, ReminderLine);
-#endif
-    end;
-
-#if not CLEAN27
-    [Obsolete('Reminder Text is being obsoleted. Use the new records Reminder Attachment Text and Reminder Email Text', '24.0')]
-    local procedure IntroduceBeginningTextFromReminderText(var ReminderHeader: Record "Reminder Header"; var ReminderLevel: Record "Reminder Level"; var ReminderLine: Record "Reminder Line")
-    var
-        ReminderText: Record "Reminder Text";
-        LineSpacing, NextLineNo : Integer;
-    begin
-        ReminderText.Reset();
-        ReminderText.SetRange("Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-        ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-        ReminderText.SetRange(Position, ReminderText.Position::Beginning);
-        ReminderHeader.OnInsertBeginTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
-        ReminderLine.Reset();
-        ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
-        ReminderLine."Reminder No." := ReminderHeader."No.";
-        if ReminderLine.Find('-') then begin
-            LineSpacing := ReminderLine."Line No." div (ReminderText.Count + 2);
-            if LineSpacing = 0 then
-                Error(NoEnoughSpaceForTextErr);
-        end else
-            LineSpacing := 10000;
-
-        NextLineNo := 0;
-        ReminderHeader.InsertTextLines(ReminderHeader, ReminderText, NextLineNo, LineSpacing);
-    end;
-
-    [Obsolete('Reminder Text is being obsoleted. Use the new records Reminder Attachment Text and Reminder Email Text', '24.0')]
-    local procedure IntroduceEndingTextFromReminderText(var ReminderHeader: Record "Reminder Header"; var ReminderLevel: Record "Reminder Level"; var ReminderLine: Record "Reminder Line")
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderLine2: Record "Reminder Line";
-        LineSpacing, NextLineNo : Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderHeader."Reminder Terms Code");
-        ReminderText.SetRange("Reminder Level", ReminderLevel."No.");
-        ReminderText.SetRange(Position, ReminderText.Position::Ending);
-        ReminderHeader.OnInsertEndTextsOnAfterReminderTextSetFilters(ReminderText, ReminderHeader);
-
+        LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(ReminderHeader."Customer No.");
         ReminderLine.Reset();
         ReminderLine.SetRange("Reminder No.", ReminderHeader."No.");
         ReminderLine.SetFilter(
-            "Line Type", '%1|%2|%3',
-            ReminderLine."Line Type"::"Reminder Line",
-            ReminderLine."Line Type"::"Additional Fee",
-            ReminderLine."Line Type"::Rounding);
-        ReminderHeader.OnInsertEndTextsOnAfterReminderLineSetFilters(ReminderLine, ReminderHeader);
+          "Line Type", '%1|%2|%3',
+          ReminderLine."Line Type"::"Reminder Line",
+          ReminderLine."Line Type"::"Additional Fee",
+          ReminderLine."Line Type"::Rounding);
+
         if ReminderLine.FindLast() then
             NextLineNo := ReminderLine."Line No."
         else
             NextLineNo := 0;
+
         ReminderLine.SetRange("Line Type");
         ReminderLine2 := ReminderLine;
         ReminderLine2.CopyFilters(ReminderLine);
         ReminderLine2.SetFilter("Line Type", '<>%1', ReminderLine2."Line Type"::"Line Fee");
-        if ReminderLine2.Next() <> 0 then begin
-            LineSpacing :=
-              (ReminderLine2."Line No." - ReminderLine."Line No.") div
-              (ReminderText.Count + 2);
-            if LineSpacing = 0 then
-                Error(NoEnoughSpaceForTextErr);
-        end else
-            LineSpacing := 10000;
-        ReminderHeader.InsertTextLines(ReminderHeader, ReminderText, NextLineNo, LineSpacing);
+        if TryGetReminderAttachmentText(ReminderLevel."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then begin
+            LineSpacing := CalculateLineSpacingForEndingText(ReminderLine, ReminderLine2, ReminderAttachmentText);
+            ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Ending Text", NextLineNo, LineSpacing);
+        end
+        else begin
+            ReminderTerms.Get(ReminderLevel."Reminder Terms Code");
+            if TryGetReminderAttachmentText(ReminderTerms."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then begin
+                LineSpacing := CalculateLineSpacingForEndingText(ReminderLine, ReminderLine2, ReminderAttachmentText);
+                ReminderHeader.InsertTextLines(ReminderHeader, ReminderAttachmentText, Enum::"Reminder Line Type"::"Ending Text", NextLineNo, LineSpacing);
+            end;
+        end;
     end;
-#endif
 
     local procedure GetCustomerLanguageOrDefaultUserLanguage(CustomerNo: Code[20]): Code[10]
     var
@@ -481,14 +378,23 @@ codeunit 1890 "Reminder Communication"
         ReminderEmailText: Record "Reminder Email Text";
         MailManagement: Codeunit "Mail Management";
     begin
-        if NewReminderCommunicationEnabled() then begin
-            AmtDueTxt := '';
-            GreetingTxt := '';
-            ClosingTxt := '';
-            BodyTxt := ReplaceTextTok;
-            DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-            IssuedReminderHeader.CalcFields("Email Text");
+        AmtDueTxt := '';
+        GreetingTxt := '';
+        ClosingTxt := '';
+        BodyTxt := ReplaceTextTok;
+        DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
+        IssuedReminderHeader.CalcFields("Email Text");
 
+        if IssuedReminderHeader."Email Text".HasValue() then begin
+            GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
+            ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
+            if Format(IssuedReminderHeader."Due Date") <> '' then
+                if not MailManagement.IsHandlingGetEmailBody() then begin
+                    SelectEmailBodyText(IssuedReminderHeader, AmtDueTxt);
+                    AmtDueTxt := StripHtmlTags(AmtDueTxt);
+                    SubstituteRelatedValues(AmtDueTxt, IssuedReminderHeader, NNC_TotalInclVAT, CopyStr(CompanyName, 1, 100));
+                end;
+        end else begin
             ReminderEmailText.SetAutoCalcFields("Body Text");
             if GetReminderEmailText(IssuedReminderHeader, ReminderEmailText) then begin
                 GreetingTxt := ReminderEmailText.Greeting;
@@ -497,7 +403,7 @@ codeunit 1890 "Reminder Communication"
                     if not MailManagement.IsHandlingGetEmailBody() then begin
                         SelectEmailBodyText(ReminderEmailText, IssuedReminderHeader, AmtDueTxt);
                         AmtDueTxt := StripHtmlTags(AmtDueTxt);
-                        SubstituteRelatedValues(AmtDueTxt, IssuedReminderHeader, IssuedReminderHeader.CalculateTotalIncludingVAT(), CopyStr(CompanyName, 1, 100));
+                        SubstituteRelatedValues(AmtDueTxt, IssuedReminderHeader, NNC_TotalInclVAT, CopyStr(CompanyName, 1, 100));
                     end;
             end else begin
                 GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
@@ -505,13 +411,9 @@ codeunit 1890 "Reminder Communication"
                     AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), IssuedReminderHeader."Due Date");
                 ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
             end;
-            SubstituteRelatedValues(GreetingTxt, IssuedReminderHeader, IssuedReminderHeader.CalculateTotalIncludingVAT(), CopyStr(CompanyName, 1, 100));
-            SubstituteRelatedValues(ClosingTxt, IssuedReminderHeader, IssuedReminderHeader.CalculateTotalIncludingVAT(), CopyStr(CompanyName, 1, 100));
         end;
-#if not CLEAN27
-        if not NewReminderCommunicationEnabled() then
-            PopulateEmailTextFromReminderText(IssuedReminderHeader, CompanyInfo, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, NNC_TotalInclVAT);
-#endif
+        SubstituteRelatedValues(GreetingTxt, IssuedReminderHeader, NNC_TotalInclVAT, CopyStr(CompanyName, 1, 100));
+        SubstituteRelatedValues(ClosingTxt, IssuedReminderHeader, NNC_TotalInclVAT, CopyStr(CompanyName, 1, 100));
     end;
 
     local procedure SelectEmailBodyText(var ReminderEmailText: Record "Reminder Email Text"; var IssuedReminderHeader: Record "Issued Reminder Header"; var BodyTxt: Text)
@@ -570,65 +472,6 @@ codeunit 1890 "Reminder Communication"
 
         OnAfterSubstituteRelatedValues(BodyTxt, IssuedReminderHeader);
     end;
-
-#if not CLEAN27
-    local procedure PopulateEmailTextFromReminderText(var IssuedReminderHeader: Record "Issued Reminder Header"; var CompanyInfo: Record "Company Information"; var GreetingTxt: Text; var AmtDueTxt: Text; var BodyTxt: Text; var ClosingTxt: Text; var DescriptionTxt: Text; NNC_TotalInclVAT: Decimal)
-    var
-        ReminderEmailText: Record "Reminder Email Text";
-        EmailTextInStream: InStream;
-        EmailTextLine: Text;
-    begin
-        AmtDueTxt := '';
-        BodyTxt := '';
-        GreetingTxt := ReminderEmailText.GetDefaultGreetingLbl();
-        ClosingTxt := ReminderEmailText.GetDefaultClosingLbl();
-        DescriptionTxt := ReminderEmailText.GetDescriptionLbl();
-        if Format(IssuedReminderHeader."Due Date") <> '' then
-            AmtDueTxt := StrSubstNo(ReminderEmailText.GetAmtDueLbl(), IssuedReminderHeader."Due Date");
-
-        if GetEmailTextInStream(EmailTextInStream, IssuedReminderHeader) then begin
-            AmtDueTxt := '';
-            BodyTxt := '';
-
-            while EmailTextInStream.ReadText(EmailTextLine) > 0 do
-                BodyTxt += EmailTextLine;
-
-            SubstituteRelatedValues(BodyTxt, IssuedReminderHeader, NNC_TotalInclVAT, CompanyInfo.Name);
-        end else
-            BodyTxt := ReminderEmailText.GetBodyLbl();
-    end;
-
-    local procedure GetEmailTextInStream(var EmailTextInStream: InStream; var IssuedReminderHeader: Record "Issued Reminder Header"): Boolean
-    var
-        ReminderText: Record "Reminder Text";
-        ReminderTextPosition: Enum "Reminder Text Position";
-    begin
-        IssuedReminderHeader.CalcFields("Email Text");
-        ReminderText.SetAutoCalcFields("Email Text");
-
-        // if there is email text on the reminder, prepare to read it                       
-        if IssuedReminderHeader."Email Text".HasValue() then begin
-            IssuedReminderHeader."Email Text".CreateInStream(EmailTextInStream);
-            exit(true);
-        end;
-
-        // otherwise, if there is email text on the reminder level, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level", ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true);
-            end;
-
-        // otherwise, if there is email text on the reminder terms, prepare to read it                       
-        if ReminderText.Get(IssuedReminderHeader."Reminder Terms Code", 0, ReminderTextPosition::"Email Body", 0) then
-            if ReminderText."Email Text".HasValue() then begin
-                ReminderText."Email Text".CreateInStream(EmailTextInstream);
-                exit(true)
-            end;
-
-        exit(false)
-    end;
-#endif
 
     internal procedure CheckMissMatchBetweenLanguages(var ReminderTerms: Record "Reminder Terms"): Boolean
     var
@@ -917,13 +760,13 @@ codeunit 1890 "Reminder Communication"
             Error(ReminderLevelNotFoundErr, IssuedReminderHeader."Reminder Level", IssuedReminderHeader."Reminder Terms Code");
 
         LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(IssuedReminderHeader."Customer No.");
-        if ReminderEmailText.Get(ReminderLevel."Reminder Email Text", LanguageCode) then
+        if TryGetReminderEmailText(ReminderLevel."Reminder Email Text", LanguageCode, ReminderEmailText) then
             exit(true);
 
         if not ReminderTerms.Get(IssuedReminderHeader."Reminder Terms Code") then
             Error(ReminderTermNotFoundErr, IssuedReminderHeader."Reminder Terms Code");
 
-        if ReminderEmailText.Get(ReminderTerms."Reminder Email Text", LanguageCode) then
+        if TryGetReminderEmailText(ReminderTerms."Reminder Email Text", LanguageCode, ReminderEmailText) then
             exit(true);
 
         exit(false);
@@ -979,16 +822,32 @@ codeunit 1890 "Reminder Communication"
             Error(ReminderLevelNotFoundErr, IssuedReminderHeader."Reminder Level", IssuedReminderHeader."Reminder Terms Code");
 
         LanguageCode := GetCustomerLanguageOrDefaultUserLanguage(IssuedReminderHeader."Customer No.");
-        if ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", LanguageCode) then
+        if TryGetReminderAttachmentText(ReminderLevel."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then
             exit(true);
 
         if not ReminderTerms.Get(IssuedReminderHeader."Reminder Terms Code") then
             Error(ReminderTermNotFoundErr, IssuedReminderHeader."Reminder Terms Code");
 
-        if ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode) then
+        if TryGetReminderAttachmentText(ReminderTerms."Reminder Attachment Text", LanguageCode, ReminderAttachmentText) then
             exit(true);
 
         exit(false);
+    end;
+
+    local procedure TryGetReminderAttachmentText(AttachmentTextId: Guid; LanguageCode: Code[10]; var ReminderAttachmentText: Record "Reminder Attachment Text"): Boolean
+    begin
+        if IsNullGuid(AttachmentTextId) then
+            exit(false);
+
+        exit(ReminderAttachmentText.Get(AttachmentTextId, LanguageCode));
+    end;
+
+    local procedure TryGetReminderEmailText(EmailTextId: Guid; LanguageCode: Code[10]; var ReminderEmailText: Record "Reminder Email Text"): Boolean
+    begin
+        if IsNullGuid(EmailTextId) then
+            exit(false);
+
+        exit(ReminderEmailText.Get(EmailTextId, LanguageCode));
     end;
 
     local procedure StripHtmlTags(HtmlText: Text): Text
@@ -1011,9 +870,6 @@ codeunit 1890 "Reminder Communication"
     end;
 
     var
-#if not CLEAN27
-        FeatureIdTok: Label 'ReminderTermsCommunicationTexts', Locked = true;
-#endif
         ReplaceTextTok: Label '==ReplaceText==', Locked = true;
         PDFFileExtensionTok: Label '.pdf', Locked = true;
         CommaSeparatedTok: Label '%1, %2', Locked = true;

--- a/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderEmailText.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderEmailText.Table.al
@@ -286,7 +286,7 @@ table 503 "Reminder Email Text"
         Language: Codeunit Language;
         CurrentGlobalLanguage: Integer;
     begin
-        if ExistingReminderEmailText.Get(Id, LanguageCode) then
+        if ExistingReminderEmailText.Get(SelectedId, LanguageCode) then
             Error(AlreadyExistsSelectedLanguageErr, LanguageCode);
 
         CurrentGlobalLanguage := GlobalLanguage();
@@ -324,4 +324,3 @@ table 503 "Reminder Email Text"
         end;
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderLevelFeeSetup.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderLevelFeeSetup.Page.al
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Reminder;
 
+using System.Environment;
+
 /// <summary>
 /// Configures interest calculation and additional fee settings for a reminder level.
 /// </summary>
@@ -68,5 +70,40 @@ page 1895 "Reminder Level Fee Setup"
             }
         }
     }
-}
 
+    actions
+    {
+        area(Processing)
+        {
+            action("View Additional Fee Chart")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'View Additional Fee Chart';
+                Image = Forecast;
+                ToolTip = 'View additional fees in a chart.';
+                Visible = IsWinClient;
+
+                trigger OnAction()
+                var
+                    AddFeeChart: Page "Additional Fee Chart";
+                begin
+                    if ClientTypeManagement.GetCurrentClientType() <> CLIENTTYPE::Windows then
+                        Error(ChartNotAvailableInWebErr, PRODUCTNAME.Short());
+
+                    AddFeeChart.SetViewMode(Rec, false, true);
+                    AddFeeChart.RunModal();
+                end;
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        IsWinClient := ClientTypeManagement.GetCurrentClientType() = CLIENTTYPE::Windows;
+    end;
+
+    var
+        ClientTypeManagement: Codeunit "Client Type Management";
+        ChartNotAvailableInWebErr: Label 'The chart cannot be shown in the %1 Web client. To see the chart, use the %1 Windows client.', Comment = '%1 - product name';
+        IsWinClient: Boolean;
+}

--- a/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderTermsList.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderTermsList.Page.al
@@ -4,6 +4,8 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Reminder;
 
+using System.Telemetry;
+
 /// <summary>
 /// Displays a list of all reminder terms with navigation to the detailed setup page.
 /// </summary>
@@ -13,11 +15,7 @@ page 837 "Reminder Terms List"
     Caption = 'Reminder Terms';
     PageType = List;
     SourceTable = "Reminder Terms";
-#if not CLEAN27
-    UsageCategory = None;
-#else
     UsageCategory = Lists;
-#endif
     CardPageID = "Reminder Terms Setup";
     DataCaptionFields = Code;
     Editable = false;
@@ -141,6 +139,22 @@ page 837 "Reminder Terms List"
             }
         }
     }
+
+    trigger OnOpenPage()
+    var
+        FeatureTelemetry: Codeunit "Feature Telemetry";
+    begin
+        if CurrPage.LookupMode() then
+            exit;
+        FeatureTelemetry.LogUptake('0000LAY', 'Reminder', Enum::"Feature Uptake Status"::Discovered);
+    end;
+
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    var
+        FeatureTelemetry: Codeunit "Feature Telemetry";
+    begin
+        FeatureTelemetry.LogUptake('0000LAZ', 'Reminder', Enum::"Feature Uptake Status"::"Set up");
+    end;
 
     var
         ReminderTermsNotSelectedErr: Label 'You need to select one Reminder Term.';

--- a/src/Layers/W1/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
+++ b/src/Layers/W1/BaseApp/Sales/Setup/SalesReceivablesSetup.Page.al
@@ -539,7 +539,7 @@ page 459 "Sales & Receivables Setup"
                     ApplicationArea = Suite;
                     Caption = 'Reminder Terms';
                     Image = ReminderTerms;
-                    RunObject = Page "Reminder Terms";
+                    RunObject = Page "Reminder Terms List";
                     ToolTip = 'Set up reminder terms that you select from on customer cards to define when and how to remind the customer of late payments.';
                 }
                 action("Rounding Methods")
@@ -622,4 +622,3 @@ page 459 "Sales & Receivables Setup"
         CRMIntegrationEnabled: Boolean;
         JnlTemplateNameVisible: Boolean;
 }
-

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigManagement.Codeunit.al
@@ -276,9 +276,11 @@ codeunit 8616 "Config. Management"
             Database::Microsoft.Sales.Reminder."Reminder Terms":
                 exit(Page::Microsoft.Sales.Reminder."Reminder Terms List");
             Database::Microsoft.Sales.Reminder."Reminder Level":
-                exit(Page::Microsoft.Sales.Reminder."Reminder Levels");
+                exit(Page::Microsoft.Sales.Reminder."Reminder Level Setup");
+#if not CLEAN29
             Database::Microsoft.Sales.Reminder."Reminder Text":
                 exit(Page::Microsoft.Sales.Reminder."Reminder Text");
+#endif
             Database::Microsoft.Sales.FinanceCharge."Finance Charge Terms":
                 exit(Page::Microsoft.Sales.FinanceCharge."Finance Charge Terms");
             Database::Microsoft.Foundation.Shipping."Shipment Method":
@@ -462,7 +464,7 @@ codeunit 8616 "Config. Management"
             Database::Microsoft.Foundation.Calendar."Base Calendar":
                 exit(Page::Microsoft.Foundation.Calendar."Base Calendar List");
             Database::Microsoft.Sales.FinanceCharge."Finance Charge Text":
-                exit(Page::Microsoft.Sales.Reminder."Reminder Text");
+                exit(Page::Microsoft.Sales.FinanceCharge."Finance Charge Text");
             Database::Microsoft.Sales.FinanceCharge."Currency for Fin. Charge Terms":
                 exit(Page::Microsoft.Sales.FinanceCharge."Currencies for Fin. Chrg Terms");
             Database::Microsoft.Sales.Reminder."Currency for Reminder Level":
@@ -855,4 +857,3 @@ codeunit 8616 "Config. Management"
     end;
 }
 #pragma warning restore AS0018
-

--- a/src/Layers/W1/DemoTool/InterfaceBasisData.Codeunit.al
+++ b/src/Layers/W1/DemoTool/InterfaceBasisData.Codeunit.al
@@ -41,7 +41,7 @@ codeunit 110000 "Interface Basis Data"
         Window.Open(DemoDataSetup."Progress Window Design");
         Window.Update(3, XBasisData);
         Steps := 0;
-        MaxSteps := 199; // Number of calls to RunCodeunit
+        MaxSteps := 198; // Number of calls to RunCodeunit
         RunCodeunit(CODEUNIT::"Create Price Calculation Setup");
         RunCodeunit(CODEUNIT::"Create Getting Started Data");
         RunCodeunit(CODEUNIT::"Create Profiles");
@@ -54,7 +54,6 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(CODEUNIT::"Create Finance Charge Text");
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(Codeunit::"Create Reminder Automation");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
@@ -926,4 +925,3 @@ codeunit 110000 "Interface Basis Data"
         RunCodeunit(Codeunit::"Create New Employee Template");
     end;
 }
-

--- a/src/Layers/W1/DemoTool/InterfaceTrialData.Codeunit.al
+++ b/src/Layers/W1/DemoTool/InterfaceTrialData.Codeunit.al
@@ -55,7 +55,6 @@ codeunit 122000 "Interface Trial Data"
         CreateFinanceChargeTerms.InsertMiniAppData();
         RunCodeunit(CODEUNIT::"Create Reminder Terms");
         RunCodeunit(CODEUNIT::"Create Reminder Level");
-        RunCodeunit(CODEUNIT::"Create Reminder Text");
         RunCodeunit(CODEUNIT::"Create Language");
         RunCodeunit(CODEUNIT::"Create Country/Region");
         RunCodeunit(CODEUNIT::"Create Post Code");
@@ -182,4 +181,3 @@ codeunit 122000 "Interface Trial Data"
         OnlineMapMgt.SetupDefault();
     end;
 }
-

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryERM.Codeunit.al
@@ -1277,6 +1277,106 @@ codeunit 131300 "Library - ERM"
         ReminderLevel.Insert(true);
     end;
 
+    procedure CreateReminderTermsAndLevel(var ReminderTerms: Record "Reminder Terms"; var ReminderLevel: Record "Reminder Level")
+    begin
+        CreateReminderTerms(ReminderTerms);
+        CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderAttachmentText(var ReminderAttachmentText: Record "Reminder Attachment Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderAttachmentTextId: Guid;
+    begin
+        ReminderAttachmentTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderAttachmentTextId) then
+            ReminderAttachmentTextId := CreateGuid();
+
+        ReminderAttachmentText.SetDefaultContentForNewLanguage(
+            ReminderAttachmentTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderAttachmentText.Get(ReminderAttachmentTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure CreateReminderAttachmentTextLine(var ReminderAttachmentTextLine: Record "Reminder Attachment Text Line"; ReminderAttachmentText: Record "Reminder Attachment Text"; Position: Option "Beginning Line","Ending Line"; LineText: Text[100])
+    var
+        LineNo: Integer;
+    begin
+        ReminderAttachmentTextLine.SetRange(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.SetRange("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.SetRange(Position, Position);
+        if ReminderAttachmentTextLine.FindLast() then
+            LineNo := ReminderAttachmentTextLine."Line No.";
+
+        ReminderAttachmentTextLine.Init();
+        ReminderAttachmentTextLine.Validate(Id, ReminderAttachmentText.Id);
+        ReminderAttachmentTextLine.Validate("Language Code", ReminderAttachmentText."Language Code");
+        ReminderAttachmentTextLine.Validate(Position, Position);
+        ReminderAttachmentTextLine.Validate("Line No.", LineNo + 10000);
+        ReminderAttachmentTextLine.Validate(Text, LineText);
+        ReminderAttachmentTextLine.Insert(true);
+    end;
+
+    procedure SetReminderAttachmentTextInlineFeeDescription(var ReminderAttachmentText: Record "Reminder Attachment Text"; InlineFeeDescription: Text[100])
+    begin
+        ReminderAttachmentText.Validate("Inline Fee Description", InlineFeeDescription);
+        ReminderAttachmentText.Modify(true);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderTerms: Record "Reminder Terms"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderTerms."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderTerms."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Term", ReminderTerms.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderTerms.Get(ReminderTerms.Code);
+    end;
+
+    procedure CreateReminderEmailText(var ReminderEmailText: Record "Reminder Email Text"; var ReminderLevel: Record "Reminder Level"; LanguageCode: Code[10])
+    var
+        ReminderEmailTextId: Guid;
+    begin
+        ReminderEmailTextId := ReminderLevel."Reminder Email Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := ReminderLevel."Reminder Attachment Text";
+        if IsNullGuid(ReminderEmailTextId) then
+            ReminderEmailTextId := CreateGuid();
+
+        ReminderEmailText.SetDefaultContentForNewLanguage(
+            ReminderEmailTextId, LanguageCode, Enum::"Reminder Text Source Type"::"Reminder Level", ReminderLevel.SystemId);
+        ReminderEmailText.Get(ReminderEmailTextId, LanguageCode);
+        ReminderLevel.Get(ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
+    end;
+
+    procedure SetReminderEmailTextBody(var ReminderEmailText: Record "Reminder Email Text"; BodyText: Text)
+    begin
+        ReminderEmailText.SetBodyText(BodyText);
+    end;
+
     procedure CreateReminderLine(var ReminderLine: Record "Reminder Line"; ReminderNo: Code[20]; Type: Enum "Reminder Source Type")
     var
         RecRef: RecordRef;
@@ -3121,4 +3221,3 @@ codeunit 131300 "Library - ERM"
     begin
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Application/ERMReminderApplyUnapply.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Application/ERMReminderApplyUnapply.Codeunit.al
@@ -177,16 +177,11 @@ codeunit 134012 "ERM Reminder Apply Unapply"
 
     local procedure Initialize()
     var
-        FeatureKey: Record "Feature Key";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reminder Apply Unapply");
         LibrarySetupStorage.Restore();
 
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
         // Lazy Setup.
         if isInitialized then
             exit;
@@ -460,4 +455,3 @@ codeunit 134012 "ERM Reminder Apply Unapply"
         VATEntry.TestField("Country/Region Code", ExpectedCountryRegionCode);
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ERMFinancialReportsII.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMFinancialReportsII.Codeunit.al
@@ -44,6 +44,7 @@
         LibraryJournals: Codeunit "Library - Journals";
         LibraryReportValidation: Codeunit "Library - Report Validation";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         OriginalWorkdate: Date;
         ExchRateWasAdjustedTxt: Label 'One or more currency exchange rates have been adjusted.';
         GenJnlTemplateNameTok: Label 'JnlTemplateName_GenJnlBatch';
@@ -58,6 +59,7 @@
         TestReportDifferentCustomerSameDocumentErr: Label '%1 posted on %2, must be separated by an empty line';
         IsInitialized: Boolean;
         InvoiceOutOfBalanceErr: Label 'Invoice %1 is out of balance by %2.';
+        RemitPaymentTxt: Label 'Please remit your payment %7', Comment = '%7 = Amount due';
         DateOutOfBalanceErr: Label 'As of %1, the lines are out of balance by %2.';
         TotalOutOfBalanceErr: Label 'The total of the lines is out of balance by%1.';
         NotAllowedPostingDateErr: Label 'The Posting Date is not within your range of allowed posting dates.';
@@ -828,7 +830,7 @@
     begin
         // [SCENARIO 122513] Reminder Report doesn't print Not Due documents when run with "Show Not Due Amounts" = FALSE
         Initialize();
-        CustomerNo := CreateCustomer();
+        CustomerNo := CreateCustomerWithReminderAttachmentText();
 
         // [GIVEN] Posted invoice with "Posting Date" = WorkDate() + 2 Month
         CreateAndPostGenJournalLineWithDate(GenJournalLine, CalcDate('<2M>', WorkDate()), CustomerNo, LibraryRandom.RandDec(1000, 2));  // Using Random value for Amount.
@@ -1699,8 +1701,6 @@
     local procedure Initialize()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Financial Reports II");
@@ -1714,15 +1714,6 @@
         if OriginalWorkdate = 0D then
             OriginalWorkdate := WorkDate();
         WorkDate := OriginalWorkdate;
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -1908,6 +1899,28 @@
         ReminderLevel.FindFirst();
         LibrarySales.CreateCustomer(Customer);
         Customer.Validate("Reminder Terms Code", ReminderLevel."Reminder Terms Code");
+        Customer.Validate("Fin. Charge Terms Code", CreateFinanceChargeTerms());
+        Customer.Modify(true);
+        exit(Customer."No.");
+    end;
+
+    local procedure CreateCustomerWithReminderAttachmentText(): Code[20]
+    var
+        Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
+        ReminderTerms: Record "Reminder Terms";
+    begin
+        LibraryERM.CreateReminderTermsAndLevel(ReminderTerms, ReminderLevel);
+        ReminderLevel.Validate("Additional Fee (LCY)", LibraryRandom.RandInt(10));
+        ReminderLevel.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", RemitPaymentTxt);
+
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Reminder Terms Code", ReminderTerms.Code);
         Customer.Validate("Fin. Charge Terms Code", CreateFinanceChargeTerms());
         Customer.Modify(true);
         exit(Customer."No.");
@@ -2306,16 +2319,18 @@
     local procedure GetRemitPaymentsMsg(IssuedReminderNo: Code[20]; Amount: Decimal): Text
     var
         IssuedReminderHeader: Record "Issued Reminder Header";
-        ReminderText: Record "Reminder Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLevel: Record "Reminder Level";
         Text: Text;
     begin
         IssuedReminderHeader.Get(IssuedReminderNo);
-        ReminderText.SetRange("Reminder Terms Code", IssuedReminderHeader."Reminder Terms Code");
-        ReminderText.SetRange("Reminder Level", 1);
-        ReminderText.SetRange(Position, 1);
-        ReminderText.FindFirst();
+        ReminderLevel.Get(IssuedReminderHeader."Reminder Terms Code", IssuedReminderHeader."Reminder Level");
+        ReminderAttachmentTextLine.SetRange(Id, ReminderLevel."Reminder Attachment Text");
+        ReminderAttachmentTextLine.SetRange("Language Code", Language.GetUserLanguageCode());
+        ReminderAttachmentTextLine.SetRange(Position, ReminderAttachmentTextLine.Position::"Ending Line");
+        ReminderAttachmentTextLine.FindFirst();
         // Replace '%7' with '%1'
-        Text := ConvertStr(ReminderText.Text, '7', '1');
+        Text := ConvertStr(ReminderAttachmentTextLine.Text, '7', '1');
         exit(StrSubstNo(Text, Amount));
     end;
 

--- a/src/Layers/W1/Tests/ERM-Finance/ERMInvoiceandReminder.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMInvoiceandReminder.Codeunit.al
@@ -3,8 +3,7 @@ codeunit 134907 "ERM Invoice and Reminder"
     Permissions = TableData "Issued Reminder Header" = rimd,
                   TableData "Issued Reminder Line" = rimd,
                   TableData "Cust. Ledger Entry" = rimd,
-                  TableData "Detailed Cust. Ledg. Entry" = rimd,
-                  TableData "Feature Data Update Status" = rimd;
+                  TableData "Detailed Cust. Ledg. Entry" = rimd;
     Subtype = Test;
     TestPermissions = NonRestrictive;
 
@@ -877,22 +876,10 @@ codeunit 134907 "ERM Invoice and Reminder"
 
     local procedure Initialize()
     var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Invoice and Reminder");
         LibrarySetupStorage.Restore();
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-            Commit();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-            Commit();
-        end;
         // Lazy Setup.
         if IsInitialized then
             exit;
@@ -1460,4 +1447,3 @@ codeunit 134907 "ERM Invoice and Reminder"
         Languages.OK().Invoke();
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ERMIssuedReminderAddnlFee.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMIssuedReminderAddnlFee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         LibraryRandom: Codeunit "Library - Random";
         LibraryReportValidation: Codeunit "Library - Report Validation";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         AmountError: Label 'Additional Fee Amount must be %1 for Issued Reminder No: %2.';
         ReminderEndingText: Label 'Balance %7';
@@ -75,9 +76,10 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     procedure CreateSalesInvoiceAndReminder()
     var
         Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         DueDate: Date;
         DocumentDate: Date;
     begin
@@ -87,8 +89,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         CreateCustomer(Customer, '');
         ReminderLevel.SetRange("Reminder Terms Code", Customer."Reminder Terms Code");
         ReminderLevel.FindFirst();
-        LibraryERM.CreateReminderText(
-          ReminderText, Customer."Reminder Terms Code", ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
 
         // Exercise: Post Sales Invoice and Create Reminder.
         DueDate := CreateAndPostSalesInvoice(Customer."No.", '');
@@ -172,9 +175,10 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     procedure UpdateReminderText()
     var
         Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderHeader: Record "Reminder Header";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
     begin
         // Check the functionality of Report Update Reminder Text.
 
@@ -182,8 +186,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         Initialize();
         CreateCustomer(Customer, '');
         GetReminderLevel(ReminderLevel, Customer."Reminder Terms Code");
-        LibraryERM.CreateReminderText(
-          ReminderText, Customer."Reminder Terms Code", ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
         ReminderLevelNo := ReminderLevel."No.";  // Assign global variable.
         CreateReminder(
           Customer."No.",
@@ -592,8 +597,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     procedure VerifyEmailOnReminderPageWhenCustomerHasNoContacts()
     var
         Customer: Record Customer;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         ReminderHeader: Record "Reminder Header";
         ReminderPage: TestPage Reminder;
         CustomerCard: TestPage "Customer Card";
@@ -618,9 +624,9 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         // [GIVEN] Create Reminder Level with Random Grace Period and Random Additional Fee.
         ReminderLevel.SetRange("Reminder Terms Code", Customer."Reminder Terms Code");
         ReminderLevel.FindFirst();
-        LibraryERM.CreateReminderText(
-            ReminderText, Customer."Reminder Terms Code",
-            ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
 
         // [WHEN] Post Sales Invoice and Create Reminder.
         DueDate := CreateAndPostSalesInvoice(Customer."No.", '');
@@ -702,23 +708,12 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         DocumentNoVisibility: Codeunit DocumentNoVisibility;
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Issued Reminder Addnl Fee");
         // Clear global variable.
         Clear(ReminderLevelNo);
         DocumentNoVisibility.ClearState();
         LibraryVariableStorage.Clear();
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -1151,4 +1146,3 @@ codeunit 134905 "ERM Issued Reminder Addnl Fee"
         BatchCancelIssuedReminders.OK().Invoke();
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ERMReminderFinChargeMemo.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMReminderFinChargeMemo.Codeunit.al
@@ -1492,7 +1492,6 @@ codeunit 134909 "ERM Reminder/Fin.Charge Memo"
 
     local procedure Initialize()
     var
-        FeatureKey: Record "Feature Key";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reminder/Fin.Charge Memo");
@@ -1501,11 +1500,6 @@ codeunit 134909 "ERM Reminder/Fin.Charge Memo"
         Clear(LibraryReportDataset);
         Clear(LibraryVariableStorage);
         LibrarySetupStorage.Restore();
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2583,4 +2577,3 @@ codeunit 134909 "ERM Reminder/Fin.Charge Memo"
         end;
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ERMReminderForAdditinalFee.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMReminderForAdditinalFee.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         Assert: Codeunit Assert;
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
+        Language: Codeunit Language;
         AmountError: Label 'Additional Fee must be %1.';
         IsInitialized: Boolean;
         ErrMsg: Label 'Rounding in the end is not expected.';
@@ -27,20 +28,10 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
 
     local procedure Initialize()
     var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reminder For Additinal Fee");
         LibrarySetupStorage.Restore();
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         // Lazy Setup.
         if IsInitialized then
             exit;
@@ -55,6 +46,37 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
 
         LibrarySetupStorage.SaveGeneralLedgerSetup();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"ERM Reminder For Additinal Fee");
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ArchivedEmailTextDoesNotRequireCurrentReminderSetup()
+    var
+        IssuedReminderHeader: Record "Issued Reminder Header";
+        CompanyInformation: Record "Company Information";
+        ReminderCommunication: Codeunit "Reminder Communication";
+        EmailTextOutStream: OutStream;
+        GreetingTxt: Text;
+        AmtDueTxt: Text;
+        BodyTxt: Text;
+        ClosingTxt: Text;
+        DescriptionTxt: Text;
+        ArchivedBody: Text;
+    begin
+        Initialize();
+        CreateIssuedReminderWithInterestAmount(IssuedReminderHeader);
+        ArchivedBody := LibraryUtility.GenerateGUID();
+
+        IssuedReminderHeader."Email Text".CreateOutStream(EmailTextOutStream, TextEncoding::UTF8);
+        EmailTextOutStream.WriteText(ArchivedBody);
+        IssuedReminderHeader."Reminder Terms Code" := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(IssuedReminderHeader."Reminder Terms Code"));
+        IssuedReminderHeader.Modify();
+        CompanyInformation.Get();
+
+        ReminderCommunication.PopulateEmailText(
+            IssuedReminderHeader, CompanyInformation, GreetingTxt, AmtDueTxt, BodyTxt, ClosingTxt, DescriptionTxt, 0);
+
+        Assert.AreEqual(ArchivedBody, AmtDueTxt, 'The archived email body must be used without reading the current reminder setup.');
     end;
 
     [Test]
@@ -150,9 +172,10 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
     [Scope('OnPrem')]
     procedure ReminderWithRounding()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         SalesHeader: Record "Sales Header";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
         ReminderNo: Code[20];
         ReminderTermsCode: Code[10];
     begin
@@ -160,8 +183,9 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
         Initialize();
         LibraryERM.SetInvRoundingPrecisionLCY(LibraryRandom.RandDec(1, 2));
         ReminderTermsCode := CreateReminderTerms(ReminderLevel, '');
-        LibraryERM.CreateReminderText(ReminderText, ReminderTermsCode, ReminderLevel."No.",
-          ReminderText.Position::Ending, 'Reminder Text');
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Reminder Text');
 
         // Setup: Create and Post Sales Invoice.
         CreateAndPostSalesInvoice(SalesHeader, CreateCustomer(ReminderTermsCode, ''));
@@ -564,17 +588,18 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
 
     local procedure CreateReminderTerm(var ReminderTerms: Record "Reminder Terms")
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
     begin
         LibraryERM.CreateReminderTerms(ReminderTerms);
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTerms.Code);
         ReminderLevel.Validate("Calculate Interest", true);
         ReminderLevel.Modify(true);
 
-        LibraryERM.CreateReminderText(
-          ReminderText, ReminderTerms.Code, ReminderLevel."No.",
-          ReminderText.Position::Beginning, LibraryUtility.GenerateGUID());
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Beginning Line", LibraryUtility.GenerateGUID());
     end;
 
     local procedure CreateReminderTerms(var ReminderLevel: Record "Reminder Level"; CurrencyCode: Code[10]): Code[10]
@@ -733,4 +758,3 @@ codeunit 134904 "ERM Reminder For Additinal Fee"
         Assert.AreNotEqual(ReminderLine."Line Type"::Rounding, ReminderLine."Line Type", ErrMsg);
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ERMRemindersGracePeriod.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMRemindersGracePeriod.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 134376 "ERM Reminders - Grace Period"
         LibraryERM: Codeunit "Library - ERM";
         LibrarySales: Codeunit "Library - Sales";
         LibraryRandom: Codeunit "Library - Random";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         AmountErr: Label '%1 must be equal to %2 in %3.';
         RemainingAmount4Txt: Label 'Remaining Amount %4';
@@ -643,7 +644,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
     procedure ReminderWhenOneInvoiceGraceExpiredOneInvoiceGraceNotExpired()
     var
         ReminderTerms: Record "Reminder Terms";
-        ReminderLevel: Record "Reminder Level";
         ReminderLine: Record "Reminder Line";
         CustomerNo: Code[20];
         ReminderNo: Code[20];
@@ -658,16 +658,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
         LibraryERM.CreateReminderTerms(ReminderTerms);
         AddFeePerLine := LibraryRandom.RandDecInRange(2, 4, 2);
         CreateReminderLevelWithText(ReminderTerms.Code, 10, 0, AddFeePerLine, RemainingAmount4Txt);
-
-        // [GIVEN] Reminder Levels have a description text.
-        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
-        if not ReminderLevel.IsEmpty() then begin
-            ReminderLevel.FindSet();
-            repeat
-                ReminderLevel."Add. Fee per Line Description" := ReminderTerms.Code;
-                ReminderLevel.Modify(true);
-            until ReminderLevel.Next() = 0;
-        end;
 
         // [GIVEN] Customer with given Reminder Terms.
         // [GIVEN] Posted Sales Invoice "I1" with "Due Date" = 01-09-2021 and Amount = "A1". Grace Period expires after 11-09-2021.
@@ -707,7 +697,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
     procedure ReminderWhenTwoInvoicesGraceExpired()
     var
         ReminderTerms: Record "Reminder Terms";
-        ReminderLevel: Record "Reminder Level";
         ReminderLine: Record "Reminder Line";
         CustomerNo: Code[20];
         ReminderNo: Code[20];
@@ -722,16 +711,6 @@ codeunit 134376 "ERM Reminders - Grace Period"
         LibraryERM.CreateReminderTerms(ReminderTerms);
         AddFeePerLine := LibraryRandom.RandDecInRange(2, 4, 2);
         CreateReminderLevelWithText(ReminderTerms.Code, 10, 0, AddFeePerLine, RemainingAmount4Txt);
-
-        // [GIVEN] Reminder Levels have a description text.
-        ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
-        if not ReminderLevel.IsEmpty() then begin
-            ReminderLevel.FindSet();
-            repeat
-                ReminderLevel."Add. Fee per Line Description" := ReminderTerms.Code;
-                ReminderLevel.Modify(true);
-            until ReminderLevel.Next() = 0;
-        end;
 
         // [GIVEN] Customer with given Reminder Terms.
         // [GIVEN] Posted Sales Invoice "I1" with "Due Date" = 01-09-2021 and Amount = "A1". Grace Period expires after 11-09-2021.
@@ -768,19 +747,9 @@ codeunit 134376 "ERM Reminders - Grace Period"
     var
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reminders - Grace Period");
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         if IsInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(CODEUNIT::"ERM Reminders - Grace Period");
@@ -991,8 +960,9 @@ codeunit 134376 "ERM Reminders - Grace Period"
 
     local procedure CreateReminderLevelWithText(ReminderTermsCode: Code[10]; GracePeriod: Integer; AdditionalFee: Decimal; AddFeePerLine: Decimal; ReminderEndingText: Text[100])
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLevel: Record "Reminder Level";
-        ReminderText: Record "Reminder Text";
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(ReminderLevel."Grace Period", '<' + Format(GracePeriod) + 'D>');
@@ -1000,7 +970,10 @@ codeunit 134376 "ERM Reminders - Grace Period"
         ReminderLevel.Validate("Add. Fee per Line Amount (LCY)", AddFeePerLine);
         ReminderLevel.Modify(true);
 
-        LibraryERM.CreateReminderText(ReminderText, ReminderTermsCode, ReminderLevel."No.", ReminderText.Position::Ending, ReminderEndingText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", ReminderEndingText);
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, ReminderTermsCode);
     end;
 
     local procedure CreateReminderTerms(): Code[10]
@@ -1278,4 +1251,3 @@ codeunit 134376 "ERM Reminders - Grace Period"
         ReminderLine.TestField(Amount, AmountValue);
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ERMSuggestReminder.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMSuggestReminder.Codeunit.al
@@ -16,8 +16,9 @@ codeunit 134910 "ERM Suggest Reminder"
         LibrarySales: Codeunit "Library - Sales";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryRandom: Codeunit "Library - Random";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
-        ReminderCaptionTxt: Label 'Reminder Text - %1 %2 Beginning', Comment = '%1=Reminder Terms Code;%2=Reminder Level';
+        ReminderLevelCommunicationCaptionTxt: Label 'Reminder Level Communication - %1 ∙ %2', Comment = '%1 = Reminder Terms Code, %2 = Reminder Level No.';
         CaptionErr: Label 'Page Captions must match.';
         ReminderLineExistErr: Label 'Reminder Line must not exist.';
         ReminderHeaderExistErr: Label 'Reminder Header must not exist.';
@@ -36,6 +37,45 @@ codeunit 134910 "ERM Suggest Reminder"
 
         // Verify: Verify the Creation of Reminder Lines.
         VerifyReminderLine(ReminderHeaderNo);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure SuggestReminderUsesTermsAttachmentTextWhenLevelTextIsMissing()
+    var
+        Customer: Record Customer;
+        ReminderTerms: Record "Reminder Terms";
+        ReminderLevel: Record "Reminder Level";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderLine: Record "Reminder Line";
+        CustomerNo: Code[20];
+        ReminderNo: Code[20];
+        BeginningText: Text[100];
+        EndingText: Text[100];
+    begin
+        Initialize();
+        CustomerNo := CreateCustomer();
+        Customer.Get(CustomerNo);
+        ReminderTerms.Get(Customer."Reminder Terms Code");
+        FindReminderLevel(ReminderLevel, ReminderTerms.Code);
+        Assert.IsTrue(IsNullGuid(ReminderLevel."Reminder Attachment Text"), 'The reminder level must not have attachment text.');
+        BeginningText := CopyStr(LibraryRandom.RandText(MaxStrLen(BeginningText)), 1, MaxStrLen(BeginningText));
+        EndingText := CopyStr(LibraryRandom.RandText(MaxStrLen(EndingText)), 1, MaxStrLen(EndingText));
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Beginning Line", BeginningText);
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", EndingText);
+
+        ReminderNo := CreateAndSuggestReminderLine(LibraryRandom.RandInt(10), CustomerNo);
+
+        Assert.IsTrue(
+            ReminderTextLineExists(ReminderNo, ReminderLine."Line Type"::"Beginning Text", BeginningText),
+            'The terms-level beginning text was not added to the reminder.');
+        Assert.IsTrue(
+            ReminderTextLineExists(ReminderNo, ReminderLine."Line Type"::"Ending Text", EndingText),
+            'The terms-level ending text was not added to the reminder.');
     end;
 
     [Test]
@@ -96,33 +136,44 @@ codeunit 134910 "ERM Suggest Reminder"
     [Scope('OnPrem')]
     procedure ReminderTextPageCaption()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
+        ReminderEmailText: Record "Reminder Email Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
-        ReminderText: Record "Reminder Text";
-        ReminderLevels: TestPage "Reminder Levels";
-        ReminderTextPage: TestPage "Reminder Text";
+        ReminderLevelCommunication: TestPage "Reminder Level Communication";
+        ReminderTermsSetup: TestPage "Reminder Terms Setup";
         ReminderTermsCode: Code[10];
         BeginningText: Text[100];
     begin
-        // Check Reminder Text Page's caption updated according to Reminder Terms.
+        // Check Reminder Level Communication Page's caption.
 
-        // Setup: Create Reminder Terms with Reminder Level and Beginning Text.
+        // Setup: Create Reminder Terms with Reminder Level and Beginning Attachment Text.
         Initialize();
         ReminderTermsCode := CreateReminderTerms(true);
         BeginningText := ReminderTermsCode + Format(LibraryRandom.RandInt(10));  // Create any Beginning Text using Random.
+        ReminderTerms.Get(ReminderTermsCode);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderEmailText(ReminderEmailText, ReminderTerms, Language.GetUserLanguageCode());
         FindReminderLevel(ReminderLevel, ReminderTermsCode);
-        LibraryERM.CreateReminderText(ReminderText, ReminderTermsCode, ReminderLevel."No.",
-          ReminderText.Position::Beginning, BeginningText);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Beginning Line", BeginningText);
+        LibraryERM.CreateReminderEmailText(ReminderEmailText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderEmailTextBody(ReminderEmailText, BeginningText);
 
-        // Open Reminder Text Page from Reminder Levels Page.
-        OpenReminderTextPage(ReminderLevels, ReminderTermsCode, ReminderLevel."No.");
-        ReminderTextPage.Trap();
+        // Open Reminder Terms Setup Page from Reminder Terms List.
+        OpenReminderTermsSetupPage(ReminderTermsSetup, ReminderTermsCode, ReminderLevel."No.");
+        ReminderLevelCommunication.Trap();
 
-        // Exercise: Invoke Reminder Text Page.
-        ReminderLevels.BeginningText.Invoke();
+        // Exercise: Invoke Reminder Level Communication Page.
+        ReminderTermsSetup.ReminderLevelSetup.CustomerCommunications.Invoke();
 
-        // Verify: Verify page caption for Reminder Text Page.
-        Assert.AreEqual(StrSubstNo(ReminderCaptionTxt, ReminderTermsCode, ReminderLevel."No."), ReminderTextPage.Caption, CaptionErr);
+        // Verify: Verify page caption for Reminder Level Communication Page.
+        Assert.AreEqual(
+            StrSubstNo(ReminderLevelCommunicationCaptionTxt, ReminderTermsCode, ReminderLevel."No."),
+            ReminderLevelCommunication.Caption,
+            CaptionErr);
 
         // Tear Down: Delete Reminder Terms created earlier.
         ReminderTerms.Get(ReminderTermsCode);
@@ -220,18 +271,8 @@ codeunit 134910 "ERM Suggest Reminder"
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Suggest Reminder");
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         if IsInitialized then
             exit;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(CODEUNIT::"ERM Suggest Reminder");
@@ -399,15 +440,15 @@ codeunit 134910 "ERM Suggest Reminder"
         ReminderLevel.FindFirst();
     end;
 
-    local procedure OpenReminderTextPage(var ReminderLevels: TestPage "Reminder Levels"; "Code": Code[10]; No: Integer)
+    local procedure OpenReminderTermsSetupPage(var ReminderTermsSetup: TestPage "Reminder Terms Setup"; "Code": Code[10]; No: Integer)
     var
-        ReminderTerms: TestPage "Reminder Terms";
+        ReminderTermsList: TestPage "Reminder Terms List";
     begin
-        ReminderTerms.OpenEdit();
-        ReminderTerms.FILTER.SetFilter(Code, Code);
-        ReminderLevels.Trap();
-        ReminderTerms."&Levels".Invoke();
-        ReminderLevels.FILTER.SetFilter("No.", Format(No));
+        ReminderTermsList.OpenView();
+        ReminderTermsList.FILTER.SetFilter(Code, Code);
+        ReminderTermsSetup.Trap();
+        ReminderTermsList.Edit().Invoke();
+        ReminderTermsSetup.ReminderLevelSetup.FILTER.SetFilter("No.", Format(No));
     end;
 
     local procedure VerifyReminderLine(ReminderNo: Code[20])
@@ -417,5 +458,19 @@ codeunit 134910 "ERM Suggest Reminder"
         ReminderLine.SetRange("Reminder No.", ReminderNo);
         ReminderLine.FindFirst();
     end;
-}
 
+    local procedure ReminderTextLineExists(ReminderNo: Code[20]; LineType: Enum "Reminder Line Type"; ExpectedText: Text[100]): Boolean
+    var
+        ReminderLine: Record "Reminder Line";
+    begin
+        ReminderLine.SetRange("Reminder No.", ReminderNo);
+        ReminderLine.SetRange("Line Type", LineType);
+        if ReminderLine.FindSet() then
+            repeat
+                if ReminderLine.Description = ExpectedText then
+                    exit(true);
+            until ReminderLine.Next() = 0;
+
+        exit(false);
+    end;
+}

--- a/src/Layers/W1/Tests/ERM-Finance/ReminderAddFeeSetup.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ReminderAddFeeSetup.Codeunit.al
@@ -2,7 +2,6 @@ codeunit 134998 "Reminder - Add. Fee Setup"
 {
     Subtype = Test;
     TestPermissions = NonRestrictive;
-    Permissions = TableData "Feature Data Update Status" = rimd;
 
     trigger OnRun()
     begin
@@ -10,18 +9,7 @@ codeunit 134998 "Reminder - Add. Fee Setup"
     end;
 
     local procedure Initialize()
-    var
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
     begin
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
         Commit();
     end;
 
@@ -33,9 +21,7 @@ codeunit 134998 "Reminder - Add. Fee Setup"
         UnexpectedAddFeeAmountErr: Label 'Unexpected Additional Fee Amount. Expected %1, Actual %2.';
         AddFeeCalculationType: Option "Fixed","Single Dynamic","Accumulated Dynamic";
         CaptionErr: Label 'Page Captions must match.';
-        ReminderTermsTxt: Label 'Reminder Terms:';
-        ReminderLevelTxt: Label 'Level:';
-        AddFeePerLineTxt: Label 'Additional Fee Setup - Additional Fee per Line Setup -';
+        ReminderLevelFeeSetupCaptionTxt: Label 'Reminder Level Fee Setup - %1 ∙ %2', Comment = '%1 = Reminder Terms Code, %2 = Reminder Level No.';
 
     [Test]
     [Scope('OnPrem')]
@@ -973,27 +959,24 @@ codeunit 134998 "Reminder - Add. Fee Setup"
     procedure AddFeeSetupOnOpenPageUT()
     var
         ReminderLevel: Record "Reminder Level";
-        AdditionalFeeSetupPage: TestPage "Additional Fee Setup";
-        ReminderLevels: TestPage "Reminder Levels";
-        PageCaption: Text;
+        ReminderLevelFeeSetup: TestPage "Reminder Level Fee Setup";
     begin
         // [SCENARIO 107048] Verify Add. Fee Setup Caption
         Initialize();
 
         // [GIVEN] When Reminder Terms and Reminder Level exist
         CreateReminderTermsAndLevel(ReminderLevel, true, true, AddFeeCalculationType);
+        ReminderLevel.Validate("Add. Fee Calculation Type", ReminderLevel."Add. Fee Calculation Type"::"Single Dynamic");
+        ReminderLevel.Modify(true);
 
-        // [WHEN] Add. Fee Setup Page is run from Reminder Levels Page.
-        OpenReminderLevelsPage(ReminderLevels, ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
-        ReminderLevels."Add. Fee Calculation Type".SetValue(ReminderLevel."Add. Fee Calculation Type"::"Single Dynamic");
+        // [WHEN] Reminder Level Fee Setup Page is run from Reminder Terms Setup Page.
+        OpenReminderLevelFeeSetupPage(ReminderLevelFeeSetup, ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
 
-        AdditionalFeeSetupPage.Trap();
-        ReminderLevels."Additional Fee per Line".Invoke();
-        PageCaption := AddFeePerLineTxt + ' ' + ReminderTermsTxt + ' ' + ReminderLevel."Reminder Terms Code" + ' ' +
-          ReminderLevelTxt + ' ' + Format(ReminderLevel."No.");
-
-        // [THEN] then caption contains Reminder Terms and Reminder Level specified
-        Assert.AreEqual(AdditionalFeeSetupPage.Caption, PageCaption, CaptionErr);
+        // [THEN] Reminder Level Fee Setup Page has the expected caption
+        Assert.AreEqual(
+            StrSubstNo(ReminderLevelFeeSetupCaptionTxt, ReminderLevel."Reminder Terms Code", ReminderLevel."No."),
+            ReminderLevelFeeSetup.Caption,
+            CaptionErr);
     end;
 
     [Test]
@@ -1002,20 +985,25 @@ codeunit 134998 "Reminder - Add. Fee Setup"
     procedure AddFeeChartOnOpenPageUT()
     var
         ReminderLevel: Record "Reminder Level";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         AdditionalFeeChart: TestPage "Additional Fee Chart";
-        ReminderLevels: TestPage "Reminder Levels";
+        ReminderLevelFeeSetup: TestPage "Reminder Level Fee Setup";
     begin
         // [SCENARIO 107048] Verify Add. Fee Chart
         Initialize();
 
         // [GIVEN] When Reminder Terms and Reminder Level exist
         CreateReminderTermsAndLevel(ReminderLevel, true, true, AddFeeCalculationType);
+        ReminderLevel.Validate("Add. Fee Calculation Type", ReminderLevel."Add. Fee Calculation Type"::"Single Dynamic");
+        ReminderLevel.Modify(true);
 
-        // [WHEN] Add. Fee Chart Page is run from Reminder Levels Page.
-        OpenReminderLevelsPage(ReminderLevels, ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
-        ReminderLevels."Add. Fee Calculation Type".SetValue(ReminderLevel."Add. Fee Calculation Type"::"Single Dynamic");
+        // [WHEN] Reminder Level Fee Setup Page is run from Reminder Terms Setup Page and Add. Fee Chart is opened
+        BindSubscription(TestClientTypeSubscriber);
+        TestClientTypeSubscriber.SetClientType(ClientType::Windows);
+        OpenReminderLevelFeeSetupPage(ReminderLevelFeeSetup, ReminderLevel."Reminder Terms Code", ReminderLevel."No.");
         AdditionalFeeChart.Trap();
-        ReminderLevels."View Additional Fee Chart".Invoke();
+        ReminderLevelFeeSetup."View Additional Fee Chart".Invoke();
+        ReminderLevelFeeSetup.Close();
 
         // [THEN] then Additional Fee  per Line, M
     end;
@@ -1276,15 +1264,18 @@ codeunit 134998 "Reminder - Add. Fee Setup"
         AdditionalFeeSetup.Modify(true);
     end;
 
-    local procedure OpenReminderLevelsPage(var ReminderLevels: TestPage "Reminder Levels"; "Code": Code[10]; No: Integer)
+    local procedure OpenReminderLevelFeeSetupPage(var ReminderLevelFeeSetup: TestPage "Reminder Level Fee Setup"; "Code": Code[10]; No: Integer)
     var
-        ReminderTerms: TestPage "Reminder Terms";
+        ReminderTermsList: TestPage "Reminder Terms List";
+        ReminderTermsSetup: TestPage "Reminder Terms Setup";
     begin
-        ReminderTerms.OpenEdit();
-        ReminderTerms.FILTER.SetFilter(Code, Code);
-        ReminderLevels.Trap();
-        ReminderTerms."&Levels".Invoke();
-        ReminderLevels.FILTER.SetFilter("No.", Format(No));
+        ReminderTermsList.OpenView();
+        ReminderTermsList.FILTER.SetFilter(Code, Code);
+        ReminderTermsSetup.Trap();
+        ReminderTermsList.Edit().Invoke();
+        ReminderTermsSetup.ReminderLevelSetup.FILTER.SetFilter("No.", Format(No));
+        ReminderLevelFeeSetup.Trap();
+        ReminderTermsSetup.ReminderLevelSetup.ReminderLevelFeeSetup.Invoke();
     end;
 
     local procedure VerifyBufferData(var BusinessChartBuffer: Record "Business Chart Buffer"; AdditionalFeeSetup: Record "Additional Fee Setup"; ReminderLevel: Record "Reminder Level")
@@ -1341,4 +1332,3 @@ codeunit 134998 "Reminder - Add. Fee Setup"
         AdditionalFeeChart.OK().Invoke();
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ReminderAddLinefee.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
+        Language: Codeunit Language;
         IsInitialized: Boolean;
         ReminderLineMustExistErr: Label 'The Reminder Line does not exists. Filters: %1.';
         ReminderLineMustNotExistErr: Label 'The Reminder Line should not exists. Filters: %1.';
@@ -46,9 +47,7 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms: Record "Reminder Terms";
         ReminderLevel: Record "Reminder Level";
         CurrencyForReminderLvl: Record "Currency for Reminder Level";
-        ReminderText: Record "Reminder Text";
         AdditionalFeeSetup: Record "Additional Fee Setup";
-        Text: Text[100];
         ReminderTermsCode: Code[10];
         NewReminderTermsCode: Code[10];
         Level: Integer;
@@ -68,13 +67,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do
             for Index := 1 to 3 do
                 CreateCurrencyforReminderLevel(ReminderTermsCode, Level, LibraryERM.CreateCurrencyWithRandomExchRates(), 0, 0);
-
-        // [GIVEN] L1 and L2 have 2 Reminder texts associated
-        for Level := 1 to 2 do
-            for Index := 1 to 2 do begin
-                Text := StrSubstNo('Random text: %1-%2', Level, Index);
-                AddReminderText(ReminderTermsCode, Level, ReminderText.Position::Ending, Text);
-            end;
 
         // [GIVEN] L1 and L2 have 2 10 Additional Fee Setup lines associated
         for Level := 1 to 2 do
@@ -96,12 +88,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         for Level := 1 to 2 do begin
             CurrencyForReminderLvl.SetRange("No.", Level);
             Assert.AreEqual(3, CurrencyForReminderLvl.Count, StrSubstNo(CountMismatchErr, CurrencyForReminderLvl.TableCaption()));
-        end;
-
-        ReminderText.SetRange("Reminder Terms Code", NewReminderTermsCode);
-        for Level := 1 to 2 do begin
-            ReminderText.SetRange("Reminder Level", Level);
-            Assert.AreEqual(2, ReminderText.Count, StrSubstNo(CountMismatchErr, ReminderText.TableCaption()));
         end;
 
         AdditionalFeeSetup.SetRange("Reminder Terms Code", NewReminderTermsCode);
@@ -324,6 +310,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvWithLineFee1stRmd()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -351,7 +338,8 @@ codeunit 134997 "Reminder - Add. Line fee"
         // [THEN] A Line Fee line is added with amount = X and description = D
         VerifyReminderLineExists(ReminderLine, ReminderNo, ReminderLine.Type::"Line Fee", ReminderLine."Document Type"::Invoice, InvoiceA);
         ReminderLevel.Get(ReminderTermCode, 1);
-        Assert.AreEqual(ReminderLevel."Add. Fee per Line Description", ReminderLine.Description,
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        Assert.AreEqual(ReminderAttachmentText."Inline Fee Description", ReminderLine.Description,
           StrSubstNo(MustMatchErr, ReminderLine.FieldCaption(Description), ReminderLine.TableCaption()));
     end;
 
@@ -547,6 +535,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestSalesInvoiceValidateLineFeeText()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
         ReminderNo: Code[20];
@@ -564,8 +553,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Line Fee description (Dx) contains a substitute for invoice number
         ReminderLevel.Get(ReminderTermCode, 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Something %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Something %8');
 
         // [GIVEN] A sales invoice (A) is posted for the customer
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -587,8 +576,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextTotalCorrect()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -602,7 +594,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -637,8 +632,11 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure SuggestUpdateReminderTextLineFeeAmountChanged()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderAttachmentTextLine: Record "Reminder Attachment Text Line";
         ReminderLine: Record "Reminder Line";
         ReminderLine2: Record "Reminder Line";
+        ReminderLevel: Record "Reminder Level";
         ReminderTermCode: Code[10];
         CustNo: Code[20];
         InvoiceA: Code[20];
@@ -652,7 +650,10 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] Reminder terms set up without additional fee and with Line Fee = X, where X > 0
         CreateStandardReminderTermSetupWithCust(CustNo, ReminderTermCode, true);
-        AddReminderText(ReminderTermCode, 1, "Reminder Text Position"::Ending, 'Total due: %7');
+        ReminderLevel.Get(ReminderTermCode, 1);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.CreateReminderAttachmentTextLine(
+            ReminderAttachmentTextLine, ReminderAttachmentText, ReminderAttachmentTextLine.Position::"Ending Line", 'Total due: %7');
 
         // [GIVEN] A reminder with over due invoice (A) and Line Fee for invoice A
         InvoiceA := PostSalesInvoice(CustNo, CalcDate('<-10D>', WorkDate()));
@@ -1475,6 +1476,7 @@ codeunit 134997 "Reminder - Add. Line fee"
     [Scope('OnPrem')]
     procedure EditChangeAppliesTo()
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderHeader: Record "Reminder Header";
         ReminderLine: Record "Reminder Line";
         ReminderLevel: Record "Reminder Level";
@@ -1490,8 +1492,8 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         // [GIVEN] The Reminder Term level has a description with document no. substituion
         ReminderLevel.Get(ReminderHeader."Reminder Terms Code", 1);
-        ReminderLevel."Add. Fee per Line Description" := 'Line Fee %8';
-        ReminderLevel.Modify(true);
+        ReminderAttachmentText.Get(ReminderLevel."Reminder Attachment Text", Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, 'Line Fee %8');
 
         // [GIVEN] A overdue sales invoice exists
         InvoiceA := PostSalesInvoice(ReminderHeader."Customer No.", CalcDate('<-10D>', WorkDate()));
@@ -2587,8 +2589,6 @@ codeunit 134997 "Reminder - Add. Line fee"
     var
         CustomerPostingGroup: Record "Customer Posting Group";
         ReminderHeader: Record "Reminder Header";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
     begin
@@ -2600,15 +2600,6 @@ codeunit 134997 "Reminder - Add. Line fee"
 
         if ClearExtReminders then
             ReminderHeader.DeleteAll(true);
-
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
 
         if IsInitialized then
             exit;
@@ -2790,16 +2781,17 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
         exit(ReminderTerms.Code)
     end;
 
     local procedure CreateReminderTermsLevel(ReminderTermsCode: Code[10]; DueDateDays: Integer; GracePeriodDays: Integer; CurrencyCode: Code[10]; AdditionalFee: Decimal; LineFee: Decimal; CalculateInterest: Boolean; Level: Integer)
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         DueDateCalcFormula: DateFormula;
         GracePeriodCalcFormula: DateFormula;
+        InlineFeeDescription: Text[100];
     begin
         LibraryERM.CreateReminderLevel(ReminderLevel, ReminderTermsCode);
         Evaluate(DueDateCalcFormula, '<+' + Format(DueDateDays) + 'D>');
@@ -2808,8 +2800,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -2817,6 +2807,11 @@ codeunit 134997 "Reminder - Add. Line fee"
             ReminderLevel.Validate("Additional Fee (LCY)", AdditionalFee);
         end;
         ReminderLevel.Modify(true);
+        InlineFeeDescription :=
+            LibraryUtility.GenerateRandomCode(
+                ReminderAttachmentText.FieldNo("Inline Fee Description"), DATABASE::"Reminder Attachment Text");
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, InlineFeeDescription);
     end;
 
     local procedure CreateAdditionalFeeSetupLine(ReminderTermsCode: Code[10]; Level: Integer; PerLine: Boolean; Currency: Code[10]; Threshold: Decimal)
@@ -2924,25 +2919,6 @@ codeunit 134997 "Reminder - Add. Line fee"
         ReminderHeader.SetRange("Customer No.", CustomerNo);
         ReminderHeader.FindFirst();
         ReminderNo := ReminderHeader."No.";
-    end;
-
-    local procedure AddReminderText(ReminderTermCode: Code[10]; Level: Integer; Position: Enum "Reminder Text Position"; Text: Text[100])
-    var
-        ReminderText: Record "Reminder Text";
-        NextLineNo: Integer;
-    begin
-        ReminderText.SetRange("Reminder Terms Code", ReminderTermCode);
-        ReminderText.SetRange("Reminder Level", Level);
-        if ReminderText.FindLast() then;
-        NextLineNo := ReminderText."Line No." + 1000;
-
-        ReminderText.Init();
-        ReminderText."Reminder Terms Code" := ReminderTermCode;
-        ReminderText."Reminder Level" := Level;
-        ReminderText.Position := Position;
-        ReminderText.Text := Text;
-        ReminderText."Line No." := NextLineNo;
-        ReminderText.Insert(true);
     end;
 
     local procedure UpdateReminderText(ReminderNo: Code[20]; Level: Integer)
@@ -3191,4 +3167,3 @@ codeunit 134997 "Reminder - Add. Line fee"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/W1/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
@@ -948,9 +948,6 @@ codeunit 134979 "Reminder Automation Tests"
         // [SCENARIO 609485] When using Transfer Texts from the old reminder term text to the new customer communications the used language is not considered
         Initialize();
 
-        // [GIVEN] Disable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', false);
-
         // [GIVEN] Set Region and Global Language to Dutch (Netherlands)
         // Save old company region so we can restore it in tear down
         CompanyInfo.Get();
@@ -966,9 +963,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         // [GIVEN] Create reminder term with levels
         CreateReminderTerm(ReminderTerms);
-
-        // [GIVEN] Enable Feature Reminder Terms Communication Texts
-        this.CheckFeatureReminderTermsCommunicationTexts('ReminderTermsCommunicationTexts', true);
 
         // [WHEN] Page Reminder Term Invoke Action Transfer Texts 
         ReminderTermList.OpenEdit();
@@ -1307,15 +1301,11 @@ codeunit 134979 "Reminder Automation Tests"
         ReminderLevel: Record "Reminder Level";
         ReminderAttachmentText: Record "Reminder Attachment Text";
     begin
-        ReminderAttachmentText.Id := CreateGuid();
-        ReminderAttachmentText."Language Code" := LanguageCode;
-        ReminderAttachmentText."File Name" := CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name"));
-        ReminderAttachmentText.Insert();
-
         ReminderLevel.SetRange("Reminder Terms Code", ReminderTerms.Code);
         ReminderLevel.FindFirst();
-        ReminderLevel."Reminder Attachment Text" := ReminderAttachmentText.Id;
-        ReminderLevel.Modify();
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderLevel, LanguageCode);
+        ReminderAttachmentText.Validate("File Name", CopyStr(LibraryRandom.RandText(20), 1, MaxStrLen(ReminderAttachmentText."File Name")));
+        ReminderAttachmentText.Modify(true);
 
         LibraryVariableStorage.Enqueue(ReminderAttachmentText."File Name" + '.pdf');
     end;
@@ -1666,19 +1656,6 @@ codeunit 134979 "Reminder Automation Tests"
 
         ReportSelections.FindEmailAttachmentUsageForCust(ReportUsage, CustomerNo, TempReportSelections);
         ReportSelections.SendEmailToCust(ReportUsage.AsInteger(), Document, '', '', true, CustomerNo);
-    end;
-
-    local procedure CheckFeatureReminderTermsCommunicationTexts(FeatureKeyCode: Code[100]; Enable: Boolean)
-    var
-        FeatureKey: Record "Feature Key";
-    begin
-        FeatureKey.Get(FeatureKeyCode);
-        if Enable then
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::"All Users")
-        else
-            FeatureKey.Validate(Enabled, FeatureKey.Enabled::None);
-
-        FeatureKey.Modify(true);
     end;
 
     local procedure CreateCustomerWithContactAndOverdueEntries(var Customer: Record Customer; var Contact: Record Contact; var ReminderTerms: Record "Reminder Terms"; NumberOfEntries: Integer)

--- a/src/Layers/W1/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ReminderLineFeeonReports.Codeunit.al
@@ -9,13 +9,13 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     end;
 
     var
+        Assert: Codeunit Assert;
         Language: Codeunit Language;
         LibraryERM: Codeunit "Library - ERM";
         LibraryInventory: Codeunit "Library - Inventory";
         LibrarySales: Codeunit "Library - Sales";
         LibraryService: Codeunit "Library - Service";
         LibraryReportDataset: Codeunit "Library - Report Dataset";
-        LibraryUtility: Codeunit "Library - Utility";
         LibraryRandom: Codeunit "Library - Random";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         IsInitialized: Boolean;
@@ -177,22 +177,23 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     [Scope('OnPrem')]
     procedure PrintServiceInvoiceTextonInvoiceTranslated()
     var
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         AddFeePerLine: Decimal;
         CustomerNo: Code[20];
         InvoiceNo: Code[20];
+        LanguageCode: Code[10];
         ReminderTermsCode: Code[10];
     begin
         // [SCENARIO 107048] A service invoice report contains translated Add. Fee Note
-        // as selected Reminder Terms contain Translated text on Report and Customer Country is set to use specific lang.
+        // as selected Reminder Terms contain attachment text in the customer's language.
         Initialize();
 
         // [GIVEN] A Reminder Term X, with level 1 with Add. Fee per Line = A, where A > 0, with Text on Report
         // defined in other language and Customer Language set to that language
         AddFeePerLine := LibraryRandom.RandDec(1000, 2);
         CreateCustomerWithReminderTermsAddFeePerLine(CustomerNo, ReminderTermsCode, true, '', AddFeePerLine);
-        CreateReminderTermsTranslationEntry(ReminderTermsTranslation, ReminderTermsCode);
-        UpdateCustomerLangCode(CustomerNo, ReminderTermsTranslation."Language Code");
+        LanguageCode := LibraryERM.GetAnyLanguageDifferentFromCurrent();
+        CreateReminderTermsInlineFeeText(ReminderTermsCode, LanguageCode);
+        UpdateCustomerLangCode(CustomerNo, LanguageCode);
 
         // [GIVEN] A posted service invoice for customer with Reminder Term = X
         InvoiceNo := PostServiceInvoice(CustomerNo, WorkDate());
@@ -200,9 +201,8 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         // [WHEN] The invoice is printed
         ExportServiceInvoice(CustomerNo);
 
-        // [THEN] The Add. Fee per Line note on report is printed on language defined in Reminder Terms Translation table
-        ValidateInvoiceAddFeePerLine(
-          ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', ReminderTermsTranslation."Language Code");
+        // [THEN] The Add. Fee per Line note on report is printed in the customer's language
+        ValidateInvoiceAddFeePerLine(ReminderTermsCode, 1, InvoiceNo, AddFeePerLine, '', LanguageCode);
     end;
 
     local procedure Initialize()
@@ -294,14 +294,16 @@ codeunit 134993 "Reminder - Line Fee on Reports"
 
     local procedure CreateReminderTerms(PostLineFee: Boolean; PostInterest: Boolean; PostAddFee: Boolean): Code[10]
     var
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderTerms: Record "Reminder Terms";
     begin
         LibraryERM.CreateReminderTerms(ReminderTerms);
         ReminderTerms.Validate("Post Interest", PostInterest);
         ReminderTerms.Validate("Post Add. Fee per Line", PostLineFee);
         ReminderTerms.Validate("Post Additional Fee", PostAddFee);
-        ReminderTerms.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
         ReminderTerms.Modify(true);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, Language.GetUserLanguageCode());
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
         exit(ReminderTerms.Code)
     end;
 
@@ -318,8 +320,6 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Validate("Due Date Calculation", DueDateCalcFormula);
         ReminderLevel.Validate("Grace Period", GracePeriodCalcFormula);
         ReminderLevel.Validate("Calculate Interest", CalculateInterest);
-        ReminderLevel.Validate("Add. Fee per Line Description",
-          LibraryUtility.GenerateRandomCode(ReminderLevel.FieldNo("Add. Fee per Line Description"), DATABASE::"Reminder Level"));
         if CurrencyCode <> '' then
             CreateCurrencyforReminderLevel(ReminderTermsCode, Level, CurrencyCode, AdditionalFee, LineFee)
         else begin
@@ -329,17 +329,14 @@ codeunit 134993 "Reminder - Line Fee on Reports"
         ReminderLevel.Modify(true);
     end;
 
-    local procedure CreateReminderTermsTranslationEntry(var ReminderTermsTranslation: Record "Reminder Terms Translation"; ReminderTermsCode: Code[10])
+    local procedure CreateReminderTermsInlineFeeText(ReminderTermsCode: Code[10]; LanguageCode: Code[10])
     var
-        Language: Record Language;
+        ReminderAttachmentText: Record "Reminder Attachment Text";
+        ReminderTerms: Record "Reminder Terms";
     begin
-        Language.FindFirst();
-        ReminderTermsTranslation.Init();
-        ReminderTermsTranslation.Validate("Reminder Terms Code", ReminderTermsCode);
-        ReminderTermsTranslation.Validate("Language Code", Language.Code);
-        ReminderTermsTranslation.Insert(true);
-        ReminderTermsTranslation.Validate("Note About Line Fee on Report", '%1 %2 %3 %4');
-        ReminderTermsTranslation.Modify(true);
+        ReminderTerms.Get(ReminderTermsCode);
+        LibraryERM.CreateReminderAttachmentText(ReminderAttachmentText, ReminderTerms, LanguageCode);
+        LibraryERM.SetReminderAttachmentTextInlineFeeDescription(ReminderAttachmentText, '%1 %2 %3 %4');
     end;
 
     local procedure ExportServiceInvoice(CustomerNo: Code[20])
@@ -408,9 +405,10 @@ codeunit 134993 "Reminder - Line Fee on Reports"
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
+        LineFeeNoteOnReportHist: Record "Line Fee Note on Report Hist.";
+        ReminderAttachmentText: Record "Reminder Attachment Text";
         ReminderLevel: Record "Reminder Level";
         ReminderTerms: Record "Reminder Terms";
-        ReminderTermsTranslation: Record "Reminder Terms Translation";
         ElementExpectedValue: Text;
         MarginalPerc: Decimal;
         TextOnReportExpected: Text[150];
@@ -435,15 +433,21 @@ codeunit 134993 "Reminder - Line Fee on Reports"
             CurrencyCode := GeneralLedgerSetup."LCY Code";
         end;
 
-        // expected result
-        if LanguageCode <> Language.GetUserLanguageCode() then begin
-            ReminderTermsTranslation.Get(ReminderTerms.Code, LanguageCode);
-            TextOnReportExpected := ReminderTermsTranslation."Note About Line Fee on Report"
-        end else
-            TextOnReportExpected := ReminderTerms."Note About Line Fee on Report";
+        ReminderAttachmentText.Get(ReminderTerms."Reminder Attachment Text", LanguageCode);
+        TextOnReportExpected := ReminderAttachmentText."Inline Fee Description";
 
         ElementExpectedValue := StrSubstNo(TextOnReportExpected, Format(AddFeePerLine, 0, 9),
             CurrencyCode, AddFeeDueDate, Format(MarginalPerc, 0, 9));
+
+        if AddFeePerLine > 0 then begin
+            Assert.IsTrue(
+                LineFeeNoteOnReportHist.Get(
+                    CustLedgerEntry."Entry No.", AddFeeDueDate, LanguageCode, ReminderTermsCode, LevelNo),
+                'The line fee note was not saved for the reminder communication language.');
+            Assert.AreEqual(
+                ElementExpectedValue, LineFeeNoteOnReportHist.ReportText,
+                'The saved line fee note does not match the reminder communication text.');
+        end;
 
         if LevelNo = 1 then
             LibraryReportDataset.LoadDataSetFile();

--- a/src/Layers/W1/Tests/Integration-Internal/MailServiceTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration-Internal/MailServiceTest.Codeunit.al
@@ -411,23 +411,12 @@ codeunit 139111 "Mail Service Test"
     local procedure Initialize()
     var
         CompanyInformation: Record "Company Information";
-        FeatureKey: Record "Feature Key";
-        FeatureKeyUpdateStatus: Record "Feature Data Update Status";
         LibraryEmail: Codeunit "Library - Email";
     begin
         LibraryEmail.SetUpEmailAccount();
         BindActiveDirectoryMockEvents();
         LibraryVariableStorage.Clear();
         LibraryERMCountryData.CreateVATData();
-        if FeatureKey.Get('ReminderTermsCommunicationTexts') then begin
-            FeatureKey.Enabled := FeatureKey.Enabled::None;
-            FeatureKey.Modify();
-        end;
-        if FeatureKeyUpdateStatus.Get('ReminderTermsCommunicationTexts', CompanyName()) then begin
-            FeatureKeyUpdateStatus."Feature Status" := FeatureKeyUpdateStatus."Feature Status"::Disabled;
-            FeatureKeyUpdateStatus.Modify();
-        end;
-
         if not IsInitialized then begin
             IsInitialized := true;
 
@@ -626,4 +615,3 @@ codeunit 139111 "Mail Service Test"
         ActiveDirectoryMockEvents.Enable();
     end;
 }
-

--- a/src/Layers/W1/Tests/Rapid Start/ERMRSWizardWorksheet.Codeunit.al
+++ b/src/Layers/W1/Tests/Rapid Start/ERMRSWizardWorksheet.Codeunit.al
@@ -382,9 +382,11 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         CheckPage(DATABASE::"Customer Posting Group", PAGE::"Customer Posting Groups");
         CheckPage(DATABASE::"Payment Terms", PAGE::"Payment Terms");
         CheckPage(DATABASE::"Payment Method", PAGE::"Payment Methods");
-        CheckPage(DATABASE::"Reminder Terms", PAGE::"Reminder Terms");
-        CheckPage(DATABASE::"Reminder Level", PAGE::"Reminder Levels");
+        CheckPage(DATABASE::"Reminder Terms", PAGE::"Reminder Terms List");
+        CheckPage(DATABASE::"Reminder Level", PAGE::"Reminder Level Setup");
+#if not CLEAN29
         CheckPage(DATABASE::"Reminder Text", PAGE::"Reminder Text");
+#endif
         CheckPage(DATABASE::"Finance Charge Terms", PAGE::"Finance Charge Terms");
         CheckPage(DATABASE::"Shipment Method", PAGE::"Shipment Methods");
         CheckPage(DATABASE::"Shipping Agent", PAGE::"Shipping Agents");
@@ -517,7 +519,7 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         CheckPage(DATABASE::"Cash Flow Manual Revenue", PAGE::"Cash Flow Manual Revenues");
         CheckPage(DATABASE::"IC Partner", PAGE::"IC Partner List");
         CheckPage(DATABASE::"Base Calendar", PAGE::"Base Calendar List");
-        CheckPage(DATABASE::"Finance Charge Text", PAGE::"Reminder Text");
+        CheckPage(DATABASE::"Finance Charge Text", PAGE::"Finance Charge Text");
         CheckPage(DATABASE::"Currency for Fin. Charge Terms", PAGE::"Currencies for Fin. Chrg Terms");
         CheckPage(DATABASE::"Currency for Reminder Level", PAGE::"Currencies for Reminder Level");
         CheckPage(DATABASE::"Currency Exchange Rate", PAGE::"Currency Exchange Rates");
@@ -3391,4 +3393,3 @@ codeunit 136606 "ERM RS Wizard & Worksheet"
         ConfigPackageRecords.Field3.AssertEquals(LibraryVariableStorage.DequeueText());
     end;
 }
-


### PR DESCRIPTION
## What & why

Backports #10504 to `releases/29.0` so the reminder attachment and email communication model is permanent on the release branch and the obsolete feature-key paths are removed consistently.

The source PR is still open. This backport is bound to source head `3bdbbc460265cf2f2ae7919379b4cd99e9d5c49d`; if #10504 changes, this PR must be refreshed before merge.

## Validation

- Applied the complete source delta as one squashed commit with no conflicts.
- Verified the exact 158-file path set with no missing or extra paths.
- Verified stable patch ID `53dc5011947537a2f13838bed67bcfa419bed337` matches #10504.
- `git diff --check` passes.

## Linked work

Fixes [AB#647932](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647932)

Source PR: #10504
