### PR TITLE
Fix extensibility triage comment pagination

### DIFF
--- a/.github/scripts/bc-extrequest-triage/find-eligible-issues.ps1
+++ b/.github/scripts/bc-extrequest-triage/find-eligible-issues.ps1
@@ -45,8 +45,9 @@ foreach ($issue in $issues) {
     }
 
     $commentsJson = gh api "repos/$($env:GITHUB_REPOSITORY)/issues/$($issue.number)/comments" `
-        --paginate --slurp --jq 'add // []'
-    $comments = @($commentsJson | ConvertFrom-Json)
+        --paginate --slurp
+    $commentPages = $commentsJson | ConvertFrom-Json
+    $comments = @($commentPages | ForEach-Object { $_ })
     $hasNotAccurateFeedback = $null -ne (
         $comments |
             Where-Object {


### PR DESCRIPTION
## What & why

The extensibility request triage dispatcher fails in the **Find eligible issues** step, as seen in [workflow run 33175952298](https://github.com/microsoft/BCApps/actions/runs/33175952298/job/98864490544).

The comments request combines `gh api --slurp` with `--jq`, but GitHub CLI does not support using `--slurp` together with `--jq` or `--template`. The command exits with code 1, and PowerShell stops the dispatcher before it can classify any eligible issues.

Fixes [AB#646910](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646910)

## Change

- Remove the incompatible `--jq 'add // []'` option from the paginated comments request.
- Deserialize the slurped response in PowerShell.
- Flatten the comment pages using the same pattern already used for paginated issues in this script.

This preserves pagination while allowing the dispatcher to inspect `/not-accurate` feedback comments without terminating.

## Validation

- Confirmed the PowerShell script parses without diagnostics.
- Confirmed a paginated comments response can be deserialized and flattened with the updated logic.


