### PR TITLE
Backport #10483: [29.x] Enable IT migration in production and preserve Legacy Subcontracting when install is declined

### DIFF
--- a/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Local/Manufacturing/Document/LegacySubcFeatureHandler.Codeunit.al
@@ -11,7 +11,6 @@ using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
 using Microsoft.Purchases.Document;
 using System.Apps;
-using System.Environment;
 using System.Environment.Configuration;
 
 codeunit 99008501 "Legacy Subc. Feature Handler"
@@ -26,7 +25,6 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         SubcontractingAppInstalledErr: Label 'Cannot activate legacy subcontracting while the Subcontracting app is installed. Use the Subcontracting app features instead.';
         OpenSubcontractingTransfersExistErr: Label 'There are still open transfer orders with WIP Items. All subcontracting transfer orders must be completed before disabling Legacy Subcontracting.';
         OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All purchase orders with WIP Items must be completed before disabling Legacy Subcontracting.';
-        MigrationNotAllowedInProductionErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
         InstallSubcontractingAppQst: Label 'The Subcontracting app is required to disable Legacy Subcontracting. Do you want to install it now?';
         InstallITMigrationAppQst: Label 'The IT Subcontracting Migration app is needed to migrate your data. Do you want to install it now?';
 
@@ -42,23 +40,24 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
         exit(ManufacturingSetup."Legacy Subcontracting");
     end;
 
-    local procedure IsMigrationAllowedInCurrentEnvironment(): Boolean
-    var
-        EnvironmentInformation: Codeunit "Environment Information";
+    /// <summary>
+    /// Checks whether Legacy Subcontracting can be disabled and raises an error if the preconditions are not met.
+    /// When a required app is missing, it offers to install it inline.
+    /// </summary>
+    procedure CheckCanDisableLegacySubcontracting()
     begin
-        exit(EnvironmentInformation.IsSandbox());
+        CanDisableLegacySubcontracting();
     end;
 
     /// <summary>
     /// Checks whether Legacy Subcontracting can be disabled and raises an error if the preconditions are not met.
-    /// When a required app is missing, it offers to install it inline and stops - after the install completes and the
-    /// session reloads, the user runs the disable action again (installing one app per run until both are present and migration proceeds).
+    /// When a required app is missing, it offers to install it inline and returns false so the caller does not disable
+    /// Legacy Subcontracting - after the install completes and the session reloads, the user runs the disable action again
+    /// (installing one app per run until both are present and migration proceeds).
+    /// Returns true only when all prerequisites are met and disabling Legacy Subcontracting can proceed.
     /// </summary>
-    procedure CheckCanDisableLegacySubcontracting()
+    internal procedure CanDisableLegacySubcontracting(): Boolean
     begin
-        if not IsMigrationAllowedInCurrentEnvironment() then
-            Error(MigrationNotAllowedInProductionErr);
-
         if OpenWIPTransfersExist() then
             Error(OpenSubcontractingTransfersExistErr);
 
@@ -67,14 +66,16 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
 
         if not IsSubcontractingAppInstalled() then begin
             OfferToInstallApp(SubcontractingAppIdTok, InstallSubcontractingAppQst);
-            exit;
+            exit(false);
         end;
 
         if DatabaseHasLegacySubcontractingData() then
             if not IsITMigrationAppInstalled() then begin
                 OfferToInstallApp(ITMigrationAppIdTok, InstallITMigrationAppQst);
-                exit;
+                exit(false);
             end;
+
+        exit(true);
     end;
 
     /// <summary>
@@ -140,7 +141,8 @@ codeunit 99008501 "Legacy Subc. Feature Handler"
             exit;
 
         if not Enabled then begin
-            CheckCanDisableLegacySubcontracting();
+            if not CanDisableLegacySubcontracting() then
+                exit;
             if DatabaseHasLegacySubcontractingData() then
                 MigrateData();
         end else

--- a/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
+++ b/src/Layers/IT/BaseApp/Manufacturing/Setup/ManufacturingSetup.Page.al
@@ -397,8 +397,8 @@ page 99000768 "Manufacturing Setup"
                         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
                         PreChecksPassedMsg: Label 'Pre-checks passed. You can now disable Legacy Subcontracting using the action "Disable Legacy Subcontracting".';
                     begin
-                        LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
-                        Message(PreChecksPassedMsg);
+                        if LegacySubcFeatureHandler.CanDisableLegacySubcontracting() then
+                            Message(PreChecksPassedMsg);
                     end;
                 }
             }

--- a/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/SCMLegacySubcontracting.Codeunit.al
@@ -17,7 +17,6 @@ using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
 using System.Environment.Configuration;
-using System.TestLibraries.Environment;
 
 codeunit 137500 "SCM Legacy Subcontracting"
 {
@@ -45,6 +44,7 @@ codeunit 137500 "SCM Legacy Subcontracting"
         LibraryITLocalization: Codeunit "Library - IT Localization";
 
         Initialized: Boolean;
+        SubcontractingAppNotInstalled: Boolean;
 
     [Test]
     [Scope('OnPrem')]
@@ -400,26 +400,6 @@ codeunit 137500 "SCM Legacy Subcontracting"
 
     [Test]
     [Scope('OnPrem')]
-    procedure CheckCanDisableRaisesErrorWhenAppNotInstalled()
-    var
-        LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        ITMigrationAppNotInstalledErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
-    begin
-        // [SCENARIO] CheckCanDisableLegacySubcontracting raises error when new subcontracting app is not installed
-        Initialize();
-
-        // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
-        SetLegacySubcontracting(true);
-
-        // [WHEN] Call CheckCanDisableLegacySubcontracting
-        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
-
-        // [THEN] Error: successor app must be installed first
-        Assert.ExpectedError(ITMigrationAppNotInstalledErr);
-    end;
-
-    [Test]
-    [Scope('OnPrem')]
     procedure UpgradeSetsFlagForCompaniesWithLegacySubcontractingData()
     var
         ManufacturingSetup: Record "Manufacturing Setup";
@@ -587,7 +567,7 @@ codeunit 137500 "SCM Legacy Subcontracting"
         LocationTo: Record Location;
         LocationInTransit: Record Location;
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        OpenSubcontractingTransfersExistErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
+        OpenSubcontractingTransfersExistErr: Label 'There are still open transfer orders with WIP Items. All subcontracting transfer orders must be completed before disabling Legacy Subcontracting.';
     begin
         // [SCENARIO] CheckCanDisableLegacySubcontracting raises error when open WIP transfer orders exist
         Initialize();
@@ -607,8 +587,8 @@ codeunit 137500 "SCM Legacy Subcontracting"
         TransferLine."WIP Outstanding Qty." := 1;
         TransferLine.Insert();
 
-        // [WHEN] Call CheckCanDisableLegacySubcontracting
-        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
+        // [WHEN] Call CanDisableLegacySubcontracting
+        asserterror LegacySubcFeatureHandler.CanDisableLegacySubcontracting();
 
         // [THEN] Error: open subcontracting transfers must be completed first
         Assert.ExpectedError(OpenSubcontractingTransfersExistErr);
@@ -624,7 +604,7 @@ codeunit 137500 "SCM Legacy Subcontracting"
         Item: Record Item;
         TransferLine: Record "Transfer Line";
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        OpenWIPPurchaseOrdersExistErr: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
+        OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All purchase orders with WIP Items must be completed before disabling Legacy Subcontracting.';
     begin
         // [SCENARIO] CheckCanDisableLegacySubcontracting raises error when open WIP purchase orders exist
         Initialize();
@@ -644,8 +624,8 @@ codeunit 137500 "SCM Legacy Subcontracting"
         PurchaseLine."WIP Item" := true;
         PurchaseLine.Modify();
 
-        // [WHEN] Call CheckCanDisableLegacySubcontracting
-        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
+        // [WHEN] Call CanDisableLegacySubcontracting
+        asserterror LegacySubcFeatureHandler.CanDisableLegacySubcontracting();
 
         // [THEN] Error: open WIP purchase orders must be completed first
         Assert.ExpectedError(OpenWIPPurchaseOrdersExistErr);
@@ -661,14 +641,10 @@ codeunit 137500 "SCM Legacy Subcontracting"
         Item: Record Item;
         TransferLine: Record "Transfer Line";
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
-        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
         OpenWIPPurchaseOrdersExistErr: Label 'There are still open purchase orders with WIP Items. All purchase orders with WIP Items must be completed before disabling Legacy Subcontracting.';
     begin
         // [SCENARIO 641607] CheckCanDisableLegacySubcontracting error wording consistently refers to purchase orders with WIP Items in both sentences, instead of implying all subcontracting purchase orders
         Initialize();
-
-        // [GIVEN] The environment is testable as a sandbox so the migration pre-checks (beyond the production gate) are reached
-        EnvironmentInfoTestLibrary.SetTestabilitySandbox(true);
 
         // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
         SetLegacySubcontracting(true);
@@ -685,26 +661,23 @@ codeunit 137500 "SCM Legacy Subcontracting"
         PurchaseLine."WIP Item" := true;
         PurchaseLine.Modify();
 
-        // [WHEN] Call CheckCanDisableLegacySubcontracting
-        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
+        // [WHEN] Call CanDisableLegacySubcontracting
+        asserterror LegacySubcFeatureHandler.CanDisableLegacySubcontracting();
 
         // [THEN] The full error message consistently refers to purchase orders "with WIP Items" in both sentences, not "all subcontracting purchase orders"
         Assert.AreEqual(OpenWIPPurchaseOrdersExistErr, GetLastErrorText(), 'Error message wording must consistently describe purchase orders with WIP Items in both sentences.');
-
-        EnvironmentInfoTestLibrary.SetTestabilitySandbox(false);
     end;
 
     [Test]
     [Scope('OnPrem')]
-    procedure PreCheckDisableFailsWhenITMigrationAppInstalled()
+    procedure PreCheckDisableSucceedsWhenPrerequisitesMet()
     var
         TransferLine: Record "Transfer Line";
         PurchaseLine: Record "Purchase Line";
         LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
         SCMLegacySubcontracting: Codeunit "SCM Legacy Subcontracting";
-        ExpectedError: Label 'To help you migrate safely, disabling Legacy Subcontracting and moving to the Subcontracting app is currently limited to sandbox environments. Test the migration in a sandbox copy of this environment first to validate the transition. Production environments will be enabled in a future release.';
     begin
-        // [SCENARIO] CheckCanDisableLegacySubcontracting fails even when no open data exists and IT Migration app is installed
+        // [SCENARIO 647210] Disabling Legacy Subcontracting is allowed once the prerequisites are met, regardless of the environment type
         Initialize();
 
         // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
@@ -719,27 +692,63 @@ codeunit 137500 "SCM Legacy Subcontracting"
         if not PurchaseLine.IsEmpty() then
             PurchaseLine.DeleteAll();
 
-        // [GIVEN] IT Migration app is mocked as installed
+        // [GIVEN] The Subcontracting app and the IT Migration app are mocked as installed
         BindSubscription(SCMLegacySubcontracting);
 
-        // [WHEN] Call CheckCanDisableLegacySubcontracting
-        asserterror LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
+        // [WHEN] Call CanDisableLegacySubcontracting
+        ClearLastError();
+        LegacySubcFeatureHandler.CanDisableLegacySubcontracting();
 
-        // [THEN] Error: disabling is limited to sandbox environments
-        Assert.ExpectedError(ExpectedError);
+        // [THEN] No error is raised - disabling is no longer restricted to sandbox environments
+        Assert.AreEqual('', GetLastErrorText(), 'Disabling Legacy Subcontracting should be allowed when the prerequisites are met.');
+        UnbindSubscription(SCMLegacySubcontracting);
+    end;
+
+    [Test]
+    [HandlerFunctions('DeclineInstallConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure DisableKeepsLegacyEnabledWhenAppInstallDeclined()
+    var
+        ManufacturingSetup: Record "Manufacturing Setup";
+        TransferLine: Record "Transfer Line";
+        PurchaseLine: Record "Purchase Line";
+        LegacySubcFeatureHandler: Codeunit "Legacy Subc. Feature Handler";
+        SCMLegacySubcontracting: Codeunit "SCM Legacy Subcontracting";
+    begin
+        // [SCENARIO 647791] Declining the "install the Subcontracting app" prompt must keep Legacy Subcontracting enabled instead of disabling it and stranding the legacy data
+        Initialize();
+
+        // [GIVEN] ManufacturingSetup."Legacy Subcontracting" = true
+        SetLegacySubcontracting(true);
+
+        // [GIVEN] No open WIP data blocking the disable pre-checks
+        TransferLine.SetRange("WIP Item", true);
+        if not TransferLine.IsEmpty() then
+            TransferLine.DeleteAll();
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("WIP Item", true);
+        if not PurchaseLine.IsEmpty() then
+            PurchaseLine.DeleteAll();
+
+        // [GIVEN] The Subcontracting app is reported as not installed
+        SCMLegacySubcontracting.SetSubcontractingAppNotInstalled(true);
+        BindSubscription(SCMLegacySubcontracting);
+
+        // [WHEN] Disabling Legacy Subcontracting and declining the prompt to install the Subcontracting app
+        ManufacturingSetup.Get();
+        LegacySubcFeatureHandler.SetLegacySubcontracting(ManufacturingSetup, false);
+
+        // [THEN] Legacy Subcontracting remains enabled so the legacy price list and data stay intact and migration can still be triggered later (no install, no migration, no session restart)
+        ManufacturingSetup.Get();
+        Assert.IsTrue(ManufacturingSetup."Legacy Subcontracting", 'Declining the app install must not disable Legacy Subcontracting.');
+
         UnbindSubscription(SCMLegacySubcontracting);
     end;
 
     local procedure Initialize()
-    var
-        EnvironmentInfoTestLibrary: Codeunit "Environment Info Test Library";
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"SCM Legacy Subcontracting");
         LibraryApplicationArea.EnablePremiumSetup();
-
-        // Ensure every test starts from a known, non-sandbox testability state, regardless of
-        // whether a previous test left the SingleInstance sandbox flag set (e.g. on assertion failure).
-        EnvironmentInfoTestLibrary.SetTestabilitySandbox(false);
 
         if Initialized then
             exit;
@@ -766,6 +775,24 @@ codeunit 137500 "SCM Legacy Subcontracting"
     local procedure MockITMigrationAppInstalled(var Result: Boolean)
     begin
         Result := true;
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Legacy Subc. Feature Handler", 'OnCheckIsSubcontractingAppInstalled', '', false, false)]
+    local procedure MockSubcontractingAppInstalled(var Result: Boolean)
+    begin
+        Result := not SubcontractingAppNotInstalled;
+    end;
+
+    internal procedure SetSubcontractingAppNotInstalled(NotInstalled: Boolean)
+    begin
+        SubcontractingAppNotInstalled := NotInstalled;
+    end;
+
+    [ConfirmHandler]
+    [Scope('OnPrem')]
+    procedure DeclineInstallConfirmHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := false;
     end;
 
     local procedure RefreshApplicationAreas()


### PR DESCRIPTION
Backport of PR #10483 into version 29.x.

[AB#647210](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647210)
[AB#647791](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647791)
