### PR TITLE
Backport #10568: [29.x] Send sample invoices from the demo guide directly

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Codeunit.al
@@ -55,20 +55,34 @@ codeunit 3309 "PA Demo Guide"
     /// <summary>
     /// Sends a demo email using the active PA setup configuration.
     /// </summary>
-    procedure SendDemoEmail()
+    /// <returns>True if the demo email was sent.</returns>
+    procedure SendDemoEmail(): Boolean
     var
         PayablesAgentSetup: Codeunit "Payables Agent Setup";
         PASetupConfiguration: Codeunit "PA Setup Configuration";
     begin
         PayablesAgentSetup.LoadSetupConfiguration(PASetupConfiguration);
-        SendDemoEmail(PASetupConfiguration);
+        exit(SendDemoEmail(PASetupConfiguration));
+    end;
+
+    /// <summary>
+    /// Sends the sample invoices by email if the agent is active, otherwise flags them to be sent at activation.
+    /// </summary>
+    /// <returns>True if the sample invoices were sent.</returns>
+    procedure SendDemoInvoicesByEmail(): Boolean
+    var
+        EDocSamplePurchInvFile: Record "E-Doc Sample Purch. Inv File";
+    begin
+        EDocSamplePurchInvFile.ModifyAll("Send By Email", true);
+        exit(SendDemoEmail());
     end;
 
     /// <summary>
     /// Sends a demo email using the provided PA setup configuration.
     /// </summary>
     /// <param name="PASetupConfiguration">An email account to send a demo email</param>
-    procedure SendDemoEmail(PASetupConfiguration: Codeunit "PA Setup Configuration");
+    /// <returns>True if the demo email was sent.</returns>
+    procedure SendDemoEmail(PASetupConfiguration: Codeunit "PA Setup Configuration"): Boolean
     var
         EDocSamplePurchInvFile: Record "E-Doc Sample Purch. Inv File";
         TempEmailAccount: Record "Email Account";
@@ -82,12 +96,12 @@ codeunit 3309 "PA Demo Guide"
         BodyTextTxt: Label 'This is a sample email from Payables Agent.', MaxLength = 255, Comment = 'Payables Agent is a term, and should not be translated.';
     begin
         if not DemoExperienceAvailable() then
-            exit;
+            exit(false);
         if not CanSendDemoEmail(PASetupConfiguration) then
-            exit;
+            exit(false);
         EDocSamplePurchInvFile.SetRange("Send By Email", true);
         if EDocSamplePurchInvFile.IsEmpty() then
-            exit;
+            exit(false);
         TempEmailAccount := PASetupConfiguration.GetEmailAccount();
 
         EmailMessage.Create(TempEmailAccount."Email Address", SubjectTxt, BodyTextTxt, true);
@@ -105,6 +119,7 @@ codeunit 3309 "PA Demo Guide"
         end;
         EDocSamplePurchInvFile.SetRange("Send By Email");
         EDocSamplePurchInvFile.ModifyAll("Send By Email", false);
+        exit(true);
     end;
 
     /// <summary>

--- a/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Page.al
@@ -6,7 +6,6 @@
 #pragma warning disable AS0007
 namespace Microsoft.Agent.PayablesAgent;
 
-using Microsoft.eServices.EDocument.Processing.Import.Purchase;
 using System.Environment;
 using System.Environment.Configuration;
 using System.Utilities;
@@ -187,6 +186,8 @@ page 3307 "PA Demo Guide"
         BackActionEnabled, FinishActionEnabled, NextActionEnabled, WelcomeStepVisible, ChooseDemoOption, ShowDemoFilesToDownloadVisible, TopBannerVisible : Boolean;
         DemoFilesToDownloadText, FinalStepHeadline, FinalStepText : Text;
         PayablesAgentTelemetryTok: Label 'Payables Agent', Locked = true;
+        DemoInvoicesSentTok: Label 'Sent demo sample invoices by email', Locked = true;
+        DemoInvoicesPreparedTok: Label 'Prepared demo sample invoices to send on agent activation', Locked = true;
         DemoFilesToDownloadLbl: Label 'Click here to select and download sample invoices (%1 file(s) available)', Comment = '%1 = number of files';
         FinalStepHeadlineEmailLbl: Label 'Sample invoices sent!';
         FinalStepTextEmailLbl: Label 'We have prepared the sample invoices and will send them when the agent is activated. If this is the first time you configure the agent, the agent is activated when you select "Update" on the configuration page. When the agent is activated you should see them appear as tasks on the agent''s avatar in the top right corner of the home screen';
@@ -227,11 +228,13 @@ page 3307 "PA Demo Guide"
 
     local procedure FinishAction();
     var
-        EDocSamplePurchInvFile: Record "E-Doc Sample Purch. Inv File";
         GuidedExperience: Codeunit "Guided Experience";
     begin
         if DemoOption = DemoOption::"Send Demo Email" then
-            EDocSamplePurchInvFile.ModifyAll("Send By Email", true);
+            if PADemoGuide.SendDemoInvoicesByEmail() then
+                Session.LogMessage('0000V8C', DemoInvoicesSentTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok)
+            else
+                Session.LogMessage('0000V8D', DemoInvoicesPreparedTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
         Session.LogMessage('0000PJV', 'Ran demo guide for payables agent', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
         GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"PA Demo Guide");
         CurrPage.Close();


### PR DESCRIPTION
## What & why

Backport of #10568 to 29.x.

On the Payables Agent guide page, the email option used to only mark the sample invoices, leaving the real send to happen when setup was saved. Saving setup before running the guide meant the invoices were never sent, yet the guide still reported success.

The guide now sends the invoices when you finish it, so the order of steps no longer matters. The marks are cleared after sending so the setup save path will not resend, and the finish step reports success only for the send path.

Fixes [AB#648145](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648145)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- change was built and validated on main
- No automated tests added, matching the original PR. This is a UI and orchestration change in the demo guide with no test hook for the mail send.

## Risk & compatibility

Backport only, scoped to the two PADemoGuide files. SendDemoEmail returns a Boolean now instead of nothing, but the codeunit is internal so there is no public break. No permission, upgrade, or telemetry impact.

