### PR TITLE
[Extensibility Request][Subscription Billing] Remove internal access from SetParameter procedures on page "Extend Contract

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ExtendContract.Page.al
+++ b/src/Apps/W1/Subscription Billing/App/Customer Contracts/Pages/ExtendContract.Page.al
@@ -630,7 +630,7 @@ page 8002 "Extend Contract"
         TempServiceCommitmentPackage.SetRange(Selected);
     end;
 
-    internal procedure SetParameters(NewCustomerNo: Code[20]; NewCustomerContractNo: Code[20]; NewProvisionStartDate: Date; NewExtendCustomerContract: Boolean)
+    procedure SetParameters(NewCustomerNo: Code[20]; NewCustomerContractNo: Code[20]; NewProvisionStartDate: Date; NewExtendCustomerContract: Boolean)
     begin
         SellToCustomerNoParam := NewCustomerNo;
         CustomerContractNoParam := NewCustomerContractNo;
@@ -661,7 +661,7 @@ page 8002 "Extend Contract"
         end;
     end;
 
-    internal procedure SetUsageBasedParameters(SupplierNo: Code[20]; NewSubscriptionEntryNo: Integer)
+    procedure SetUsageBasedParameters(SupplierNo: Code[20]; NewSubscriptionEntryNo: Integer)
     begin
         UsageDataSupplierNoParam := SupplierNo;
         SubscriptionEntryNoParam := NewSubscriptionEntryNo;


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
The procedures `internal procedure SetParameters(NewCustomerNo: Code[20]; NewCustomerContractNo: Code[20]; NewProvisionStartDate: Date; NewExtendCustomerContract: Boolean)` and `internal procedure SetUsageBasedParameters(SupplierNo: Code[20]; NewSubscriptionEntryNo: Integer)` are both changed so they can be accessed externally, so that we can called from a dependent app.
The page should be called from the import a custom usage data connector (like it is for the existing generic connector)

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #10629

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** 

- Verified that the page "Extend Contract" can be called from dependent app and works properly
- No Tests added or updated because functionality of the Subscription Billing App is unchanged only a few procedure are now externally accessible.

## Risk & compatibility
Existing behavior is unchanged because only visibility changed; no posting, amount, metadata, or billing logic was edited.


