### PR TITLE
Classify PEPPOL and E-Document uptake data sensitivity

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -10,6 +10,7 @@ using Microsoft.eServices.EDocument.OrderMatch;
 using Microsoft.EServices.EDocument.Processing;
 using Microsoft.eServices.EDocument.Processing.Import;
 using Microsoft.eServices.EDocument.Processing.Import.Purchase;
+using Microsoft.eServices.EDocument.Processing.Import.Sales;
 using Microsoft.eServices.EDocument.Processing.Interfaces;
 using Microsoft.eServices.EDocument.Processing.Message;
 using Microsoft.eServices.EDocument.Service.Participant;
@@ -528,6 +529,8 @@ codeunit 6103 "E-Document Subscribers"
 #pragma warning restore AL0432
 #endif
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc Sample Purch. Inv File");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Sales Header");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Sales Line");
     end;
 
 

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Peppol;
 
 using Microsoft.Foundation.Company;
+using Microsoft.Utilities;
 
 codeunit 37217 "PEPPOL 3.0 Subscribers"
 {

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
@@ -21,5 +21,12 @@ codeunit 37217 "PEPPOL 3.0 Subscribers"
     end;
 
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Data Classification Eval. Data", 'OnCreateEvaluationDataOnAfterClassifyTablesToNormal', '', false, false)]
+    local procedure ClassifyDataSensitivity()
+    var
+        DataClassificationEvalData: Codeunit "Data Classification Eval. Data";
+    begin
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"PEPPOL 3.0 Setup");
+    end;
 
 }


### PR DESCRIPTION
## Why

The 28.x PEPPOL uptake introduced the PEPPOL 3.0 Setup and E-Document sales tables without registering them when evaluation-company sensitivity data is created. NAV data sensitivity validation therefore reports unclassified fields for tables 37202 and 6153.

## Summary

- **Registered** the PEPPOL 3.0 Setup table with the data classification evaluation subscriber.
- **Classified** the E-Document Sales Header and E-Document Sales Line fields as Normal.
- **Resolved** the TestDataSensitivities failures exposed by the 28.x BCApps uptake.
Fixes
[AB#647666](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647666)


