### PR TITLE
Remove OnPrem scope from Table 1226 "Payment Export Data".SetSwissExport

### DIFF
--- a/src/Layers/CH/BaseApp/Bank/Payment/PaymentExportData.Table.al
+++ b/src/Layers/CH/BaseApp/Bank/Payment/PaymentExportData.Table.al
@@ -803,7 +803,6 @@ table 1226 "Payment Export Data"
         "End-to-End ID" := "Payment Information ID";
     end;
 
-    [Scope('OnPrem')]
     procedure SetSwissExport(NewSwissExport: Boolean)
     begin
         SwissExport := NewSwissExport;


### PR DESCRIPTION
## Summary
Fixes #10731

Removes the `[Scope('OnPrem')]` attribute from `SetSwissExport(NewSwissExport: Boolean)` on `Table 1226 "Payment Export Data"`, so the procedure can be called from Business Central Online (Cloud) extensions.

## Motivation
Extensions implementing Swiss payment/SEPA (ISO 20022 credit transfer) export logic and targeting Business Central Online currently fail to compile when calling `SetSwissExport`:

```
AL0296: The application object or method 'SetSwissExport' has scope 'OnPrem' and cannot be used for 'Cloud' development.
```

The `SwissExport` field itself, and every other setter on this table (`SetCreditorIdentifier`, `SetCreditTransferIDs`, `SetBankAsSenderBank`, etc.), are already unrestricted. `SetSwissExport` is the only member on this table scoped to `OnPrem`, which appears to be an inconsistency rather than an intentional platform restriction.

## Changes
- `PaymentExportData.al`: removed `[Scope('OnPrem')]` from `SetSwissExport`.

## Why this should be safe
- No change to the procedure body - only the scope restriction is removed.
- Widens (never narrows) where the procedure can be called from, so it stays backward compatible for existing OnPrem callers.
- The field it mutates, and all sibling setters on the same table, are already callable from Cloud extensions - this only resolves the inconsistency.

## Testing
- [x] Base application compiles after the change (OnPrem target)
- [x] A test extension targeting Cloud can call `SetSwissExport` without raising `AL0296`

## Related
Fixes #10731 
