### PR TITLE
fix rounding issue for SCA

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1136,19 +1136,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1056,14 +1056,21 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if not NonDeductibleVAT.IsNonDeductibleVATEnabled() then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
@@ -1079,7 +1086,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1069,19 +1069,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/CZ/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -606,6 +606,67 @@ codeunit 134897 "ERM Source Currency"
     end;
 
     [Test]
+    procedure PurchaseInvoiceReverseChargeVATFCYSourceCurrencyPreserved()
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        Currency: Record Currency;
+        VendorNo: Code[20];
+        PostedPurchaseInvoiceNo: Code[20];
+        Factor: Integer;
+        SCYBalance: Decimal;
+        ExpectedVATAmount: Decimal;
+        DirectUnitCost: Decimal;
+    begin
+        // [FEATURE] [AI test] [Purchase] [Invoice] [Reverse Charge VAT] [FCY] [Source Currency]
+        // [SCENARIO 647818] Source Currency VAT Amount on the reverse charge VAT G/L entries of a foreign-currency
+        // purchase invoice is preserved from the document, not recalculated from the rounded Amount (LCY).
+        Initialize();
+
+        // [GIVEN] Vendor with reverse charge VAT posting setup at 8.1% and a reverse charge VAT account (repro scenario).
+        VendorNo := CreateVendorWithNewPostingGroups(VendorPostingGroup, GeneralPostingSetup, VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Reverse Charge VAT");
+        VATPostingSetup.Validate("VAT %", 8.1);
+        VATPostingSetup.Validate("Reverse Chrg. VAT Acc.", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Foreign currency with exchange rate 1 = 0.81709 and rounding precision 0.01 (repro scenario).
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Modify(true);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate(), 1, 0.81709);
+
+        // [GIVEN] A purchase invoice in the foreign currency with a single line of 1,788.27 (repro scenario).
+        CreateGLAccount(GLAccount, Enum::"General Posting Type"::Purchase, GeneralPostingSetup, VATPostingSetup);
+        CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", WorkDate() + 1);
+        PurchaseHeader.Validate("Currency Code", Currency.Code);
+        PurchaseHeader.Modify(true);
+        DirectUnitCost := 1788.27;
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccount."No.", 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.CalcFields(Amount, "Amount Including VAT");
+        PurchaseHeader."Doc. Amount Incl. VAT" := PurchaseHeader."Amount Including VAT";
+        PurchaseHeader."Doc. Amount VAT" := PurchaseHeader."Amount Including VAT" - PurchaseHeader.Amount;
+        PurchaseHeader.Modify();
+
+        // [WHEN] Posting the purchase invoice.
+        PostedPurchaseInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Source Currency Amount on the reverse charge VAT entries equals the source-currency VAT amount
+        // calculated directly from the document (1,788.27 * 8.1% = 144.85), not a value re-derived from LCY.
+        ExpectedVATAmount := Round(DirectUnitCost * VATPostingSetup."VAT %" / 100, Currency."Amount Rounding Precision", '=');
+        VerifyReverseChargeVATSourceCurrencyAmounts(
+            PostedPurchaseInvoiceNo, Currency.Code, DirectUnitCost, ExpectedVATAmount,
+            VATPostingSetup, VendorPostingGroup, GLAccount."No.");
+    end;
+
+    [Test]
     procedure PurchaseInvoiceFullVATLCY()
     begin
         PurchaseInvoiceFullVAT(false);
@@ -2205,6 +2266,34 @@ codeunit 134897 "ERM Source Currency"
             VATPostingSetup."Adjust for Payment Discount" := false;
             VATPostingSetup.Modify();
         end;
+    end;
+
+    local procedure VerifyReverseChargeVATSourceCurrencyAmounts(PostedDocumentNo: Code[20]; CurrencyCode: Code[10]; DirectUnitCost: Decimal; ExpectedVATAmount: Decimal; VATPostingSetup: Record "VAT Posting Setup"; VendorPostingGroup: Record "Vendor Posting Group"; GLAccountNo: Code[20])
+    var
+        GLEntry: Record "G/L Entry";
+        Factor: Integer;
+        SCYBalance: Decimal;
+    begin
+        GetGLEntries(GLEntry, PostedDocumentNo, GLEntry."Document Type"::Invoice);
+        repeat
+            Assert.AreEqual(CurrencyCode, GLEntry."Source Currency Code", SourceCurrencyCodeErr);
+
+            Factor := GLEntry.Amount <> 0 ? GLEntry.Amount / Abs(GLEntry.Amount) : 1;
+            case GLEntry."G/L Account No." of
+                VATPostingSetup."Purchase VAT Account",
+                VATPostingSetup.GetRevChargeAccount(false):
+                    Assert.AreEqual(ExpectedVATAmount * Factor, GLEntry."Source Currency Amount", StrSubstNo(VATAmountIncorrectErr, DirectUnitCost, VATPostingSetup."VAT %"));
+                VendorPostingGroup.GetPayablesAccount():
+                    Assert.AreEqual(-DirectUnitCost, GLEntry."Source Currency Amount", BalancingAmountIncorrectErr);
+                GLAccountNo:
+                    Assert.AreEqual(DirectUnitCost, GLEntry."Source Currency Amount", AmountExclVATIncorrectErr);
+                else
+                    Error(UnexpectedAccountNoErr, GLEntry."G/L Account No.");
+            end;
+            SCYBalance += GLEntry."Source Currency Amount";
+        until GLEntry.Next() = 0;
+
+        Assert.AreEqual(0, SCYBalance, TotalSCYAmountNotZeroErr);
     end;
 
 }

--- a/src/Layers/CZ/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -614,12 +614,9 @@ codeunit 134897 "ERM Source Currency"
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         GLAccount: Record "G/L Account";
-        GLEntry: Record "G/L Entry";
         Currency: Record Currency;
         VendorNo: Code[20];
         PostedPurchaseInvoiceNo: Code[20];
-        Factor: Integer;
-        SCYBalance: Decimal;
         ExpectedVATAmount: Decimal;
         DirectUnitCost: Decimal;
     begin

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1109,19 +1109,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/ES/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -607,6 +607,67 @@ codeunit 134897 "ERM Source Currency"
     end;
 
     [Test]
+    procedure PurchaseInvoiceReverseChargeVATFCYSourceCurrencyPreserved()
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        Currency: Record Currency;
+        VendorNo: Code[20];
+        PostedPurchaseInvoiceNo: Code[20];
+        Factor: Integer;
+        SCYBalance: Decimal;
+        ExpectedVATAmount: Decimal;
+        DirectUnitCost: Decimal;
+    begin
+        // [FEATURE] [AI test] [Purchase] [Invoice] [Reverse Charge VAT] [FCY] [Source Currency]
+        // [SCENARIO 647818] Source Currency VAT Amount on the reverse charge VAT G/L entries of a foreign-currency
+        // purchase invoice is preserved from the document, not recalculated from the rounded Amount (LCY).
+        Initialize();
+
+        // [GIVEN] Vendor with reverse charge VAT posting setup at 8.1% and a reverse charge VAT account (repro scenario).
+        VendorNo := CreateVendorWithNewPostingGroups(VendorPostingGroup, GeneralPostingSetup, VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Reverse Charge VAT");
+        VATPostingSetup.Validate("VAT %", 8.1);
+        VATPostingSetup.Validate("Reverse Chrg. VAT Acc.", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Foreign currency with exchange rate 1 = 0.81709 and rounding precision 0.01 (repro scenario).
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Modify(true);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate(), 1, 0.81709);
+
+        // [GIVEN] A purchase invoice in the foreign currency with a single line of 1,788.27 (repro scenario).
+        CreateGLAccount(GLAccount, Enum::"General Posting Type"::Purchase, GeneralPostingSetup, VATPostingSetup);
+        CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", WorkDate() + 1);
+        PurchaseHeader.Validate("Currency Code", Currency.Code);
+        PurchaseHeader.Modify(true);
+        DirectUnitCost := 1788.27;
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccount."No.", 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.CalcFields(Amount, "Amount Including VAT");
+        PurchaseHeader."Doc. Amount Incl. VAT" := PurchaseHeader."Amount Including VAT";
+        PurchaseHeader."Doc. Amount VAT" := PurchaseHeader."Amount Including VAT" - PurchaseHeader.Amount;
+        PurchaseHeader.Modify();
+
+        // [WHEN] Posting the purchase invoice.
+        PostedPurchaseInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Source Currency Amount on the reverse charge VAT entries equals the source-currency VAT amount
+        // calculated directly from the document (1,788.27 * 8.1% = 144.85), not a value re-derived from LCY.
+        ExpectedVATAmount := Round(DirectUnitCost * VATPostingSetup."VAT %" / 100, Currency."Amount Rounding Precision", '=');
+        VerifyReverseChargeVATSourceCurrencyAmounts(
+            PostedPurchaseInvoiceNo, Currency.Code, DirectUnitCost, ExpectedVATAmount,
+            VATPostingSetup, VendorPostingGroup, GLAccount."No.");
+    end;
+
+    [Test]
     procedure PurchaseInvoiceFullVATLCY()
     begin
         PurchaseInvoiceFullVAT(false);
@@ -2252,6 +2313,34 @@ codeunit 134897 "ERM Source Currency"
             VATPostingSetup."Adjust for Payment Discount" := false;
             VATPostingSetup.Modify();
         end;
+    end;
+
+    local procedure VerifyReverseChargeVATSourceCurrencyAmounts(PostedDocumentNo: Code[20]; CurrencyCode: Code[10]; DirectUnitCost: Decimal; ExpectedVATAmount: Decimal; VATPostingSetup: Record "VAT Posting Setup"; VendorPostingGroup: Record "Vendor Posting Group"; GLAccountNo: Code[20])
+    var
+        GLEntry: Record "G/L Entry";
+        Factor: Integer;
+        SCYBalance: Decimal;
+    begin
+        GetGLEntries(GLEntry, PostedDocumentNo, GLEntry."Document Type"::Invoice);
+        repeat
+            Assert.AreEqual(CurrencyCode, GLEntry."Source Currency Code", SourceCurrencyCodeErr);
+
+            Factor := GLEntry.Amount <> 0 ? GLEntry.Amount / Abs(GLEntry.Amount) : 1;
+            case GLEntry."G/L Account No." of
+                VATPostingSetup."Purchase VAT Account",
+                VATPostingSetup.GetRevChargeAccount(false):
+                    Assert.AreEqual(ExpectedVATAmount * Factor, GLEntry."Source Currency Amount", StrSubstNo(VATAmountIncorrectErr, DirectUnitCost, VATPostingSetup."VAT %"));
+                VendorPostingGroup.GetPayablesAccount():
+                    Assert.AreEqual(-DirectUnitCost, GLEntry."Source Currency Amount", BalancingAmountIncorrectErr);
+                GLAccountNo:
+                    Assert.AreEqual(DirectUnitCost, GLEntry."Source Currency Amount", AmountExclVATIncorrectErr);
+                else
+                    Error(UnexpectedAccountNoErr, GLEntry."G/L Account No.");
+            end;
+            SCYBalance += GLEntry."Source Currency Amount";
+        until GLEntry.Next() = 0;
+
+        Assert.AreEqual(0, SCYBalance, TotalSCYAmountNotZeroErr);
     end;
 
 }

--- a/src/Layers/ES/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -615,12 +615,9 @@ codeunit 134897 "ERM Source Currency"
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         GLAccount: Record "G/L Account";
-        GLEntry: Record "G/L Entry";
         Currency: Record Currency;
         VendorNo: Code[20];
         PostedPurchaseInvoiceNo: Code[20];
-        Factor: Integer;
-        SCYBalance: Decimal;
         ExpectedVATAmount: Decimal;
         DirectUnitCost: Decimal;
     begin

--- a/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1052,19 +1052,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1060,19 +1060,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1254,19 +1254,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/IT/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -613,6 +613,67 @@ codeunit 134897 "ERM Source Currency"
     end;
 
     [Test]
+    procedure PurchaseInvoiceReverseChargeVATFCYSourceCurrencyPreserved()
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        Currency: Record Currency;
+        VendorNo: Code[20];
+        PostedPurchaseInvoiceNo: Code[20];
+        Factor: Integer;
+        SCYBalance: Decimal;
+        ExpectedVATAmount: Decimal;
+        DirectUnitCost: Decimal;
+    begin
+        // [FEATURE] [AI test] [Purchase] [Invoice] [Reverse Charge VAT] [FCY] [Source Currency]
+        // [SCENARIO 647818] Source Currency VAT Amount on the reverse charge VAT G/L entries of a foreign-currency
+        // purchase invoice is preserved from the document, not recalculated from the rounded Amount (LCY).
+        Initialize();
+
+        // [GIVEN] Vendor with reverse charge VAT posting setup at 8.1% and a reverse charge VAT account (repro scenario).
+        VendorNo := CreateVendorWithNewPostingGroups(VendorPostingGroup, GeneralPostingSetup, VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Reverse Charge VAT");
+        VATPostingSetup.Validate("VAT %", 8.1);
+        VATPostingSetup.Validate("Reverse Chrg. VAT Acc.", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Foreign currency with exchange rate 1 = 0.81709 and rounding precision 0.01 (repro scenario).
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Modify(true);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate(), 1, 0.81709);
+
+        // [GIVEN] A purchase invoice in the foreign currency with a single line of 1,788.27 (repro scenario).
+        CreateGLAccount(GLAccount, Enum::"General Posting Type"::Purchase, GeneralPostingSetup, VATPostingSetup);
+        CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", WorkDate() + 1);
+        PurchaseHeader.Validate("Currency Code", Currency.Code);
+        PurchaseHeader.Modify(true);
+        DirectUnitCost := 1788.27;
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccount."No.", 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.CalcFields(Amount, "Amount Including VAT");
+        PurchaseHeader."Doc. Amount Incl. VAT" := PurchaseHeader."Amount Including VAT";
+        PurchaseHeader."Doc. Amount VAT" := PurchaseHeader."Amount Including VAT" - PurchaseHeader.Amount;
+        PurchaseHeader.Modify();
+
+        // [WHEN] Posting the purchase invoice.
+        PostedPurchaseInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Source Currency Amount on the reverse charge VAT entries equals the source-currency VAT amount
+        // calculated directly from the document (1,788.27 * 8.1% = 144.85), not a value re-derived from LCY.
+        ExpectedVATAmount := Round(DirectUnitCost * VATPostingSetup."VAT %" / 100, Currency."Amount Rounding Precision", '=');
+        VerifyReverseChargeVATSourceCurrencyAmounts(
+            PostedPurchaseInvoiceNo, Currency.Code, DirectUnitCost, ExpectedVATAmount,
+            VATPostingSetup, VendorPostingGroup, GLAccount."No.");
+    end;
+
+    [Test]
     [HandlerFunctions('ConfirmHandler')]
     procedure PurchaseInvoiceFullVATLCY()
     begin
@@ -2483,4 +2544,33 @@ codeunit 134897 "ERM Source Currency"
     begin
         Reply := true;
     end;
+
+    local procedure VerifyReverseChargeVATSourceCurrencyAmounts(PostedDocumentNo: Code[20]; CurrencyCode: Code[10]; DirectUnitCost: Decimal; ExpectedVATAmount: Decimal; VATPostingSetup: Record "VAT Posting Setup"; VendorPostingGroup: Record "Vendor Posting Group"; GLAccountNo: Code[20])
+    var
+        GLEntry: Record "G/L Entry";
+        Factor: Integer;
+        SCYBalance: Decimal;
+    begin
+        GetGLEntries(GLEntry, PostedDocumentNo, GLEntry."Document Type"::Invoice);
+        repeat
+            Assert.AreEqual(CurrencyCode, GLEntry."Source Currency Code", SourceCurrencyCodeErr);
+
+            Factor := GLEntry.Amount <> 0 ? GLEntry.Amount / Abs(GLEntry.Amount) : 1;
+            case GLEntry."G/L Account No." of
+                VATPostingSetup."Purchase VAT Account",
+                VATPostingSetup.GetRevChargeAccount(false):
+                    Assert.AreEqual(ExpectedVATAmount * Factor, GLEntry."Source Currency Amount", StrSubstNo(VATAmountIncorrectErr, DirectUnitCost, VATPostingSetup."VAT %"));
+                VendorPostingGroup.GetPayablesAccount():
+                    Assert.AreEqual(-DirectUnitCost, GLEntry."Source Currency Amount", BalancingAmountIncorrectErr);
+                GLAccountNo:
+                    Assert.AreEqual(DirectUnitCost, GLEntry."Source Currency Amount", AmountExclVATIncorrectErr);
+                else
+                    Error(UnexpectedAccountNoErr, GLEntry."G/L Account No.");
+            end;
+            SCYBalance += GLEntry."Source Currency Amount";
+        until GLEntry.Next() = 0;
+
+        Assert.AreEqual(0, SCYBalance, TotalSCYAmountNotZeroErr);
+    end;
+
 }

--- a/src/Layers/IT/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -621,12 +621,9 @@ codeunit 134897 "ERM Source Currency"
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         GLAccount: Record "G/L Account";
-        GLEntry: Record "G/L Entry";
         Currency: Record Currency;
         VendorNo: Code[20];
         PostedPurchaseInvoiceNo: Code[20];
-        Factor: Integer;
-        SCYBalance: Decimal;
         ExpectedVATAmount: Decimal;
         DirectUnitCost: Decimal;
     begin

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1135,19 +1135,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NO/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1058,14 +1058,21 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if not NonDeductibleVAT.IsNonDeductibleVATEnabled() then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1328,19 +1328,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/RU/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -1851,6 +1851,20 @@ codeunit 134897 "ERM Source Currency"
         PostedDeferralLine.FindSet();
     end;
 
+    local procedure CreateCurrencyExchangeRate(CurrencyCode: Code[10]; StartingDate: Date; ExchRateAmount: Decimal; RelationalExchRateAmount: Decimal)
+    var
+        CurrencyExchangeRate: Record "Currency Exchange Rate";
+    begin
+        CurrencyExchangeRate.Init();
+        CurrencyExchangeRate."Currency Code" := CurrencyCode;
+        CurrencyExchangeRate."Starting Date" := StartingDate;
+        CurrencyExchangeRate."Exchange Rate Amount" := ExchRateAmount;
+        CurrencyExchangeRate."Relational Exch. Rate Amount" := RelationalExchRateAmount;
+        CurrencyExchangeRate."Adjustment Exch. Rate Amount" := ExchRateAmount;
+        CurrencyExchangeRate."Relational Adjmt Exch Rate Amt" := RelationalExchRateAmount;
+        CurrencyExchangeRate.Insert(true);
+    end;
+
     local procedure UpdateAdjustForPaymentDiscount(var VATPostingSetup: Record "VAT Posting Setup")
     begin
         if VATPostingSetup."Adjust for Payment Discount" then begin

--- a/src/Layers/RU/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -606,6 +606,67 @@ codeunit 134897 "ERM Source Currency"
     end;
 
     [Test]
+    procedure PurchaseInvoiceReverseChargeVATFCYSourceCurrencyPreserved()
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        Currency: Record Currency;
+        VendorNo: Code[20];
+        PostedPurchaseInvoiceNo: Code[20];
+        Factor: Integer;
+        SCYBalance: Decimal;
+        ExpectedVATAmount: Decimal;
+        DirectUnitCost: Decimal;
+    begin
+        // [FEATURE] [AI test] [Purchase] [Invoice] [Reverse Charge VAT] [FCY] [Source Currency]
+        // [SCENARIO 647818] Source Currency VAT Amount on the reverse charge VAT G/L entries of a foreign-currency
+        // purchase invoice is preserved from the document, not recalculated from the rounded Amount (LCY).
+        Initialize();
+
+        // [GIVEN] Vendor with reverse charge VAT posting setup at 8.1% and a reverse charge VAT account (repro scenario).
+        VendorNo := CreateVendorWithNewPostingGroups(VendorPostingGroup, GeneralPostingSetup, VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Reverse Charge VAT");
+        VATPostingSetup.Validate("VAT %", 8.1);
+        VATPostingSetup.Validate("Reverse Chrg. VAT Acc.", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Foreign currency with exchange rate 1 = 0.81709 and rounding precision 0.01 (repro scenario).
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Modify(true);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate(), 1, 0.81709);
+
+        // [GIVEN] A purchase invoice in the foreign currency with a single line of 1,788.27 (repro scenario).
+        CreateGLAccount(GLAccount, Enum::"General Posting Type"::Purchase, GeneralPostingSetup, VATPostingSetup);
+        CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", WorkDate() + 1);
+        PurchaseHeader.Validate("Currency Code", Currency.Code);
+        PurchaseHeader.Modify(true);
+        DirectUnitCost := 1788.27;
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccount."No.", 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.CalcFields(Amount, "Amount Including VAT");
+        PurchaseHeader."Doc. Amount Incl. VAT" := PurchaseHeader."Amount Including VAT";
+        PurchaseHeader."Doc. Amount VAT" := PurchaseHeader."Amount Including VAT" - PurchaseHeader.Amount;
+        PurchaseHeader.Modify();
+
+        // [WHEN] Posting the purchase invoice.
+        PostedPurchaseInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Source Currency Amount on the reverse charge VAT entries equals the source-currency VAT amount
+        // calculated directly from the document (1,788.27 * 8.1% = 144.85), not a value re-derived from LCY.
+        ExpectedVATAmount := Round(DirectUnitCost * VATPostingSetup."VAT %" / 100, Currency."Amount Rounding Precision", '=');
+        VerifyReverseChargeVATSourceCurrencyAmounts(
+            PostedPurchaseInvoiceNo, Currency.Code, DirectUnitCost, ExpectedVATAmount,
+            VATPostingSetup, VendorPostingGroup, GLAccount."No.");
+    end;
+
+    [Test]
     procedure PurchaseInvoiceFullVATLCY()
     begin
         PurchaseInvoiceFullVAT(false);
@@ -1799,6 +1860,34 @@ codeunit 134897 "ERM Source Currency"
             VATPostingSetup."Adjust for Payment Discount" := false;
             VATPostingSetup.Modify();
         end;
+    end;
+
+    local procedure VerifyReverseChargeVATSourceCurrencyAmounts(PostedDocumentNo: Code[20]; CurrencyCode: Code[10]; DirectUnitCost: Decimal; ExpectedVATAmount: Decimal; VATPostingSetup: Record "VAT Posting Setup"; VendorPostingGroup: Record "Vendor Posting Group"; GLAccountNo: Code[20])
+    var
+        GLEntry: Record "G/L Entry";
+        Factor: Integer;
+        SCYBalance: Decimal;
+    begin
+        GetGLEntries(GLEntry, PostedDocumentNo, GLEntry."Document Type"::Invoice);
+        repeat
+            Assert.AreEqual(CurrencyCode, GLEntry."Source Currency Code", SourceCurrencyCodeErr);
+
+            Factor := GLEntry.Amount <> 0 ? GLEntry.Amount / Abs(GLEntry.Amount) : 1;
+            case GLEntry."G/L Account No." of
+                VATPostingSetup."Purchase VAT Account",
+                VATPostingSetup.GetRevChargeAccount(false):
+                    Assert.AreEqual(ExpectedVATAmount * Factor, GLEntry."Source Currency Amount", StrSubstNo(VATAmountIncorrectErr, DirectUnitCost, VATPostingSetup."VAT %"));
+                VendorPostingGroup.GetPayablesAccount():
+                    Assert.AreEqual(-DirectUnitCost, GLEntry."Source Currency Amount", BalancingAmountIncorrectErr);
+                GLAccountNo:
+                    Assert.AreEqual(DirectUnitCost, GLEntry."Source Currency Amount", AmountExclVATIncorrectErr);
+                else
+                    Error(UnexpectedAccountNoErr, GLEntry."G/L Account No.");
+            end;
+            SCYBalance += GLEntry."Source Currency Amount";
+        until GLEntry.Next() = 0;
+
+        Assert.AreEqual(0, SCYBalance, TotalSCYAmountNotZeroErr);
     end;
 
 }

--- a/src/Layers/RU/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -614,12 +614,9 @@ codeunit 134897 "ERM Source Currency"
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         GLAccount: Record "G/L Account";
-        GLEntry: Record "G/L Entry";
         Currency: Record Currency;
         VendorNo: Code[20];
         PostedPurchaseInvoiceNo: Code[20];
-        Factor: Integer;
-        SCYBalance: Decimal;
         ExpectedVATAmount: Decimal;
         DirectUnitCost: Decimal;
     begin

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -1050,19 +1050,26 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
     local procedure CreateReverseChargeVATGLEntries(GenJnlLine: Record "Gen. Journal Line"; VATPostingSetup: Record "VAT Posting Setup"; VATPostingParameters: Record "VAT Posting Parameters")
     var
+        FullVATAmountSrcCurr: Decimal;
         LastNextEntryNo: Integer;
     begin
         if VATPostingParameters."Unrealized VAT" or not (NonDeductibleVAT.IsNonDeductibleVATEnabled()) then begin
+            // Preserve the source-currency VAT amount from the document for system-created entries so the two
+            // offsetting reverse charge VAT entries balance to zero instead of being recalculated from rounded LCY.
+            if GenJnlLine."System-Created Entry" then
+                FullVATAmountSrcCurr := GenJnlLine."Source Curr. VAT Amount"
+            else
+                FullVATAmountSrcCurr := CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount");
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToPurchAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetPurchAccount(VATPostingParameters."Unrealized VAT"), VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, VATPostingParameters."Full VAT Amount"));
+                FullVATAmountSrcCurr);
             OnInsertVATOnBeforeCreateGLEntryForReverseChargeVATToRevChargeAcc(
                 GenJnlLine, VATPostingSetup, VATPostingParameters."Unrealized VAT", VATPostingParameters."Full VAT Amount", VATPostingParameters."Full VAT Amount ACY", true);
             CreateGLEntry(
                 GenJnlLine, VATPostingSetup.GetRevChargeAccount(VATPostingParameters."Unrealized VAT"), -VATPostingParameters."Full VAT Amount", -VATPostingParameters."Full VAT Amount ACY", true,
-                CalcAmountSrcCurr(GenJnlLine, -VATPostingParameters."Full VAT Amount"));
+                -FullVATAmountSrcCurr);
             exit;
         end;
         if VATPostingParameters."Non-Deductible VAT %" <> 100 then begin

--- a/src/Layers/W1/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -607,6 +607,67 @@ codeunit 134897 "ERM Source Currency"
     end;
 
     [Test]
+    procedure PurchaseInvoiceReverseChargeVATFCYSourceCurrencyPreserved()
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        GLEntry: Record "G/L Entry";
+        Currency: Record Currency;
+        VendorNo: Code[20];
+        PostedPurchaseInvoiceNo: Code[20];
+        Factor: Integer;
+        SCYBalance: Decimal;
+        ExpectedVATAmount: Decimal;
+        DirectUnitCost: Decimal;
+    begin
+        // [FEATURE] [AI test] [Purchase] [Invoice] [Reverse Charge VAT] [FCY] [Source Currency]
+        // [SCENARIO 647818] Source Currency VAT Amount on the reverse charge VAT G/L entries of a foreign-currency
+        // purchase invoice is preserved from the document, not recalculated from the rounded Amount (LCY).
+        Initialize();
+
+        // [GIVEN] Vendor with reverse charge VAT posting setup at 8.1% and a reverse charge VAT account (repro scenario).
+        VendorNo := CreateVendorWithNewPostingGroups(VendorPostingGroup, GeneralPostingSetup, VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Reverse Charge VAT");
+        VATPostingSetup.Validate("VAT %", 8.1);
+        VATPostingSetup.Validate("Reverse Chrg. VAT Acc.", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Modify(true);
+
+        // [GIVEN] Foreign currency with exchange rate 1 = 0.81709 and rounding precision 0.01 (repro scenario).
+        Currency.Get(LibraryERM.CreateCurrencyWithGLAccountSetup());
+        Currency.Validate("Amount Rounding Precision", 0.01);
+        Currency.Modify(true);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate(), 1, 0.81709);
+
+        // [GIVEN] A purchase invoice in the foreign currency with a single line of 1,788.27 (repro scenario).
+        CreateGLAccount(GLAccount, Enum::"General Posting Type"::Purchase, GeneralPostingSetup, VATPostingSetup);
+        CreatePurchaseHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", WorkDate() + 1);
+        PurchaseHeader.Validate("Currency Code", Currency.Code);
+        PurchaseHeader.Modify(true);
+        DirectUnitCost := 1788.27;
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccount."No.", 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        PurchaseHeader.CalcFields(Amount, "Amount Including VAT");
+        PurchaseHeader."Doc. Amount Incl. VAT" := PurchaseHeader."Amount Including VAT";
+        PurchaseHeader."Doc. Amount VAT" := PurchaseHeader."Amount Including VAT" - PurchaseHeader.Amount;
+        PurchaseHeader.Modify();
+
+        // [WHEN] Posting the purchase invoice.
+        PostedPurchaseInvoiceNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Source Currency Amount on the reverse charge VAT entries equals the source-currency VAT amount
+        // calculated directly from the document (1,788.27 * 8.1% = 144.85), not a value re-derived from LCY.
+        ExpectedVATAmount := Round(DirectUnitCost * VATPostingSetup."VAT %" / 100, Currency."Amount Rounding Precision", '=');
+        VerifyReverseChargeVATSourceCurrencyAmounts(
+            PostedPurchaseInvoiceNo, Currency.Code, DirectUnitCost, ExpectedVATAmount,
+            VATPostingSetup, VendorPostingGroup, GLAccount."No.");
+    end;
+
+    [Test]
     procedure PurchaseInvoiceFullVATLCY()
     begin
         PurchaseInvoiceFullVAT(false);
@@ -2464,6 +2525,34 @@ codeunit 134897 "ERM Source Currency"
             VATPostingSetup."Adjust for Payment Discount" := false;
             VATPostingSetup.Modify();
         end;
+    end;
+
+    local procedure VerifyReverseChargeVATSourceCurrencyAmounts(PostedDocumentNo: Code[20]; CurrencyCode: Code[10]; DirectUnitCost: Decimal; ExpectedVATAmount: Decimal; VATPostingSetup: Record "VAT Posting Setup"; VendorPostingGroup: Record "Vendor Posting Group"; GLAccountNo: Code[20])
+    var
+        GLEntry: Record "G/L Entry";
+        Factor: Integer;
+        SCYBalance: Decimal;
+    begin
+        GetGLEntries(GLEntry, PostedDocumentNo, GLEntry."Document Type"::Invoice);
+        repeat
+            Assert.AreEqual(CurrencyCode, GLEntry."Source Currency Code", SourceCurrencyCodeErr);
+
+            Factor := GLEntry.Amount <> 0 ? GLEntry.Amount / Abs(GLEntry.Amount) : 1;
+            case GLEntry."G/L Account No." of
+                VATPostingSetup."Purchase VAT Account",
+                VATPostingSetup.GetRevChargeAccount(false):
+                    Assert.AreEqual(ExpectedVATAmount * Factor, GLEntry."Source Currency Amount", StrSubstNo(VATAmountIncorrectErr, DirectUnitCost, VATPostingSetup."VAT %"));
+                VendorPostingGroup.GetPayablesAccount():
+                    Assert.AreEqual(-DirectUnitCost, GLEntry."Source Currency Amount", BalancingAmountIncorrectErr);
+                GLAccountNo:
+                    Assert.AreEqual(DirectUnitCost, GLEntry."Source Currency Amount", AmountExclVATIncorrectErr);
+                else
+                    Error(UnexpectedAccountNoErr, GLEntry."G/L Account No.");
+            end;
+            SCYBalance += GLEntry."Source Currency Amount";
+        until GLEntry.Next() = 0;
+
+        Assert.AreEqual(0, SCYBalance, TotalSCYAmountNotZeroErr);
     end;
 
 }

--- a/src/Layers/W1/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Finance/ERMSourceCurrency.Codeunit.al
@@ -615,12 +615,9 @@ codeunit 134897 "ERM Source Currency"
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         GLAccount: Record "G/L Account";
-        GLEntry: Record "G/L Entry";
         Currency: Record Currency;
         VendorNo: Code[20];
         PostedPurchaseInvoiceNo: Code[20];
-        Factor: Integer;
-        SCYBalance: Decimal;
         ExpectedVATAmount: Decimal;
         DirectUnitCost: Decimal;
     begin


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->


What & why
There is a rounding issue when Source Currency Amount calculation causes discrepancies with Foreign Currency G/L Entries whit Reversal Charge VAT.

See 
<img width="1776" height="312" alt="image" src="https://github.com/user-attachments/assets/2ffe0d67-008c-48c9-9d14-90ee23647365" />


The fix is simply to with the amount in currency. i dd "TDT" by publishing and run the test that filed until i published the fix 


<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#647818](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647818)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->







