### PR TITLE
[Backport 29.x] Harden Contact Sync delta URL and ownership checks (#9966)

### DIFF
--- a/src/Layers/CZ/Tests/User/TestUserTasks.Codeunit.al
+++ b/src/Layers/CZ/Tests/User/TestUserTasks.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 134769 "Test User Tasks"
         UserTaskGroupMember: Record "User Task Group Member";
         Assert: Codeunit Assert;
         LibraryUtility: Codeunit "Library - Utility";
+        RecordsWithNewUsernameErr: Label 'Records with new username should exist in %1.', Comment = '%1 = table name';
 
     [Test]
     [Scope('OnPrem')]
@@ -164,6 +165,84 @@ codeunit 134769 "Test User Tasks"
 
         UserTask2.Get(UserTask.ID);
         Assert.AreEqual('Vytvorení úcetního období pro rok 2018', UserTask2.GetDescription(), 'Unexpected value in the Task Description');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestRenameUser()
+    var
+        User: Record User;
+        FieldRec: Record "Field";
+        Company: Record Company;
+        TableInformation: Record "Table Information";
+        TempTablesAlreadyInserted: Record Integer temporary;
+        UserCodeunit: Codeunit User;
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        // [GIVEN] Create data for tables with fields having relation with User table
+        Company.FindFirst();
+        FieldRec.SetFilter(ObsoleteState, '<>%1', FieldRec.ObsoleteState::Removed);
+        FieldRec.SetRange(RelationTableNo, DATABASE::User);
+        FieldRec.SetRange(RelationFieldNo, User.FieldNo("User Name"));
+        FieldRec.SetFilter(Type, '%1|%2', FieldRec.Type::Code, FieldRec.Type::Text);
+        if FieldRec.FindSet() then
+            repeat
+                if not SkipTable(FieldRec.TableNo) then begin
+                    TableInformation.SetFilter("Company Name", '%1|%2', '', Company.Name);
+                    TableInformation.SetRange("Table No.", FieldRec.TableNo);
+                    if TableInformation.FindFirst() then begin
+                        RecRef.Open(FieldRec.TableNo, false, Company.Name);
+                        if TempTablesAlreadyInserted.Get(FieldRec.TableNo) then begin
+                            RecRef.FindFirst();
+                            FldRef := RecRef.Field(FieldRec."No.");
+                            FldRef.Value('OLD');
+                            RecRef.Modify();
+                        end else begin
+                            RecRef.DeleteAll();
+                            RecRef.Init();
+                            FldRef := RecRef.Field(FieldRec."No.");
+                            FldRef.Value('OLD');
+                            RecRef.Insert();
+
+                            TempTablesAlreadyInserted.Init();
+                            TempTablesAlreadyInserted.Number := FieldRec.TableNo;
+                            TempTablesAlreadyInserted.Insert();
+                        end;
+                        RecRef.Close();
+                    end;
+                end;
+            until FieldRec.Next() = 0;
+
+        // [WHEN] RenameUser is invoked
+        UserCodeunit.RenameUser('OLD', 'NEW');
+
+        // [THEN] The data in the table fields has been updated
+        if FieldRec.FindSet() then
+            repeat
+                TableInformation.SetFilter("Company Name", '%1|%2', '', Company.Name);
+                TableInformation.SetRange("Table No.", FieldRec.TableNo);
+                if TableInformation.FindFirst() then
+                    if not SkipTable(FieldRec.TableNo) then begin
+                        RecRef.Open(FieldRec.TableNo, false, Company.Name);
+                        FldRef := RecRef.Field(FieldRec."No.");
+                        FldRef.SetRange('NEW');
+                        Assert.AreEqual(1, RecRef.Count(), StrSubstNo(RecordsWithNewUsernameErr, TableInformation."Table Name"));
+                        RecRef.Close();
+                    end;
+            until FieldRec.Next() = 0;
+    end;
+
+    local procedure SkipTable(TableNo: Integer): Boolean
+    begin
+        if TableNo = DATABASE::"Fin. Report Package Recipient" then
+            exit(true);
+        if TableNo = DATABASE::"Contact Sync User" then
+            exit(true);
+        if TableNo = 11745 then
+            exit(true);
+        exit(false);
     end;
 
     [Test]

--- a/src/Layers/DACH/Tests/User/TestUserTasks.Codeunit.al
+++ b/src/Layers/DACH/Tests/User/TestUserTasks.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 134769 "Test User Tasks"
         UserTaskGroupMember: Record "User Task Group Member";
         Assert: Codeunit Assert;
         LibraryUtility: Codeunit "Library - Utility";
+        RecordsWithNewUsernameErr: Label 'Records with new username should exist in %1.', Comment = '%1 = table name';
 
     [Test]
     [Scope('OnPrem')]
@@ -164,6 +165,82 @@ codeunit 134769 "Test User Tasks"
 
         UserTask2.Get(UserTask.ID);
         Assert.AreEqual('Vytvorení úcetního období pro rok 2018', UserTask2.GetDescription(), 'Unexpected value in the Task Description');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure TestRenameUser()
+    var
+        User: Record User;
+        FieldRec: Record "Field";
+        Company: Record Company;
+        TableInformation: Record "Table Information";
+        TempTablesAlreadyInserted: Record Integer temporary;
+        UserCodeunit: Codeunit User;
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        // [GIVEN] Create data for tables with fields having relation with User table
+        Company.FindFirst();
+        FieldRec.SetFilter(ObsoleteState, '<>%1', FieldRec.ObsoleteState::Removed);
+        FieldRec.SetRange(RelationTableNo, DATABASE::User);
+        FieldRec.SetRange(RelationFieldNo, User.FieldNo("User Name"));
+        FieldRec.SetFilter(Type, '%1|%2', FieldRec.Type::Code, FieldRec.Type::Text);
+        if FieldRec.FindSet() then
+            repeat
+                if not SkipTable(FieldRec.TableNo) then begin
+                    TableInformation.SetFilter("Company Name", '%1|%2', '', Company.Name);
+                    TableInformation.SetRange("Table No.", FieldRec.TableNo);
+                    if TableInformation.FindFirst() then begin
+                        RecRef.Open(FieldRec.TableNo, false, Company.Name);
+                        if TempTablesAlreadyInserted.Get(FieldRec.TableNo) then begin
+                            RecRef.FindFirst();
+                            FldRef := RecRef.Field(FieldRec."No.");
+                            FldRef.Value('OLD');
+                            RecRef.Modify();
+                        end else begin
+                            RecRef.DeleteAll();
+                            RecRef.Init();
+                            FldRef := RecRef.Field(FieldRec."No.");
+                            FldRef.Value('OLD');
+                            RecRef.Insert();
+
+                            TempTablesAlreadyInserted.Init();
+                            TempTablesAlreadyInserted.Number := FieldRec.TableNo;
+                            TempTablesAlreadyInserted.Insert();
+                        end;
+                        RecRef.Close();
+                    end;
+                end;
+            until FieldRec.Next() = 0;
+
+        // [WHEN] RenameUser is invoked
+        UserCodeunit.RenameUser('OLD', 'NEW');
+
+        // [THEN] The data in the table fields has been updated
+        if FieldRec.FindSet() then
+            repeat
+                TableInformation.SetFilter("Company Name", '%1|%2', '', Company.Name);
+                TableInformation.SetRange("Table No.", FieldRec.TableNo);
+                if TableInformation.FindFirst() then
+                    if not SkipTable(FieldRec.TableNo) then begin
+                        RecRef.Open(FieldRec.TableNo, false, Company.Name);
+                        FldRef := RecRef.Field(FieldRec."No.");
+                        FldRef.SetRange('NEW');
+                        Assert.AreEqual(1, RecRef.Count(), StrSubstNo(RecordsWithNewUsernameErr, TableInformation."Table Name"));
+                        RecRef.Close();
+                    end;
+            until FieldRec.Next() = 0;
+    end;
+
+    local procedure SkipTable(TableNo: Integer): Boolean
+    begin
+        if TableNo = DATABASE::"Fin. Report Package Recipient" then
+            exit(true);
+        if TableNo = DATABASE::"Contact Sync User" then
+            exit(true);
+        exit(false);
     end;
 
     [Test]

--- a/src/Layers/W1/BaseApp/CRM/Outlook/ContactSync.Page.al
+++ b/src/Layers/W1/BaseApp/CRM/Outlook/ContactSync.Page.al
@@ -126,12 +126,6 @@ page 7100 "Contact Sync"
                             end;
                         end;
                     }
-                    field(fullSyncField; FullSyncOption)
-                    {
-                        ApplicationArea = All;
-                        Caption = 'Force full sync';
-                        ToolTip = 'When this is enabled, Business Central will synchronize contacts no matter when they were last modified. This may take longer, but can overcome some synchronization issues.';
-                    }
                     field(PreviewText; PreviewTextLbl)
                     {
                         ApplicationArea = All;
@@ -149,6 +143,39 @@ page 7100 "Contact Sync"
                         MultiLine = false;
                         ShowCaption = false;
                         Style = Subordinate;
+                    }
+                    group(AdvancedGroup)
+                    {
+                        Caption = 'Advanced';
+
+                        group(ClearSyncDetailsGroup)
+                        {
+                            Caption = '';
+                            field(fullSyncField; FullSyncOption)
+                            {
+                                ApplicationArea = All;
+                                Caption = 'Force full sync';
+                                ToolTip = 'When this is enabled, Business Central will synchronize contacts no matter when they were last modified. This may take longer, but can overcome some synchronization issues.';
+                            }
+                            field(ClearSyncDetailsField; ClearSyncDetailsLbl)
+                            {
+                                ApplicationArea = All;
+                                Caption = '';
+                                Editable = false;
+                                ShowCaption = false;
+                                Style = StandardAccent;
+                                StyleExpr = true;
+
+                                trigger OnDrillDown()
+                                begin
+                                    if Confirm(ClearLastSyncConfirmMsg) then begin
+                                        ClearSyncRecordsForCurrentUser();
+                                        Message(LastSyncClearedMsg);
+                                        GoToStep(Step::Welcome);
+                                    end;
+                                end;
+                            }
+                        }
                     }
                 }
             }
@@ -521,10 +548,18 @@ page 7100 "Contact Sync"
         end
         else
             if not (NewDeltaLink = '') then begin
-                ContactSyncUserRec.SetDeltaUrl(CopyStr(NewDeltaLink, 1, 2048));
                 ContactSyncUserRec."Last Sync Date Time" := CurrentDateTime();
-                ContactSyncUserRec.Modify(false);
+                ContactSyncUserRec.SetDeltaUrl(CopyStr(NewDeltaLink, 1, 2048));
             end;
+    end;
+
+    local procedure ClearSyncRecordsForCurrentUser()
+    var
+        ContactSyncUserRec: Record "Contact Sync User";
+    begin
+        ContactSyncUserRec.SetRange("User ID", CopyStr(UserId(), 1, 50));
+        if not ContactSyncUserRec.IsEmpty() then
+            ContactSyncUserRec.DeleteAll();
     end;
 
     local procedure GoToStep(NewStep: Option)
@@ -651,6 +686,9 @@ page 7100 "Contact Sync"
         NewLineChar: Char;
         Deltalink: Text;
         SyncDirection: Enum "ContactSyncDirection";
+        ClearLastSyncConfirmMsg: Label 'This will delete the internal log of your last synchronization, but will not modify any contacts you have synchronized to date. Do you want to proceed?';
+        ClearSyncDetailsLbl: Label 'Clear last sync details';
+        LastSyncClearedMsg: Label 'Your last synchronization details were cleared. Choose ok to start over.';
         ContactsSentToM365Count: Integer;
         ContactsSentToBCCount: Integer;
         ContactsFailedCount: Integer;

--- a/src/Layers/W1/BaseApp/CRM/Outlook/ContactSyncUser.Table.al
+++ b/src/Layers/W1/BaseApp/CRM/Outlook/ContactSyncUser.Table.al
@@ -1,5 +1,6 @@
 namespace Microsoft.CRM.Outlook;
 using System.Security.AccessControl;
+using System.Utilities;
 
 table 7121 "Contact Sync User"
 {
@@ -67,6 +68,9 @@ table 7121 "Contact Sync User"
         if "ID" = 0 then
             exit;
 
+        if not ValidateApprovedGraphDeltaUrl(NewDeltaUrl) then
+            exit;
+
         "Delta Url" := CopyStr(NewDeltaUrl, 1, MaxStrLen("Delta Url"));
         if StrLen(NewDeltaUrl) > MaxStrLen("Delta Url") then
             Session.LogMessage('0000SET', StrSubstNo(DeltaUrlTruncatedTelemetryMsg, StrLen(NewDeltaUrl)), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Contact Sync');
@@ -78,6 +82,46 @@ table 7121 "Contact Sync User"
         exit("Delta Url");
     end;
 
+    internal procedure EnforceRecordOwnership()
+    begin
+        if Session.GetExecutionContext() in [ExecutionContext::Install, ExecutionContext::Upgrade] then
+            exit;
+
+        if "User ID" <> CopyStr(UserId(), 1, MaxStrLen("User ID")) then
+            Error(CannotModifyOtherUsersSyncErr);
+    end;
+
+    internal procedure EnforceRecordOwnershipOnModify(OriginalUserId: Code[50])
+    begin
+        if Session.GetExecutionContext() in [ExecutionContext::Install, ExecutionContext::Upgrade] then
+            exit;
+
+        if "User ID" <> OriginalUserId then
+            Error(CannotChangeRecordOwnerErr);
+
+        if OriginalUserId <> CopyStr(UserId(), 1, MaxStrLen("User ID")) then
+            Error(CannotModifyOtherUsersSyncErr);
+    end;
+
+    internal procedure ValidateApprovedGraphDeltaUrl(DeltaUrlToValidate: Text): Boolean
+    var
+        Uri: Codeunit Uri;
+        IsApproved: Boolean;
+    begin
+        if DeltaUrlToValidate = '' then
+            exit(true);
+        IsApproved := Uri.ValidateIntegrationURL(LowerCase(DeltaUrlToValidate), LowerCase(GraphUrlPrefixLbl)) = LowerCase(DeltaUrlToValidate);
+        if not IsApproved then
+            Session.LogMessage('0000V1Y', StrSubstNo(DeltaUrlValidationTelemetryMsg, DeltaUrlToValidate, IsApproved, InvalidDeltaUrlErr), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', 'Contact Sync');
+        exit(IsApproved);
+    end;
+
     var
         DeltaUrlTruncatedTelemetryMsg: Label 'Delta URL was truncated for user Original length: %1', Locked = true, Comment = '%1 = original Delta URL length';
+        CannotModifyOtherUsersSyncErr: Label 'You can only modify Contact Sync settings for your own user.';
+        CannotChangeRecordOwnerErr: Label 'You cannot change the owner of an existing Contact Sync record.';
+        InvalidDeltaUrlErr: Label 'The Delta URL must be an HTTPS Microsoft Graph URL.';
+        GraphUrlPrefixLbl: Label 'https://graph.microsoft.com/v1.0/', Locked = true;
+        DeltaUrlValidationTelemetryMsg: Label 'Contact Sync delta URL validation. URL: %1; Approved: %2; context : %3', Locked = true, Comment = '%1 = delta URL, %2 = whether URL is approved, %3 = invalid delta url';
 }
+

--- a/src/Layers/W1/BaseApp/CRM/Outlook/ContactSyncUserSubscriber.Codeunit.al
+++ b/src/Layers/W1/BaseApp/CRM/Outlook/ContactSyncUserSubscriber.Codeunit.al
@@ -1,0 +1,33 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.CRM.Outlook;
+
+codeunit 7100 "Contact Sync User Subscriber"
+{
+    Access = Internal;
+
+    [EventSubscriber(ObjectType::Table, Database::"Contact Sync User", 'OnBeforeInsertEvent', '', false, false)]
+    local procedure OnBeforeInsertContactSyncUser(var Rec: Record "Contact Sync User"; RunTrigger: Boolean)
+    begin
+        Rec.EnforceRecordOwnership();
+        if not Rec.ValidateApprovedGraphDeltaUrl(Rec."Delta Url") then
+            Error(InvalidDeltaUrlErr);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Contact Sync User", 'OnBeforeModifyEvent', '', false, false)]
+    local procedure OnBeforeModifyContactSyncUser(RunTrigger: Boolean; var Rec: Record "Contact Sync User"; var xRec: Record "Contact Sync User")
+    begin
+        // Allow upgrade/data-fix updates on legacy rows unless Delta Url is being changed.
+        if Session.GetExecutionContext() in [ExecutionContext::Install, ExecutionContext::Upgrade] then
+            exit;
+        Rec.EnforceRecordOwnershipOnModify(xRec."User ID");
+        if not Rec.ValidateApprovedGraphDeltaUrl(Rec."Delta Url") then
+            Error(InvalidDeltaUrlErr);
+    end;
+
+    var
+        InvalidDeltaUrlErr: Label 'The Delta URL must be an HTTPS Microsoft Graph URL.';
+}
+

--- a/src/Layers/W1/BaseApp/CRM/Outlook/O365BidirectionalSync.Codeunit.al
+++ b/src/Layers/W1/BaseApp/CRM/Outlook/O365BidirectionalSync.Codeunit.al
@@ -1,5 +1,6 @@
 namespace Microsoft.CRM.Outlook;
 using Microsoft.CRM.Contact;
+using System.Utilities;
 
 codeunit 7106 "O365 Bidirectional Sync"
 {
@@ -16,6 +17,7 @@ codeunit 7106 "O365 Bidirectional Sync"
         NoContactFoldersMsg: Label 'No contact folders found in the response.';
         AccessTokenEmptyMsg: Label 'Access token cannot be empty';
         DefaultFolderTxt: Label 'Default', Locked = true, Comment = 'Default folder Name';
+        GraphUrlPrefixTxt: Label 'https://graph.microsoft.com/v1.0/', Locked = true;
         GraphApiUrlTxt: Label 'https://graph.microsoft.com/v1.0/me/contactFolders/', Locked = true;
         DeltaUrlTxt: Label '/contacts/delta', Locked = true;
         ExistingEmails: Dictionary of [Text, Boolean];
@@ -96,6 +98,8 @@ codeunit 7106 "O365 Bidirectional Sync"
         AccessTokenEmptyTeleTxt: Label 'Access token is empty', Locked = true;
         InvalidJsonTeleTxt: Label 'Invalid JSON response received from Microsoft Graph', Locked = true;
         NetworkErrorTeleTxt: Label 'Network error occurred: %1', Locked = true, Comment = '%1 = error description';
+        InvalidGraphDeltaUrlResetTxt: Label 'Invalid Contact Sync delta URL detected for folder %1. Falling back to full sync.', Locked = true, Comment = '%1 = folder id';
+        InvalidGraphEndpointErr: Label 'The contact sync endpoint is invalid. Please run a full synchronization to continue.';
 #if not CLEAN29
     [Obsolete('Removed due to Contact Sync redesign, will be deleted in future release.', '29.0')]
     procedure GetContacts(AccessToken: SecretText; var OutSyncQueue: Record "Contact Sync Queue" temporary; ContactFilterText: Text; FolderId: Text)
@@ -140,6 +144,13 @@ codeunit 7106 "O365 Bidirectional Sync"
         end;
         Uri := '';
         DeltaUrl := GetDeltaUrl(FolderId);
+        if not IsApprovedGraphRequestUri(DeltaUrl) then begin
+            if DeltaUrl <> '' then
+                Session.LogMessage('0000UX8', StrSubstNo(InvalidGraphDeltaUrlResetTxt, FolderId), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', getTracecat());
+            DeltaUrl := '';
+            UpdateDeltaUrl(FolderId, '');
+        end;
+
         if not FullSync then begin
             if DeltaUrl = '' then begin
                 if not Confirm(CustomSyncMsg) then
@@ -168,6 +179,9 @@ codeunit 7106 "O365 Bidirectional Sync"
                     ExistingEmails.Add(NormalizeEmail(O365Records."Email Address"), true);
             until O365Records.Next() = 0;
         repeat
+            if not IsApprovedGraphRequestUri(Uri) then
+                Error(InvalidGraphEndpointErr);
+
             if not HttpClient.Get(Uri, HttpResponse) then begin
                 Session.LogMessage('0000QTA', StrSubstNo(NetworkErrorTeleTxt, HttpGetRequestFailedTxt), Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', getTracecat());
                 Error(NetworkErrorMsg);
@@ -191,6 +205,8 @@ codeunit 7106 "O365 Bidirectional Sync"
                 if JsonObj.Contains(ODataNextLinkPropertyTxt) then begin
                     JsonObj.Get(ODataNextLinkPropertyTxt, JsonValue);
                     NextLink := JsonValue.AsValue().AsText();
+                    if not IsApprovedGraphRequestUri(NextLink) then
+                        Error(InvalidGraphEndpointErr);
                     Session.LogMessage('0000QTG', StrSubstNo(PaginationNextLinkTxt, NextLink), Verbosity::Verbose, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', getTracecat());
                 end else begin
                     NextLink := '';
@@ -199,6 +215,8 @@ codeunit 7106 "O365 Bidirectional Sync"
                 if JsonObj.Contains(ODataDeltaPropertyTxt) then begin
                     JsonObj.Get(ODataDeltaPropertyTxt, JsonValue);
                     DeltaLink := JsonValue.AsValue().AsText();
+                    if not IsApprovedGraphRequestUri(DeltaLink) then
+                        Error(InvalidGraphEndpointErr);
                 end;
             end;
 
@@ -227,11 +245,9 @@ codeunit 7106 "O365 Bidirectional Sync"
         ContactSyncUserRec.SetCurrentKey("User ID", "Folder ID");
         ContactSyncUserRec.SetRange("User ID", CopyStr(UserId(), 1, 50));
         ContactSyncUserRec.SetRange("Folder ID", CopyStr(FolderId, 1, 250));
-        ContactSyncUserRec.SetLoadFields("Delta Url");
-        if ContactSyncUserRec.FindFirst() and not (NewDeltaLink = '') then begin
+        ContactSyncUserRec.SetLoadFields("Delta Url", "User ID");
+        if ContactSyncUserRec.FindFirst() then
             ContactSyncUserRec.SetDeltaUrl(CopyStr(NewDeltaLink, 1, 2048));
-            ContactSyncUserRec.Modify(false);
-        end;
     end;
 
     local procedure DoFullSync(FolderId: Text; var O365Records: Record "Outlook Contacts"; var Uri: Text)
@@ -459,6 +475,16 @@ codeunit 7106 "O365 Bidirectional Sync"
         if ContactSyncUserRec.FindFirst() then
             exit(ContactSyncUserRec.GetDeltaUrl());
         exit('');
+    end;
+
+    local procedure IsApprovedGraphRequestUri(UriToValidate: Text): Boolean
+    var
+        Uri: Codeunit Uri;
+    begin
+        if UriToValidate = '' then
+            exit(true);
+
+        exit(Uri.ValidateIntegrationURL(LowerCase(UriToValidate), LowerCase(GraphUrlPrefixTxt)) = LowerCase(UriToValidate));
     end;
 
     local procedure GetSecondaryEmailAddress(JsonObject: JsonObject): Text

--- a/src/Layers/W1/Tests/CRM integration/ContactSyncTest.Codeunit.al
+++ b/src/Layers/W1/Tests/CRM integration/ContactSyncTest.Codeunit.al
@@ -12,6 +12,8 @@ codeunit 130481 "Contact Sync Test"
         ActualMessageText: Text;
         MessageHandlerCalled: Boolean;
         ContactsSyncedMsg: Label '%1 contacts have been synchronized successfully.', Comment = '%1 = Number of synced contacts';
+        CannotModifyOtherUsersSyncErr: Label 'You can only modify Contact Sync settings for your own user.';
+        InvalidDeltaUrlErr: Label 'The Delta URL must be an HTTPS Microsoft Graph URL.';
 
     [Test]
     [HandlerFunctions('SyncSuccessMessageHandler')]
@@ -497,6 +499,117 @@ codeunit 130481 "Contact Sync Test"
         AssertAreEqual('+1-555-0102', TempSyncQueue."Home Phone", 'Home Phone should match');
     end;
 
+    [Test]
+    procedure TestContactSyncUserInsertFailsForDifferentUser()
+    var
+        ContactSyncUser: Record "Contact Sync User";
+    begin
+        // [SCENARIO] Inserting a Contact Sync User record for another user should fail.
+        Initialize();
+
+        // [GIVEN] A Contact Sync User record owned by another user
+        ContactSyncUser.Init();
+        ContactSyncUser."User ID" := 'ANOTHERUSER';
+        ContactSyncUser."Folder ID" := 'folder-insert-owner';
+
+        // [WHEN] Insert is executed
+        asserterror ContactSyncUser.Insert(true);
+
+        // [THEN] Ownership validation should reject the insert
+        AssertIsTrue(StrPos(GetLastErrorText(), CannotModifyOtherUsersSyncErr) > 0, 'Expected ownership error. Actual: ' + GetLastErrorText());
+    end;
+
+    [Test]
+    procedure TestContactSyncUserModifyFailsWhenChangingOwner()
+    var
+        ContactSyncUser: Record "Contact Sync User";
+        ContactSyncUserToModify: Record "Contact Sync User";
+    begin
+        // [SCENARIO] Changing owner on an existing Contact Sync User record should fail.
+        Initialize();
+
+        // [GIVEN] A Contact Sync User record owned by the current user
+        CreateContactSyncUserForCurrentUser(ContactSyncUser, 'folder-owner-change', '');
+        ContactSyncUserToModify.Get(ContactSyncUser."ID");
+        ContactSyncUserToModify."User ID" := 'ANOTHERUSER';
+
+        // [WHEN] Modify is executed with a changed owner
+        asserterror ContactSyncUserToModify.Modify(true);
+
+        // [THEN] Ownership validation should reject the modify
+        AssertIsTrue(StrPos(GetLastErrorText(), CannotModifyOtherUsersSyncErr) > 0, 'Expected ownership error. Actual: ' + GetLastErrorText());
+
+        if ContactSyncUser.Get(ContactSyncUser."ID") then
+            ContactSyncUser.Delete();
+    end;
+
+    [Test]
+    procedure TestContactSyncUserInsertFailsWithInvalidDeltaUrl()
+    var
+        ContactSyncUser: Record "Contact Sync User";
+    begin
+        // [SCENARIO] Inserting Contact Sync User with non-Graph Delta URL should fail.
+        Initialize();
+
+        // [GIVEN] A Contact Sync User record with invalid Delta URL
+        ContactSyncUser.Init();
+        ContactSyncUser."User ID" := CopyStr(UserId(), 1, MaxStrLen(ContactSyncUser."User ID"));
+        ContactSyncUser."Folder ID" := 'folder-invalid-insert-url';
+        ContactSyncUser."Delta Url" := 'https://contoso.example.com/v1.0/me/contactFolders/folder-invalid-insert-url/contacts/delta';
+
+        // [WHEN] Insert is executed
+        asserterror ContactSyncUser.Insert(true);
+
+        // [THEN] Delta URL validation should reject the insert
+        AssertIsTrue(StrPos(GetLastErrorText(), InvalidDeltaUrlErr) > 0, 'Expected error containing: "' + InvalidDeltaUrlErr + '". Actual: ' + GetLastErrorText());
+    end;
+
+    [Test]
+    procedure TestContactSyncUserSetDeltaUrlFailsWithInvalidUrl()
+    var
+        ContactSyncUser: Record "Contact Sync User";
+        OriginalDeltaUrl: Text;
+    begin
+        // [SCENARIO] Setting Delta URL to a non-Graph URL should silently reject the change.
+        Initialize();
+
+        // [GIVEN] An existing Contact Sync User record with a valid Delta URL
+        CreateContactSyncUserForCurrentUser(ContactSyncUser, 'folder-set-invalid-url', 'https://graph.microsoft.com/v1.0/me/contactFolders/folder-set-invalid-url/contacts/delta');
+        OriginalDeltaUrl := ContactSyncUser.GetDeltaUrl();
+
+        // [WHEN] SetDeltaUrl is called with invalid URL
+        ContactSyncUser.SetDeltaUrl('https://contoso.example.com/v1.0/me/contactFolders/folder-set-invalid-url/contacts/delta');
+
+        // [THEN] Delta URL should not be persisted (validation rejects it silently)
+        ContactSyncUser.Get(ContactSyncUser."ID");
+        AssertAreEqual(OriginalDeltaUrl, ContactSyncUser.GetDeltaUrl(), 'Delta URL should remain unchanged when invalid URL is provided.');
+
+        ContactSyncUser.Delete();
+    end;
+
+    [Test]
+    procedure TestContactSyncUserSetDeltaUrlAcceptsGraphUrl()
+    var
+        ContactSyncUser: Record "Contact Sync User";
+        DeltaUrl: Text;
+    begin
+        // [SCENARIO] Setting Delta URL to a valid Graph URL should succeed.
+        Initialize();
+
+        // [GIVEN] An existing Contact Sync User record
+        CreateContactSyncUserForCurrentUser(ContactSyncUser, 'folder-set-valid-url', '');
+        DeltaUrl := 'https://graph.microsoft.com/v1.0/me/contactFolders/folder-set-valid-url/contacts/delta?$deltatoken=abc';
+
+        // [WHEN] SetDeltaUrl is called with valid Graph URL
+        ContactSyncUser.SetDeltaUrl(DeltaUrl);
+
+        // [THEN] The URL should be persisted
+        ContactSyncUser.Get(ContactSyncUser."ID");
+        AssertAreEqual(DeltaUrl, ContactSyncUser.GetDeltaUrl(), 'Delta URL should persist when valid.');
+
+        ContactSyncUser.Delete();
+    end;
+
     local procedure Initialize()
     begin
         if IsInitialized then
@@ -605,6 +718,16 @@ codeunit 130481 "Contact Sync Test"
         Contact."Middle Name" := 'C';
         Contact.Initials := 'BC';
         Contact.Insert(true);
+    end;
+
+    local procedure CreateContactSyncUserForCurrentUser(var ContactSyncUser: Record "Contact Sync User"; FolderId: Text; DeltaUrl: Text)
+    begin
+        ContactSyncUser.Init();
+        ContactSyncUser."User ID" := CopyStr(UserId(), 1, MaxStrLen(ContactSyncUser."User ID"));
+        ContactSyncUser."Folder ID" := CopyStr(FolderId, 1, MaxStrLen(ContactSyncUser."Folder ID"));
+        ContactSyncUser."Folder Name" := CopyStr('Test Folder', 1, MaxStrLen(ContactSyncUser."Folder Name"));
+        ContactSyncUser."Delta Url" := CopyStr(DeltaUrl, 1, MaxStrLen(ContactSyncUser."Delta Url"));
+        ContactSyncUser.Insert(true);
     end;
 
     // Assert helper procedures - replace external Assert codeunit

--- a/src/Layers/W1/Tests/User/TestUserTasks.Codeunit.al
+++ b/src/Layers/W1/Tests/User/TestUserTasks.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 134769 "Test User Tasks"
         UserTaskGroupMember: Record "User Task Group Member";
         Assert: Codeunit Assert;
         LibraryUtility: Codeunit "Library - Utility";
+        RecordsWithNewUsernameErr: Label 'Records with new username should exist in %1.', Comment = '%1 = table name';
 
     [Test]
     [Scope('OnPrem')]
@@ -176,9 +177,9 @@ codeunit 134769 "Test User Tasks"
         Company: Record Company;
         TableInformation: Record "Table Information";
         TempTablesAlreadyInserted: Record Integer temporary;
+        UserCodeunit: Codeunit User;
         RecRef: RecordRef;
         FldRef: FieldRef;
-        UserCodeunit: Codeunit User;
     begin
         // [GIVEN] Create data for tables with fields having relation with User table
         Company.FindFirst();
@@ -188,26 +189,29 @@ codeunit 134769 "Test User Tasks"
         FieldRec.SetFilter(Type, '%1|%2', FieldRec.Type::Code, FieldRec.Type::Text);
         if FieldRec.FindSet() then
             repeat
-                TableInformation.SetFilter("Company Name", '%1|%2', '', Company.Name);
-                TableInformation.SetRange("Table No.", FieldRec.TableNo);
-                if TableInformation.FindFirst() then begin
-                    RecRef.Open(FieldRec.TableNo, false, Company.Name);
-                    if TempTablesAlreadyInserted.Get(FieldRec.TableNo) then begin
-                        RecRef.FindFirst();
-                        FldRef := RecRef.Field(FieldRec."No.");
-                        FldRef.Value('OLD');
-                        RecRef.Modify();
-                    end else begin
-                        RecRef.DeleteAll();
-                        RecRef.Init();
-                        FldRef := RecRef.Field(FieldRec."No.");
-                        FldRef.Value('OLD');
-                        RecRef.Insert();
-                        TempTablesAlreadyInserted.Init();
-                        TempTablesAlreadyInserted.Number := FieldRec.TableNo;
-                        TempTablesAlreadyInserted.Insert();
+                if not SkipTable(FieldRec.TableNo) then begin
+                    TableInformation.SetFilter("Company Name", '%1|%2', '', Company.Name);
+                    TableInformation.SetRange("Table No.", FieldRec.TableNo);
+                    if TableInformation.FindFirst() then begin
+                        RecRef.Open(FieldRec.TableNo, false, Company.Name);
+                        if TempTablesAlreadyInserted.Get(FieldRec.TableNo) then begin
+                            RecRef.FindFirst();
+                            FldRef := RecRef.Field(FieldRec."No.");
+                            FldRef.Value('OLD');
+                            RecRef.Modify();
+                        end else begin
+                            RecRef.DeleteAll();
+                            RecRef.Init();
+                            FldRef := RecRef.Field(FieldRec."No.");
+                            FldRef.Value('OLD');
+                            RecRef.Insert();
+
+                            TempTablesAlreadyInserted.Init();
+                            TempTablesAlreadyInserted.Number := FieldRec.TableNo;
+                            TempTablesAlreadyInserted.Insert();
+                        end;
+                        RecRef.Close();
                     end;
-                    RecRef.Close();
                 end;
             until FieldRec.Next() = 0;
 
@@ -224,7 +228,7 @@ codeunit 134769 "Test User Tasks"
                         RecRef.Open(FieldRec.TableNo, false, Company.Name);
                         FldRef := RecRef.Field(FieldRec."No.");
                         FldRef.SetRange('NEW');
-                        Assert.AreEqual(1, RecRef.Count(), StrSubstNo('Records with new username should exist in %1.', TableInformation."Table Name"));
+                        Assert.AreEqual(1, RecRef.Count(), StrSubstNo(RecordsWithNewUsernameErr, TableInformation."Table Name"));
                         RecRef.Close();
                     end;
             until FieldRec.Next() = 0;
@@ -233,6 +237,8 @@ codeunit 134769 "Test User Tasks"
     local procedure SkipTable(TableNo: Integer): Boolean
     begin
         if TableNo = DATABASE::"Fin. Report Package Recipient" then
+            exit(true);
+        if TableNo = DATABASE::"Contact Sync User" then
             exit(true);
         exit(false);
     end;


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

What it does:

Delta URL validation — Any URL stored as a Contact Sync delta URL is now validated against an approved https://graph.microsoft.com/v1.0/ prefix before being persisted. If an invalid URL is already stored, the sync falls back to a full sync instead of using it.

Record ownership enforcement — New EnforceRecordOwnership / EnforceRecordOwnershipOnModify procedures on Contact Sync User table prevent a user from inserting or modifying another user's sync record, and prevent changing the User ID of an existing record.

Event subscriber codeunit (ContactSyncUserSubscriber.Codeunit.al) — Wires the two checks above into OnBeforeInsert and OnBeforeModify table events, so the guards fire on every write path. Install/upgrade execution contexts are exempt.

Test coverage — Adds TestRenameUser tests across the W1, CZ, and DACH test layers covering the rename/ownership scenarios.

Why:

Fixes ADO work item [AB#645036](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/e4c7e7b1d6/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — closing a security gap where a malicious delta URL or cross-user record manipulation could be exploited in the Contact Sync flow.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes # [AB#645036](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645036)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
Ran Contact Sync in a fastprod environment with a valid delta URL (https://graph.microsoft.com/v1.0/...); sync completed normally with no errors.
Manually set an invalid/tampered delta URL directly in the database; on next sync the invalid URL was detected, a warning was logged, and the sync fell back to a full sync as expected.
Attempted to insert a Contact Sync User record for a different user; received the expected ownership error and the record was not saved.
Attempted to modify the User ID field on an existing Contact Sync User record; received the expected error blocking the change.
Verified install/upgrade execution context skips ownership checks (no regressions on company copy/upgrade scenarios).

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility
None
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->















































