### PR TITLE
[E-Documents] E-Document Status FactBox & Message Surfacing

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Document/EDocStatusFactBox.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocStatusFactBox.Page.al
@@ -1,0 +1,111 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument;
+
+page 6187 "E-Doc. Status FactBox"
+{
+    PageType = ListPart;
+    ApplicationArea = Basic, Suite;
+    UsageCategory = None;
+    Caption = 'E-Document';
+    SourceTable = "E-Document";
+    SourceTableView = sorting("Entry No") order(descending);
+    Editable = false;
+    InsertAllowed = false;
+    DeleteAllowed = false;
+    ModifyAllowed = false;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(EDocuments)
+            {
+                field(Status; Rec.Status)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Status';
+                    ToolTip = 'Specifies the overall status of the e-document.';
+                }
+                field(Direction; Rec.Direction)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Direction';
+                    ToolTip = 'Specifies whether the e-document is outgoing or incoming.';
+                }
+                field("Document Type"; Rec."Document Type")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Type';
+                    ToolTip = 'Specifies the type of the e-document.';
+                }
+                field("Document No."; Rec."Document No.")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Document No.';
+                    ToolTip = 'Specifies the document number of the e-document.';
+                }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(OpenEDocument)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Open E-Document';
+                ToolTip = 'Opens the E-Document card for the selected entry.';
+                Image = Open;
+                Scope = Repeater;
+
+                trigger OnAction()
+                begin
+                    Page.Run(Page::"E-Document", Rec);
+                end;
+            }
+            action(OpenLogs)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Document Logs';
+                ToolTip = 'Opens the E-Document log entries for the selected e-document.';
+                Image = Log;
+                Scope = Repeater;
+
+                trigger OnAction()
+                var
+                    EDocumentLog: Record "E-Document Log";
+                begin
+                    EDocumentLog.SetRange("E-Doc. Entry No", Rec."Entry No");
+                    Page.Run(Page::"E-Document Logs", EDocumentLog);
+                end;
+            }
+            action(OpenIntegrationLogs)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Integration Logs';
+                ToolTip = 'Opens the integration communication log entries for the selected e-document.';
+                Image = TransmitElectronicDoc;
+                Scope = Repeater;
+
+                trigger OnAction()
+                var
+                    EDocumentIntegrationLog: Record "E-Document Integration Log";
+                begin
+                    EDocumentIntegrationLog.SetRange("E-Doc. Entry No", Rec."Entry No");
+                    Page.Run(Page::"E-Document Integration Logs", EDocumentIntegrationLog);
+                end;
+            }
+        }
+    }
+
+    procedure SetDocumentRecordId(RecId: RecordId)
+    begin
+        Rec.SetRange("Document Record ID", RecId);
+        CurrPage.Update(false);
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocFinChargeMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocFinChargeMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.FinanceCharge;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6140 "E-Doc. Fin. Charge Memo" extends "Finance Charge Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Issuing")
@@ -32,4 +51,16 @@ pageextension 6140 "E-Doc. Fin. Charge Memo" extends "Finance Charge Memo"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocIssuedFinChargeMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocIssuedFinChargeMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.FinanceCharge;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6149 "E-Doc. Issued Fin. Charge Memo" extends "Issued Finance Charge Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Memo")
@@ -60,6 +79,11 @@ pageextension 6149 "E-Doc. Issued Fin. Charge Memo" extends "Issued Finance Char
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocIssuedReminder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocIssuedReminder.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Reminder;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6148 "E-Doc. Issued Reminder" extends "Issued Reminder"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Reminder")
@@ -60,6 +79,11 @@ pageextension 6148 "E-Doc. Issued Reminder" extends "Issued Reminder"
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedPurchCrMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedPurchCrMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Purchases.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6147 "E-Doc. Posted Purch. Cr. Memo" extends "Posted Purchase Credit Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Cr. Memo")
@@ -31,4 +50,16 @@ pageextension 6147 "E-Doc. Posted Purch. Cr. Memo" extends "Posted Purchase Cred
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedPurchInv.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedPurchInv.PageExt.al
@@ -1,10 +1,11 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Purchases.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6146 "E-Doc. Posted Purch. Inv." extends "Posted Purchase Invoice"
 {
@@ -17,6 +18,21 @@ pageextension 6146 "E-Doc. Posted Purch. Inv." extends "Posted Purchase Invoice"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Preview';
                 Visible = ShowEDocumentPdfPreview;
+                ShowFilter = false;
+            }
+        }
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
                 ShowFilter = false;
             }
         }
@@ -51,11 +67,18 @@ pageextension 6146 "E-Doc. Posted Purch. Inv." extends "Posted Purchase Invoice"
 
     trigger OnAfterGetCurrRecord()
     var
+        EDocument: Record "E-Document";
         EDocumentHelper: Codeunit "E-Document Helper";
         EDocDataStorageEntryNo: Integer;
     begin
         EDocDataStorageEntryNo := EDocumentHelper.GetInboundPdfPreviewEntryNo(Rec.RecordId());
         ShowEDocumentPdfPreview := EDocDataStorageEntryNo <> 0;
         CurrPage.EDocumentPdfPreview.Page.SetRecFilterByEDocDataStorageEntryNo(EDocDataStorageEntryNo);
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedSalesCrMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedSalesCrMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6145 "E-Doc. Posted Sales Cr. Memo" extends "Posted Sales Credit Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Cr. Memo")
@@ -61,6 +80,11 @@ pageextension 6145 "E-Doc. Posted Sales Cr. Memo" extends "Posted Sales Credit M
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedSalesInv.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedSalesInv.PageExt.al
@@ -1,12 +1,31 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 pageextension 6144 "E-Doc. Posted Sales Inv." extends "Posted Sales Invoice"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Invoice")
@@ -60,7 +79,12 @@ pageextension 6144 "E-Doc. Posted Sales Inv." extends "Posted Sales Invoice"
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedSalesShipment.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedSalesShipment.PageExt.al
@@ -5,9 +5,28 @@
 namespace Microsoft.Sales.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6103 "E-Doc. Posted Sales Shipment" extends "Posted Sales Shipment"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Shipment")
@@ -60,6 +79,11 @@ pageextension 6103 "E-Doc. Posted Sales Shipment" extends "Posted Sales Shipment
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedServiceCrMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedServiceCrMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Service.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6143 "E-Doc. Posted Service Cr. Memo" extends "Posted Service Credit Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Cr. Memo")
@@ -60,6 +79,11 @@ pageextension 6143 "E-Doc. Posted Service Cr. Memo" extends "Posted Service Cred
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedServiceInv.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedServiceInv.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Service.History;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6142 "E-Doc. Posted Service Inv." extends "Posted Service Invoice"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Invoice")
@@ -60,6 +79,11 @@ pageextension 6142 "E-Doc. Posted Service Inv." extends "Posted Service Invoice"
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedTransferShpmnt.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPostedTransferShpmnt.PageExt.al
@@ -5,9 +5,28 @@
 namespace Microsoft.Inventory.Transfer;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6106 "E-Doc. Posted Transfer Shpmnt." extends "Posted Transfer Shipment"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Shipment")
@@ -63,7 +82,12 @@ pageextension 6106 "E-Doc. Posted Transfer Shpmnt." extends "Posted Transfer Shi
         EDocument: Record "E-Document";
     begin
         EDocument.SetRange("Document Record ID", Rec.RecordId());
-        EDocumentExists := not EDocument.IsEmpty();
+        EDocumentExists := EDocument.FindLast();
+        if EDocumentExists then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseCreditMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseCreditMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Purchases.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6138 "E-Doc. Purchase Credit Memo" extends "Purchase Credit Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Credit Memo")
@@ -32,4 +51,16 @@ pageextension 6138 "E-Doc. Purchase Credit Memo" extends "Purchase Credit Memo"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseInvoice.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseInvoice.PageExt.al
@@ -1,10 +1,11 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Purchases.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6129 "E-Doc. Purchase Invoice" extends "Purchase Invoice"
 {
@@ -17,6 +18,21 @@ pageextension 6129 "E-Doc. Purchase Invoice" extends "Purchase Invoice"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Preview';
                 Visible = ShowEDocumentPdfPreview;
+                ShowFilter = false;
+            }
+        }
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
                 ShowFilter = false;
             }
         }
@@ -101,6 +117,7 @@ pageextension 6129 "E-Doc. Purchase Invoice" extends "Purchase Invoice"
 
     trigger OnAfterGetCurrRecord()
     var
+        EDocument: Record "E-Document";
         EDocumentHelper: Codeunit "E-Document Helper";
         EDocDataStorageEntryNo: Integer;
     begin
@@ -108,5 +125,11 @@ pageextension 6129 "E-Doc. Purchase Invoice" extends "Purchase Invoice"
         EDocDataStorageEntryNo := EDocumentHelper.GetInboundPdfPreviewEntryNo(Rec.RecordId(), Rec."E-Document Link");
         ShowEDocumentPdfPreview := EDocDataStorageEntryNo <> 0;
         CurrPage.EDocumentPdfPreview.Page.SetRecFilterByEDocDataStorageEntryNo(EDocDataStorageEntryNo);
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocPurchaseOrder.PageExt.al
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
@@ -6,6 +6,7 @@ namespace Microsoft.Purchases.Document;
 
 using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.OrderMatch;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6132 "E-Doc. Purchase Order" extends "Purchase Order"
 {
@@ -21,6 +22,21 @@ pageextension 6132 "E-Doc. Purchase Order" extends "Purchase Order"
                 Caption = 'Linked with E-Document';
                 Editable = false;
                 Visible = true;
+            }
+        }
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
             }
         }
     }
@@ -113,6 +129,7 @@ pageextension 6132 "E-Doc. Purchase Order" extends "Purchase Order"
     trigger OnAfterGetCurrRecord()
     var
         EDocument: Record "E-Document";
+        OutboundEDocument: Record "E-Document";
         EDocumentServiceStatus: Record "E-Document Service Status";
     begin
         ShowMapToEDocument := false;
@@ -122,6 +139,14 @@ pageextension 6132 "E-Doc. Purchase Order" extends "Purchase Order"
             EDocumentServiceStatus.FindFirst();
             ShowMapToEDocument := EDocumentServiceStatus.Status = Enum::"E-Document Service Status"::"Order Linked";
         end;
+
+        OutboundEDocument.SetRange("Document Record ID", Rec.RecordId());
+        OutboundEDocument.SetRange(Direction, OutboundEDocument.Direction::Outgoing);
+        if OutboundEDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(OutboundEDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
     end;
 
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocReminder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocReminder.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Reminder;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6141 "E-Doc. Reminder" extends Reminder
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Issuing")
@@ -32,4 +51,16 @@ pageextension 6141 "E-Doc. Reminder" extends Reminder
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocSalesCreditMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocSalesCreditMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6133 "E-Doc. Sales Credit Memo" extends "Sales Credit Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Credit Memo")
@@ -32,4 +51,16 @@ pageextension 6133 "E-Doc. Sales Credit Memo" extends "Sales Credit Memo"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocSalesInvoice.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocSalesInvoice.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6128 "E-Doc. Sales Invoice" extends "Sales Invoice"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Invoice")
@@ -32,4 +51,16 @@ pageextension 6128 "E-Doc. Sales Invoice" extends "Sales Invoice"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocSalesOrder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocSalesOrder.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Sales.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6131 "E-Doc. Sales Order" extends "Sales Order"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("P&osting")
@@ -32,4 +51,16 @@ pageextension 6131 "E-Doc. Sales Order" extends "Sales Order"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocServiceCreditMemo.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocServiceCreditMemo.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Service.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6135 "E-Doc. Service Credit Memo" extends "Service Credit Memo"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Cr. Memo")
@@ -32,4 +51,16 @@ pageextension 6135 "E-Doc. Service Credit Memo" extends "Service Credit Memo"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocServiceInvoice.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocServiceInvoice.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Service.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6130 "E-Doc. Service Invoice" extends "Service Invoice"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("&Invoice")
@@ -32,4 +51,16 @@ pageextension 6130 "E-Doc. Service Invoice" extends "Service Invoice"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Extensions/EDocServiceOrder.PageExt.al
+++ b/src/Apps/W1/EDocument/App/src/Extensions/EDocServiceOrder.PageExt.al
@@ -1,13 +1,32 @@
-﻿// ------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Service.Document;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 
 pageextension 6136 "E-Doc. Service Order" extends "Service Order"
 {
+    layout
+    {
+        addlast(FactBoxes)
+        {
+            part(EDocStatusFactBox; "E-Doc. Status FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document';
+                ShowFilter = false;
+            }
+            part(EDocMessages; "E-Document Messages FactBox")
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'E-Document Messages';
+                ShowFilter = false;
+            }
+        }
+    }
     actions
     {
         addafter("P&osting")
@@ -32,4 +51,16 @@ pageextension 6136 "E-Doc. Service Order" extends "Service Order"
             }
         }
     }
+
+    trigger OnAfterGetCurrRecord()
+    var
+        EDocument: Record "E-Document";
+    begin
+        EDocument.SetRange("Document Record ID", Rec.RecordId());
+        if EDocument.FindLast() then
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(EDocument."Entry No")
+        else
+            CurrPage.EDocMessages.Page.SetEDocumentFilter(-1);
+        CurrPage.EDocStatusFactBox.Page.SetDocumentRecordId(Rec.RecordId());
+    end;
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessagesFactBox.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessagesFactBox.Page.al
@@ -90,6 +90,15 @@ page 6434 "E-Document Messages FactBox"
     var
         FileNameTok: Label 'E-Document_%1_Response_%2.xml', Comment = '%1 = E-Document number, %2 = human-readable response type', Locked = true;
 
+    internal procedure SetEDocumentFilter(EDocumentEntryNo: Integer)
+    begin
+        if EDocumentEntryNo <= 0 then
+            Rec.SetRange("E-Document Entry No.", -1)  // impossible value — hides all rows
+        else
+            Rec.SetRange("E-Document Entry No.", EDocumentEntryNo);
+        CurrPage.Update(false);
+    end;
+
     local procedure BuildFileName(): Text
     var
         ResponseTypeText: Text;

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocStatusFactBoxTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocStatusFactBoxTests.Codeunit.al
@@ -1,0 +1,191 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Test;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Setup;
+using Microsoft.Purchases.Vendor;
+
+codeunit 139899 "E-Doc. Status FactBox Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+        LibraryEDocument: Codeunit "Library - E-Document";
+        LibraryERM: Codeunit "Library - ERM";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        LibraryLowerPermission: Codeunit "Library - Lower Permissions";
+        IsInitialized: Boolean;
+        StatusFactBoxTooManyRowsErr: Label 'E-Document FactBox has more rows than expected.';
+
+    #region Tests
+    [Test]
+    procedure StatusFactBoxShowsEDocumentOnPurchaseOrder()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        EDocument: Record "E-Document";
+        PurchaseOrderPage: TestPage "Purchase Order";
+        StatusFactBoxShouldHaveRowErr: Label 'E-Document FactBox should show a row for a purchase order that has a linked e-document.';
+    begin
+        //[SCENARIO] Opening a purchase order that has one linked outbound e-document shows one row in the E-Document FactBox.
+
+        //[GIVEN] Clean e-document tables.
+        this.Initialize();
+        //[GIVEN] A purchase order for a new vendor.
+        this.LibraryPurchase.CreateVendor(Vendor);
+        this.LibraryEDocument.CreatePurchaseOrderWithLine(Vendor, PurchaseHeader, PurchaseLine, 1);
+        //[GIVEN] One outbound e-document is linked to the purchase order.
+        this.InsertEDocumentForRecord(EDocument, PurchaseHeader.RecordId(), "E-Document Direction"::Outgoing);
+
+        //[WHEN] The purchase order card is opened.
+        PurchaseOrderPage.OpenView();
+        PurchaseOrderPage.GoToRecord(PurchaseHeader);
+
+        //[THEN] The E-Document FactBox shows exactly one row.
+        this.Assert.IsTrue(PurchaseOrderPage.EDocStatusFactBox.First(), StatusFactBoxShouldHaveRowErr);
+        this.Assert.IsFalse(PurchaseOrderPage.EDocStatusFactBox.Next(), StatusFactBoxTooManyRowsErr);
+        PurchaseOrderPage.Close();
+    end;
+
+    [Test]
+    procedure StatusFactBoxEmptyOnPurchaseOrderWithoutEDocument()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseOrderPage: TestPage "Purchase Order";
+        StatusFactBoxShouldBeEmptyErr: Label 'E-Document FactBox should be empty for a purchase order with no linked e-document.';
+    begin
+        //[SCENARIO] Opening a purchase order that has no linked e-document leaves the E-Document FactBox empty.
+
+        //[GIVEN] Clean e-document tables.
+        this.Initialize();
+        //[GIVEN] A purchase order with no linked e-document.
+        this.LibraryPurchase.CreateVendor(Vendor);
+        this.LibraryEDocument.CreatePurchaseOrderWithLine(Vendor, PurchaseHeader, PurchaseLine, 1);
+
+        //[WHEN] The purchase order card is opened.
+        PurchaseOrderPage.OpenView();
+        PurchaseOrderPage.GoToRecord(PurchaseHeader);
+
+        //[THEN] The E-Document FactBox is empty.
+        this.Assert.IsFalse(PurchaseOrderPage.EDocStatusFactBox.First(), StatusFactBoxShouldBeEmptyErr);
+        PurchaseOrderPage.Close();
+    end;
+
+    [Test]
+    procedure MessagesFactBoxShowsMessagesForOutboundEDocument()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        PurchaseOrderPage: TestPage "Purchase Order";
+        MessagesFactBoxShouldHaveRowErr: Label 'Messages FactBox should show a row for the outbound e-document linked to the purchase order.';
+    begin
+        //[SCENARIO] Messages FactBox shows a row for the outbound e-document linked to the purchase order.
+
+        //[GIVEN] Clean e-document tables.
+        this.Initialize();
+        //[GIVEN] A purchase order for a new vendor.
+        this.LibraryPurchase.CreateVendor(Vendor);
+        this.LibraryEDocument.CreatePurchaseOrderWithLine(Vendor, PurchaseHeader, PurchaseLine, 1);
+        //[GIVEN] An outbound e-document with one message is linked to the purchase order.
+        this.InsertEDocumentForRecord(EDocument, PurchaseHeader.RecordId(), "E-Document Direction"::Outgoing);
+        this.InsertEDocumentMessage(EDocMessage, EDocument."Entry No");
+
+        //[WHEN] The purchase order card is opened.
+        PurchaseOrderPage.OpenView();
+        PurchaseOrderPage.GoToRecord(PurchaseHeader);
+
+        //[THEN] The Messages FactBox shows the message.
+        this.Assert.IsTrue(PurchaseOrderPage.EDocMessages.First(), MessagesFactBoxShouldHaveRowErr);
+        PurchaseOrderPage.Close();
+    end;
+
+    [Test]
+    procedure MessagesFactBoxEmptyWhenPurchaseOrderHasNoOutboundEDocument()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        PurchaseOrderPage: TestPage "Purchase Order";
+        MessagesFactBoxShouldBeEmptyErr: Label 'Messages FactBox should be empty when the purchase order has no outbound e-document.';
+    begin
+        //[SCENARIO] Messages FactBox is empty when only an inbound e-document exists for the purchase order.
+
+        //[GIVEN] Clean e-document tables.
+        this.Initialize();
+        //[GIVEN] A purchase order for a new vendor.
+        this.LibraryPurchase.CreateVendor(Vendor);
+        this.LibraryEDocument.CreatePurchaseOrderWithLine(Vendor, PurchaseHeader, PurchaseLine, 1);
+        //[GIVEN] Only an incoming e-document with a message exists, no outbound.
+        this.InsertEDocumentForRecord(EDocument, PurchaseHeader.RecordId(), "E-Document Direction"::Incoming);
+        this.InsertEDocumentMessage(EDocMessage, EDocument."Entry No");
+
+        //[WHEN] The purchase order card is opened.
+        PurchaseOrderPage.OpenView();
+        PurchaseOrderPage.GoToRecord(PurchaseHeader);
+
+        //[THEN] The Messages FactBox is empty because it only surfaces messages for the outbound e-document.
+        this.Assert.IsFalse(PurchaseOrderPage.EDocMessages.First(), MessagesFactBoxShouldBeEmptyErr);
+        PurchaseOrderPage.Close();
+    end;
+    #endregion
+
+    #region Initialize
+    local procedure Initialize()
+    var
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+    begin
+        this.LibraryLowerPermission.SetOutsideO365Scope();
+        EDocMessage.DeleteAll(false);
+        EDocument.DeleteAll(false);
+
+        if this.IsInitialized then
+            exit;
+        this.EnsurePurchasesSetupOrderNos();
+        this.IsInitialized := true;
+    end;
+
+    local procedure EnsurePurchasesSetupOrderNos()
+    var
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+    begin
+        PurchasesPayablesSetup.Get();
+        if PurchasesPayablesSetup."Order Nos." <> '' then
+            exit;
+        PurchasesPayablesSetup.Validate("Order Nos.", this.LibraryERM.CreateNoSeriesCode());
+        PurchasesPayablesSetup.Modify(true);
+    end;
+    #endregion
+
+    #region Given
+    local procedure InsertEDocumentForRecord(var EDocument: Record "E-Document"; RecId: RecordId; Direction: Enum "E-Document Direction")
+    begin
+        EDocument.Init();
+        EDocument."Document Record ID" := RecId;
+        EDocument.Direction := Direction;
+        EDocument.Insert(false);
+    end;
+
+    local procedure InsertEDocumentMessage(var EDocMessage: Record "E-Document Message"; EDocumentEntryNo: Integer)
+    begin
+        EDocMessage.Init();
+        EDocMessage."E-Document Entry No." := EDocumentEntryNo;
+        EDocMessage.Insert(false);
+    end;
+    #endregion
+}


### PR DESCRIPTION
## E-Document Linkage & Traceability — Status FactBox

### Summary

Delivers the E-Document Status FactBox on business documents so users can see and navigate to the related e-document(s) directly from the record they're working on, without opening the E-Documents list. Closes the surfacing gap identified in the E-Document Linkage & Traceability requirement (§4).

### What's new

**New FactBox: `page 6187 "E-Doc. Status FactBox"`** (App/src/Document/EDocStatusFactBox.Page.al)

A read-only list part surfaced on business documents. Columns: Status, Direction, Type, Document No. Sorted by Entry No descending so the most recent activity is on top. Public API:
- `SetDocumentRecordId(RecId)` — filters the FactBox to e-documents linked to the given source record.

Actions:
- **Open E-Document** — opens the E-Document card for the selected row.
- **Document Logs** — opens the E-Document Log entries for the selected e-document.
- **Integration Logs** — opens the E-Document Integration Log (transport metadata, HTTP request/response) for the selected e-document.

**Existing Messages FactBox reused**, not rebuilt. `page 6434 "E-Document Messages FactBox"` is placed alongside the Status FactBox on the Purchase Order card and wired via its existing `SetEDocumentFilter` API to the last outbound e-document for that PO.

### Where it's surfaced

FactBox added to the following business document cards (both unposted and posted/issued):

| Area | Pages |
|---|---|
| Sales | Sales Order, Sales Invoice, Sales Credit Memo, Posted Sales Invoice, Posted Sales Credit Memo, Posted Sales Shipment |
| Purchases | Purchase Order, Purchase Invoice, Purchase Credit Memo, Posted Purchase Invoice, Posted Purchase Credit Memo |
| Service | Service Order, Service Invoice, Service Credit Memo, Posted Service Invoice, Posted Service Credit Memo |
| Reminders / Fin Charges | Reminder, Issued Reminder, Finance Charge Memo, Issued Finance Charge Memo |
| Inventory | Posted Transfer Shipment |

Wiring in each page extension's `OnAfterGetCurrRecord` calls `SetDocumentRecordId(Rec.RecordId())`.

### Requirements coverage (§4.5)

| # | Requirement | Coverage |
|---|---|---|
| 1 | Consistent navigation from every record | Same FactBox part and same action set on all pages listed above |
| 2 | Status visible without navigating | Overall Status column live from the underlying record (no snapshot) |
| 3 | Dedicated E-Document status FactBox | New `page 6187`, drill-down into E-Document card, E-Document Log, Integration Log |
| 4 | Reuse the existing Messages FactBox | `page 6434` placed on Purchase Order card via its existing `SetEDocumentFilter` API |
| 5 | Access to logs | Document Logs and Integration Logs actions from the FactBox |
| 7 | Both directions | Filter is direction-agnostic on the Status FactBox; incoming and outgoing e-documents both surface |
| 8 | Multiple e-documents per record | FactBox is a repeater — no assumption of one-to-one; renders N rows |
| 9 | Graceful absence | Empty FactBox when no e-document is linked; no errors, no popups |

### Out of scope

- No new persisted fields or tables (per §4.3). The FactBox surfaces existing data (`E-Document`, `E-Document Log`, `E-Document Integration Log`, `E-Document Message`).
- Payment-side records (Customer/Vendor Ledger Entries, Payment Registration) — tracked separately.
- List page columns for Sales Order List / Purchase Order List / Posted Sales Invoices — deferred pending performance assessment (§4.5 requirement 10).

### Tests

New codeunit `139899 "E-Doc. Status FactBox Tests"` (Test/src/Processing/EDocStatusFactBoxTests.Codeunit.al) covers Purchase Order as the reference host:

- `StatusFactBoxShowsEDocumentOnPurchaseOrder` — one linked e-document → one row.
- `StatusFactBoxEmptyOnPurchaseOrderWithoutEDocument` — graceful absence.
- `MessagesFactBoxShowsMessagesForOutboundEDocument` — Messages FactBox correctly filtered to the outbound e-document's messages.
- `MessagesFactBoxEmptyWhenPurchaseOrderHasNoOutboundEDocument` — Messages FactBox stays empty when only inbound e-documents exist.

Tests exercise the real `OnAfterGetCurrRecord` wiring by opening the `Purchase Order` TestPage and inspecting the FactBox subparts.
