### PR TITLE
[Bug Fix] #304: [SOA] Re-resolve new sender to created contact after 'I have added the contact'

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al
@@ -1232,7 +1232,7 @@ codeunit 4400 "SOA Setup"
         SOAContactInterventionSuggestionCodeLbl: Label 'SOA-CONTACT-ADDED', Locked = true;
         SOAContactInterventionSuggestionSummaryLbl: Label 'I have added the contact', MaxLength = 100;
         SOAContactInterventionSuggestionDescriptionLbl: Label 'Used to indicate that a user has done some manual updates to add the contact information. Rerun the contact information check', Locked = true, MaxLength = 1024;
-        SOAContactInterventionSuggestionInstructionsLbl: Label 'I have updated the contact information. Rerun the contact information check on the contact list page and proceed further.', Locked = true, MaxLength = 1024;
+        SOAContactInterventionSuggestionInstructionsLbl: Label 'I have updated the contact information. Navigate to the contact list page and search for the contact again. If the contact is found, proceed with it, and only search the customer list if the contact is still not found.', Locked = true, MaxLength = 1024;
         NewEmailsSinceDeactivationLbl: Label 'New e-mails (%1) have arrived since %2 but haven''t been processed yet. Should Sales Order Agent also process these?', Comment = '%1 - Number of emails, %2 - Date and time of deactivation.';
         SOAAttemptedConnectionFailedErr: Label 'The agent can''t be activated because the connection to the selected Microsoft 365 mailbox failed. Ask your Microsoft 365 administrator to check if the user configuring the agent has permission to access the mailbox.';
         SOAAttemptedConnectionHttpRequestFailedErr: Label 'The agent can''t be activated because its settings don''t allow Http Requests. Ask your administrator to update this setting and try again.';


### PR DESCRIPTION
## Bug Reference
Work item microsoft/BCAppsBugFix#304

Fixes microsoft/BCAppsBugFix#304

Fixes [AB#615541](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/615541)

## Summary
Sales Order Agent (SOA) failed to recover when an email arrived from a new/unrecognized sender: after the user created the contact from the agent chat and confirmed with the "I have added the contact" suggestion, the agent still reported that it could not find the customer. This fix strengthens the intervention instruction so the agent re-resolves the sender starting from the contact list after the contact is created, instead of remaining in the stale customer-list context.

## Root Cause
The AL data resolution is already correct: `AgentTaskMessage.From` and the newly created contact's `"E-Mail"` both come from `EmailInbox."Sender Address"`, so `GetSecurityFiltersForContacts` (codeunit 4305 "SOA Filters Impl.") finds the new contact on re-resolution, and a contact without a linked customer is already supported (`SetFilterOnSalesHeader` in codeunit 4306 falls back to the "Sell-to Contact No." filter; quote creation uses customer templates).

The defect was in the agent's continuation behavior, driven by the `SOA-CONTACT-ADDED` intervention instruction text (`SOAContactInterventionSuggestionInstructionsLbl` in `SOASetup.Codeunit.al`). It only said "Rerun the contact information check on the contact list page and proceed further" and did not explicitly command the agent to navigate back to the contact list and search again before concluding. When the assistance request had been raised from the Customer List page, the agent stayed in that stale context after the contact was created and re-reported "can't find the customer".

## Changes Made
- `src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Codeunit.al`: Reworded the `SOAContactInterventionSuggestionInstructionsLbl` label (`Locked = true`, `MaxLength = 1024` unchanged) to explicitly instruct the agent to navigate to the contact list page, search for the contact again, proceed with the contact if found, and only fall back to the customer list if the contact is still not found. This is the only source change.

## Implementation Process

- Fix iterations: Not applicable - tests not required
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app published successfully
- Validation: Tests not required by the approved plan

## Validation Evidence

### No-Test Validation Evidence

- **Tests required by plan**: No
- **Rationale**: The defect only manifests through the live SOA agent runtime (inbound email → agent task → LLM interpreting the intervention instruction text → multi-turn user intervention/Continue navigation). The changed artifact is a `Locked` label consumed as natural-language guidance for the LLM, not deterministic AL branch logic. The underlying AL data resolution and security-filter logic were verified correct, so there is no deterministic AL defect for a red-to-green automated test, and there is no SOA test project in the repository. Reproducing the symptom requires the external email system and the agent/LLM runtime, which the AL test environment cannot control.
- **Compilation**: ✅ All modified projects compiled successfully
- **Publish**: ✅ Modified app published successfully
- **Manual/external validation approach**: With SOA configured so input reviews are not required, send an email from a new sender, use the chat link to create the contact, select "I have added the contact", click Continue, and confirm the agent re-resolves to the newly created contact and proceeds (creates the sales quote/order) instead of reporting it cannot find the customer.

## Validation Coverage

- [x] Automated tests: Not applicable per approved Test Strategy
- [x] Build and publish validation completed
- [ ] Manual/external validation: Run the 6-step repro from the issue with input reviews disabled and confirm the agent proceeds after the contact is created
- [ ] Regression testing: Confirm normal (recognized-sender) contact/customer resolution and security filtering are unaffected

## Miapp Propagation

- **Layers propagated to**: None - the fix touched no propagated path
- **Files changed by propagation**: 0
- **VerifyMiappSync**: ✅ No files still need to be integrated

## Review Notes
The change is limited to a single agent-instruction label string. Reviewers should focus on the wording of the new instruction to confirm it unambiguously directs the agent to re-resolve from the contact list first and only fall back to the customer list when the contact is still not found.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#313: https://github.com/microsoft/BCAppsBugFix/pull/313


