### PR TITLE
[28.x] Fix E-Document registration number vendor test setup

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -10,6 +10,11 @@
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "28.5",
+  "incrementalBuilds": {
+    "onPush": false,
+    "onPull_Request": false,
+    "onSchedule": false
+  },
   "conditionalSettings": [
     {
       "buildModes": [

--- a/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Receive/EDocHelperTest.Codeunit.al
@@ -21,7 +21,6 @@ codeunit 139799 "E-Doc. Helper Test"
         Assert: Codeunit "Assert";
         LibraryEDoc: Codeunit "Library - E-Document";
         LibraryLowerPermission: Codeunit "Library - Lower Permissions";
-        LibraryPurchase: Codeunit "Library - Purchase";
         MultipleVendorsWithRegistrationNoErr: Label 'Multiple vendors match the registration number on the electronic document.';
 
     trigger OnRun()
@@ -69,7 +68,7 @@ codeunit 139799 "E-Doc. Helper Test"
         // [FEATURE] [AI test]
         // [SCENARIO 646793] A vendor can be resolved by Registration No. when other identifiers are unavailable.
         RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
-        LibraryPurchase.CreateVendor(Vendor);
+        CreateVendorForLookup(Vendor);
         Vendor."Use Reg. No. in E-Document" := true;
         Vendor."Registration Number" := RegistrationNo;
         Vendor.Modify();
@@ -88,7 +87,7 @@ codeunit 139799 "E-Doc. Helper Test"
         // [FEATURE] [AI test]
         // [SCENARIO 646793] Registration No. matching requires explicit vendor setup.
         RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
-        LibraryPurchase.CreateVendor(Vendor);
+        CreateVendorForLookup(Vendor);
         Vendor."Registration Number" := RegistrationNo;
         Vendor.Modify();
 
@@ -106,11 +105,11 @@ codeunit 139799 "E-Doc. Helper Test"
         // [FEATURE] [AI test]
         // [SCENARIO 646793] Vendor matching fails when a registration number identifies multiple vendors.
         RegistrationNo := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(RegistrationNo));
-        LibraryPurchase.CreateVendor(Vendor[1]);
+        CreateVendorForLookup(Vendor[1]);
         Vendor[1]."Use Reg. No. in E-Document" := true;
         Vendor[1]."Registration Number" := RegistrationNo;
         Vendor[1].Modify();
-        LibraryPurchase.CreateVendor(Vendor[2]);
+        CreateVendorForLookup(Vendor[2]);
         Vendor[2]."Use Reg. No. in E-Document" := true;
         Vendor[2]."Registration Number" := RegistrationNo;
         Vendor[2].Modify();
@@ -197,6 +196,15 @@ codeunit 139799 "E-Doc. Helper Test"
 
         // Cleanup
         EDocument.Delete();
+    end;
+
+    local procedure CreateVendorForLookup(var Vendor: Record Vendor)
+    var
+        LibraryUtility: Codeunit "Library - Utility";
+    begin
+        Vendor.Init();
+        Vendor."No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(Vendor."No."));
+        Vendor.Insert();
     end;
 
 }


### PR DESCRIPTION
## Why

The E-Document registration number vendor tests fail in localized test environments where VAT posting groups are not initialized. The tests only exercise vendor lookup and should not depend on posting setup created by `LibraryPurchase.CreateVendor`.

## Summary

- **Replaced** full vendor creation with a focused lookup vendor helper.
- **Removed** the unrelated VAT posting setup dependency from the registration number tests.

FIxes
[AB#647666](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647666)



