### PR TITLE
[Shopify] Optimize unmapped cue counts

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyCue.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyCue.Table.al
@@ -26,13 +26,13 @@ table 30100 "Shpfy Cue"
         }
         field(2; "Unmapped Customers"; Integer)
         {
-            CalcFormula = count("Shpfy Customer" where("Customer No." = const('')));
+            CalcFormula = count("Shpfy Customer" where("Customer SystemId" = const('00000000-0000-0000-0000-000000000000')));
             Caption = 'Unmapped Customers';
             FieldClass = FlowField;
         }
         field(3; "Unmapped Products"; Integer)
         {
-            CalcFormula = count("Shpfy Product" where("Item No." = const('')));
+            CalcFormula = count("Shpfy Product" where("Item SystemId" = const('00000000-0000-0000-0000-000000000000')));
             Caption = 'Unmapped Products';
             FieldClass = FlowField;
         }
@@ -81,7 +81,7 @@ table 30100 "Shpfy Cue"
         }
         field(9; "Unmapped Companies"; Integer)
         {
-            CalcFormula = count("Shpfy Company" where("Customer No." = const('')));
+            CalcFormula = count("Shpfy Company" where("Customer SystemId" = const('00000000-0000-0000-0000-000000000000')));
             Caption = 'Unmapped Companies';
             FieldClass = FlowField;
         }

--- a/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyProduct.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyProduct.Table.al
@@ -168,6 +168,9 @@ table 30127 "Shpfy Product"
         key(Key2; "Shop Code", "Item SystemId")
         {
         }
+        key(Key3; "Item SystemId")
+        {
+        }
     }
 
     trigger OnDelete()


### PR DESCRIPTION
## Summary

The Shopify Activities cues for unmapped customers, products, and companies currently count records through lookup FlowFields. Business Central cannot push those predicates into a SQL aggregate, so it materializes the source tables and evaluates the lookup row by row on every Role Center refresh.

## Change

- Count empty stored Customer/Item SystemId fields so SQL can execute a direct `COUNT(*)`.
- Add a key led by `Item SystemId` so the global unmapped-product count can seek without an unconstrained `Shop Code` prefix.

## Behavioral note

A record with a nonempty SystemId that points to a deleted Customer or Item is no longer included in the cue. Such dangling mappings are a separate data-integrity concern.

Fixes [AB#648153](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648153)



