### PR TITLE
[28.4] Classify PEPPOL setup data sensitivity

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Peppol;
 
 using Microsoft.Foundation.Company;
+using Microsoft.Utilities;
 
 codeunit 37217 "PEPPOL 3.0 Subscribers"
 {

--- a/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Common/PEPPOL30Subscribers.Codeunit.al
@@ -21,5 +21,12 @@ codeunit 37217 "PEPPOL 3.0 Subscribers"
     end;
 
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Data Classification Eval. Data", 'OnCreateEvaluationDataOnAfterClassifyTablesToNormal', '', false, false)]
+    local procedure ClassifyDataSensitivity()
+    var
+        DataClassificationEvalData: Codeunit "Data Classification Eval. Data";
+    begin
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"PEPPOL 3.0 Setup");
+    end;
 
 }


### PR DESCRIPTION
## Why

The 28.4 PEPPOL uptake introduced the PEPPOL 3.0 Setup table without registering it when evaluation-company sensitivity data is created. NAV test codeunit 135153 therefore reports field 2 of table 37202 as unclassified in PR 253189.

## Summary

- **Registered** the PEPPOL 3.0 Setup table with the data classification evaluation subscriber.
- **Classified** its fields with Normal data sensitivity.
- **Resolved** the TestDataSensitivities failure exposed by the 28.4 uptake.

[AB#647510](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647510)


