### PR TITLE
[releases/29.x] [Shopify] Update Tax Matching Agent documentation

### DIFF
--- a/src/Apps/NA/ShopifyNA/app/Architecture.md
+++ b/src/Apps/NA/ShopifyNA/app/Architecture.md
@@ -1,455 +1,176 @@
-# Shopify Tax Matching Agent — Architecture & Design
+# Shopify Tax Matching Agent - Architecture
 
-## Problem
+## Purpose
 
-When Shopify orders are imported into Business Central, each order carries free-text tax line descriptions (e.g. "NEW YORK STATE TAX at 4%"). BC requires structured Tax Jurisdiction codes and a Tax Area to apply correct tax rules, accounts, and reporting. The standard connector attempts an address-based lookup, but when that fails the Tax Area remains blank and must be filled manually.
+Shopify orders contain free-text tax descriptions, while Business Central requires structured Tax Jurisdictions and a Tax Area. The Tax Matching Agent attempts to resolve that gap when the standard address-based tax-area lookup does not find a match.
 
-This feature uses an LLM to automate the mapping from free-text Shopify tax descriptions to BC Tax Jurisdictions and Tax Areas.
+The feature is part of the Shopify Connector NA app and is currently enabled for supported North American scenarios.
 
-## Design Principles
+## Design goals
 
-- **Minimal footprint**: Ships as a separate app. Requires a small set of additions to the standard connector (integration event, Tax Jurisdiction Code field on tax lines, Tax Area/Tax Liable/Tax Exempt fields on order header, MapTaxArea procedure). The Tax Matching Agent app hooks in via the integration event.
-- **Sync, invisible**: Runs inline during order import with no user interaction. No AI dialog, chat, or wizard.
-- **Fail-safe**: If the LLM call fails or returns bad data, the order proceeds unchanged — same as if the feature were disabled.
-- **Admin-controlled**: Every creation action (jurisdictions, areas) requires explicit opt-in per shop. The feature itself requires both a per-shop toggle and Copilot AI Capabilities activation.
+- **Conservative by default**: The feature is disabled until an administrator enables it for a shop.
+- **Preserve the standard flow**: Existing address-based tax mapping runs first and takes precedence.
+- **Fail safely**: If the AI service or its required safeguards are unavailable, matching is skipped and order synchronization continues normally.
+- **Require explicit creation settings**: New tax jurisdictions and tax areas are created only when the corresponding shop settings allow it.
+- **Keep people in control**: Incomplete, conflicting, or policy-selected matches are held for review before a sales document is created.
+- **Remain auditable**: Applied matches and review decisions are recorded through standard Business Central surfaces.
 
-## App Identity
+## Execution flow
 
-Tax Matching Agent ships as a **feature inside the `Shopify Connector NA` app** — a North America
-connector-localization container (mirrors *Shopify Connector BE*) that can host additional NA-only
-features. The feature source lives under `src/Tax Matching Agent/`. Built, tested and published **US
-only** for now (add CA/MX when supported). The main Shopify Connector shows a notification prompting
-US environments to install this app (see *Localization promotion* below).
-
-| Property | Value |
-|----------|-------|
-| App name | Shopify Connector NA |
-| App ID | a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c |
-| Folder | `src/Apps/NA/ShopifyNA` (feature under `app/src/Tax Matching Agent`) |
-| Countries | US (add CA/MX when supported) |
-| Object ID Range | 30470-30499 |
-| Version | 29.0.0.0 |
-| Target | OnPrem |
-| Dependency | Shopify Connector (`ec255f57-31d0-4ca2-b751-f2fa7c745abb`) |
-
-## Object Inventory
-
-| ID | Type | Name | Purpose |
-|----|------|------|---------|
-| 30470 | Codeunit | Shpfy TMA Register | Capability registration + `OnRegisterCopilotCapability` subscriber |
-| 30471 | Codeunit | Shpfy TMA Matcher | Core: gather data, call AOAI, parse response, apply matches |
-| 30472 | Codeunit | Shpfy Tax Area Builder | Find existing or create new Tax Area from matched jurisdictions |
-| 30473 | Codeunit | Shpfy TMA Events | `OnAfterMapShopifyOrder` subscriber — orchestrates the flow |
-| 30474 | Codeunit | Shpfy Tax Match Function | `AOAI Function` interface — tool definition + passthrough Execute |
-| 30475 | Codeunit | Shpfy TMA Install | Install trigger → registers capability (per database) + invokes the tag-guarded Shop-defaults backfill (per company) |
-| 30478 | Codeunit | Shpfy TMA Upgrade | Upgrade trigger + shared `BackfillShopDefaults` — sets the tax config defaults on existing shops, guarded by an upgrade tag so it runs once per company (called from both install and upgrade) |
-| 30470 | TableExtension | Shpfy TMA Shop | 4 config fields on `Shpfy Shop` |
-| 30470 | PageExtension | Shpfy TMA Shop Card | "Tax Matching Agent" group on Shop Card |
-| 30470 | EnumExtension | Shpfy TMA Cap. | `"Shopify Tax Matching Agent"` value on `Copilot Capability` enum (its space-stripped name `ShopifyTaxMatchingAgent` is the LLM-API COS/taxonomy key) |
-| 30470 | PermissionSet | Shpfy TMA Matching | RIMD on tax tables + all codeunits; includes `Shpfy - Edit` |
-| 30476 | Codeunit | Shpfy TMA Notify | Owns both review notifications (Sales Order + Shopify Order) and the review-page drills (`RunReviewForSalesHeader`, `OpenReviewForOrder`, single `RunReviewPage`). Notifications are stateless — no table |
-| 30477 | Codeunit | Shpfy TMA Activity Log | Wraps `Activity Log Builder` chain for per-line + per-area AI audit entries |
-| 30476 | TableExtension | Shpfy TMA Order Header | Per-order markers on `Shpfy Order Header`: `Tax Match Applied`, `Tax Match Reviewed`, `Tax Rate Conflict`, `Tax Match Incomplete`, and `Tax Match Low Confidence` (set when a match is not high confidence — e.g. a provisional-jurisdiction match forced low) |
-| 30477 | TableExtension | Shpfy TMA Sales Header | `Shpfy Tax Match Applied` Boolean marker on `Sales Header` |
-| 30480 | TableExtension | Shpfy TMA Order Tax Line | `Tax Jurisdiction Code` (Code[10], `TableRelation = "Tax Jurisdiction"`) — moved out of the connector since the connector itself does not read or write it |
-| 30481 | TableExtension | Shpfy TMA Tax Jurisdiction | Provenance on `Tax Jurisdiction`: `Shpfy Created by Agent`, `Shpfy Verified`. Marks agent-auto-created jurisdictions as **provisional** until a human verifies them |
-| 30470 | TableExtension | Shpfy TMA Shop | 5 config fields on `Shpfy Shop` (incl. `Tax Match Review Mode` — Always / Low Confidence Only / Never) |
-| 30478 | PageExtension | Shpfy TMA Order Tax Lines | Adds the Tax Jurisdiction Code column to the standalone Tax Lines list, visible only when the parent order's shop has Tax Matching Agent enabled |
-| 30471 | Page (Card) | Shpfy TMA Review | Per-order review summary: resolved Tax Area (with AI confidence indicator), ship-to context, and the tax lines ListPart (each line shows the item it taxes). Hosts the **Approve** action that sets `Tax Match Reviewed` |
-| 30479 | Page (ListPart) | Shpfy TMA Order Tax Lines Part | Tax lines list embedded as a subform on the **Tax Match Review page** so the platform AI confidence indicator renders on the Tax Jurisdiction Code cell; `SetTaxLineFilter` scopes it to one order |
-| 30479 | PageExtension | Shpfy TMA Order | Adds the review entry action (AI `SparkleFilled` icon) that opens the review page — captioned **Review and Approve Tax Match** while approval is pending, else **Review Tax Match** — and fires the actionable order-page review notification |
-| 30476 | PageExtension | Shpfy TMA Sales Order | Read-only badge field, **Review Tax Match** action (opens the review page), `OnAfterGetCurrRecord` notification trigger |
-
-## Execution Flow
-
-```
-Shopify Order Import (standard connector)
+```text
+Shopify order import
   |
   v
-OrderMapping.DoMapping()
-  |-- MapHeaderFields() or MapB2BHeaderFields()
-  |     |-- MapTaxArea() (address-based lookup, respects Tax Exempt)
-  |-- Map order lines (items, tips, gift cards)
-  |-- OnAfterMapShopifyOrder event fires
+Standard order mapping
+  |-- Import the order, lines, shipping charges, and tax lines
+  |-- Attempt the standard address-based Tax Area lookup
   |
   v
-TMA Events (30473) — Event Subscriber
-  |-- Guard: Result = true?
-  |-- Guard: Tax Area Code still blank?
-  |-- Guard: Tax Exempt = false?
-  |-- Guard: Shop.Get + Tax Matching Agent Enabled?
-  |-- Guard: Capability registered + active?
-  |-- Telemetry: log start
+Tax Matching Agent eligibility checks
+  |-- Did order mapping succeed?
+  |-- Is the order taxable?
+  |-- Is the Tax Area still unresolved?
+  |-- Are the feature and Copilot capability enabled?
+  |-- Are the required AI safeguards available?
+  |     \-- No: skip matching and continue standard synchronization
   |
   v
-Tax Matcher (30471) — MatchTaxLines()
-  |-- Walk the order's tax lines — BOTH product-line tax lines (Parent Id = order line
-  |   "Line Id") AND shipping-charge tax lines (Parent Id = "Shopify Shipping Line Id",
-  |   iterated from Shpfy Order Shipping Charges):
-  |     |-- Tax Jurisdiction Code = '' -> send to the LLM (unmatched)
-  |     |-- Tax Jurisdiction Code set (from a prior run) -> carry into MatchedJurisdictions
-  |         so the Tax Area is built from the order's COMPLETE jurisdiction set on a re-run
-  |   (product lines first to preserve state -> ... -> city ordering; shipping jurisdictions
-  |    usually duplicate product ones and are de-duplicated)
-  |-- Gather all BC Tax Jurisdictions (code + description)
-  |-- Build ship-to address context (country, state, city)
-  |-- Construct user prompt from template
+Prepare the matching request
+  |-- Collect unmatched product and shipping tax lines
+  |-- Retain existing jurisdiction assignments for reprocessing
+  |-- Include candidate jurisdictions and coarse ship-to geography
   |
   v
-CallLLMAndApplyMatches()
-  |-- Load system prompt from .resources
-  |-- Configure AOAI: GPT-4.1, temp=0, max_tokens=4096
-  |-- Add tool: match_tax_jurisdictions (forced)
-  |-- GenerateChatCompletion()
-  |-- Parse function call response
+AI-assisted jurisdiction matching
+  |-- Receive structured match proposals
+  |-- Reject malformed or invalid references
+  |-- Leave unresolved tax lines unmatched
+  |-- Create missing jurisdictions only when configured
+  |     \-- Newly created jurisdictions remain provisional
   |
   v
-ApplyMatches()
-  |-- For each match in response:
-  |     |-- Skip if jurisdiction_code empty or low-confidence + no auto-create
-  |     |-- Parse tax_line_id -> ParentId + LineNo
-  |     |-- Validate jurisdiction exists, or create if auto-create enabled
-  |     |-- ApplyAssignedJurisdiction(): write jurisdiction code to Shpfy Order Tax Line
-  |     |   (the match is always applied — the jurisdiction is correct) and:
-  |     |     |-- Resolve the tax line's Tax Group Code by owner: a product-line tax line uses
-  |     |     |   the order line item's Tax Group Code; a shipping-charge tax line uses the Shop's
-  |     |     |   Shipping Charges Account Tax Group Code.
-  |     |     |-- Rate-conflict check: if a Tax Detail bracket valid at the order date already
-  |     |     |   EXISTS for (jurisdiction × that tax group) with a DIFFERENT rate than Shopify's,
-  |     |     |   set HasRateConflict, log telemetry 0000UMR + a per-line "matched, but rate
-  |     |     |   differs" entry, and leave the existing (admin-maintained) rate untouched. This
-  |     |     |   applies equally to product-line and shipping-charge tax lines.
-  |     |     |-- Otherwise: seed a Tax Detail for (jurisdiction × that tax group) at Shopify's
-  |     |         rate if none exists. Each tax line (product or shipping) seeds its own bracket
-  |     |         from its OWN rate — there is no product-line-derived shipping inference.
-  |-- FixReportToJurisdictions() if >1 jurisdiction matched — points every matched jurisdiction
-  |     whose Report-to is still blank at the state (this covers jurisdictions auto-created this
-  |     run AND pre-existing ones that never had a rollup target, including the state itself,
-  |     which reports to itself), so the Tax Area rolls up correctly; a jurisdiction that already
-  |     has a Report-to (admin-maintained hierarchy) is left untouched
-  |-- Return matched jurisdiction list + HasRateConflict
+Apply and validate tax setup
+  |-- Assign validated jurisdictions to tax lines
+  |-- Reuse or seed the relevant Tax Details
+  |-- Preserve existing Business Central rates
+  |     \-- Rate difference: flag a conflict; do not overwrite
+  |-- Reuse an exact Tax Area or create one when configured
   |
   v
-TMA Events (30473):
-  |-- (A rate conflict no longer blocks matching — the jurisdiction is applied and the Tax
-  |   Area is built as usual; the conflict is recorded on the order to force review.)
+Record the result
+  |-- Store applied, confidence, incomplete, and conflict state
+  |-- Record audit entries for the applied decisions
   |
   v
-Tax Area Builder (30472) — FindOrCreateTaxArea()
-  |-- Search all Tax Areas for exact jurisdiction set match
-  |-- If found: use existing (WasCreated = false)
-  |-- If not found + Auto Create Tax Areas: create new area (WasCreated = true)
-  |     |-- Code: {NamingPattern}{LowestJurisdiction} (e.g. SHPFY-MTATAX)
-  |     |-- Collision: append -2, -3, ... up to -999
-  |     |-- Description: "Shopify - " + joined jurisdiction descriptions
-  |     |-- Create Tax Area Lines with calculation order
-  |-- Set OrderHeader."Tax Area Code" + "Tax Liable" = true
+Review gate before Sales Document creation
+  |-- Incomplete match or rate conflict: always hold
+  |-- Otherwise evaluate the shop's review mode
+  |     |-- Always: hold
+  |     |-- Low Confidence Only: hold when additional validation is needed
+  |     \-- Never: continue
+  |
+  +-- Held for review
+  |     |-- Reviewer inspects and corrects jurisdictions or rates
+  |     |-- Approval rebuilds the Tax Area and rechecks safety conditions
+  |     \-- The order remains held while incomplete or conflicting
   |
   v
-TMA Events (30473) — HITL writes (after Tax Area resolved)
-  |-- Set OrderHeader."Tax Match Applied" = true
-  |-- Set OrderHeader."Tax Rate Conflict" = HasRateConflict
-  |     (a conflict forces review in all review modes; telemetry 0000UMF logged)
-  |-- Shpfy TMA Activity Log (30477):
-  |     |-- LogPerLineEntries — one Activity Log entry per tax line (matched, or on a rate
-  |     |     conflict a "matched, but rate differs" entry explaining the conflict)
-  |     |     (anchor = Shpfy Order Tax Line, field "Tax Jurisdiction Code")
-  |     |-- LogTaxAreaEntry — one Activity Log entry on the Order Header
-  |           (anchor = Shpfy Order Header, field "Tax Area Code")
-  |
-  v
-Order continues through standard import pipeline
-  |
-  v
-ShpfyProcessOrder.CreateHeaderFromShopifyOrder()
-  |-- Fires OnBeforeCreateSalesHeader event
-          |
-          v
-      TMA Events (30473) — OnBeforeCreateSalesHeader subscriber [BLOCKING GATE]
-          |-- If OrderHeader."Tax Match Applied" AND
-          |     NOT OrderHeader."Tax Match Reviewed" AND
-          |     (held by Tax Match Review Mode OR OrderHeader."Tax Rate Conflict" OR "Tax Match Incomplete"):
-          |        |-- Tax Rate Conflict is the stored flag (field 30478), set at match
-          |        |     time when a matched line's BC Tax Detail rate differs from Shopify's and
-          |        |     refreshed on Approve — the single source of truth for the whole feature.
-          |        |-- Handled := true  (connector skips Sales Doc creation)
-          |        |-- A rate-conflict order is held in all review modes; a normal successful
-          |              match is held per the shop's review mode.
-          |        |-- Order stays in pending-review state until the user opens the
-          |              Tax Match Review page (via the Shpfy Order page action
-          |              or the order-page notification) and clicks Approve
-  |
-  |  (only when Handled = false — i.e. blocking off, or user already approved)
-  v
-  ShpfyProcessOrder propagates Tax Area Code + Tax Liable to Sales Header,
-  fires OnAfterCreateSalesHeader event
-        |
-        v
-      TMA Events (30473) — OnAfterCreateSalesHeader subscriber
-        |-- If OrderHeader."Tax Match Applied" -> true:
-        |     |-- Set SalesHeader."Shpfy Tax Match Applied" = true
-        |           (badge only — no notification queued; the Sales Order prompt
-        |            is derived live on page open)
-        |
-        v
-  Review surfaces (all open the Tax Match Review page 30471):
-    - Shpfy Order page (30479): review entry action (Review and Approve
-      Tax Match when approval is pending, else Review Tax
-      Match) + an
-      actionable "Review" notification fired on open (once per order/session)
-      while the order is matched and not yet reviewed.
-    - Sales Order page (30476): OnAfterGetCurrRecord sends one notification
-      (once per session) when the Sales Header is marked and the originating
-      order is not yet reviewed — Show Tax Match Decisions / Mark as reviewed /
-      Don't show again. No table: the prompt reads the order's
-      Tax Match Reviewed flag + the per-user My Notifications toggle.
-    Approving on the review page (or Mark as reviewed) sets the order's
-    Tax Match Reviewed flag — the single source of truth that stops
-    both prompts.
+Sales Document creation
+  |-- Propagate the resolved tax context
+  \-- Expose the applied-match marker and review entry points
 ```
 
-## Human-in-the-loop
+The standard address-based result always takes precedence. On a re-run, existing assignments are included so the Tax Area is rebuilt from the order's complete jurisdiction set rather than only newly matched lines.
 
-The matcher runs synchronously during order import without prompting the user, but every agent decision is recorded, customer-configurable to block document creation, and surfaced for human review. The primary review surface is the **Tax Match Review page** (page 30471) — a per-order Card that shows the resolved Tax Area (with the platform AI confidence indicator), the ship-to context the Tax Matching Agent reasoned over, and the tax lines with their matched Tax Jurisdiction Codes. Both entry points below open it. Five pillars:
+## Responsibilities
 
-1. **Audit trail** — `Shpfy TMA Activity Log` (30477) writes a System Application `Activity Log` entry (Type = `AI`) for each matched tax line and one for the resulting Tax Area. Each entry carries the LLM confidence (`Low`/`Medium`/`High`), the LLM's reasoning text, and a drill-back URL to the Tax Jurisdiction or Tax Area card. The platform automatically renders a confidence indicator next to the field on the originating record (Shpfy Order Tax Line for per-line — shown in the review page's tax lines ListPart; Shpfy Order Header for per-area — shown on the review page's Tax Area Code field).
+| Area | Responsibility |
+|------|----------------|
+| Orchestration | Runs after standard order mapping, applies eligibility checks, and coordinates matching and review state. |
+| Matching | Supplies the minimum required tax and geographic context to the AI service and validates its structured response. |
+| Tax setup | Reuses existing tax setup where possible and creates jurisdictions, tax details, or tax areas only when configured. |
+| Review | Shows the proposed result, rate differences, confidence, and unresolved lines before approval when review is required. |
+| Audit and notifications | Records applied decisions and provides entry points from Shopify orders and sales orders. |
 
-2. **Persistent badge** — a `Tax Match Applied` Boolean on `Shpfy Order Header` (field 30476, set by `ShpfyTMAEvents` after `FindOrCreateTaxArea` succeeds) propagates to `Sales Header` (field 30476) via the existing `OnAfterCreateSalesHeader` event in `ShpfyOrderEvents`. The Sales Order page extension shows this as a read-only field (`Importance = Additional`) plus a **Review Tax Match** action that opens the review page.
+Implementation-specific object IDs and inventories are intentionally kept in source rather than duplicated here.
 
-3. **Review page** (page 30471) — the single canonical review-and-adjust surface for an order. It summarizes the resolved Tax Area (with AI confidence indicator), the ship-to context, and the tax lines. Each line shows the **item it taxes** (applies-to Item No. + description), **Shopify's rate**, the **Business Central Tax Detail rate** that would apply to that item for the assigned jurisdiction as of the order date, and the matched **Tax Jurisdiction Code** (with AI confidence indicators). The Tax Jurisdiction Code is **editable** so a reviewer can correct or complete a match, and the row is highlighted **green** when Shopify's and BC's rates agree and **red** when they differ. The **Approve** action (Approve icon, shown only while the order is being **held** — per the review mode, or a live rate conflict / incomplete match — and it is not yet reviewed) **rebuilds the Tax Area from the current line jurisdictions** (re-seeding any missing Tax Detail brackets and re-detecting rate conflicts), then sets `Tax Match Reviewed` — the single source of truth that also stops the Sales Order and order-page prompts. When the review mode does not hold the order and there is no rate conflict, the order is never held (its Sales Document is created automatically), so Approve is hidden and the page is purely informational. Approve is blocked while any tax line is still unmatched (blank jurisdiction), so tax is never silently dropped. An **Undo Approval** action (Undo icon) reverses an approval while the order is still held-when-unapproved and no Sales Document has been created yet (`Sales Order No.`/`Sales Invoice No.` still blank) — it clears `Tax Match Reviewed` so the order is held again, and un-verifies the agent-created jurisdictions the order used (returning them to provisional). If the order is being held and the user closes without approving, `OnQueryClosePage` warns them. **Rate-conflict case:** the jurisdiction is applied and a Tax Area is built, but the divergent line shows red and a guidance message on the Overview tab (shown only on a conflict) explains that approving will post at BC's rate. The reviewer can resolve it three ways: accept BC's rate (just Approve), change the jurisdiction, or click **Use Shopify Rate** on the tax lines part — which creates/updates a Tax Detail (effective the order's document date, at Shopify's rate) so BC posts what the customer paid. **Use Shopify Rate** mutates shared BC tax setup (not scoped to this order), so it asks for confirmation first; after it runs the row turns green, and approving then rebuilds the Tax Area and clears the stored rate-conflict flag. The tax lines ListPart is scoped to the order via `SetTaxLineFilter`. (tax lines link to order lines, so the page passes the order's order line ids). The standalone tax lines ListPart is **no longer embedded on the Shopify Order Card** — it lives only on this review page.
+## Safety and validation
 
-4. **Configurable review mode (default hold everything)** — a per-shop `Tax Match Review Mode` enum (field 30474, default `Always`) and a per-order `Tax Match Reviewed` Boolean (field 30477) gate Sales Document creation. `ShpfyTMAEvents` subscribes to `OnBeforeCreateSalesHeader` and sets `Handled := true` when the order has the marker, is not yet approved, and **(the review mode holds it OR the order has a `Tax Rate Conflict` OR the match is incomplete (`Tax Match Incomplete`))**. The review mode is evaluated by `IsHeldForReviewPreference`: **Always** holds every matched order; **Low Confidence Only** holds only when the order carries a non-high-confidence match (the stored `Tax Match Low Confidence` flag, field 30480, which includes a match to a provisional agent-created jurisdiction forced low); **Never** does not hold for review preference. The `Tax Rate Conflict` Boolean (field 30478) is the **single source of truth** for a rate conflict: it is set at match time when a matched line's BC Tax Detail rate differs from Shopify's, and refreshed whenever the match is re-applied on Approve. The `Tax Match Incomplete` Boolean (field 30479) is set when one or more tax lines could not be resolved to a jurisdiction (the model returned the `UNKNOWN` sentinel for a title that is not a genuine tax description — e.g. an injection/obfuscation attempt): the line is left unmatched, no jurisdiction is created from the untrusted text, and the order is always held so a human assigns the missing jurisdiction (the review page rebuilds the Tax Area from the completed set on Approve, which clears the flag). The gate, the notifications, the order-page action caption, and the review-page guidance + Approve visibility all read these stored flags via the shared `IsHeldForReviewPreference`, so they can never disagree. Because edits to a tax line's jurisdiction on the review page only take effect on Approve — and are **reverted** if the user closes without approving — the stored flag always matches the persisted tax lines. A rate conflict or an incomplete match holds the order in **all** review modes (they are hard safety gates); a normal successful match (no conflict, all lines resolved) is held per the review mode — always in **Always**, only when low-confidence in **Low Confidence Only**, and never in **Never**. The **Shpfy Order page** exposes a **Review and Approve Tax Match** entry action (shown while approval is pending — the order is held and not yet approved; captioned just **Review Tax Match** once approved or when not held) which opens the review page where the match is approved. On the review page, an unmatched tax line (blank Tax Jurisdiction Code) is highlighted **red**, the same visual weight as a rate conflict, so the reviewer is drawn to the line they must complete. If the user closes the review page while approval is still pending, an `OnQueryClosePage` confirm warns them the Sales Document will not be created until it is approved. On the next process run (auto or manual) the order proceeds. Customers set the shop's `Tax Match Review Mode` to choose how much is held.
+All externally supplied text is treated as untrusted data. The feature uses managed safeguards around the model request and does not run matching when those safeguards cannot be applied. The exact prompts and security configuration are intentionally not documented in this public repository.
 
-   **Provisional agent-created jurisdictions.** When the shop has *Auto Create Tax Jurisdictions* enabled and the model matches a tax line to a code that does not yet exist, the matcher creates the jurisdiction and stamps it `Created by Agent = true`, `Verified = false` (tableextension 30481). Such a jurisdiction is **provisional**: on this and every later order (except when the shop's review mode is *Never*, where nothing is held and the downgrade is skipped), a match to a jurisdiction that is `Created by Agent AND NOT Verified` is deterministically forced to **low confidence** in AL (never trusting the model to down-rank its own creation) and the order is flagged `Tax Match Low Confidence` (field 30480) so the review gate holds it for a human — otherwise the agent could "launder" master data it invented into a later high-confidence, auto-released match. Approving any order that uses the jurisdiction sets `Verified = true` (in the review page's Approve action, via `MarkJurisdictionsVerified`), which clears the provisional state so future high-confidence matches ride through. Conversely, undoing an order's approval reverses this (via `UnverifyAgentJurisdictions`): the agent-created jurisdictions the order used are set back to `Verified = false`, returning them to their provisional (forced-low, held) state. This is deliberately unconditional and cheap — only the order's own tax lines are read — so a jurisdiction that another approved order also uses is re-quarantined too and is simply re-verified when a later order using it is approved. The model's free-text `reason` (untrusted, buyer-controlled) is **replaced** with a deterministic explanation for these forced-low matches, so the reviewer sees why the match is held. Because the check is `Created by Agent AND NOT Verified`, pre-existing and user/admin-created jurisdictions (`Created by Agent = false`) are never quarantined and need no migration.
+Model output is treated as a proposal, not as an instruction:
 
-5. **Active notifications** — two actionable, dismissible BC `Notification`s prompt the user to review, each with its own `MyNotifications` GUID so "Don't show again" is scoped per surface:
-   - **Shopify Order page** (all review modes) — `ShpfyTMAEvents`/the Order page extension fires (once per order per page session, via `SendOrderReviewNotification`) when the order was agent-matched and not yet reviewed: "Tax Matching Agent set Tax Area %1 on this Shopify order. Review the matched tax jurisdictions." Actions: **Review** (opens the review page) and **Don't show again**.
-   - **Sales Order page** (auto-released orders) — on open, the page's `OnAfterGetCurrRecord` calls `SendForCurrentSalesHeader`, which fires a notification when the Sales Header is marked `Tax Match Applied` and the originating Shopify order (resolved via `Sales Order No.`) has `Tax Match Reviewed = false` and the user hasn't disabled the prompt. **No table or queue** — the decision is derived live from the order's `Reviewed` flag plus the per-user `My Notifications` toggle, and a per-session dedupe var prevents re-firing on refresh. Actions: **Show Tax Match Decisions** (opens the review page), **Mark as reviewed** (sets the order's `Reviewed` flag), and **Don't show again** (`My Notifications.Disable`). Naturally suppressed once the order is reviewed (approving a held order already sets that flag).
+- The response must have the expected structured shape.
+- Referenced tax lines and jurisdictions must be valid.
+- New jurisdictions are created only when explicitly allowed.
+- Unresolved lines are left for a person to complete.
+- Existing Business Central tax rates are not silently overwritten.
 
-For safety, `ShpfyTMAEvents.OnAfterMapShopifyOrder` resets both the marker and the reviewed flag to `false` before each matcher run so re-matching (after a user manually clears Tax Area Code on the Shpfy Order Header) cannot leave stale flags from a prior run.
+When Shopify's rate differs from an existing Business Central Tax Detail, the jurisdiction can still be matched, but the existing rate is preserved and the order is held for review. A reviewer can accept the Business Central rate, select another jurisdiction, or explicitly choose to update tax setup to the Shopify rate.
 
-## Data Sent to LLM
+Jurisdictions created by the agent remain provisional until they are approved through the review workflow. This prevents newly generated master data from being treated as trusted without human confirmation.
 
-A single API call per order. The user prompt is assembled from this template:
+## Review policy
 
-```
-Match the following Shopify tax lines to BC Tax Jurisdictions.
+Each shop selects a review mode:
 
-Tax lines:
-[{id, title, rate_pct, channel_liable}, ...]
+| Mode | Behavior |
+|------|----------|
+| Always | Hold every applied match for review. |
+| Low Confidence Only | Hold matches that require additional validation. |
+| Never | Do not hold solely because of the review preference. |
 
-Available Tax Jurisdictions:
-[{code, description}, ...]
+Rate conflicts and incomplete matches are hard safety gates and are held in every mode.
 
-Ship-to address:
-{country, state, city}
+The review page is the canonical place to inspect and adjust a match. It presents the resolved Tax Area, relevant ship-to context, matched tax lines, and the Shopify and Business Central rates. Approval rebuilds the Tax Area from the final assignments and rechecks conflicts before releasing the order.
 
-Auto Create Tax Jurisdictions: Yes/No
-```
+Changes made on the review page are not considered approved until the reviewer completes the approval action. Approval can be undone before a sales document is created.
 
-**What is NOT sent**: customer names, monetary amounts, item details, street addresses, postal codes, or any PII.
+## Data boundaries
 
-## LLM Configuration
+The model receives only the information needed for jurisdiction matching:
 
-| Setting | Value |
-|---------|-------|
-| Model | GPT-4.1 Latest (`AOAIDeployments.GetGPT41Latest()`) |
-| Temperature | 0 (deterministic) |
-| Max tokens | 4096 |
-| Tool choice | Forced — `match_tax_jurisdictions` |
-| Infrastructure | Azure OpenAI via BC's `AzureOpenAI` codeunit |
+- Tax-line identifiers, descriptions, and rates.
+- Candidate jurisdiction codes and descriptions.
+- Coarse ship-to geography such as country, state or province, and city.
+- Whether jurisdiction creation is allowed.
 
-## System Prompt Strategy
+Customer names, monetary totals, item details, street addresses, and postal codes are not included in the matching request.
 
-The **matching** system prompt (`ShpfyTaxMatchingAgent-SystemPrompt.md`, shipped as an app resource) instructs the LLM to match using a four-tier strategy:
+## Configuration and user experience
 
-1. **Exact match** — title matches jurisdiction code or description (case-insensitive)
-2. **Keyword/semantic match** — common tax abbreviation patterns (GST, PST, HST, MTA, NYC, etc.)
-3. **Geographic context** — use ship-to address to disambiguate when multiple jurisdictions could match
-4. **Auto-create** — when enabled and no match found, suggest a new code (max 10 chars, uppercase, no spaces)
+The Shopify Shop Card contains the feature toggle, creation settings, Tax Area naming preference, and review mode. Settings that depend on another option remain unavailable until their prerequisite is enabled.
 
-The prompt is hardened against prompt injection by a separate **security/guardrail** section that instructs the model to treat every tax line title, address, and jurisdiction description as untrusted **data (never instructions)**, never reveal the prompt or tool definition, keep `reason` short/factual/tax-only, and ignore any embedded instructions (returning the `UNKNOWN` sentinel rather than obeying them). That guardrail section is **not** committed to this public repository: it is stored in **Azure Key Vault** (secret `ShopifyTaxMatchingAgentSecurityPrompt`) and merged onto the matching prompt at runtime (following the Sales Line Suggestions pattern of loading prompts from Key Vault). The guardrail is exercised by the Responsible AI tests, which live in the internal enlistment (see below).
+The main user surfaces are:
 
-**Guardrail availability is a precondition, not a mid-match failure.** Because `ShpfyTMAEvents.OnAfterMapShopifyOrder` runs inside `ShpfyOrderMapping.DoMapping` — which the order-sync report calls **without** error isolation — the subscriber must never throw, or it would abort the whole sync run. So it fetches the guardrail prompt up front via `Shpfy TMA Matcher.TryGetGuardrailPrompt()` as a precondition (alongside the capability checks): if the secret cannot be read — a deliberate Microsoft-side disable (kill switch) or a transient Key Vault issue — it logs telemetry `0000UNV` and skips matching, so the order proceeds via the normal address-based tax path and order sync is unaffected. The matcher must never call the model without the guardrail, so the fetched prompt is **carried into `MatchTaxLines`** (Key Vault is read only once per order) and merged onto the matching prompt there.
+- **Tax Match Review**: Review, correct, and approve jurisdiction assignments and rate differences.
+- **Shopify Order**: Open the review page and see when approval is pending.
+- **Sales Order**: Review the originating tax match for orders that were allowed to continue automatically.
 
-## Tool Definition
+Notifications are derived from the current order state and can be disabled by the user through standard notification settings.
 
-The LLM must return a structured JSON object via function calling:
+## Data and integration boundaries
 
-```json
-{
-  "matches": [
-    {
-      "tax_line_id": "12345-1",
-      "jurisdiction_code": "NYSTAX",
-      "confidence": "high|medium|low",
-      "reason": "Brief explanation"
-    }
-  ]
-}
-```
+The feature stores jurisdiction assignments and review state with the Shopify order, reads and updates standard Business Central tax setup as configured, and propagates the resolved tax context to the sales document.
 
-Confidence levels drive business logic:
-- `high` / `medium` — match applied if jurisdiction exists
-- `low` — only applied if Auto Create Tax Jurisdictions is enabled (treated as a "suggestion" for a new jurisdiction)
-- Empty `jurisdiction_code` — always skipped
+It integrates with the connector at three lifecycle points:
 
-## UI Surface
+1. After Shopify order mapping, to attempt matching when standard tax mapping did not succeed.
+2. Before sales document creation, to enforce the review gate.
+3. After sales document creation, to propagate the applied-match marker.
 
-The Tax Matching Agent's matching itself runs silently during order import — no dialog, wizard, or chat interface. The visible surfaces are:
+The feature does not replace the connector's import or document-creation pipeline.
 
-**Shopify Shop Card** — a "Tax Matching Agent" group with the per-shop configuration. Fields that have no effect without a prerequisite are disabled (greyed out) until the prerequisite is set:
+## Installation and upgrades
 
-| Field | Type | Default | Enabled when | Purpose |
-|-------|------|---------|--------------|---------|
-| Tax Matching Agent Enabled | Boolean | false | always | Master toggle per shop |
-| Auto Create Tax Jurisdictions | Boolean | false | Tax Matching Agent Enabled | Allow LLM-suggested new jurisdictions to be created |
-| Auto Create Tax Areas | Boolean | true | Tax Matching Agent Enabled | Allow system to create Tax Area records |
-| Tax Area Naming Pattern | Text[20] | `SHPFY-` | Enabled **and** Auto Create Tax Areas | Prefix for auto-generated Tax Area codes |
-| Tax Match Review Mode | Enum (Always / Low Confidence Only / Never) | Always | Tax Matching Agent Enabled | Controls when a matched order is held for approval on the Tax Match Review page. **Always** holds every matched order (default, per RAI guidance); **Low Confidence Only** holds only orders with a non-high-confidence match (incl. a match to a provisional, agent-created jurisdiction); **Never** holds none for review preference. A rate conflict or incomplete match always holds regardless. |
+Feature enablement and automatic jurisdiction creation remain opt-in. Dependent settings receive defaults for new and existing shops without enabling the agent on behalf of the administrator.
 
-**Tax Match Review page** (page 30471) — the single canonical review-and-adjust surface. A Card showing the resolved Tax Area (with AI confidence indicator), the ship-to context, and an editable tax lines ListPart where each line shows the item it taxes (applies-to Item No. + description), Shopify's rate, Business Central's Tax Detail rate for the assigned jurisdiction, and its per-line Tax Jurisdiction Code (with AI confidence indicators). The Tax Jurisdiction Code is editable, and a line is highlighted green when the two rates agree, red when they differ. The **Approve** action (Approve icon) shows only while the order is being held (per the shop's review mode, or a live rate conflict / incomplete match) and is not yet reviewed; it rebuilds the Tax Area from the current line jurisdictions and is blocked while any line is unmatched. An **Undo Approval** action (Undo icon) reverses an approval before the Sales Document is created; it also un-verifies the agent-created jurisdictions the order used (returning them to provisional). When the review mode does not hold the order and there is no conflict, the order isn't held, so Approve is hidden and the page is informational. On a rate conflict the divergent line is red and a guidance message on the Overview tab explains that approving posts at BC's rate; a **Use Shopify Rate** action on the tax lines part lets the reviewer instead create/update a Tax Detail (effective the order's document date, at Shopify's rate) so BC posts the Shopify rate — it warns first that this changes shared tax setup beyond this order. The review-drill actions on the Shopify Order and Sales Order pages both use the AI `SparkleFilled` icon.
-
-**Shopify Order page** — adds a review entry action (AI `SparkleFilled` icon) that opens the review page — captioned **Review and Approve Tax Match** while approval is pending, else **Review Tax Match** — and fires an actionable **Review** notification on open when the order was agent-matched and not yet reviewed. The tax lines are no longer embedded here — they live on the review page.
-
-**BC Sales Order page** — a secondary HITL surface:
-
-- Read-only `Tax Match Applied` field (next to Tax Liable, `Importance = Additional`).
-- **Review Tax Match** navigation action (visible when the marker is set) that opens the review page for the originating order.
-- One-time notification on first open of the Sales Order (shown for auto-released orders — those the review mode did not hold), with actions to open the review page, mark reviewed, or suppress per-user.
-
-## Data Model
-
-The feature reads from and writes to the standard Shopify connector tables and BC tax tables:
-
-### Connector tables (read/write)
-
-| Table | Field | Usage |
-|-------|-------|-------|
-| Shpfy Order Header | Tax Area Code (1070) | Written by Tax Area Builder |
-| Shpfy Order Header | Tax Liable (1080) | Set to `true` by Tax Area Builder |
-| Shpfy Order Header | Tax Exempt (1090) | Imported from Shopify `taxExempt` field; guards skip matching |
-| Shpfy Order Tax Line | Tax Jurisdiction Code (30476, via TMA TableExt) | Written by Matcher for each matched line |
-| Shpfy Refund Header | Tax Area Code (110) | FlowField → Order Header; shown on Refund page |
-| Shpfy Refund Header | Tax Liable (111) | FlowField → Order Header; inherited by credit memo |
-| Shpfy Refund Header | Tax Exempt (112) | FlowField → Order Header; shown on Refund page |
-| Shpfy Shop | 4 config fields (30470-30473) | Read by Events + Matcher + Builder |
-
-### BC tax tables
-
-| Table | Usage |
-|-------|-------|
-| Tax Jurisdiction | Read for matching; created when `Auto Create Tax Jurisdictions` enabled |
-| Tax Area | Read for exact-match search; created when `Auto Create Tax Areas` enabled |
-| Tax Area Line | Read/created as part of Tax Area |
-| Tax Detail | Seeded per matched tax line for `(jurisdiction × the tax line's Tax Group)` at Shopify's reported rate. The Tax Group is resolved by what the tax line is charged on: a product-line tax line uses the order line item's `Tax Group Code`; a shipping-charge tax line uses the Shop's `Shipping Charges Account` Tax Group Code (`G/L Account.Tax Group Code`). For each seed, look for the latest Tax Detail with `Effective Date <= order date` for the jurisdiction + tax group + tax type. If none exists, insert a new one at the order date with Shopify's rate. If one exists with the same rate, do nothing. **Rate conflict:** if the bracket exists with a *different* rate, the existing (admin-maintained) rate is left untouched, telemetry `0000UMR` is logged, and the order is flagged (`Tax Rate Conflict`) — the jurisdiction is still matched and the Tax Area is built, but the order is held for review so a human accepts BC's rate or corrects the detail (see Human-in-the-loop). This applies uniformly to product-line and shipping-charge tax lines (a shipping rate conflict holds the order too). Empty Tax Group Code is a valid value (an item or shipping account with no group results in a `(Jurisdiction × '')` Tax Detail row). |
-
-## Integration Points
-
-The feature hooks into the standard connector via three existing integration events on `Shpfy Order Events` (codeunit 30162):
-
-```al
-[IntegrationEvent(false, false)]
-internal procedure OnAfterMapShopifyOrder(var ShopifyOrderHeader: Record "Shpfy Order Header"; Result: Boolean)
-
-[IntegrationEvent(false, false)]
-internal procedure OnBeforeCreateSalesHeader(ShopifyOrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header"; var LastCreatedDocumentId: Guid; var Handled: Boolean)
-
-[IntegrationEvent(false, false)]
-internal procedure OnAfterCreateSalesHeader(OrderHeader: Record "Shpfy Order Header"; var SalesHeader: Record "Sales Header")
-```
-
-- `OnAfterMapShopifyOrder` fires after `OrderMapping.DoMapping()` completes; the agent subscriber runs the matcher (the connector's `MapTaxArea` runs first via address-based lookup; the agent only activates if that lookup didn't find a Tax Area).
-- `OnBeforeCreateSalesHeader` fires at the top of `ShpfyProcessOrder.CreateHeaderFromShopifyOrder()`; the agent subscriber sets `Handled := true` to skip Sales Doc creation when the order is held for review (per the review mode, a rate conflict, or an incomplete match) and hasn't yet been approved.
-- `OnAfterCreateSalesHeader` fires after the connector's existing Tax Area Code propagation; the agent subscriber uses it to propagate the marker flag onto the Sales Header (the review prompt itself is derived live on page open, not queued).
-
-## Capability Registration
-
-Registration follows the standard BC Copilot capability pattern:
-
-1. **Install codeunit** (30475) — calls `RegisterCopilotCapability()` on `OnInstallAppPerDatabase`
-2. **Register codeunit** (30470) — subscribes to `OnRegisterCopilotCapability` on the Copilot AI Capabilities page, so the capability is also registered when the admin visits that page
-3. The capability appears as **"Shopify Tax Jurisdiction Matching with AI"** in the Copilot AI Capabilities page
-
-### Shop defaults on install/upgrade
-
-The tax config fields carry their defaults as field `InitValue`s (`Auto Create Tax Areas = true`, `Tax Area Naming Pattern = 'SHPFY-'`, `Tax Match Review Mode = Always`), which only apply to Shop records created *after* the app is installed. Because Shopify shops usually already exist when this app is added, `Shpfy TMA Upgrade` (30478) backfills those three fields onto existing shops from an `Init()`'d record. The backfill is guarded by an **upgrade tag** (`MS-445769-TMAShopDefaults-…`) so it runs **exactly once per company**, and it is invoked from both paths: the Install codeunit's `OnInstallAppPerCompany` (new install into a company that already has shops) and the Upgrade codeunit's `OnUpgradePerCompany` (a previously installed app being updated). The tag is intentionally **not** registered in `OnGetPerCompanyUpgradeTags`, so a fresh install — which has no tag yet — still backfills any pre-existing shops (mirroring how `Shpfy Installer` guards its Cue/retention setup). The other two fields (`Tax Matching Agent Enabled`, `Auto Create Tax Jurisdictions`) intentionally default to `false` and are left untouched.
-
-## Telemetry
-
-| Event ID | Level | Location | Trigger |
-|----------|-------|----------|---------|
-| 0000UMF | Warning | Events | Order held for review due to a rate conflict |
-| 0000UMG | Normal (ExtensionPublisher scope) | Events | Tax Match Applied marker set on Order Header |
-| 0000UMH | Normal (ExtensionPublisher scope) | Events | Tax lines matched (match successful) |
-| 0000UMI | Warning | Events | Sales Document creation blocked pending tax match review |
-| 0000UMJ | Normal (ExtensionPublisher scope) | Events | Tax Match Applied marker propagated to Sales Header |
-| 0000UMK | Normal (ExtensionPublisher scope) | Events | Match starting for order |
-| 0000UML | Uptake: Used | Matcher | MatchTaxLines called |
-| 0000UMM | Error (ExtensionPublisher scope) | Matcher | AOAI call failed (HTTP status code in a custom dimension; no echoed error text) |
-| 0000UMN | Error (ExtensionPublisher scope) | Matcher | No function call in LLM response |
-| 0000UMO | Error (ExtensionPublisher scope) | Matcher | Function execution failed |
-| 0000UMP | Normal | Matcher | Low-confidence match skipped |
-| 0000UMQ | Warning | Matcher | Jurisdiction not found, auto-create disabled |
-| 0000UMR | Warning | Matcher | A matched tax line's Tax Detail rate differs from Shopify's (item or shipping tax group) — jurisdiction still matched, order held for review |
-| 0000UMT | Usage | Notify | Sales Order review notification sent |
-| 0000UMU | Usage | Notify | User opened the Tax Match Review page from the Sales Order notification (logged only when the review page actually opened) |
-| 0000UMV | Usage | Notify | Order-page review notification sent |
-| 0000UMW | Usage | Notify | User opened the Tax Match Review page from the order-page notification |
-| 0000UMX | Usage | Notify | User marked notification reviewed |
-| 0000UMY | Usage | Notify | User chose "Don't show again" |
-| 0000UMZ | Uptake: Set up | Register | App installed |
-| 0000UN0 | Normal | Activity Log | Per-tax-line entry written (jurisdiction match) |
-| 0000UN1 | Normal | Activity Log | Per-tax-area entry written (Tax Area resolved) |
-| 0000UN7 | Usage | Notify | User undid an approval (order held for review again) |
-| 0000UNP | Usage | Order Tax Lines Part | Reviewer clicked **Use Shopify Rate** — adopted Shopify's rate into a Tax Detail |
-| 0000UNR | Warning | Matcher | Tax line unresolved (model returned `UNKNOWN`) — left unmatched for review |
-| 0000UNT | Warning | Events | Order held for review due to an unresolved (`UNKNOWN`) tax line |
-| 0000UNV | Error | Events | Guardrail/security prompt unavailable from Key Vault — matching skipped, order proceeds via the normal tax path |
-| 0000UN8 | Uptake: Discovered | Shop Card | User opened the shop configuration surface where the Tax Matching Agent settings live |
-| 0000UN9 | Usage | Notify | Review drill-through fell back to the raw Shopify order because the review page could not be resolved |
-
-## Test App
-
-A separate test app — **Shopify Connector NA Test** (`ShopifyNA/test/`, sources under
-`test/src/Tax Matching Agent/`, ID range 134713-134720) — carries the public coverage in two layers:
-
-**AI Test Toolkit (data-driven, real LLM):**
-- `Shpfy TMA Match Test` (134717), `Shpfy TMA Tax Area Test` (134718), `Shpfy TMA Guard Test` (134719) read their scenarios via `AITTestContext.GetInput()` and must run **through the AI Test Toolkit** (they need the YAML datasets + suite). Only the Match test issues real LLM calls; Tax Area and Guard exercise post-LLM logic through the same harness.
-- Data-driven YAML scenarios iterated by the framework; test output logged via `AITTestContext.SetQueryResponse()` for eval spreadsheets.
-- Categories: Jurisdiction Matching (J, H), Jurisdiction Creation (JC), Tax Detail (TD), Shipping Tax (S), Tax Area (TA), Guard (G), End-to-End (F).
-
-**Plain unit tests (standard test runner, no LLM, no toolkit):**
-- `Shpfy TMA HITL Test` (134716) and `Shpfy TMA Rate Conflict Test` (134720) build records directly and drive the codeunit helpers (marker propagation, gate decision, rate-conflict recheck/flip, Undo Approval). They run as ordinary AL tests — the AI Test Toolkit is not required.
-
-**Responsible AI (RAI) — prompt injection + harms (internal enlistment, not this repo):**
-- Because `microsoft/BCApps` is public, the RAI tests — which would otherwise expose the adversarial datasets and the jailbreak-testing approach — live in a **separate internal app in the NAV enlistment**: **Shopify Connector NA AI Tests** (`App/Internal/Apps/ShopifyNAAITest`, ID range 134721-134732), covering deterministic cross-prompt-injection scenarios and dynamic Red Team Scan harms/jailbreak passes.
-- It reuses this public test app's `Shpfy TMA Test Library` + `Shpfy TMA Verify` and calls the matcher via `internalsVisibleTo` (granted by both **Shopify Connector NA** and **Shopify Connector NA Test**).
-- The tests read the security prompt from Key Vault (the norm — like Sales Line Suggestions), so the eval environment must have the secret provisioned (see *Capability Registration* below); there is no mock.
-
-See `TestMatrix.md` for the full test scenario inventory and the Automated Test Coverage map.
-
-## Localization promotion
-
-The main Shopify Connector nudges eligible environments to install this app, mirroring the Belgian
-localization pattern. `Shpfy Shop Mgt.SendNorthAmericaLocalizationNotification()` (called from the
-`Shpfy Shops` list `OnOpenPage`) shows a dismissible `Notification` with **Install**
-(`ExtensionManagement.InstallMarketplaceExtension`) and **Don't show again** (`MyNotifications`)
-actions when: the application family is **US** (CA/MX to be added when supported), the app is not
-already installed, and the user hasn't dismissed the prompt.
-
-## Refund Support
-
-Refunds inherit all tax context from their parent order — no separate LLM call or tax matching is performed for refunds.
-
-### Data flow
-- **Refund Header** has FlowFields (110-112) that look up Tax Area Code, Tax Liable, and Tax Exempt from the linked `Shpfy Order Header` via `Order Id`. No data duplication.
-- **Credit memo creation** (`ShpfyCreateSalesDocRefund`) reads Tax Area Code and Tax Liable from the original order header and validates both on the Sales Credit Memo header.
-- **Tax-exempt orders**: If the parent order is tax exempt, the credit memo's Tax Liable stays false (no Tax Area Code to trigger the block).
-
-### UI
-- The **Refund page** shows a "Tax" group with Tax Area Code, Tax Liable, and Tax Exempt (read-only, inherited from order).
-- A **"Tax Lines"** navigation action opens the existing `Shpfy Order Tax Lines` page filtered to the parent order's lines, so users can see the tax jurisdiction breakdown without leaving the refund.
-
-### Why no tax matching for refunds
-The Tax Matching Agent event subscriber (`ShpfyTMAEvents`) only subscribes to `OnAfterMapShopifyOrder`. Refunds don't go through order mapping — they reference an already-processed order. If the order's tax was matched by the Tax Matching Agent, that data is already on the order and flows through to the refund via FlowFields.
+Eligible environments can be prompted to install the North America app through the standard extension-management experience.
+
+## Refunds
+
+Refunds do not invoke the matcher again. They inherit the Tax Area, tax-liable state, and related tax context from the original Shopify order so that the resulting credit memo remains consistent with the processed order.
+
+## Verification
+
+Coverage is split between deterministic AL tests, AI evaluation scenarios, and client-level review workflow checks. See [TestMatrix.md](TestMatrix.md) for the public coverage summary.

--- a/src/Apps/NA/ShopifyNA/app/TestMatrix.md
+++ b/src/Apps/NA/ShopifyNA/app/TestMatrix.md
@@ -1,359 +1,142 @@
-# Shopify Tax Matching Agent — Test Matrix
-
-## Setup Variations
-
-| Setting | Values |
-|---------|--------|
-| Tax Matching Agent Enabled | Yes / No |
-| Auto Create Tax Jurisdictions | Yes / No |
-| Auto Create Tax Areas | Yes / No |
-| Tax Area Naming Pattern | `SHPFY-` / Custom / Blank |
-
-## Pre-conditions
-
-| ID | Condition | Description |
-|----|-----------|-------------|
-| P1 | Tax Matching Agent disabled | Shop has Tax Matching Agent Enabled = No |
-| P2 | Copilot capability not registered | Capability missing from Copilot AI Capabilities page |
-| P3 | Copilot capability inactive | Registered but turned off |
-| P4 | Tax Area already assigned | Order already has a Tax Area Code from address-based MapTaxArea |
-| P5 | No tax lines on order | Order has no Shopify tax lines at all |
-| P6 | All tax lines already matched | All tax lines already have a Tax Jurisdiction Code |
-
----
-
-## Jurisdiction Matching Scenarios
-
-| # | Scenario | Existing Jurisdictions | Auto Create Juris. | LLM Returns | Expected Result |
-|---|----------|----------------------|--------------------|--------------|----|
-| J1 | Exact match — all lines | NYSTAX, NYCTAX, MTATAX exist | N/A | high confidence matches to all 3 | Tax Jurisdiction Code set on all tax lines |
-| J2 | Partial match — some lines | NYSTAX exists, NYCTAX does not | No | high for NYSTAX, low for NYCTAX | Only NYSTAX matched; NYCTAX skipped (logged) |
-| J3 | Partial match + auto-create | NYSTAX exists, NYCTAX does not | Yes | high for NYSTAX, low for NYCTAX | NYSTAX matched; NYCTAX created and matched |
-| J4 | No match — all new | None exist | No | low confidence for all | No matches applied (all skipped) |
-| J5 | No match + auto-create | None exist | Yes | low confidence with suggested codes | All jurisdictions created and matched |
-| J6 | LLM returns empty jurisdiction_code | Any | Yes | `jurisdiction_code: ""` | Skipped (logged as low confidence) |
-| J7 | LLM returns medium confidence | Jurisdiction exists | N/A | medium confidence | Matched (medium is accepted regardless of auto-create) |
-| J8 | Duplicate jurisdiction codes | NYSTAX exists | Yes | Same code for multiple tax lines | Jurisdiction used for all lines; added to MatchedJurisdictions once |
-
----
-
-## Tax Jurisdiction Creation Details (Auto Create = Yes)
-
-| # | Scenario | Expected Result |
-|---|----------|-----------------|
-| JC1 | Country/Region | New jurisdiction has Country/Region from order's Ship-to |
-| JC2 | Report-to Jurisdiction — multiple | 3 jurisdictions created (state, county, city): all have Report-to = state-level jurisdiction (first in list) |
-| JC3 | Report-to — single jurisdiction | Only 1 jurisdiction matched: FixReportToJurisdictions not called (guard: Count > 1) |
-| JC4 | Jurisdiction already exists | LLM suggests code that already exists: existing jurisdiction used as-is (not modified, not re-created) |
-| JC5 | Description | New jurisdiction description = jurisdiction code (e.g. "NYSTAX") |
-| JC6 | Report-to on a pre-existing blank jurisdiction | A matched jurisdiction already exists with a blank Report-to (e.g. from an earlier run): its Report-to is set to the state-level jurisdiction, not left blank (covered by `ReapplySetsReportToOnBlankJurisdictions`); a jurisdiction that already has a non-blank Report-to is preserved (`ReapplyPreservesExistingReportTo`) |
-
----
-
-## Tax Detail Scenarios (Auto Create Jurisdictions = Yes)
-
-| # | Scenario | Existing Tax Details | Expected Result |
-|---|----------|---------------------|-----------------|
-| TD1 | No existing detail | None for this jurisdiction + tax group | Tax Detail created with rate from tax line |
-| TD2 | Exact detail exists | Same jurisdiction, tax group, and rate | No duplicate created |
-| TD3 | Same jurisdiction, different rate | Valid bracket exists at earlier date with a different rate than Shopify's | **Line is matched** to the (correct) jurisdiction and the **Tax Area is built**; existing detail preserved (not overwritten or duplicated); rate conflict logged (telemetry `0000UMR`) and flagged on the order (`Tax Rate Conflict`); the order is held for review; the line is highlighted red (BC rate vs Shopify rate) on the review page (see RD1) |
-| TD4 | Same jurisdiction, different tax group | Detail exists with different Tax Group Code | New Tax Detail created for the new tax group |
-| TD5 | Item has no tax group | Order line item has blank Tax Group Code | Tax Detail created with blank Tax Group Code |
-| TD6 | Order line has no item | Item No. is blank on order line | Tax Detail created with blank Tax Group Code |
-| TD7 | Multiple tax lines across jurisdictions | Two tax lines on different jurisdictions, auto-create on | One Tax Detail per jurisdiction |
-| TD8 | Effective date | Order Document Date = 2026-01-15 | Tax Detail has Effective Date = 2026-01-15 |
-
----
-
-## Rate Divergence Scenarios
-
-When a matched jurisdiction's existing Tax Detail (for the line's item tax group, valid as of
-the order date) has a rate that differs from Shopify's, the agent still matches the (correct)
-jurisdiction and builds the Tax Area, but sets the stored `Tax Rate Conflict` flag and
-holds the order for human review. That flag is the single source of truth (gate, notifications,
-order-page caption, review-page guidance + Approve all read it). The reviewer sees Shopify's and
-BC's rates side by side (green/red) on the review page and decides whether to accept BC's rate,
-change the jurisdiction, or correct the Tax Detail. Jurisdiction edits on the page only take
-effect on Approve and are reverted if the page is closed without approving.
-
-| # | Scenario | Setup | Expected Result |
-|---|----------|-------|-----------------|
-| RD1 | Item-group rate conflict | `NYSTAX × FURNITURE` Tax Detail = 10%; order line taxed at 20% for NYSTAX (group FURNITURE) | Line matched to NYSTAX; existing 10% detail untouched; telemetry `0000UMR`; `Tax Match Applied` + `Tax Rate Conflict` set; **Tax Area built**; Activity Log entry on the line noting the rate difference; order held (see RD3/RD4) |
-| RD2 | Partial conflict, multi-line | Lines A (NYSTAX, no existing detail) and B (NYCTAX × FURNITURE conflict) | A matched (code written, detail seeded); B matched (code written, existing detail untouched); **Tax Area built from both**; order flagged `Tax Rate Conflict` and held |
-| RD3 | Held in Always mode | RD1 + shop Tax Match Review Mode = Always | `OnBeforeCreateSalesHeader` sets `Handled := true`; no Sales Document created |
-| RD4 | Held in Never mode | RD1 + shop Tax Match Review Mode = Never | Still held — the gate holds because `Tax Rate Conflict` is set, regardless of the review mode, so a rate difference is never auto-posted without review |
-| RD5 | Resolved then approved / re-run | After RD1 the reviewer either (a) accepts BC's 10% and clicks Approve, or (b) corrects the Tax Detail rate to 20% then Approves (or re-runs Find Mappings on the Shopify order) | On Approve the Tax Area is rebuilt from the line jurisdictions, `Tax Rate Conflict` is recomputed (clears when rates now agree), and the order is released. A re-run rebuilds from the order's **full** jurisdiction set (carried in from persisted codes), not just the re-matched line |
-| RD8 | Edit discarded on close | On a held order the reviewer changes a line's Tax Jurisdiction Code, then closes the page **without** Approve | A confirmation warns the edit will be discarded; on confirm the line's Tax Jurisdiction Code is reverted to its pre-edit value and `Tax Rate Conflict` is unchanged (still authoritative) |
-| RD9 | Undo Approval | On an approved, held order with no Sales Document yet (`Sales Order No.`/`Sales Invoice No.` blank), **Undo Approval** (after a confirm) clears `Tax Match Reviewed` so the order is held again; the action is hidden once a Sales Document exists or the order is not held-when-unapproved |
-| RD11 | Undo un-verifies agent jurisdiction | An approved order uses an agent-created, `Verified` jurisdiction; reviewer clicks **Undo Approval** | The jurisdiction is set back to `Verified` = false (returns to provisional/held) — `UndoApprovalUnverifiesAgentJurisdiction` |
-| RD12 | Undo re-quarantines a shared jurisdiction | Two approved orders use the same agent-created, `Verified` jurisdiction; reviewer undoes one | The jurisdiction is un-verified (deliberately re-quarantined; a later approval re-verifies it) — `UndoApprovalUnverifiesJurisdictionSharedByAnotherOrder` |
-| RD10 | Use Shopify Rate resolves the conflict | On a conflict line the reviewer clicks **Use Shopify Rate** (after a confirm warning it changes shared tax setup beyond this order): a Tax Detail is created/updated for the line's jurisdiction + tax group, effective the order's document date, at Shopify's rate. The row turns green (BC rate now equals Shopify's); on Approve the Tax Area is rebuilt and `Tax Rate Conflict` clears. The action is disabled when the rates already agree or no jurisdiction is assigned. **Verified manually / by TestPage** (page action + Confirm) |
-
----
-
-## Review Mode & Provenance Scenarios
-
-The shop's `Tax Match Review Mode` (Always / Low Confidence Only / Never) decides whether a matched
-order is held for the review *preference* (evaluated by `IsHeldForReviewPreference`). A rate conflict
-or an incomplete match always holds regardless of the mode. An agent-auto-created Tax Jurisdiction is
-**provisional** (`Created by Agent` = true, `Verified` = false); in Always and Low Confidence Only
-modes a match to a provisional jurisdiction is deterministically forced to low confidence and sets
-the order's `Tax Match Low Confidence` flag, so the order is held (in Never mode the downgrade is
-skipped, since nothing is held). Approving any order that uses the jurisdiction sets `Verified` = true,
-clearing the provisional state (`MarkJurisdictionsVerified`). Undoing an order's approval reverses this
-(`UnverifyAgentJurisdictions`): the agent-created jurisdictions the order used are set back to
-`Verified` = false (re-quarantined; a later approval re-verifies them). The gate rows RM1–RM7
-are deterministic in-memory unit tests; the provisional rows PV1–PV3 exercise the LLM path and live in
-the internal RAI app.
-
-| # | Scenario | Setup | Expected Result |
-|---|----------|-------|-----------------|
-| RM1 | Always holds every match | Applied, not reviewed, high confidence, no conflict; mode = Always | Held (`GateHeldWhenAlwaysRegardlessOfConfidence`) |
-| RM2 | Low Confidence Only holds low-confidence | Applied, not reviewed, `Tax Match Low Confidence` = true, no conflict; mode = Low Confidence Only | Held (`GateHeldWhenLowConfidenceOnlyAndLowConfidence`) |
-| RM3 | Low Confidence Only releases high-confidence | As RM2 but `Tax Match Low Confidence` = false | Not held (`GateNotHeldWhenLowConfidenceOnlyAndHighConfidence`) |
-| RM4 | Never releases a low-confidence match | Applied, not reviewed, low confidence, no conflict/incomplete; mode = Never | Not held (`GateNotHeldWhenNeverAndLowConfidence`) |
-| RM5 | Never still holds a rate conflict | Mode = Never, `Tax Rate Conflict` = true | Held (`GateHeldWhenNeverButRateConflict`) |
-| RM6 | Never still holds an incomplete match | Mode = Never, `Tax Match Incomplete` = true | Held (`GateHeldWhenNeverButIncomplete`) |
-| RM7 | Preference tracks the mode | One order; flip the mode across Always / Never / Low Confidence Only | `IsHeldForReviewPreference` returns true / false / flag-driven (`ReviewPreferenceFollowsMode`) |
-| PV1 | Provisional jurisdiction forced low | Auto-create on; model matches a not-yet-existing code; jurisdiction created (`Created by Agent` = true, `Verified` = false) | The created jurisdiction is matched, the match is recorded **low** confidence, `Tax Match Low Confidence` set → order held (LLM / XPIA scenario, internal app) |
-| PV2 | Later match stays provisional until verified | Second order, same ship-to; jurisdiction now exists but `Verified` = false | Match forced low again; order held (LLM / XPIA scenario, internal app) |
-| PV3 | Verify on approve | Reviewer approves an order using the provisional jurisdiction | `Verified` set true on every jurisdiction the order uses; a subsequent high-confidence match then rides through per mode (LLM / AIT scenario) |
-| PV4 | Non-agent jurisdiction never quarantined | Pre-existing / admin jurisdiction (`Created by Agent` = false) matched | Never forced low by provenance (the gate short-circuits on `Created by Agent`) |
-
----
-
-## Shipping Tax Scenarios
-
-Shipping-charge tax lines (stored by the connector on `Shpfy Order Tax Line` with
-`Parent Id = "Shopify Shipping Line Id"`) are treated as **first-class** tax lines: the LLM
-matches each to a jurisdiction, and it seeds a Tax Detail for the Shop's `Shipping Charges
-Account` Tax Group Code at the **shipping line's own rate** (not derived from product lines).
-A shipping-line rate conflict holds the order for review exactly like a product-line one.
-
-| # | Scenario | Shop Setup | Order Data | Expected Result |
-|---|----------|------------|------------|-----------------|
-| S1 | Shipping bracket seeded at its own rate | Shipping Charges Account `GLA-SHIP`, group `SHIPGRP`; NYSTAX exists | Item tax line NYSTAX @ 4%, shipping tax line NYSTAX @ **3%** | `(NYSTAX × TAXABLE)` @ 4% and `(NYSTAX × SHIPGRP)` @ **3%** — the shipping bracket comes from the shipping line's own rate |
-| S2 | Shipping bracket under new jurisdiction | Same + Auto Create Jurisdictions = Yes | Item + shipping tax lines, no existing jurisdictions | Jurisdiction created; both `(NYSTAX × TAXABLE)` and `(NYSTAX × SHIPGRP)` seeded |
-| S3 | Shipping charge without tax lines | Shipping account configured | Shipping charge present but **no** shipping tax lines (untaxed) | Only the item-side detail seeded; `(NYSTAX × SHIPGRP)` count = 0; no error |
-| S4 | Shipping account with empty Tax Group Code | `GLA-SHIP` with blank Tax Group Code | Item + shipping tax lines | Item-group detail plus a `(Jurisdiction × '')` detail from the shipping line |
-| S5 | Shipping group same as item group | Shipping account's group = `TAXABLE` (same as item), same jurisdiction & rate | Item + shipping tax lines both NYSTAX @ 4% | Single `(NYSTAX × TAXABLE)` row (idempotent seeding, count = 1) |
-| S6 | Multiple shipping charges, same jurisdiction | Shipping account group `SHIPGRP` | Two shipping charges both NYSTAX @ 4% | Exactly one `(NYSTAX × SHIPGRP)` row (idempotency); no rate conflict |
-| S7 | Shipping rate conflict holds order | Shipping account group `FREIGHT`; existing `(NYSTAX × FREIGHT)` @ 5% | Shipping tax line NYSTAX @ 8% | Shipping line matched; existing 5% untouched; `Tax Rate Conflict` set; order held (covered by `Shpfy TMA Rate Conflict Test`) |
-
----
-
-## Tax Area Scenarios
-
-| # | Scenario | Auto Create Areas | Existing Tax Areas | Expected Result |
-|---|----------|-------------------|-------------------|-----------------|
-| TA1 | Exact area exists | N/A | Area with exactly NYSTAX+NYCTAX+MTATAX | Existing area reused; no new area created |
-| TA2 | Superset area exists | N/A | Area with NYSTAX+NYCTAX+MTATAX+EXTRA | Not matched (line count differs); new area or skip |
-| TA3 | Subset area exists | N/A | Area with only NYSTAX+NYCTAX | Not matched; new area or skip |
-| TA4 | No matching area + auto-create | Yes | None match | New Tax Area created: code = `SHPFY-MTATAX`, description = `Shopify - ...` |
-| TA5 | No matching area, no auto-create | No | None match | Tax Area Code remains blank on order |
-| TA6 | Area code collision | Yes | `SHPFY-MTATAX` already exists (different jurisdictions) | New area created as `SHPFY-MTATAX-2` |
-| TA7 | Country/Region on area | Yes | N/A | New Tax Area has Country/Region from order's Ship-to |
-| TA8 | Tax Liable flag | Yes | N/A | Order Header has Tax Liable = Yes after area assigned |
-| TA9 | Custom naming pattern | Yes, pattern = `TAX-` | N/A | Area code = `TAX-MTATAX` |
-| TA10 | Empty naming pattern | Yes, pattern = blank | N/A | Area code = `MTATAX` |
-| TA11 | No matched jurisdictions | N/A | N/A | FindOrCreateTaxArea not called (guard in Events) |
-
----
-
-## Guard / Early Exit Scenarios
-
-| # | Scenario | Expected Result |
-|---|----------|-----------------|
-| G1 | Tax Matching Agent disabled on shop | No LLM call; order unchanged |
-| G2 | Copilot capability not registered | No LLM call; order unchanged |
-| G3 | Copilot capability inactive | No LLM call; order unchanged |
-| G4 | Tax Area already set by MapTaxArea | the agent skipped; existing Tax Area kept |
-| G5 | Order is Tax Exempt | the agent skipped; order unchanged |
-| G6 | No order lines | MatchTaxLines returns false |
-| G7 | All tax lines already have jurisdiction codes | MatchTaxLines returns false (no unmatched lines) |
-| G8 | Order import Result = false | Event subscriber exits immediately |
-
----
-
-## HITL (Human-in-the-loop) Scenarios
-
-| # | Scenario | Expected Result |
-|---|----------|-----------------|
-| HITL-1 | Order Header marker set; Sales Header created | `Sales Header."Shpfy Tax Match Applied" = true` (propagated via `OnAfterCreateSalesHeader`) |
-| HITL-2 | Order Header marker false; Sales Header created | Sales Header marker stays false (no propagation) |
-| HITL-3 | `MarkReviewed` from the Sales Order notification | Sets the originating order's `Tax Match Reviewed = true` (resolved via `Sales Order No.`) |
-| HITL-4 | `DisableForUser` from the Sales Order notification | Sets the order's `Tax Match Reviewed = true` and disables the prompt via `My Notifications` |
-| HITL-5 | Successful match applied | `Activity Log Entry` count for the Order Header `Tax Area Code` field ≥ 1; per-line entries on each matched `Shpfy Order Tax Line` |
-| HITL-6 | LLM returns 'low'/'medium'/'high'/unknown confidence | `Capitalize` helper maps to 'Low'/'Medium'/'High'/'Low' (safe fallback); `Activity Log Builder.SetConfidence` does not error |
-| HITL-7 | Review page Approve visibility (held order) | On a held order (the review mode holds it, or a live rate conflict) that isn't yet approved, **Approve** is visible; it sets `Tax Match Reviewed = true` and the order's Sales Document is created on the next process run |
-| HITL-8 | Review page Approve hidden (auto-released, no conflict) | When the review mode does not hold the order and there is no rate conflict, the order isn't held (its Sales Document is created automatically), so the page's **Approve** action is hidden and the page is informational |
-| HITL-9 | Review page scoping + content | The tax lines ListPart shows exactly the tax lines of the current order (filtered by the order's order line ids via `SetTaxLineFilter`), each with its applies-to Item No./description; AI confidence indicators render on Tax Jurisdiction Code |
-| HITL-10 | Sales Order prompt is stateless | With `Sales Header."Shpfy Tax Match Applied"` set, the prompt fires iff the originating order's `Tax Match Reviewed = false` and `My Notifications` is enabled; no `Shpfy TMA Notification` table exists |
-| HITL-11 | Order-page review notification | On opening a matched, not-yet-reviewed Shopify order, `SendOrderReviewNotification` fires once per order/session; **Review** opens the review page; **Don't show again** disables it via `MyNotifications` |
-| HITL-12 | Page review actions | Shpfy Order page: **Review and Approve Tax Match** shows while the order is held (per the review mode or a live rate conflict) and it isn't yet approved, else **Review Tax Match**; both open the review page (hidden when not agent-matched). BC Sales Order page: **Review Tax Match** opens the review page when the marker is set |
-| HITL-13 | Review page close guard | When the order is being held (per the review mode, or a rate conflict) and it is not yet approved, closing the Tax Match Review page raises the `OnQueryClosePage` confirmation; declining keeps the page open. No warning once the order is approved |
-| RD6 | Approve rebuilds Tax Area | On a **held**, not-yet-reviewed order the **Approve** action is shown; it re-applies the line jurisdictions (re-seeding brackets, re-detecting conflicts), rebuilds the Tax Area, refreshes `Tax Rate Conflict`, and sets `Tax Match Reviewed`. Approve is blocked (error) while any tax line has a blank Tax Jurisdiction Code, **and** errors without releasing the order if no Tax Area can be resolved for the selected jurisdictions (e.g. edited to a set with no existing area and Auto Create Tax Areas is off) |
-| RD7 | Rate comparison + edit | Each tax line shows Shopify's rate next to Business Central's Tax Detail rate; the row is green when they agree, red when they differ. Editing a line's Tax Jurisdiction Code recomputes the BC rate/colour; on a rate conflict, the Overview tab shows a guidance message that approving posts at BC's rate |
-
-**Shop Card field dependencies (SC scenarios)**
-
-| # | Scenario | Expected Result |
-|---|----------|-----------------|
-| SC-1 | Tax Matching Agent Enabled = No | Auto Create Jurisdictions/Areas, Naming Pattern, and Review Mode are disabled (greyed out) |
-| SC-2 | Enabled = Yes, Auto Create Tax Areas = No | Tax Area Naming Pattern is disabled; the other three are enabled |
-| SC-3 | Enabled = Yes, Auto Create Tax Areas = Yes | Tax Area Naming Pattern is enabled |
-
----
-
-## Hard Matching Scenarios (LLM Stress Tests)
-
-These scenarios test the LLM's ability to handle ambiguous, misleading, or complex matching situations with real AOAI calls. All use `autoCreateTaxJurisdictions: false` unless noted.
-
-| # | Scenario | Challenge | Jurisdictions | Tax Lines | Ship-to | Expected |
-|---|----------|-----------|---------------|-----------|---------|----------|
-| H1 | Similar codes, different states | CASTAX (California) vs CATAX (Canada) — "CA" is ambiguous | CASTAX, CATAX, COSTAX | "CA STATE TAX" @ 7.25% | US / CA / Los Angeles | CASTAX (geographic context: CA = California) |
-| H2 | Abbreviated title, multiple similar | "NYC MTA" with 3 MTA-related jurisdictions | MTATAX, MTANYC, MTANYS | "NYC MTA" @ 0.375% | US / NY / New York | Any of the 3 (soft assertion) |
-| H3 | Multi-state distractors | Texas order with 15 distractor jurisdictions from other states | 13 non-TX + TXSTAX, TXCTAX | "TEXAS STATE SALES TAX" @ 6.25%, "HOUSTON CITY TAX" @ 2.0% | US / TX / Houston | TXSTAX, TXCTAX |
-| H4 | Truncated Shopify title | "METROPOLITAN COMMUTE" (truncated) must match full description | MTATAX, MCTMTX | "METROPOLITAN COMMUTE" @ 0.375% | US / NY / New York | MCTMTX |
-| H5 | Canadian HST/GST/PST | Ontario gets HST (combined), not separate GST or PST | CAHST, CAGST, CAPST, BCPST | "HST" @ 13.0% | CA / ON / Toronto | CAHST |
-| H6 | Same rate, different scopes | County tax vs transit tax — both LA, similar names | LACOTR, LACOTX, CASTAX | "LOS ANGELES COUNTY TAX" @ 1.0%, "CALIFORNIA STATE TAX" @ 6.0% | US / CA / Los Angeles | LACOTX, CASTAX |
-| H7 | Unusual formatting/casing | "State of New York - Sales & Use Tax", "The City of New York Tax" | NYSTAX, NYCTAX | Unusual wording | US / NY / New York | NYSTAX, NYCTAX |
-| H8 | Geographic disambiguation | "NEW YORK SALES TAX" from Albany — state not city level | NYCSAL, NYSSAL, NJSSAL | "NEW YORK SALES TAX" @ 4.0% | US / NY / Albany | NYSSAL (state-level, Albany is not NYC) |
-| H9 | 5 tax lines, mixed difficulty | Large order — some trivial, others need semantic reasoning | TXSTAX, TXHTAX, TXHCTX, TXMTD, TXESD | "TEXAS STATE SALES TAX", "CITY OF HOUSTON TAX", "HARRIS CO TAX", "METRO TRANSIT AUTHORITY", "ESD #1" | US / TX / Houston | All 5 matched (soft assertion) |
-| H10 | Misleading jurisdiction code | WATAX = Washington, not Waterloo — LLM must read descriptions | WATAX, IASTAX, IACTAX | "IOWA STATE TAX" @ 6.0%, "WATERLOO LOCAL TAX" @ 1.0% | US / IA / Waterloo | IASTAX, IACTAX |
-| H11 | Auto-create with distractors | 10+ existing jurisdictions; match what fits, create new for rest | 10 mixed-state jurisdictions including NYSTAX | "NEW YORK STATE TAX" @ 4.0%, "YONKERS SURCHARGE" @ 1.5% | US / NY / Yonkers | NYSTAX matched; Yonkers auto-created (autoCreate=true) |
-| H12 | Non-English tax titles | French Canadian abbreviations: TPS = GST, TVQ = QST | QCGST, QCQST, CAHST | "TPS/GST" @ 5.0%, "TVQ/QST" @ 9.975% | CA / QC / Montreal | QCGST, QCQST |
-
----
-
-## LLM Error / Edge Cases
-
-| # | Scenario | Expected Result |
-|---|----------|-----------------|
-| E1 | LLM API call fails | Logged as error; no matches applied; order unchanged |
-| E2 | LLM returns no function call | Logged as error; no matches applied |
-| E3 | Function call marked as failed | Logged as error; no matches applied |
-| E4 | Malformed tax_line_id (not `ParentId-LineNo` format) | Skipped gracefully (Evaluate guard) |
-| E5 | Non-numeric tax_line_id parts | Skipped gracefully (Evaluate returns false) |
-| E6 | LLM returns jurisdiction_code > 10 chars | Truncated by CopyStr to 10 chars |
-| E7 | LLM returns unknown confidence value | Treated as non-low (matched if jurisdiction exists) |
-| E8 | Empty matches array | ApplyMatches returns false; no changes |
-| E9 | Missing `matches` key in response | ApplyMatches returns false; no changes |
-| E10 | Tax line ID points to non-existent record | TaxLine.Get fails; skipped; other matches still applied |
-
----
-
-## End-to-End Flows
-
-| # | Flow | Setup | Order Data | Expected End State |
-|---|------|-------|------------|-------------------|
-| F1 | Full auto-create | Enabled, Auto Create Juris.=Yes, Auto Areas=Yes | 3 tax lines: NY State, NYC City, MTA | 3 new jurisdictions (with Country/Region, Report-to=state), 3 tax details, 1 new tax area `SHPFY-MTATAX`, order has Tax Area Code + Tax Liable=Yes |
-| F2 | Match only, no create | Enabled, Auto Create=No for both | 3 tax lines, all 3 jurisdictions + tax area pre-exist | Existing jurisdictions matched, existing tax area found and assigned |
-| F3 | Partial match | Enabled, Auto Create Juris.=No, Auto Areas=Yes | 3 tax lines, only NYSTAX exists | Only NYSTAX matched; no tax area created (only 1 of 3 jurisdictions matched, so area wouldn't match expected set) |
-| F4 | Re-import same order | Same as F1 | Same order imported again | Tax lines already matched, Tax Area already set; the agent skipped entirely (guard: Tax Area Code <> '') |
-| F5 | Address-based match wins | Enabled | Order where MapTaxArea finds a match by address | Tax Area set by MapTaxArea; the agent never runs (guard: Tax Area Code <> '') |
-| F6 | Sales document creation | After F1 completes | Create Sales Order from Shopify order | Sales Header has Tax Area Code = `SHPFY-MTATAX`, Tax Liable = Yes |
-
----
-
-## Responsible AI (RAI)
-
-The Tax Matching Agent is covered by Responsible AI tests — deterministic cross-prompt-injection
-(XPIA) scenarios and dynamic **Red Team Scan** harms/jailbreak passes. Because this repository is
-public, those tests and their adversarial datasets are **not** kept here: they live in the internal
-NAV enlistment app **Shopify Connector NA AI Tests** (`App/Internal/Apps/ShopifyNAAITest`, ID range
-134721-134732), which reuses this test app's library/verify and the matcher via `internalsVisibleTo`.
-The mitigation under test is the security/guardrail prompt merged from Azure Key Vault at runtime
-(secret `ShopifyTaxMatchingAgentSecurityPrompt`); the tests read it from the vault (no mock), so the
-eval environment must have the secret provisioned via the enlistment commands.
-
----
-
-## Generated Accuracy Dataset (large-scale matching accuracy)
-
-To measure jurisdiction-matching accuracy at scale (beyond the small curated J/H set), a dedicated
-**Weekly** suite `TMA-ACCUR` runs a large, generated corpus through `Shpfy TMA Match Test` (134717).
-The small curated J/H scenarios stay in the **Daily** `TMA-UNIT` gate; the large corpus runs Weekly
-(mirrors the Payables Agent `PA-ACCUR` split):
-
-| Dataset | Scenarios | Coverage |
-|---------|-----------|----------|
-| `TMA-TS-AccUS-1.yaml` | ~144 | US states (first half of the catalog) — synthetic perturbations |
-| `TMA-TS-AccUS-2.yaml` | ~139 | US states (second half) — synthetic perturbations |
-| `TMA-TS-AccCA.yaml` | ~65 | Canada provinces incl. French (TPS/TVQ) — synthetic perturbations |
-| `TMA-TS-RealUS.yaml` | ~45 | Real US localities, real Shopify titles, reworded BC descriptions |
-| `TMA-TS-RealCA.yaml` | ~14 | Real CA provinces, real Shopify titles (GST/PST/HST/QST + TPS/TVQ) |
-| `TMA-TS-Heldout.yaml` | ~6 | Held-out generalization: unusual official names **not** named in the prompt |
-| `TMA-TS-Traps.yaml` | ~7 | Traps: correct answer is no-match despite tempting distractors (false-positive probes) |
-| `TMA-TS-Hard.yaml` | ~10 | Adversarial hard mode: homonym places, geo/substring traps, code-vs-desc conflict, many distractors, level discrimination, Code[20] truncation collision |
-
-**Two dataset families.** *Synthetic* (`TMA-TS-Acc*`) exercises breadth through systematic title
-**perturbations** — 24 US states + 7 CA provinces (state/province + county/city/district), via
-exact, sales-variant, abbreviation, minimal-abbreviation, punctuation, embedded-rate, reworded,
-`Code[20]` truncation, plus structural cases: multi-line orders, distractor jurisdictions, unmatched
-(`jurisdictionCode: ""`), auto-create (`hasJurisdictionCode`), and non-English (Quebec French).
-
-*Real-world* (`TMA-TS-Real*`) reduces the circularity of the synthetic set by using the **actual
-Shopify tax-line title conventions** (US `"<State> State Tax"` / `"<County> County Tax"` /
-`"<City> City Tax"`; CA bare `"GST"`/`"PST"`/`"HST"`/`"QST"` + French `"TPS"`/`"TVQ"`), **real**
-US state/county/city and CA province tax authorities, and BC candidate jurisdiction Descriptions that
-are deliberately **reworded** so they are not string-identical to the title (e.g. Shopify
-`"Los Angeles City Tax"` vs BC `"City of Los Angeles"`). This forces a genuine semantic match rather
-than string equality — a closer proxy for production accuracy. Sources: Shopify Admin API TaxLine
-docs/community examples; Tax Foundation *Sales Tax Rates by City, 2024*; CRA GST/HST + provincial
-PST/QST.
-
-**Generation** — both families are produced deterministically (no PII; public US/CA tax facts) so the
-corpus can be regenerated while hill-climbing the prompt. Each tax line is labeled with its target
-jurisdiction, so accuracy = matched / total.
-
-**Held-out generalization + false-positive probes.** Because the matcher prompt intentionally carries
-a few real official-name aliases (e.g. Retailers' Occupation Tax = state sales tax; RST = PST), a
-scenario whose answer is *spelled out in the prompt* proves little. Two datasets guard against that:
-
-- `TMA-TS-Heldout.yaml` — real jurisdictions with **unusual official names deliberately NOT mentioned
-  in the prompt** (Hawaii General Excise Tax, New Mexico Gross Receipts Tax, Puerto Rico *IVU*
-  (Spanish), Colorado RTD district, Nevada Local School Support Tax, Florida Discretionary Sales
-  Surtax). Passing these measures **generalization** of the general geography/level principle, not
-  memorization of prompt aliases.
-- `TMA-TS-Traps.yaml` — cases where the correct answer is **no match** (or one specific look-alike)
-  despite a tempting distractor: wrong-state, near-duplicate city (geo disambiguation), missing
-  county level, similar-name-different-scope, absent city, wrong tax *type* (franchise vs sales), and
-  empty candidate list. A non-empty wrong match here is a **false positive** — the dangerous failure
-  mode for a human-in-the-loop matcher (a no-match is safe; a confident wrong match is not).
-
-**False-positive metric.** Plain pass-rate hides confident wrong matches. `files/tma_fp_metric.py`
-(session artifact) reads any `*_Eval_Summary.xlsx` and classifies every jurisdiction assertion as
-*correct*, *miss/no-match (safe)*, or *wrong-match / over-match (false positive)*, reported overall
-and per family. The target is **zero false positives**; misses are tolerated (held for review).
-
-**Adversarial hard mode.** Because the model aces the sets above (GPT-4.1 has strong public tax
-knowledge), `TMA-TS-Hard.yaml` is deliberately built to find the failure boundary, each case with a
-single defensible answer: homonym places disambiguated only by ship-to (Washington/Franklin County
-across states; Portland OR vs ME; Columbus OH vs GA); geography traps (Kansas City is in *Missouri*;
-"Arkansas" contains "kansas"); a **code-vs-description conflict** (a candidate coded `TEXAS` but
-described "Tennessee"); level discrimination against a higher-overlap distractor; a dozen near-
-identical Springfields; and a **Code[20] truncation collision** (two titles that both truncate to
-`METROPOLITAN TRANSPO` — a data-pipeline limitation probe, expected to be effectively impossible).
-This family is *expected* to score below 100%; a miss here is a real hill-climb target (or, for the
-truncation case, motivation to store a longer title).
-
-**Metric** — this corpus is intentionally **not** a 100% pass gate. Accuracy is expected to be
-below 100% and improved over time (hill-climb); each scenario asserts the exact expected
-jurisdiction, so the AI Test Toolkit reports the pass rate per dataset line. The *real-world* family
-is the more honest accuracy signal; the *synthetic* family is the broader regression/robustness net.
-
----
-## Automated Test Coverage
-
-| Test codeunit | ID | Covers |
-|---------------|----|--------|
-| `Shpfy TMA Match Test` | 134717 | Jurisdiction matching (J*), creation (JC*), Tax Detail incl. rate-conflict TD3/RD1, shipping (ST*) — data-driven via the real LLM + `MatchTaxLines`; plus the large generated US/CA accuracy corpus (`TMA-TS-Acc*.yaml`, run Weekly via the `TMA-ACCUR` suite) |
-| `Shpfy TMA Tax Area Test` | 134718 | Tax Area find/create (TA*) — `FindOrCreateTaxArea` |
-| `Shpfy TMA Guard Test` | 134719 | Guard / early-exit (GD*, P1–P6) |
-| `Shpfy TMA HITL Test` | 134716 | HITL-1…6 — marker propagation, `MarkReviewed`, `DisableForUser`, Activity Log helpers, `Capitalize` |
-| `Shpfy TMA Rate Conflict Test` | 134720 | Rate-conflict recheck/flip on approve (RD1/RD5/RD6 core via `ReapplyFromAssignedLines`), including **shipping** tax lines (shipping bracket seeded from the shipping line's own rate; shipping rate conflict holds — S7); the Report-to rollup on re-apply (JC6 — `ReapplySetsReportToOnBlankJurisdictions` sets a blank Report-to on any matched jurisdiction incl. the state; `ReapplyPreservesExistingReportTo` leaves an admin-set one untouched); the creation gate RD3/RD4 + released cases (`IsSalesDocumentCreationHeld`), the **review-mode** gate RM1–RM7 and `IsHeldForReviewPreference` (`GateHeldWhenAlwaysRegardlessOfConfidence`, `GateHeldWhenLowConfidenceOnlyAndLowConfidence`, `GateNotHeldWhenLowConfidenceOnlyAndHighConfidence`, `GateNotHeldWhenNeverAndLowConfidence`, `GateHeldWhenNeverButRateConflict`, `GateHeldWhenNeverButIncomplete`, `ReviewPreferenceFollowsMode`), the business guards P4/tax-exempt/enabled (`ShouldAttemptMatch`), and Undo Approval RD9 (`UndoApproval`) |
-
-The Responsible AI tests (XPIA + Red Team Scan harms/jailbreak — codeunits 134721-134724) are **not** in this public app; they live in the internal **Shopify Connector NA AI Tests** app (`App/Internal/Apps/ShopifyNAAITest`). See the Responsible AI section above.
-
-**Verified manually / by TestPage (not unit-automated):** the page-property scenarios — Approve/Undo action visibility, BC-rate column + green/red styling (RD7), edit-revert-on-close (RD8), the **Use Shopify Rate** action (RD10), review-page close guard (HITL-13), page action captions (HITL-12), notification prompts (HITL-10/11), and Shop Card field enable/disable (SC-1…3) — as these are page-lifecycle/UI behaviors best exercised through the client.
+# Shopify Tax Matching Agent - Test Coverage
+
+This document summarizes the behavioral coverage for the Tax Matching Agent. It intentionally avoids duplicating every test object, dataset entry, telemetry tag, and security evaluation detail from the implementation.
+
+## Configuration dimensions
+
+Coverage exercises the meaningful combinations of:
+
+- Feature and Copilot capability availability.
+- Automatic creation of Tax Jurisdictions and Tax Areas.
+- Existing versus missing Business Central tax setup.
+- Review mode: Always, Low Confidence Only, or Never.
+- Product, shipping, complete, partial, and conflicting tax data.
+
+## Numbered scenario matrix
+
+The scenario IDs provide stable references for reviews and defect discussions. Detailed mappings to test methods, objects, and datasets remain in the test source.
+
+### Eligibility and guard scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| G1 | Feature disabled for the shop | No AI request or order change; standard synchronization continues. |
+| G2 | Copilot capability unavailable or inactive | Matching is skipped without affecting order import. |
+| G3 | Standard address mapping already assigned a Tax Area | The existing Tax Area takes precedence and the agent does not run. |
+| G4 | Order is tax exempt | Matching is skipped and the tax-exempt state is preserved. |
+| G5 | No unmatched tax lines are available | No matching work or tax setup changes are performed. |
+| G6 | Required AI safeguards are unavailable | Matching is skipped and synchronization continues through the standard path. |
+
+### Jurisdiction matching scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| J1 | All tax lines have clear existing jurisdiction matches | Every validated line is assigned to the existing jurisdiction. |
+| J2 | Only some lines can be matched and creation is disabled | Valid matches are retained; unresolved lines remain blank and require review. |
+| J3 | A required jurisdiction is missing and creation is enabled | A provisional jurisdiction can be created and the order is held according to the review rules. |
+| J4 | Similar candidates require geographic disambiguation | Coarse ship-to geography is used to select the defensible candidate. |
+| J5 | No defensible match exists | No jurisdiction is invented from untrusted text; the line remains unresolved. |
+| J6 | An order is reprocessed with existing assignments | Existing assignments are retained and combined with newly validated matches. |
+
+### Tax setup scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| JC1 | Multiple jurisdictions are created for one order | Records are created only when enabled and form a usable jurisdiction hierarchy. |
+| JC2 | A suggested jurisdiction already exists | The existing record is reused rather than duplicated or overwritten. |
+| TD1 | No applicable Tax Detail exists | A detail is seeded for the relevant jurisdiction, tax group, rate, and effective date. |
+| TD2 | An equivalent Tax Detail already exists | No duplicate detail is created. |
+| TD3 | Product and shipping tax lines use different tax groups or rates | Each line uses the tax setup associated with what the tax was charged on. |
+| TA1 | A Tax Area has exactly the required jurisdictions | The existing Tax Area is reused. |
+| TA2 | No exact Tax Area exists and creation is disabled | The order remains unresolved and cannot be released as a completed match. |
+| TA3 | No exact Tax Area exists and creation is enabled | A new Tax Area is created without overwriting an unrelated existing code. |
+
+### Rate divergence scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| RD1 | A product tax line differs from the maintained Business Central rate | The jurisdiction is retained, the maintained rate is preserved, and the order is held. |
+| RD2 | A shipping tax line differs from the maintained Business Central rate | The shipping conflict is handled with the same safety gate as a product-line conflict. |
+| RD3 | Review mode is set to Never but a rate conflict exists | The order is still held; conflicts override the review preference. |
+| RD4 | Reviewer accepts the Business Central rate | Approval rebuilds the Tax Area and allows the maintained rate to remain authoritative. |
+| RD5 | Reviewer explicitly adopts the Shopify rate | The shared Tax Detail is updated only after confirmation, then the conflict is re-evaluated. |
+| RD6 | Reviewer changes a jurisdiction assignment | Approval rebuilds the complete Tax Area and recalculates applicable rates and conflicts. |
+
+### Review mode and provenance scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| RM1 | Review mode is Always | Every applied match is held until approved. |
+| RM2 | Review mode is Low Confidence Only and validation is needed | The order is held. |
+| RM3 | Review mode is Low Confidence Only and all matches are sufficiently validated | The order can continue automatically when no hard safety gate exists. |
+| RM4 | Review mode is Never with a complete, non-conflicting match | The order is not held solely for review preference. |
+| RM5 | Any review mode with an incomplete match | The order remains held until all tax lines are resolved. |
+| PV1 | An agent-created jurisdiction is first used | It remains provisional and requires human validation under the applicable review policy. |
+| PV2 | A reviewer approves a provisional jurisdiction | It becomes verified for subsequent matching. |
+| PV3 | Approval is undone before document creation | The order is held again and its agent-created jurisdictions return to provisional state. |
+
+### Human-in-the-loop scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| HITL-1 | Reviewer opens a held order | The review page shows the resolved Tax Area, tax lines, assignments, and rate comparison. |
+| HITL-2 | A tax line is still unresolved | Approval is blocked until the reviewer assigns a jurisdiction. |
+| HITL-3 | Reviewer edits a jurisdiction and closes without approving | The pending edit is not silently accepted. |
+| HITL-4 | Reviewer approves a completed match | The Tax Area and safety state are recalculated before the order is released. |
+| HITL-5 | Reviewer undoes approval before a Sales Document exists | The order returns to the held state. |
+| HITL-6 | A Shopify Order or Sales Order has an applied match | The appropriate review entry point is available. |
+| HITL-7 | Review notification is dismissed or the order is reviewed | Notification behavior follows the current order and user-notification state. |
+| HITL-8 | Shopify and Business Central rates differ | The difference is visually apparent and corrective actions require an explicit decision. |
+
+### Error and reprocessing scenarios
+
+| ID | Scenario | Expected result |
+|----|----------|-----------------|
+| E1 | The AI service call fails | No unvalidated match is applied and Shopify synchronization continues. |
+| E2 | The response is missing or malformed | The response is rejected without creating tax setup from invalid data. |
+| E3 | The response references an invalid tax line or jurisdiction | The invalid assignment is not persisted. |
+| E4 | The same order or setup is processed again | Existing assignments and setup are reused without duplication. |
+| E5 | A refund is created for a matched order | Tax context is inherited from the original order without another AI request. |
+
+## End-to-end acceptance
+
+| ID | Flow | Expected end state |
+|----|------|--------------------|
+| F1 | Complete match using existing setup | Existing jurisdictions and Tax Area are assigned and the order follows its review policy. |
+| F2 | Complete match with permitted setup creation | Required tax setup is created once and remains provisional until applicable review completes. |
+| F3 | Partial or unresolved match | The resolved work is retained, but the order remains held until the missing assignments are completed. |
+| F4 | Match with a rate conflict | Existing Business Central setup remains unchanged until the reviewer makes an explicit decision. |
+| F5 | Approved order creates a Sales Document and later a refund | The resolved tax context is propagated to the Sales Document and inherited by the refund. |
+
+## AI evaluation
+
+AI evaluations cover representative US and Canadian jurisdiction naming, abbreviations, regional terminology, multilingual titles, geographic ambiguity, distractors, and valid no-match outcomes. They include both curated scenarios and broader generated datasets.
+
+Evaluation emphasizes false-positive avoidance: leaving an uncertain line unmatched is safer than confidently assigning the wrong jurisdiction because unresolved lines are held for review.
+
+Security and Responsible AI evaluations are maintained in restricted test infrastructure. Exact prompts, adversarial inputs, datasets, and mitigation details are intentionally not described in this public document.
+
+| ID | Evaluation family | Focus |
+|----|-------------------|-------|
+| AIT-1 | Clear and abbreviated titles | Exact, common abbreviation, and semantic matching. |
+| AIT-2 | Geographic ambiguity | State, province, county, city, and district disambiguation using coarse location context. |
+| AIT-3 | Multilingual terminology | Representative English and French Canadian tax terminology. |
+| AIT-4 | Distractors and similar names | Avoiding attractive but incorrect jurisdiction candidates. |
+| AIT-5 | Valid no-match cases | Preferring an unresolved result over a false-positive assignment. |
+| AIT-6 | Broad regression datasets | Matching quality across a larger generated and representative scenario set. |
+
+## Test layers
+
+| Layer | Focus |
+|-------|-------|
+| Deterministic AL tests | Guards, tax setup behavior, review gates, rate-conflict handling, reprocessing, and state transitions. |
+| AI Test Toolkit evaluations | Matching quality and structured-response behavior using representative tax scenarios. |
+| Client-level verification | Page actions, field visibility, notifications, confirmation dialogs, rate highlighting, and edit/close behavior. |
+
+## Release criteria
+
+- Disabled or unavailable AI functionality leaves the standard connector behavior intact.
+- Incomplete and conflicting tax matches cannot be auto-released.
+- Existing tax rates are not changed without an explicit reviewer decision.
+- Repeated processing does not duplicate tax setup or lose existing assignments.
+- Public documentation and tests do not expose restricted prompt or security-evaluation details.


### PR DESCRIPTION
Documentation cleanup for the Tax Matching Agent.

Fixes [AB#445769](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/445769)


