### PR TITLE
[28.x] Disable incremental builds

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -10,6 +10,11 @@
   "country": "base",
   "useProjectDependencies": true,
   "repoVersion": "28.5",
+  "incrementalBuilds": {
+    "onPush": false,
+    "onPull_Request": false,
+    "onSchedule": false
+  },
   "conditionalSettings": [
     {
       "buildModes": [


### PR DESCRIPTION
## Problem

PR builds on `releases/28.x` fail during the **Apps (W1) (Clean)** build with:

```
AL1022 A package with publisher 'Microsoft', name 'Application', and a version
compatible with '28.5.0.0' could not be found in the package cache folders
AL1022 ... name 'Tests-TestLibraries' ...
```

This is **not** an artifact problem (artifact `sandbox/28.5.54028.0` contains `Application` at a compatible version) and **not** caused by the code change in the triggering PR — it fails at dependency resolution before any test code compiles.

## Root cause

The failure comes from AL-Go's **default** incremental build behavior, which BCApps does not override:

```
"incrementalBuilds": { "onPush": false, "onPull_Request": true, "onSchedule": false, "mode": "modifiedApps" }
```

- **Push / schedule** builds run with incremental **off** → full build → the compiler-folder `.packages` is populated with all symbols → `Application` resolves → green.
- **PR** builds run with incremental **on** (`modifiedApps`) → only the modified app rebuilds against a compiler folder that is never seeded with the `Application` (`c1335042…`) and `Tests-TestLibraries` symbols → `AL1022` → red.

Evidence: on the same artifact `28.5.54028.0`, the push-triggered maintenance run resolved `Microsoft_Application_28.5.0.0` → *"Dependency App exists"*, while the PR build reported *"Dependency App not found"*.

## Fix

Disable incremental builds for all triggers so PR builds behave consistently with CI/CD push/schedule builds.
