### PR TITLE
[Expense Agent] Add spend request expense report integration

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
@@ -214,6 +214,14 @@ page 6928 "Expense Reports API"
                 {
                     Caption = 'Spend Request Close';
                 }
+                part(spendRequest; "Spend Requests API")
+                {
+                    Caption = 'Spend Request';
+                    EntityName = 'spendRequest';
+                    EntitySetName = 'spendRequests';
+                    Multiplicity = ZeroOrOne;
+                    SubPageLink = "No." = field("Spend Request No.");
+                }
                 part(expenseReportLines; "Expense Report Lines API")
                 {
                     Caption = 'Expense Report Lines';

--- a/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapabilitiesProvider.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapabilitiesProvider.Codeunit.al
@@ -36,6 +36,8 @@ codeunit 6906 "Expense Capabilities Provider"
                 exit(true);
             Capability::AiAssistedPolicyEvaluation:
                 exit(IsAiAssistedPolicyEvaluationEnabled());
+            Capability::SpendRequest:
+                exit(true);
         end;
         exit(false);
     end;

--- a/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapability.Enum.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapability.Enum.al
@@ -73,4 +73,12 @@ enum 6984 "Expense Capability"
     {
         Caption = 'AI-Assisted Policy Evaluation', Locked = true;
     }
+
+    /// <summary>
+    /// Spend requests are available in the expense app.
+    /// </summary>
+    value(6; SpendRequest)
+    {
+        Caption = 'Spend Request', Locked = true;
+    }
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Common/Extensions/ExpenseSpendRequest.TableExt.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Common/Extensions/ExpenseSpendRequest.TableExt.al
@@ -23,7 +23,8 @@ tableextension 6908 "Expense Spend Request" extends "Spend Request"
             trigger OnValidate()
             begin
                 TestStatusOpen();
-                UpdateRequestedForTraveler(xRec."Requested For");
+                if SpendRequestExists() then
+                    UpdateRequestedForTraveler(xRec."Requested For");
             end;
         }
         field(6901; "Business Justification"; Text[2048])
@@ -130,6 +131,11 @@ tableextension 6908 "Expense Spend Request" extends "Spend Request"
             end;
         }
     }
+    trigger OnAfterInsert()
+    begin
+        InsertRequestedForTraveler();
+    end;
+
     trigger OnDelete()
     var
         Traveler: Record Traveler;
@@ -211,5 +217,15 @@ tableextension 6908 "Expense Spend Request" extends "Spend Request"
         end;
 
         Rec.Validate("International Travel", Rec."Origin Country/Region Code" <> Rec."Dest. Country/Region Code");
+    end;
+
+    local procedure SpendRequestExists(): Boolean
+    var
+        SpendRequest: Record "Spend Request";
+    begin
+        if Rec."No." = '' then
+            exit(false);
+
+        exit(SpendRequest.Get(Rec."No."));
     end;
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/ExpenseEventSubscriber.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/ExpenseEventSubscriber.Codeunit.al
@@ -197,6 +197,15 @@ codeunit 6908 "Expense Event Subscriber"
         AutoApproveSpendRequestWhenAgentDisabled(SpendRequest);
     end;
 
+    [EventSubscriber(ObjectType::Table, Database::"Spend Request", OnAfterModifyEvent, '', false, false)]
+    local procedure OnAfterModifySpendRequest(var Rec: Record "Spend Request")
+    begin
+        if (Rec.Status <> Rec.Status::Approved) or (Rec."Requested For" = '') then
+            exit;
+
+        CreateExpenseReportFromSpendRequest(Rec);
+    end;
+
     internal procedure IsSourceExpense(SourceCode: Code[10]): Boolean
     var
         SourceCodeSetup: Record "Source Code Setup";
@@ -320,5 +329,24 @@ codeunit 6908 "Expense Event Subscriber"
 
         SpendRequest.Status := SpendRequest.Status::Approved;
         SpendRequest.Modify();
+    end;
+
+    local procedure CreateExpenseReportFromSpendRequest(SpendRequest: Record "Spend Request")
+    var
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        SpendRequest.TestField("Requested For");
+
+        ExpenseReportHeader.SetRange("Spend Request No.", SpendRequest."No.");
+        if not ExpenseReportHeader.IsEmpty() then
+            exit;
+
+        ExpenseReportHeader.Init();
+        ExpenseReportHeader.Validate(Description, CopyStr(SpendRequest.Purpose, 1, MaxStrLen(ExpenseReportHeader.Description)));
+        ExpenseReportHeader.Validate("Expense User No.", SpendRequest."Requested For");
+        ExpenseReportHeader.Validate("Expense Report Date", SpendRequest."Expected Start Date");
+        ExpenseReportHeader.Validate("Reimbursement Currency Code", SpendRequest."Currency Code");
+        ExpenseReportHeader.Validate("Spend Request No.", SpendRequest."No.");
+        ExpenseReportHeader.Insert(true);
     end;
 }

--- a/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseCapabilitiesAPITest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseCapabilitiesAPITest.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 148318 "Expense Capabilities API Test"
         IsInitialized: Boolean;
         ServiceNameTok: Label 'expenseCapabilities', Locked = true;
         ActivityLogCapabilityNameTok: Label 'activityLog', Locked = true;
+        SpendRequestCapabilityNameTok: Label 'spendRequest', Locked = true;
 
     [Test]
     procedure CapabilitiesProjectsEnabledViaAPI()
@@ -59,22 +60,25 @@ codeunit 148318 "Expense Capabilities API Test"
     end;
 
     [Test]
-    procedure ActivityLogCapabilityEnabledViaAPI()
+    procedure AlwaysEnabledCapabilitiesEnabledViaAPI()
     var
         TargetURL: Text;
         ResponseText: Text;
     begin
-        // [SCENARIO] The Activity Log capability is always advertised when the API is installed.
+        // [SCENARIO] Always-enabled capabilities are advertised when the API is installed.
         Initialize();
 
         // [WHEN] The expenseCapabilities collection is fetched through the API.
         TargetURL := LibraryGraphMgt.CreateTargetURL('', Page::"Expense Capabilities API", ServiceNameTok);
         LibraryGraphMgt.GetFromWebServiceAndCheckResponseCode(ResponseText, TargetURL, 200);
 
-        // [THEN] ActivityLog is present and enabled.
+        // [THEN] ActivityLog and SpendRequest are present and enabled.
         Assert.IsTrue(
             ResponseContainsCapabilityState(ResponseText, ActivityLogCapabilityNameTok, true),
             'Response must contain an enabled activityLog capability row.');
+        Assert.IsTrue(
+            ResponseContainsCapabilityState(ResponseText, SpendRequestCapabilityNameTok, true),
+            'Response must contain an enabled spendRequest capability row.');
     end;
 
     [Test]

--- a/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
@@ -36,6 +36,10 @@ codeunit 148339 "Spend Request Test"
         ClosedByDocMsg: Label 'Closed By Document No. should be set on the closed spend request.';
         SpendReqReleasedMsg: Label 'The spend request should be released.';
         SpendReqApprovedMsg: Label 'The spend request should be approved automatically when the agent is disabled.';
+        ExpenseReportCreatedMsg: Label 'One expense report should be created for the approved spend request.';
+        ExpenseReportUserMsg: Label 'The expense report should be created for the requested expense user.';
+        ExpenseReportDescriptionMsg: Label 'The expense report description should match the spend request purpose.';
+        ExpenseReportDateMsg: Label 'The expense report date should match the spend request start date.';
         SpendReqNoSetMsg: Label 'The Spend Request No. should be assigned to the expense report line.';
         HeaderSpendReqNoSetMsg: Label 'The Spend Request No. should be assigned to the expense report header.';
         HeaderCloseFlagMsg: Label 'The header should store the confirmed close flag.';
@@ -319,6 +323,7 @@ codeunit 148339 "Spend Request Test"
     [Test]
     procedure ReleaseSpendReqAutoApprovesWhenAgentDisabled()
     var
+        ExpenseReportHeader: Record "Expense Report Header";
         SpendRequest: Record "Spend Request";
         ExpenseUser: Record "Expense User";
         ReleaseSpendRequest: Codeunit "Release Spend Request";
@@ -335,11 +340,18 @@ codeunit 148339 "Spend Request Test"
         // [THEN] The spend request is approved automatically because there is no agent to approve it.
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Approved, SpendRequest.Status, SpendReqApprovedMsg);
+
+        // [THEN] An expense report is created and linked to the spend request.
+        ExpenseReportHeader.SetRange("Spend Request No.", SpendRequest."No.");
+        Assert.AreEqual(1, ExpenseReportHeader.Count(), ExpenseReportCreatedMsg);
+        ExpenseReportHeader.FindFirst();
+        Assert.AreEqual(ExpenseUser."No.", ExpenseReportHeader."Expense User No.", ExpenseReportUserMsg);
     end;
 
     [Test]
     procedure ReleaseSpendReqStaysReleasedWhenAgentEnabled()
     var
+        ExpenseReportHeader: Record "Expense Report Header";
         SpendRequest: Record "Spend Request";
         ExpenseUser: Record "Expense User";
         ReleaseSpendRequest: Codeunit "Release Spend Request";
@@ -357,6 +369,51 @@ codeunit 148339 "Spend Request Test"
         // [THEN] The spend request stays released.
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Released, SpendRequest.Status, SpendReqReleasedMsg);
+        ExpenseReportHeader.SetRange("Spend Request No.", SpendRequest."No.");
+        Assert.RecordIsEmpty(ExpenseReportHeader);
+    end;
+
+    [Test]
+    procedure ApproveSpendReqCreatesExpenseReport()
+    var
+        ExpenseReportHeader: Record "Expense Report Header";
+        SpendRequest: Record "Spend Request";
+        ExpenseUser: Record "Expense User";
+        ReleaseSpendRequest: Codeunit "Release Spend Request";
+        StartDate: Date;
+        ExpectedPurpose: Text[100];
+    begin
+        // [SCENARIO] Approving a released spend request creates one linked expense report.
+        Initialize();
+        LibraryExpense.UpdateEnableAgentInAgentSetup(true);
+
+        // [GIVEN] A released spend request.
+        CreateReleasableSpendRequest(SpendRequest, ExpenseUser);
+        StartDate := DMY2Date(4, 10, 2026);
+        ExpectedPurpose := 'Customer conference';
+        SpendRequest.Validate("Expected End Date", StartDate + 7);
+        SpendRequest.Validate("Expected Start Date", StartDate);
+        SpendRequest.Validate(Purpose, ExpectedPurpose);
+        SpendRequest.Modify(true);
+        ReleaseSpendRequest.Release(SpendRequest);
+
+        // [WHEN] The spend request is approved.
+        LibraryExpense.SetSpendRequestStatus(SpendRequest, SpendRequest.Status::Approved);
+
+        // [THEN] One expense report is created for the requested expense user.
+        ExpenseReportHeader.SetRange("Spend Request No.", SpendRequest."No.");
+        Assert.AreEqual(1, ExpenseReportHeader.Count(), ExpenseReportCreatedMsg);
+        ExpenseReportHeader.FindFirst();
+        Assert.AreEqual(ExpenseUser."No.", ExpenseReportHeader."Expense User No.", ExpenseReportUserMsg);
+        Assert.AreEqual(ExpectedPurpose, ExpenseReportHeader.Description, ExpenseReportDescriptionMsg);
+        Assert.AreEqual(StartDate, ExpenseReportHeader."Expense Report Date", ExpenseReportDateMsg);
+
+        // [WHEN] The approved spend request is modified again.
+        SpendRequest.Modify();
+
+        // [THEN] A duplicate expense report is not created.
+        ExpenseReportHeader.SetRange("Spend Request No.", SpendRequest."No.");
+        Assert.AreEqual(1, ExpenseReportHeader.Count(), ExpenseReportCreatedMsg);
     end;
 
     [Test]
@@ -487,6 +544,30 @@ codeunit 148339 "Spend Request Test"
         SpendRequest.Modify(true);
 
         // [THEN] A traveler is created for that user.
+        Traveler.SetRange("Spend Request No.", SpendRequest."No.");
+        Traveler.SetRange("Expense User No.", ExpenseUser."No.");
+        Assert.RecordCount(Traveler, 1);
+    end;
+
+    [Test]
+    procedure RequestedForBeforeInsertAddsTravelerAfterInsert()
+    var
+        SpendRequest: Record "Spend Request";
+        ExpenseUser: Record "Expense User";
+        Traveler: Record Traveler;
+    begin
+        // [SCENARIO] Setting "Requested For" before inserting a spend request creates the traveler after the request exists.
+        Initialize();
+
+        // [GIVEN] An expense user and a new, uninserted spend request.
+        LibraryExpense.CreateExpenseUser(ExpenseUser);
+        SpendRequest.Init();
+
+        // [WHEN] "Requested For" is assigned before the delayed insert used by the API.
+        SpendRequest.Validate("Requested For", ExpenseUser."No.");
+        SpendRequest.Insert(true);
+
+        // [THEN] The spend request is inserted and the requested user is added as a traveler.
         Traveler.SetRange("Spend Request No.", SpendRequest."No.");
         Traveler.SetRange("Expense User No.", ExpenseUser."No.");
         Assert.RecordCount(Traveler, 1);

--- a/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequest.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequest.Table.al
@@ -69,7 +69,7 @@ table 6840 "Spend Request"
                 CreateDimFromDefaultDim(FieldNo("G/L Account No."));
             end;
         }
-        field(8; Purpose; Text[1000])
+        field(8; Purpose; Text[100])
         {
             Caption = 'Purpose';
             ToolTip = 'Specifies the purpose of the spend request.';

--- a/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequestCard.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequestCard.Page.al
@@ -31,7 +31,6 @@ page 6841 "Spend Request Card"
                 }
                 field(Purpose; Rec.Purpose)
                 {
-                    MultiLine = true;
                 }
                 field(Status; Rec.Status)
                 {


### PR DESCRIPTION
## Summary
- expose the linked spend request as a zero-or-one OData navigation from expense reports
- advertise spend requests as an always-enabled Expense Agent capability
- create one linked expense report when a spend request is approved, carrying over the requested user, purpose, expected start date, and currency
- support OData delayed inserts by creating the requested-for traveler after the spend request is inserted
- shorten Purpose to 100 characters and render it as a single-line field

## Tests
- cover automatic and manual approval report creation, field mapping, and duplicate prevention
- cover requested-for traveler creation during delayed insert
- verify the spend request capability through the capabilities API
