### PR TITLE
[29.x][Pmt. Recon. Journal] Optimize opening of the Payment Application screen

### DIFF
--- a/src/Apps/DK/FIK/app/src/codeunits/FIKMatchBankRecLines.Codeunit.al
+++ b/src/Apps/DK/FIK/app/src/codeunits/FIKMatchBankRecLines.Codeunit.al
@@ -327,15 +327,16 @@ Codeunit 13651 FIK_MatchBankRecLines
     VAR
         CustLedgerEntry: Record "Cust. Ledger Entry";
     BEGIN
-        CustLedgerEntry.SETAUTOCALCFIELDS("Remaining Amt. (LCY)");
-        IF CustLedgerEntry.FINDSET() THEN
+        CustLedgerEntry.SetRange("Document Type", CustLedgerEntry."Document Type"::Invoice);
+        CustLedgerEntry.SetRange(Open, true);
+        CustLedgerEntry.SetLoadFields("Customer No.");
+        CustLedgerEntry.SetAutoCalcFields("Remaining Amt. (LCY)");
+        IF CustLedgerEntry.FindSet() THEN
             REPEAT
-                IF (CustLedgerEntry."Document Type" = CustLedgerEntry."Document Type"::Invoice) AND
-                   (CustLedgerEntry."Remaining Amt. (LCY)" > 0)
-                THEN
+                IF CustLedgerEntry."Remaining Amt. (LCY)" > 0 THEN
                     TempBankStatementMatchingBuffer2.AddMatchCandidate(StatementLineNo, CustLedgerEntry."Entry No.", 5,
                       TempBankStatementMatchingBuffer2."Account Type"::Customer, CustLedgerEntry."Customer No.");
-            UNTIL CustLedgerEntry.NEXT() = 0;
+            UNTIL CustLedgerEntry.Next() = 0;
     END;
 }
 

--- a/src/Layers/APAC/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -872,6 +872,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/CH/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
@@ -96,6 +96,7 @@ codeunit 1255 "Match Bank Payments"
         CHMgt: Codeunit CHMgt;
         BankPmtApplSettingsInitialized: Boolean;
         ApplyEntries: Boolean;
+        CandidateFilterReferenceDate: Date;
 #pragma warning disable AA0470
         CannotApplyDocumentNoOneToManyApplicationTxt: Label 'Document No. %1 was not applied because the transaction amount was insufficient.';
 #pragma warning restore AA0470
@@ -551,6 +552,7 @@ codeunit 1255 "Match Bank Payments"
 
     local procedure MapLedgerEntriesToStatementLines(var BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line"; Overwrite: Boolean; ApplyEntries: Boolean)
     var
+        BankAccReconciliationLine2: Record "Bank Acc. Reconciliation Line";
         Window: Dialog;
         TotalNoOfLines: Integer;
         ProcessedLines: Integer;
@@ -567,6 +569,7 @@ codeunit 1255 "Match Bank Payments"
         DisableEmployeeLedgerEntriesMatch: Boolean;
         SkipOtherEntries: Boolean;
     begin
+        CandidateFilterReferenceDate := 0D;
         TempBankStatementMatchingBuffer.Reset();
         TempBankStatementMatchingBuffer.DeleteAll();
         TempCustomerLedgerEntryMatchingBuffer.DeleteAll();
@@ -590,6 +593,12 @@ codeunit 1255 "Match Bank Payments"
                                                   BankAccReconciliationLine."Match Confidence"::Accepted,
                                                   BankAccReconciliationLine."Match Confidence"::Manual);
         if BankAccReconciliationLine.FindSet() then begin
+            BankAccReconciliationLine2.CopyFilters(BankAccReconciliationLine);
+            BankAccReconciliationLine2.SetCurrentKey("Transaction Date");
+            BankAccReconciliationLine2.SetAscending("Transaction Date", true);
+            if BankAccReconciliationLine2.FindFirst() then
+                CandidateFilterReferenceDate := BankAccReconciliationLine2."Transaction Date";
+
             OnDisableCustomerLedgerEntriesMatch(DisableCustomerLedgerEntriesMatch, BankAccReconciliationLine);
             OnDisableVendorLedgerEntriesMatch(DisableVendorLedgerEntriesMatch, BankAccReconciliationLine);
             OnDisableEmployeeLedgerEntriesMatch(DisableEmployeeLedgerEntriesMatch, BankAccReconciliationLine);
@@ -679,6 +688,7 @@ codeunit 1255 "Match Bank Payments"
 
             Window.Close();
         end;
+        CandidateFilterReferenceDate := 0D;
     end;
 
     local procedure RemoveAppliedEntriesFromBufferTables()
@@ -1152,6 +1162,7 @@ codeunit 1255 "Match Bank Payments"
         CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
         SalesReceivablesSetup.Get();
@@ -1166,6 +1177,10 @@ codeunit 1255 "Match Bank Payments"
 
         if ApplyEntries then
             CustLedgerEntry.SetRange("Applies-to ID", '');
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            CustLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitCustomerLedgerEntriesMatchingBufferSetFilter(CustLedgerEntry, BankAccReconciliationLine);
 
@@ -1213,6 +1228,7 @@ codeunit 1255 "Match Bank Payments"
         VendorLedgerEntry: Record "Vendor Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
         PurchasesPayablesSetup.Get();
@@ -1227,6 +1243,10 @@ codeunit 1255 "Match Bank Payments"
 
         if ApplyEntries then
             VendorLedgerEntry.SetRange("Applies-to ID", '');
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            VendorLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitVendorLedgerEntriesMatchingBufferSetFilter(VendorLedgerEntry, BankAccReconciliationLine);
 
@@ -1273,6 +1293,7 @@ codeunit 1255 "Match Bank Payments"
     procedure InitializeEmployeeLedgerEntriesMatchingBuffer(var BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line"; var TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary; ApplyEntries: Boolean)
     var
         EmployeeLedgerEntry: Record "Employee Ledger Entry";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
 
@@ -1281,6 +1302,10 @@ codeunit 1255 "Match Bank Payments"
 
         if ApplyEntries then
             EmployeeLedgerEntry.SetRange("Applies-to ID", '');
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            EmployeeLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitEmployeeLedgerEntriesMatchingBufferSetFilter(EmployeeLedgerEntry, BankAccReconciliationLine);
 
@@ -1322,6 +1347,7 @@ codeunit 1255 "Match Bank Payments"
         BankAccLedgerEntry: Record "Bank Account Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
         PurchasesPayablesSetup.Get();
@@ -1330,6 +1356,10 @@ codeunit 1255 "Match Bank Payments"
         BankAccLedgerEntry.SetRange("Bank Account No.", BankAccReconciliationLine."Bank Account No.");
         if SkipReversed then
             BankAccLedgerEntry.SetRange(Reversed, false);
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            BankAccLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitBankAccLedgerEntriesMatchingBufferSetFilter(BankAccLedgerEntry, BankAccReconciliationLine);
 
@@ -2698,6 +2728,19 @@ codeunit 1255 "Match Bank Payments"
 
         BankPmtApplSettings.GetOrInsert();
         BankPmtApplSettingsInitialized := true;
+    end;
+
+    local procedure GetCandidateFilterStartDate(BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line"): Date
+    var
+        ReferenceDate: Date;
+    begin
+        InitializeBankPmtApplSettings();
+        // Buffers are built once per journal, so the batch's earliest transaction date is used to keep every line's candidates.
+        if CandidateFilterReferenceDate <> 0D then
+            ReferenceDate := CandidateFilterReferenceDate
+        else
+            ReferenceDate := BankAccReconciliationLine."Transaction Date";
+        exit(BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate));
     end;
 
     /// <summary>

--- a/src/Layers/CH/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -794,6 +794,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/CH/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/CH/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -6212,6 +6212,298 @@
         BankAccReconciliationLine.DisplayApplication();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackStartDateMath()
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+        ReferenceDate: Date;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] GetCandidateLookbackStartDate returns the earliest posting date to include, or 0D when not applicable.
+        Initialize();
+        ReferenceDate := DMY2Date(15, 6, 2026);
+
+        // [WHEN] Lookback is 0 [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 0;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate), 'Zero lookback should not set a lower bound.');
+
+        // [WHEN] There is no reference date [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 30;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(0D), 'A missing reference date should not set a lower bound.');
+
+        // [WHEN] A positive lookback is configured [THEN] the bound is the reference date minus the configured days
+        Assert.AreEqual(
+          CalcDate('<-30D>', ReferenceDate), BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate),
+          'The lower bound should be the reference date minus the configured days.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With a lookback configured, entries posted before the window are not loaded as candidates.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Entry posted before the lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackZeroLoadsAllEntries()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With lookback disabled (0), entries are loaded regardless of how far back they were posted.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line and lookback disabled
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(0);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Both entries are loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Recent entry should be a candidate when lookback is disabled.');
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Old entry should be a candidate when lookback is disabled.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBoundaryIsInclusive()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        StartDate: Date;
+        OnBoundaryEntryNo: Integer;
+        BeforeBoundaryEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback lower bound is inclusive: an entry posted exactly on the boundary date is a candidate.
+        Initialize();
+
+        // [GIVEN] Invoices posted exactly on, and one day before, the lookback boundary
+        StartDate := CalcDate('<-30D>', WorkDate());
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        OnBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, StartDate);
+        BeforeBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-1D>', StartDate));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] The entry on the boundary is included and the one before it is excluded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OnBoundaryEntryNo), 'Entry posted on the boundary date should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, BeforeBoundaryEntryNo), 'Entry posted before the boundary date should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBatchUsesEarliestTransactionDate()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        EarlyLine: Record "Bank Acc. Reconciliation Line";
+        LateLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        Amount: Decimal;
+        InWindowEntryNo: Integer;
+        OutOfWindowEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] For a multi-line journal the lookback window is measured from the earliest line's transaction date, so a later line can still see older entries.
+        Initialize();
+
+        // [GIVEN] A customer with an invoice inside, and one before, the earliest line's lookback window
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        InWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-45D>', WorkDate()));
+        OutOfWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-100D>', WorkDate()));
+
+        // [GIVEN] A journal with an early line (60 days ago) and a late line (today), and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, EarlyLine, Amount, '', '');
+        EarlyLine.Validate("Transaction Date", CalcDate('<-60D>', WorkDate()));
+        EarlyLine.Modify(true);
+        CreateBankReconciliationLine(BankAccReconciliation, LateLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The whole journal is matched
+        RunMatch(BankAccReconciliation, false);
+
+        // [THEN] The late line sees the invoice within the earliest line's window (posted 45 days ago, outside its own 30 day window)
+        Assert.IsTrue(
+          CandidateExistsForLine(LateLine."Statement Line No.", InWindowEntryNo),
+          'A later line should consider entries within the earliest line''s lookback window.');
+        // [THEN] An entry posted before the earliest line's window is still excluded
+        Assert.IsFalse(
+          CandidateExistsForLine(LateLine."Statement Line No.", OutOfWindowEntryNo),
+          'Entries posted before the earliest line''s lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesVendorEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Vendor: Record Vendor;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback also limits vendor candidates: entries posted before the window are not loaded.
+        Initialize();
+
+        // [GIVEN] A vendor with one recent and one old open invoice
+        CreateVendor(Vendor);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, WorkDate());
+        OldEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, -Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The vendor candidate buffer is initialized
+        MatchBankPayments.InitializeVendorLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Vendor entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Vendor entry posted before the lookback window should be excluded.');
+    end;
+
+    local procedure SetCandidateLookbackDays(Days: Integer)
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+    begin
+        BankPmtApplSettings.GetOrInsert();
+        BankPmtApplSettings."Candidate Lookback (Days)" := Days;
+        BankPmtApplSettings.Modify();
+    end;
+
+    local procedure PostCustomerInvoiceWithPostingDate(CustomerNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, CustomerNo);
+        SalesHeader.Validate("Posting Date", PostingDate);
+        SalesHeader.Validate("External Document No.", GenerateExtDocNo());
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        CustLedgerEntry.SetRange("Customer No.", CustomerNo);
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        exit(CustLedgerEntry."Entry No.");
+    end;
+
+    local procedure PostVendorInvoiceWithPostingDate(VendorNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", PostingDate);
+        PurchaseHeader.Validate("Vendor Invoice No.", GenerateExtDocNo());
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document No.", DocumentNo);
+        VendorLedgerEntry.FindFirst();
+        exit(VendorLedgerEntry."Entry No.");
+    end;
+
+    local procedure BufferHasEntry(var TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary; EntryNo: Integer): Boolean
+    begin
+        TempLedgerEntryMatchingBuffer.Reset();
+        TempLedgerEntryMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempLedgerEntryMatchingBuffer.IsEmpty());
+    end;
+
+    local procedure CandidateExistsForLine(LineNo: Integer; EntryNo: Integer): Boolean
+    begin
+        TempBankStatementMatchingBuffer.Reset();
+        TempBankStatementMatchingBuffer.SetRange("Line No.", LineNo);
+        TempBankStatementMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempBankStatementMatchingBuffer.IsEmpty());
+    end;
 
     local procedure Initialize()
     var

--- a/src/Layers/DK/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/DK/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -6000,6 +6000,298 @@
         BankAccReconciliationLine.DisplayApplication();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackStartDateMath()
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+        ReferenceDate: Date;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] GetCandidateLookbackStartDate returns the earliest posting date to include, or 0D when not applicable.
+        Initialize();
+        ReferenceDate := DMY2Date(15, 6, 2026);
+
+        // [WHEN] Lookback is 0 [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 0;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate), 'Zero lookback should not set a lower bound.');
+
+        // [WHEN] There is no reference date [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 30;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(0D), 'A missing reference date should not set a lower bound.');
+
+        // [WHEN] A positive lookback is configured [THEN] the bound is the reference date minus the configured days
+        Assert.AreEqual(
+          CalcDate('<-30D>', ReferenceDate), BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate),
+          'The lower bound should be the reference date minus the configured days.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With a lookback configured, entries posted before the window are not loaded as candidates.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Entry posted before the lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackZeroLoadsAllEntries()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With lookback disabled (0), entries are loaded regardless of how far back they were posted.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line and lookback disabled
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(0);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Both entries are loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Recent entry should be a candidate when lookback is disabled.');
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Old entry should be a candidate when lookback is disabled.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBoundaryIsInclusive()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        StartDate: Date;
+        OnBoundaryEntryNo: Integer;
+        BeforeBoundaryEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback lower bound is inclusive: an entry posted exactly on the boundary date is a candidate.
+        Initialize();
+
+        // [GIVEN] Invoices posted exactly on, and one day before, the lookback boundary
+        StartDate := CalcDate('<-30D>', WorkDate());
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        OnBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, StartDate);
+        BeforeBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-1D>', StartDate));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] The entry on the boundary is included and the one before it is excluded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OnBoundaryEntryNo), 'Entry posted on the boundary date should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, BeforeBoundaryEntryNo), 'Entry posted before the boundary date should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBatchUsesEarliestTransactionDate()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        EarlyLine: Record "Bank Acc. Reconciliation Line";
+        LateLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        Amount: Decimal;
+        InWindowEntryNo: Integer;
+        OutOfWindowEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] For a multi-line journal the lookback window is measured from the earliest line's transaction date, so a later line can still see older entries.
+        Initialize();
+
+        // [GIVEN] A customer with an invoice inside, and one before, the earliest line's lookback window
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        InWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-45D>', WorkDate()));
+        OutOfWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-100D>', WorkDate()));
+
+        // [GIVEN] A journal with an early line (60 days ago) and a late line (today), and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, EarlyLine, Amount, '', '');
+        EarlyLine.Validate("Transaction Date", CalcDate('<-60D>', WorkDate()));
+        EarlyLine.Modify(true);
+        CreateBankReconciliationLine(BankAccReconciliation, LateLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The whole journal is matched
+        RunMatch(BankAccReconciliation, false);
+
+        // [THEN] The late line sees the invoice within the earliest line's window (posted 45 days ago, outside its own 30 day window)
+        Assert.IsTrue(
+          CandidateExistsForLine(LateLine."Statement Line No.", InWindowEntryNo),
+          'A later line should consider entries within the earliest line''s lookback window.');
+        // [THEN] An entry posted before the earliest line's window is still excluded
+        Assert.IsFalse(
+          CandidateExistsForLine(LateLine."Statement Line No.", OutOfWindowEntryNo),
+          'Entries posted before the earliest line''s lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesVendorEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Vendor: Record Vendor;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback also limits vendor candidates: entries posted before the window are not loaded.
+        Initialize();
+
+        // [GIVEN] A vendor with one recent and one old open invoice
+        CreateVendor(Vendor);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, WorkDate());
+        OldEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, -Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The vendor candidate buffer is initialized
+        MatchBankPayments.InitializeVendorLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Vendor entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Vendor entry posted before the lookback window should be excluded.');
+    end;
+
+    local procedure SetCandidateLookbackDays(Days: Integer)
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+    begin
+        BankPmtApplSettings.GetOrInsert();
+        BankPmtApplSettings."Candidate Lookback (Days)" := Days;
+        BankPmtApplSettings.Modify();
+    end;
+
+    local procedure PostCustomerInvoiceWithPostingDate(CustomerNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, CustomerNo);
+        SalesHeader.Validate("Posting Date", PostingDate);
+        SalesHeader.Validate("External Document No.", GenerateExtDocNo());
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        CustLedgerEntry.SetRange("Customer No.", CustomerNo);
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        exit(CustLedgerEntry."Entry No.");
+    end;
+
+    local procedure PostVendorInvoiceWithPostingDate(VendorNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", PostingDate);
+        PurchaseHeader.Validate("Vendor Invoice No.", GenerateExtDocNo());
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document No.", DocumentNo);
+        VendorLedgerEntry.FindFirst();
+        exit(VendorLedgerEntry."Entry No.");
+    end;
+
+    local procedure BufferHasEntry(var TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary; EntryNo: Integer): Boolean
+    begin
+        TempLedgerEntryMatchingBuffer.Reset();
+        TempLedgerEntryMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempLedgerEntryMatchingBuffer.IsEmpty());
+    end;
+
+    local procedure CandidateExistsForLine(LineNo: Integer; EntryNo: Integer): Boolean
+    begin
+        TempBankStatementMatchingBuffer.Reset();
+        TempBankStatementMatchingBuffer.SetRange("Line No.", LineNo);
+        TempBankStatementMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempBankStatementMatchingBuffer.IsEmpty());
+    end;
 
     local procedure Initialize()
     var

--- a/src/Layers/ES/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -856,6 +856,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/FI/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -808,6 +808,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/FR/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/FR/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -789,6 +789,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/GB/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -798,6 +798,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/IT/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -843,6 +843,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/IT/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/IT/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -6220,6 +6220,298 @@
         BankAccReconciliationLine.DisplayApplication();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackStartDateMath()
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+        ReferenceDate: Date;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] GetCandidateLookbackStartDate returns the earliest posting date to include, or 0D when not applicable.
+        Initialize();
+        ReferenceDate := DMY2Date(15, 6, 2026);
+
+        // [WHEN] Lookback is 0 [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 0;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate), 'Zero lookback should not set a lower bound.');
+
+        // [WHEN] There is no reference date [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 30;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(0D), 'A missing reference date should not set a lower bound.');
+
+        // [WHEN] A positive lookback is configured [THEN] the bound is the reference date minus the configured days
+        Assert.AreEqual(
+          CalcDate('<-30D>', ReferenceDate), BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate),
+          'The lower bound should be the reference date minus the configured days.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With a lookback configured, entries posted before the window are not loaded as candidates.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Entry posted before the lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackZeroLoadsAllEntries()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With lookback disabled (0), entries are loaded regardless of how far back they were posted.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line and lookback disabled
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(0);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Both entries are loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Recent entry should be a candidate when lookback is disabled.');
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Old entry should be a candidate when lookback is disabled.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBoundaryIsInclusive()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        StartDate: Date;
+        OnBoundaryEntryNo: Integer;
+        BeforeBoundaryEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback lower bound is inclusive: an entry posted exactly on the boundary date is a candidate.
+        Initialize();
+
+        // [GIVEN] Invoices posted exactly on, and one day before, the lookback boundary
+        StartDate := CalcDate('<-30D>', WorkDate());
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        OnBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, StartDate);
+        BeforeBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-1D>', StartDate));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] The entry on the boundary is included and the one before it is excluded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OnBoundaryEntryNo), 'Entry posted on the boundary date should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, BeforeBoundaryEntryNo), 'Entry posted before the boundary date should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBatchUsesEarliestTransactionDate()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        EarlyLine: Record "Bank Acc. Reconciliation Line";
+        LateLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        Amount: Decimal;
+        InWindowEntryNo: Integer;
+        OutOfWindowEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] For a multi-line journal the lookback window is measured from the earliest line's transaction date, so a later line can still see older entries.
+        Initialize();
+
+        // [GIVEN] A customer with an invoice inside, and one before, the earliest line's lookback window
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        InWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-45D>', WorkDate()));
+        OutOfWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-100D>', WorkDate()));
+
+        // [GIVEN] A journal with an early line (60 days ago) and a late line (today), and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, EarlyLine, Amount, '', '');
+        EarlyLine.Validate("Transaction Date", CalcDate('<-60D>', WorkDate()));
+        EarlyLine.Modify(true);
+        CreateBankReconciliationLine(BankAccReconciliation, LateLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The whole journal is matched
+        RunMatch(BankAccReconciliation, false);
+
+        // [THEN] The late line sees the invoice within the earliest line's window (posted 45 days ago, outside its own 30 day window)
+        Assert.IsTrue(
+          CandidateExistsForLine(LateLine."Statement Line No.", InWindowEntryNo),
+          'A later line should consider entries within the earliest line''s lookback window.');
+        // [THEN] An entry posted before the earliest line's window is still excluded
+        Assert.IsFalse(
+          CandidateExistsForLine(LateLine."Statement Line No.", OutOfWindowEntryNo),
+          'Entries posted before the earliest line''s lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesVendorEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Vendor: Record Vendor;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback also limits vendor candidates: entries posted before the window are not loaded.
+        Initialize();
+
+        // [GIVEN] A vendor with one recent and one old open invoice
+        CreateVendor(Vendor);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, WorkDate());
+        OldEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, -Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The vendor candidate buffer is initialized
+        MatchBankPayments.InitializeVendorLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Vendor entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Vendor entry posted before the lookback window should be excluded.');
+    end;
+
+    local procedure SetCandidateLookbackDays(Days: Integer)
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+    begin
+        BankPmtApplSettings.GetOrInsert();
+        BankPmtApplSettings."Candidate Lookback (Days)" := Days;
+        BankPmtApplSettings.Modify();
+    end;
+
+    local procedure PostCustomerInvoiceWithPostingDate(CustomerNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, CustomerNo);
+        SalesHeader.Validate("Posting Date", PostingDate);
+        SalesHeader.Validate("External Document No.", GenerateExtDocNo());
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        CustLedgerEntry.SetRange("Customer No.", CustomerNo);
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        exit(CustLedgerEntry."Entry No.");
+    end;
+
+    local procedure PostVendorInvoiceWithPostingDate(VendorNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", PostingDate);
+        PurchaseHeader.Validate("Vendor Invoice No.", GenerateExtDocNo());
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document No.", DocumentNo);
+        VendorLedgerEntry.FindFirst();
+        exit(VendorLedgerEntry."Entry No.");
+    end;
+
+    local procedure BufferHasEntry(var TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary; EntryNo: Integer): Boolean
+    begin
+        TempLedgerEntryMatchingBuffer.Reset();
+        TempLedgerEntryMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempLedgerEntryMatchingBuffer.IsEmpty());
+    end;
+
+    local procedure CandidateExistsForLine(LineNo: Integer; EntryNo: Integer): Boolean
+    begin
+        TempBankStatementMatchingBuffer.Reset();
+        TempBankStatementMatchingBuffer.SetRange("Line No.", LineNo);
+        TempBankStatementMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempBankStatementMatchingBuffer.IsEmpty());
+    end;
 
     local procedure Initialize()
     var

--- a/src/Layers/NA/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -807,6 +807,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -555,6 +555,10 @@ table 5222 "Employee Ledger Entry"
         key(Key2; "Employee No.", "Applies-to ID", Open, Positive)
         {
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/NL/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -833,6 +833,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/NO/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -819,6 +819,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/RU/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -905,6 +905,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/AppliedPaymentEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/AppliedPaymentEntry.Table.al
@@ -895,6 +895,11 @@ table 1294 "Applied Payment Entry"
         OnAfterGetLedgEntryInfo(Rec);
     end;
 
+    internal procedure RunOnAfterGetLedgEntryInfo()
+    begin
+        OnAfterGetLedgEntryInfo(Rec);
+    end;
+
     local procedure GetCustLedgEntryInfo()
     var
         CustLedgEntry: Record "Cust. Ledger Entry";

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/BankPmtApplSettings.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/BankPmtApplSettings.Table.al
@@ -131,6 +131,18 @@ table 1253 "Bank Pmt. Appl. Settings"
         field(14; "Empl Ledg Hidden In Apply Man"; Boolean)
         {
         }
+        /// <summary>
+        /// Number of days back from the earliest bank statement transaction date in the journal to search for candidate ledger entries.
+        /// A single window is applied to the whole journal so that the earliest line keeps all its candidates.
+        /// A value of 0 searches all open entries; a positive value limits candidates to improve performance.
+        /// </summary>
+        field(15; "Candidate Lookback (Days)"; Integer)
+        {
+            Caption = 'Candidate Lookback (Days)';
+            DataClassification = CustomerContent;
+            MinValue = 0;
+            ToolTip = 'Specifies how many days back from the earliest bank statement transaction date in the journal the automatic matching searches for candidate ledger entries. A single window is applied to the whole journal. Limiting the range improves performance when there are many open entries. Set to 0 to search all open entries.';
+        }
 
     }
 
@@ -145,6 +157,9 @@ table 1253 "Bank Pmt. Appl. Settings"
     fieldgroups
     {
     }
+
+    var
+        LookbackFormulaLbl: Label '<-%1D>', Locked = true, Comment = '%1 = number of days to look back';
 
     /// <summary>
     /// Retrieves existing settings record or creates a new one with default values.
@@ -162,6 +177,24 @@ table 1253 "Bank Pmt. Appl. Settings"
         "Empl. Ledger Entries Matching" := true;
         "Bank Ledg Closing Doc No Match" := false;
         Insert(true);
+    end;
+
+    /// <summary>
+    /// Calculates the earliest posting date to include when searching for candidate ledger entries.
+    /// Returns 0D (no lower bound) when the lookback is not configured or no reference date is available.
+    /// </summary>
+    /// <param name="ReferenceDate">The earliest bank statement transaction date in the journal to count the lookback from.</param>
+    /// <returns>The earliest posting date to include, or 0D when candidates should not be date-limited.</returns>
+    procedure GetCandidateLookbackStartDate(ReferenceDate: Date): Date
+    var
+        LookbackFormula: DateFormula;
+    begin
+        if "Candidate Lookback (Days)" <= 0 then
+            exit(0D);
+        if ReferenceDate = 0D then
+            exit(0D);
+        Evaluate(LookbackFormula, StrSubstNo(LookbackFormulaLbl, "Candidate Lookback (Days)"));
+        exit(CalcDate(LookbackFormula, ReferenceDate));
     end;
 }
 

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/MatchBankPayments.Codeunit.al
@@ -94,6 +94,7 @@ codeunit 1255 "Match Bank Payments"
         TempDirectDebitCollectionBuffer: Record "Direct Debit Collection Buffer" temporary;
         BankPmtApplSettingsInitialized: Boolean;
         ApplyEntries: Boolean;
+        CandidateFilterReferenceDate: Date;
 #pragma warning disable AA0470
         CannotApplyDocumentNoOneToManyApplicationTxt: Label 'Document No. %1 was not applied because the transaction amount was insufficient.';
 #pragma warning restore AA0470
@@ -548,6 +549,7 @@ codeunit 1255 "Match Bank Payments"
 
     local procedure MapLedgerEntriesToStatementLines(var BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line"; Overwrite: Boolean; ApplyEntries: Boolean)
     var
+        BankAccReconciliationLine2: Record "Bank Acc. Reconciliation Line";
         Window: Dialog;
         TotalNoOfLines: Integer;
         ProcessedLines: Integer;
@@ -564,6 +566,7 @@ codeunit 1255 "Match Bank Payments"
         DisableEmployeeLedgerEntriesMatch: Boolean;
         SkipOtherEntries: Boolean;
     begin
+        CandidateFilterReferenceDate := 0D;
         TempBankStatementMatchingBuffer.Reset();
         TempBankStatementMatchingBuffer.DeleteAll();
         TempCustomerLedgerEntryMatchingBuffer.DeleteAll();
@@ -587,6 +590,12 @@ codeunit 1255 "Match Bank Payments"
                                                   BankAccReconciliationLine."Match Confidence"::Accepted,
                                                   BankAccReconciliationLine."Match Confidence"::Manual);
         if BankAccReconciliationLine.FindSet() then begin
+            BankAccReconciliationLine2.CopyFilters(BankAccReconciliationLine);
+            BankAccReconciliationLine2.SetCurrentKey("Transaction Date");
+            BankAccReconciliationLine2.SetAscending("Transaction Date", true);
+            if BankAccReconciliationLine2.FindFirst() then
+                CandidateFilterReferenceDate := BankAccReconciliationLine2."Transaction Date";
+
             OnDisableCustomerLedgerEntriesMatch(DisableCustomerLedgerEntriesMatch, BankAccReconciliationLine);
             OnDisableVendorLedgerEntriesMatch(DisableVendorLedgerEntriesMatch, BankAccReconciliationLine);
             OnDisableEmployeeLedgerEntriesMatch(DisableEmployeeLedgerEntriesMatch, BankAccReconciliationLine);
@@ -676,6 +685,7 @@ codeunit 1255 "Match Bank Payments"
 
             Window.Close();
         end;
+        CandidateFilterReferenceDate := 0D;
     end;
 
     local procedure RemoveAppliedEntriesFromBufferTables()
@@ -1142,6 +1152,7 @@ codeunit 1255 "Match Bank Payments"
         CustLedgerEntry: Record "Cust. Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         SalesReceivablesSetup: Record "Sales & Receivables Setup";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
         SalesReceivablesSetup.Get();
@@ -1156,6 +1167,10 @@ codeunit 1255 "Match Bank Payments"
 
         if ApplyEntries then
             CustLedgerEntry.SetRange("Applies-to ID", '');
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            CustLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitCustomerLedgerEntriesMatchingBufferSetFilter(CustLedgerEntry, BankAccReconciliationLine);
 
@@ -1203,6 +1218,7 @@ codeunit 1255 "Match Bank Payments"
         VendorLedgerEntry: Record "Vendor Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
         PurchasesPayablesSetup.Get();
@@ -1217,6 +1233,10 @@ codeunit 1255 "Match Bank Payments"
 
         if ApplyEntries then
             VendorLedgerEntry.SetRange("Applies-to ID", '');
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            VendorLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitVendorLedgerEntriesMatchingBufferSetFilter(VendorLedgerEntry, BankAccReconciliationLine);
 
@@ -1263,6 +1283,7 @@ codeunit 1255 "Match Bank Payments"
     procedure InitializeEmployeeLedgerEntriesMatchingBuffer(var BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line"; var TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary; ApplyEntries: Boolean)
     var
         EmployeeLedgerEntry: Record "Employee Ledger Entry";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
 
@@ -1271,6 +1292,10 @@ codeunit 1255 "Match Bank Payments"
 
         if ApplyEntries then
             EmployeeLedgerEntry.SetRange("Applies-to ID", '');
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            EmployeeLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitEmployeeLedgerEntriesMatchingBufferSetFilter(EmployeeLedgerEntry, BankAccReconciliationLine);
 
@@ -1312,6 +1337,7 @@ codeunit 1255 "Match Bank Payments"
         BankAccLedgerEntry: Record "Bank Account Ledger Entry";
         GeneralLedgerSetup: Record "General Ledger Setup";
         PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        CandidateFilterStartDate: Date;
     begin
         BankAccount.Get(BankAccReconciliationLine."Bank Account No.");
         PurchasesPayablesSetup.Get();
@@ -1320,6 +1346,10 @@ codeunit 1255 "Match Bank Payments"
         BankAccLedgerEntry.SetRange("Bank Account No.", BankAccReconciliationLine."Bank Account No.");
         if SkipReversed then
             BankAccLedgerEntry.SetRange(Reversed, false);
+
+        CandidateFilterStartDate := GetCandidateFilterStartDate(BankAccReconciliationLine);
+        if CandidateFilterStartDate <> 0D then
+            BankAccLedgerEntry.SetFilter("Posting Date", '>=%1', CandidateFilterStartDate);
 
         OnInitBankAccLedgerEntriesMatchingBufferSetFilter(BankAccLedgerEntry, BankAccReconciliationLine);
 
@@ -2675,6 +2705,19 @@ codeunit 1255 "Match Bank Payments"
 
         BankPmtApplSettings.GetOrInsert();
         BankPmtApplSettingsInitialized := true;
+    end;
+
+    local procedure GetCandidateFilterStartDate(BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line"): Date
+    var
+        ReferenceDate: Date;
+    begin
+        InitializeBankPmtApplSettings();
+        // Buffers are built once per journal, so the batch's earliest transaction date is used to keep every line's candidates.
+        if CandidateFilterReferenceDate <> 0D then
+            ReferenceDate := CandidateFilterReferenceDate
+        else
+            ReferenceDate := BankAccReconciliationLine."Transaction Date";
+        exit(BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate));
     end;
 
     /// <summary>

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationProposal.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationProposal.Table.al
@@ -485,6 +485,115 @@ table 1293 "Payment Application Proposal"
         TransferFields(TempAppliedPmtEntry);
     end;
 
+    local procedure LoadLedgEntryInfoAndRemainingAmount(BankAccount: Record "Bank Account")
+    var
+        CustLedgEntry: Record "Cust. Ledger Entry";
+        VendLedgEntry: Record "Vendor Ledger Entry";
+        EmployeeLedgEntry: Record "Employee Ledger Entry";
+        BankAccLedgEntry: Record "Bank Account Ledger Entry";
+        LedgerRemainingAmount: Decimal;
+        IsHandled: Boolean;
+        RemainingAmountHandled: Boolean;
+    begin
+        // Reads the applied ledger entry only once to populate both the informational fields and the remaining amount.
+        IsHandled := false;
+        OnBeforeLoadLedgEntryInfoAndRemainingAmount(Rec, BankAccount, IsHandled);
+        if IsHandled then begin
+            GetLedgEntryInfo();
+            exit;
+        end;
+
+        "Remaining Amount" := 0;
+        if "Applies-to Entry No." = 0 then
+            exit;
+
+        case "Account Type" of
+            "Account Type"::Customer:
+                begin
+                    CustLedgEntry.SetLoadFields(
+                      Description, "Posting Date", "Due Date", "Document Type", "Document No.", "External Document No.", "Currency Code");
+                    if BankAccount.IsInLocalCurrency() then
+                        CustLedgEntry.SetAutoCalcFields("Remaining Amt. (LCY)")
+                    else
+                        CustLedgEntry.SetAutoCalcFields("Remaining Amount");
+                    CustLedgEntry.Get("Applies-to Entry No.");
+                    Description := CustLedgEntry.Description;
+                    "Posting Date" := CustLedgEntry."Posting Date";
+                    "Due Date" := CustLedgEntry."Due Date";
+                    "Document Type" := CustLedgEntry."Document Type";
+                    "Document No." := CustLedgEntry."Document No.";
+                    "External Document No." := CustLedgEntry."External Document No.";
+                    "Currency Code" := CustLedgEntry."Currency Code";
+                    if BankAccount.IsInLocalCurrency() then
+                        LedgerRemainingAmount := CustLedgEntry."Remaining Amt. (LCY)"
+                    else
+                        LedgerRemainingAmount := CustLedgEntry."Remaining Amount";
+                end;
+            "Account Type"::Vendor:
+                begin
+                    VendLedgEntry.SetLoadFields(
+                      Description, "Posting Date", "Due Date", "Document Type", "Document No.", "External Document No.", "Currency Code");
+                    if BankAccount.IsInLocalCurrency() then
+                        VendLedgEntry.SetAutoCalcFields("Remaining Amt. (LCY)")
+                    else
+                        VendLedgEntry.SetAutoCalcFields("Remaining Amount");
+                    VendLedgEntry.Get("Applies-to Entry No.");
+                    Description := VendLedgEntry.Description;
+                    "Posting Date" := VendLedgEntry."Posting Date";
+                    "Due Date" := VendLedgEntry."Due Date";
+                    "Document Type" := VendLedgEntry."Document Type";
+                    "Document No." := VendLedgEntry."Document No.";
+                    "External Document No." := VendLedgEntry."External Document No.";
+                    "Currency Code" := VendLedgEntry."Currency Code";
+                    if BankAccount.IsInLocalCurrency() then
+                        LedgerRemainingAmount := VendLedgEntry."Remaining Amt. (LCY)"
+                    else
+                        LedgerRemainingAmount := VendLedgEntry."Remaining Amount";
+                end;
+            "Account Type"::Employee:
+                begin
+                    EmployeeLedgEntry.SetLoadFields(
+                      Description, "Posting Date", "Document Type", "Document No.", "Currency Code");
+                    if BankAccount.IsInLocalCurrency() then
+                        EmployeeLedgEntry.SetAutoCalcFields("Remaining Amt. (LCY)")
+                    else
+                        EmployeeLedgEntry.SetAutoCalcFields("Remaining Amount");
+                    EmployeeLedgEntry.Get("Applies-to Entry No.");
+                    Description := EmployeeLedgEntry.Description;
+                    "Posting Date" := EmployeeLedgEntry."Posting Date";
+                    "Document Type" := EmployeeLedgEntry."Document Type";
+                    "Document No." := EmployeeLedgEntry."Document No.";
+                    "Currency Code" := EmployeeLedgEntry."Currency Code";
+                    if BankAccount.IsInLocalCurrency() then
+                        LedgerRemainingAmount := EmployeeLedgEntry."Remaining Amt. (LCY)"
+                    else
+                        LedgerRemainingAmount := EmployeeLedgEntry."Remaining Amount";
+                end;
+            "Account Type"::"Bank Account":
+                begin
+                    BankAccLedgEntry.SetLoadFields(
+                      Description, "Posting Date", "Document Type", "Document No.", "External Document No.", "Currency Code", "Remaining Amount");
+                    BankAccLedgEntry.Get("Applies-to Entry No.");
+                    Description := BankAccLedgEntry.Description;
+                    "Posting Date" := BankAccLedgEntry."Posting Date";
+                    "Due Date" := 0D;
+                    "Document Type" := BankAccLedgEntry."Document Type";
+                    "Document No." := BankAccLedgEntry."Document No.";
+                    "External Document No." := BankAccLedgEntry."External Document No.";
+                    "Currency Code" := BankAccLedgEntry."Currency Code";
+                    LedgerRemainingAmount := BankAccLedgEntry."Remaining Amount";
+                end;
+            else
+                GetLedgEntryInfo();
+        end;
+
+        // Keep firing the legacy event so extensions that override the remaining amount still run when a proposal is created.
+        RemainingAmountHandled := false;
+        OnBeforeUpdateRemainingAmount(Rec, BankAccount, RemainingAmountHandled);
+        if not RemainingAmountHandled then
+            "Remaining Amount" := LedgerRemainingAmount;
+    end;
+
     procedure TransferFromBankAccReconLine(BankAccReconLine: Record "Bank Acc. Reconciliation Line")
     begin
         "Statement Type" := BankAccReconLine."Statement Type";
@@ -524,12 +633,12 @@ table 1293 "Payment Application Proposal"
         else
             "Applies-to Entry No." := TempBankStmtMatchingBuffer."Entry No.";
 
-        GetLedgEntryInfo();
+        LoadLedgEntryInfoAndRemainingAmount(BankAccount);
         Quality := TempBankStmtMatchingBuffer.Quality;
         "Match Confidence" :=
             Enum::"Bank Rec. Match Confidence".FromInteger(BankPmtApplRule.GetMatchConfidence(TempBankStmtMatchingBuffer.Quality));
 
-        UpdateDefaultCalculatedFields(BankAccount, Rec."Applies-to Entry No.");
+        UpdateDefaultCalculatedFields(BankAccount, Rec."Applies-to Entry No.", true);
 
         "Stmt To Rem. Amount Difference" := Abs(BankAccReconciliationLine."Statement Amount" - "Remaining Amount");
         "Applied Amt. Incl. Discount" := "Applied Amount" - "Applied Pmt. Discount";
@@ -539,8 +648,14 @@ table 1293 "Payment Application Proposal"
 
     procedure UpdateDefaultCalculatedFields(var BankAccount: Record "Bank Account"; AppliesToEntryNo: Integer)
     begin
+        UpdateDefaultCalculatedFields(BankAccount, AppliesToEntryNo, false);
+    end;
+
+    procedure UpdateDefaultCalculatedFields(var BankAccount: Record "Bank Account"; AppliesToEntryNo: Integer; SkipRemainingAmountUpdate: Boolean)
+    begin
         UpdatePaymentDiscInfo();
-        UpdateRemainingAmount(BankAccount);
+        if not SkipRemainingAmountUpdate then
+            UpdateRemainingAmount(BankAccount);
         UpdateRemainingAmountExclDiscount();
 
         if AppliesToEntryNo > 0 then
@@ -940,6 +1055,12 @@ table 1293 "Payment Application Proposal"
     var
         CheckLedgerEntry: Record "Check Ledger Entry";
     begin
+        // Type only distinguishes bank account entries; the check-ledger lookup is skipped for other account types.
+        if "Account Type" <> "Account Type"::"Bank Account" then begin
+            Type := Type::"Bank Account Ledger Entry";
+            exit;
+        end;
+
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", EntryNo);
         if CheckLedgerEntry.FindFirst() then
             Type := Type::"Check Ledger Entry"
@@ -985,6 +1106,11 @@ table 1293 "Payment Application Proposal"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdateRemainingAmount(var PaymentApplicationProposal: Record "Payment Application Proposal"; BankAccount: Record "Bank Account"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeLoadLedgEntryInfoAndRemainingAmount(var PaymentApplicationProposal: Record "Payment Application Proposal"; BankAccount: Record "Bank Account"; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationProposal.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationProposal.Table.al
@@ -494,6 +494,7 @@ table 1293 "Payment Application Proposal"
         LedgerRemainingAmount: Decimal;
         IsHandled: Boolean;
         RemainingAmountHandled: Boolean;
+        LedgEntryInfoLoaded: Boolean;
     begin
         // Reads the applied ledger entry only once to populate both the informational fields and the remaining amount.
         IsHandled := false;
@@ -507,6 +508,7 @@ table 1293 "Payment Application Proposal"
         if "Applies-to Entry No." = 0 then
             exit;
 
+        LedgEntryInfoLoaded := true;
         case "Account Type" of
             "Account Type"::Customer:
                 begin
@@ -583,15 +585,31 @@ table 1293 "Payment Application Proposal"
                     "Currency Code" := BankAccLedgEntry."Currency Code";
                     LedgerRemainingAmount := BankAccLedgEntry."Remaining Amount";
                 end;
-            else
+            else begin
                 GetLedgEntryInfo();
+                LedgEntryInfoLoaded := false;
+            end;
         end;
+
+        // Re-fire the legacy OnAfterGetLedgEntryInfo extension point for the fast path without a second ledger read.
+        if LedgEntryInfoLoaded then
+            RaiseOnAfterGetLedgEntryInfoEvent();
 
         // Keep firing the legacy event so extensions that override the remaining amount still run when a proposal is created.
         RemainingAmountHandled := false;
         OnBeforeUpdateRemainingAmount(Rec, BankAccount, RemainingAmountHandled);
         if not RemainingAmountHandled then
             "Remaining Amount" := LedgerRemainingAmount;
+    end;
+
+    local procedure RaiseOnAfterGetLedgEntryInfoEvent()
+    var
+        TempAppliedPmtEntry: Record "Applied Payment Entry" temporary;
+    begin
+        // Round-trips already-loaded fields through a temp Applied Payment Entry so existing OnAfterGetLedgEntryInfo subscribers still run.
+        TempAppliedPmtEntry.TransferFields(Rec);
+        TempAppliedPmtEntry.RunOnAfterGetLedgEntryInfo();
+        TransferFields(TempAppliedPmtEntry);
     end;
 
     procedure TransferFromBankAccReconLine(BankAccReconLine: Record "Bank Acc. Reconciliation Line")

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationSettings.Page.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationSettings.Page.al
@@ -45,6 +45,12 @@ page 1253 "Payment Application Settings"
                         Caption = 'Related Party Name Matching';
                         ApplicationArea = All;
                     }
+
+                    field(CandidateLookbackDays; Rec."Candidate Lookback (Days)")
+                    {
+                        Caption = 'Candidate Lookback (Days)';
+                        ApplicationArea = All;
+                    }
                 }
 
                 group(LedgerEntriesSpecific)

--- a/src/Layers/W1/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -519,6 +519,10 @@ table 5222 "Employee Ledger Entry"
         key(Key2; "Employee No.", "Applies-to ID", Open, Positive)
         {
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/W1/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Payables/VendorLedgerEntry.Table.al
@@ -789,6 +789,10 @@ table 25 "Vendor Ledger Entry"
         {
             IncludedFields = "Accepted Payment Tolerance";
         }
+        // Supports the Payment Reconciliation Journal candidate search (Document Type + Open + date range).
+        key(PmtReconCandidates; "Document Type", Open, "Posting Date")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/W1/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
+++ b/src/Layers/W1/Tests/Bank/BankPmtApplAlgorithm.Codeunit.al
@@ -6212,6 +6212,298 @@
         BankAccReconciliationLine.DisplayApplication();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackStartDateMath()
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+        ReferenceDate: Date;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] GetCandidateLookbackStartDate returns the earliest posting date to include, or 0D when not applicable.
+        Initialize();
+        ReferenceDate := DMY2Date(15, 6, 2026);
+
+        // [WHEN] Lookback is 0 [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 0;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate), 'Zero lookback should not set a lower bound.');
+
+        // [WHEN] There is no reference date [THEN] there is no lower bound
+        BankPmtApplSettings."Candidate Lookback (Days)" := 30;
+        Assert.AreEqual(0D, BankPmtApplSettings.GetCandidateLookbackStartDate(0D), 'A missing reference date should not set a lower bound.');
+
+        // [WHEN] A positive lookback is configured [THEN] the bound is the reference date minus the configured days
+        Assert.AreEqual(
+          CalcDate('<-30D>', ReferenceDate), BankPmtApplSettings.GetCandidateLookbackStartDate(ReferenceDate),
+          'The lower bound should be the reference date minus the configured days.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With a lookback configured, entries posted before the window are not loaded as candidates.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Entry posted before the lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackZeroLoadsAllEntries()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] With lookback disabled (0), entries are loaded regardless of how far back they were posted.
+        Initialize();
+
+        // [GIVEN] A customer with one recent and one old open invoice
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, WorkDate());
+        OldEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line and lookback disabled
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(0);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Both entries are loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Recent entry should be a candidate when lookback is disabled.');
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Old entry should be a candidate when lookback is disabled.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBoundaryIsInclusive()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        StartDate: Date;
+        OnBoundaryEntryNo: Integer;
+        BeforeBoundaryEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback lower bound is inclusive: an entry posted exactly on the boundary date is a candidate.
+        Initialize();
+
+        // [GIVEN] Invoices posted exactly on, and one day before, the lookback boundary
+        StartDate := CalcDate('<-30D>', WorkDate());
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        OnBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, StartDate);
+        BeforeBoundaryEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-1D>', StartDate));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The customer candidate buffer is initialized
+        MatchBankPayments.InitializeCustomerLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] The entry on the boundary is included and the one before it is excluded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, OnBoundaryEntryNo), 'Entry posted on the boundary date should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, BeforeBoundaryEntryNo), 'Entry posted before the boundary date should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackBatchUsesEarliestTransactionDate()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        EarlyLine: Record "Bank Acc. Reconciliation Line";
+        LateLine: Record "Bank Acc. Reconciliation Line";
+        Customer: Record Customer;
+        Amount: Decimal;
+        InWindowEntryNo: Integer;
+        OutOfWindowEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] For a multi-line journal the lookback window is measured from the earliest line's transaction date, so a later line can still see older entries.
+        Initialize();
+
+        // [GIVEN] A customer with an invoice inside, and one before, the earliest line's lookback window
+        CreateCustomer(Customer);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        InWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-45D>', WorkDate()));
+        OutOfWindowEntryNo := PostCustomerInvoiceWithPostingDate(Customer."No.", Amount, CalcDate('<-100D>', WorkDate()));
+
+        // [GIVEN] A journal with an early line (60 days ago) and a late line (today), and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, EarlyLine, Amount, '', '');
+        EarlyLine.Validate("Transaction Date", CalcDate('<-60D>', WorkDate()));
+        EarlyLine.Modify(true);
+        CreateBankReconciliationLine(BankAccReconciliation, LateLine, Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The whole journal is matched
+        RunMatch(BankAccReconciliation, false);
+
+        // [THEN] The late line sees the invoice within the earliest line's window (posted 45 days ago, outside its own 30 day window)
+        Assert.IsTrue(
+          CandidateExistsForLine(LateLine."Statement Line No.", InWindowEntryNo),
+          'A later line should consider entries within the earliest line''s lookback window.');
+        // [THEN] An entry posted before the earliest line's window is still excluded
+        Assert.IsFalse(
+          CandidateExistsForLine(LateLine."Statement Line No.", OutOfWindowEntryNo),
+          'Entries posted before the earliest line''s lookback window should be excluded.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CandidateLookbackExcludesVendorEntriesPostedBeforeWindow()
+    var
+        BankAccReconciliation: Record "Bank Acc. Reconciliation";
+        BankAccReconciliationLine: Record "Bank Acc. Reconciliation Line";
+        Vendor: Record Vendor;
+        TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary;
+        MatchBankPayments: Codeunit "Match Bank Payments";
+        Amount: Decimal;
+        RecentEntryNo: Integer;
+        OldEntryNo: Integer;
+    begin
+        // [FEATURE] [Candidate Lookback]
+        // [SCENARIO] The lookback also limits vendor candidates: entries posted before the window are not loaded.
+        Initialize();
+
+        // [GIVEN] A vendor with one recent and one old open invoice
+        CreateVendor(Vendor);
+        Amount := LibraryRandom.RandDecInRange(1, 1000, 2);
+        RecentEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, WorkDate());
+        OldEntryNo := PostVendorInvoiceWithPostingDate(Vendor."No.", Amount, CalcDate('<-400D>', WorkDate()));
+
+        // [GIVEN] A payment reconciliation line dated today and a 30 day lookback
+        CreateBankReconciliationAmountTolerance(BankAccReconciliation, 0);
+        CreateBankReconciliationLine(BankAccReconciliation, BankAccReconciliationLine, -Amount, '', '');
+        SetCandidateLookbackDays(30);
+
+        // [WHEN] The vendor candidate buffer is initialized
+        MatchBankPayments.InitializeVendorLedgerEntriesMatchingBuffer(BankAccReconciliationLine, TempLedgerEntryMatchingBuffer);
+
+        // [THEN] Only the entry posted within the lookback window is loaded
+        Assert.IsTrue(BufferHasEntry(TempLedgerEntryMatchingBuffer, RecentEntryNo), 'Vendor entry posted within the lookback window should be a candidate.');
+        Assert.IsFalse(BufferHasEntry(TempLedgerEntryMatchingBuffer, OldEntryNo), 'Vendor entry posted before the lookback window should be excluded.');
+    end;
+
+    local procedure SetCandidateLookbackDays(Days: Integer)
+    var
+        BankPmtApplSettings: Record "Bank Pmt. Appl. Settings";
+    begin
+        BankPmtApplSettings.GetOrInsert();
+        BankPmtApplSettings."Candidate Lookback (Days)" := Days;
+        BankPmtApplSettings.Modify();
+    end;
+
+    local procedure PostCustomerInvoiceWithPostingDate(CustomerNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Invoice, CustomerNo);
+        SalesHeader.Validate("Posting Date", PostingDate);
+        SalesHeader.Validate("External Document No.", GenerateExtDocNo());
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        CustLedgerEntry.SetRange("Customer No.", CustomerNo);
+        CustLedgerEntry.SetRange("Document No.", DocumentNo);
+        CustLedgerEntry.FindFirst();
+        exit(CustLedgerEntry."Entry No.");
+    end;
+
+    local procedure PostVendorInvoiceWithPostingDate(VendorNo: Code[20]; Amount: Decimal; PostingDate: Date): Integer
+    var
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        DocumentNo: Code[20];
+        SavedWorkDate: Date;
+    begin
+        CreateItem(Item, Amount);
+        // Align the work date to the posting date so back-dated posting does not raise the work-date confirmation.
+        SavedWorkDate := WorkDate();
+        WorkDate(PostingDate);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, VendorNo);
+        PurchaseHeader.Validate("Posting Date", PostingDate);
+        PurchaseHeader.Validate("Vendor Invoice No.", GenerateExtDocNo());
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        DocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+        WorkDate(SavedWorkDate);
+
+        VendorLedgerEntry.SetRange("Vendor No.", VendorNo);
+        VendorLedgerEntry.SetRange("Document No.", DocumentNo);
+        VendorLedgerEntry.FindFirst();
+        exit(VendorLedgerEntry."Entry No.");
+    end;
+
+    local procedure BufferHasEntry(var TempLedgerEntryMatchingBuffer: Record "Ledger Entry Matching Buffer" temporary; EntryNo: Integer): Boolean
+    begin
+        TempLedgerEntryMatchingBuffer.Reset();
+        TempLedgerEntryMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempLedgerEntryMatchingBuffer.IsEmpty());
+    end;
+
+    local procedure CandidateExistsForLine(LineNo: Integer; EntryNo: Integer): Boolean
+    begin
+        TempBankStatementMatchingBuffer.Reset();
+        TempBankStatementMatchingBuffer.SetRange("Line No.", LineNo);
+        TempBankStatementMatchingBuffer.SetRange("Entry No.", EntryNo);
+        exit(not TempBankStatementMatchingBuffer.IsEmpty());
+    end;
 
     local procedure Initialize()
     var


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:
https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md Local dev environment:
https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md -->

## What & why

- Introducing a simple date filter setting on Payment Application Settings page.
- Avoiding double database reads when building temporary record set in memory.
- Avoiding excessive SetAutoCalcfields calls.
- In DK FIK payment matching, fixing a major blunder - unconditional unfiltered full table scan of customer ledger entry table on every drilldown.

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>". Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#648380](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648380)
Backport of https://github.com/microsoft/BCApps/pull/10498 to releases/29.x

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

Compatibility: no issues, because it adds a beneficial setting for narrowing down the candidate list, which is off by default. Risk: low-medium, because we are introducing a new index on Vendor Ledger Entry that facilitates the date filtering. Note: this exact index already exists on Customer Ledger Entry and Bank Account Ledger Entry table. I decided not to add it for Employee Ledger Entry because it would not give a significant performance gain.
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

(cherry picked from commit 5359c313825f29f39b400ab2d82c088b46765134)

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#648380](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648380)
Backport of https://github.com/microsoft/BCApps/pull/10498 to releases/29.x

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->





