### PR TITLE
[29.0] Extend OnBeforeCheckBankAcc to skip specific bank reversal checks

### DIFF
--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -728,9 +728,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -740,10 +744,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2397,8 +2401,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/BE/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/BE/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -719,9 +719,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -731,10 +735,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2342,8 +2346,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -730,9 +730,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -742,10 +746,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2344,8 +2348,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -738,9 +738,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -750,10 +754,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2352,8 +2356,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/Tests/Reverse/ERMReverseBankLedger.Codeunit.al
+++ b/src/Layers/ES/Tests/Reverse/ERMReverseBankLedger.Codeunit.al
@@ -29,7 +29,12 @@
         ReconciliationErr: Label 'You cannot reverse %1 No. %2 because the entry is included in a bank account reconciliation line. The bank reconciliation has not yet been posted.', Locked = true;
         CompressErr: Label 'The transaction cannot be reversed, because the %1 has been compressed.', Locked = true;
         VerifyErr: Label 'Error must match.', Locked = true;
+        ReversalSuccessfulTxt: Label 'The entries were successfully reversed.', Locked = true;
+        BankAccCheckSubscriberNotInvokedErr: Label 'The bank account check subscriber was not invoked.', Locked = true;
         isInitialized: Boolean;
+        BankAccCheckSubscriberInvoked: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
         VoidType: Option "Unapply and void check","Void check only";
         IncorrectCountErr: Label 'Incorrect count of G/L Entries';
 
@@ -181,6 +186,122 @@
         ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
         // Verify: Verify Reversing Error for Bank Account Ledger Entry After Modify and Post Bank Reconciliation.
         Assert.AreEqual(StrSubstNo(ReverseErr, BankAccountLedgerEntry."Entry No."), GetLastErrorText, VerifyErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,ReversalMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ReverseClosedBankLedgerEntryWhenOpenCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] A closed bank account ledger entry can be reversed when the open check is skipped.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(true, false);
+        BindSubscription(ERMReverseBankLedger);
+        LibraryVariableStorage.Enqueue(ReversalSuccessfulTxt);
+        ReverseBankAccountLedgerEntryNoErr(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        BankAccountLedgerEntry.TestField(Reversed, true);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CannotReverseClosedBankLedgerEntryWhenOnlyStatementNoCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] Skipping the statement number check does not skip the open check.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(false, true);
+        BindSubscription(ERMReverseBankLedger);
+        ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        Assert.AreEqual(StrSubstNo(ReverseErr, BankAccountLedgerEntry."Entry No."), GetLastErrorText, VerifyErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,ReversalMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ReverseBankLedgerEntryWithStatementNoWhenStatementCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] A bank account ledger entry with a statement number can be reversed when the statement number check is skipped.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(false, true);
+        BindSubscription(ERMReverseBankLedger);
+        LibraryVariableStorage.Enqueue(ReversalSuccessfulTxt);
+        ReverseBankAccountLedgerEntryNoErr(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        BankAccountLedgerEntry.TestField(Reversed, true);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CannotReverseBankLedgerEntryWithStatementNoWhenOnlyOpenCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] Skipping the open check does not skip the statement number check.
+        Initialize();
+        CreateAndPostGenJournalLine(
+            GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+            GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(true, false);
+        BindSubscription(ERMReverseBankLedger);
+        ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        Assert.AreEqual(
+            StrSubstNo(ReconciliationErr, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No."),
+            GetLastErrorText, VerifyErr);
     end;
 
     [Test]
@@ -788,6 +909,8 @@
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reverse Bank Ledger");
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
         if isInitialized then
             exit;
 
@@ -1240,6 +1363,16 @@
     begin
     end;
 
+    [MessageHandler]
+    [Scope('OnPrem')]
+    procedure ReversalMessageHandler(Message: Text[1024])
+    var
+        ExpectedMessage: Text;
+    begin
+        ExpectedMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage(ExpectedMessage, Message);
+    end;
+
     [RequestPageHandler]
     [Scope('OnPrem')]
     procedure SuggestBankAccReconLinesRPH(var SuggestBankAccReconLines: TestRequestPage "Suggest Bank Acc. Recon. Lines")
@@ -1247,6 +1380,26 @@
         LibraryVariableStorage.Enqueue(SuggestBankAccReconLines.ExcludeReversedEntries.Visible());
         LibraryVariableStorage.Enqueue(SuggestBankAccReconLines.ExcludeReversedEntries.Enabled());
         SuggestBankAccReconLines.Cancel().Invoke();
+    end;
+
+    procedure SetBankAccCheckSkipFlags(SkipOpenCheck: Boolean; SkipStatementNoCheck: Boolean)
+    begin
+        BankAccCheckSubscriberInvoked := false;
+        SkipBankAccLedgEntryOpenCheck := SkipOpenCheck;
+        SkipBankAccLedgEntryStatementNoCheck := SkipStatementNoCheck;
+    end;
+
+    procedure AssertBankAccCheckSubscriberInvoked()
+    begin
+        Assert.IsTrue(BankAccCheckSubscriberInvoked, BankAccCheckSubscriberNotInvokedErr);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Reversal Entry", 'OnBeforeCheckBankAcc', '', false, false)]
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
+    begin
+        BankAccCheckSubscriberInvoked := true;
+        SkipBankAccountLedgerEntryOpenCheck := SkipBankAccLedgEntryOpenCheck;
+        SkipBankAccountLedgerEntryStatementNoCheck := SkipBankAccLedgEntryStatementNoCheck;
     end;
 
     [EventSubscriber(ObjectType::Report, Report::"Suggest Bank Acc. Recon. Lines", 'OnPreDataItemBankAccount', '', false, false)]

--- a/src/Layers/FR/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/FR/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -719,9 +719,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -731,10 +735,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2335,8 +2339,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/IT/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -723,9 +723,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -735,10 +739,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2353,8 +2357,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/RU/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/RU/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -788,9 +788,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -800,10 +804,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2636,8 +2640,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/SE/Tests/Reverse/ERMReverseBankLedger.Codeunit.al
+++ b/src/Layers/SE/Tests/Reverse/ERMReverseBankLedger.Codeunit.al
@@ -28,7 +28,12 @@
         ReconciliationErr: Label 'You cannot reverse %1 No. %2 because the entry is included in a bank account reconciliation line. The bank reconciliation has not yet been posted.', Locked = true;
         CompressErr: Label 'The transaction cannot be reversed, because the %1 has been compressed.', Locked = true;
         VerifyErr: Label 'Error must match.', Locked = true;
+        ReversalSuccessfulTxt: Label 'The entries were successfully reversed.', Locked = true;
+        BankAccCheckSubscriberNotInvokedErr: Label 'The bank account check subscriber was not invoked.', Locked = true;
         isInitialized: Boolean;
+        BankAccCheckSubscriberInvoked: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
         VoidType: Option "Unapply and void check","Void check only";
 
     [Test]
@@ -179,6 +184,122 @@
         ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
         // Verify: Verify Reversing Error for Bank Account Ledger Entry After Modify and Post Bank Reconciliation.
         Assert.AreEqual(StrSubstNo(ReverseErr, BankAccountLedgerEntry."Entry No."), GetLastErrorText, VerifyErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,ReversalMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ReverseClosedBankLedgerEntryWhenOpenCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] A closed bank account ledger entry can be reversed when the open check is skipped.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(true, false);
+        BindSubscription(ERMReverseBankLedger);
+        LibraryVariableStorage.Enqueue(ReversalSuccessfulTxt);
+        ReverseBankAccountLedgerEntryNoErr(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        BankAccountLedgerEntry.TestField(Reversed, true);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CannotReverseClosedBankLedgerEntryWhenOnlyStatementNoCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] Skipping the statement number check does not skip the open check.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(false, true);
+        BindSubscription(ERMReverseBankLedger);
+        ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        Assert.AreEqual(StrSubstNo(ReverseErr, BankAccountLedgerEntry."Entry No."), GetLastErrorText, VerifyErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,ReversalMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ReverseBankLedgerEntryWithStatementNoWhenStatementCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] A bank account ledger entry with a statement number can be reversed when the statement number check is skipped.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(false, true);
+        BindSubscription(ERMReverseBankLedger);
+        LibraryVariableStorage.Enqueue(ReversalSuccessfulTxt);
+        ReverseBankAccountLedgerEntryNoErr(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        BankAccountLedgerEntry.TestField(Reversed, true);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CannotReverseBankLedgerEntryWithStatementNoWhenOnlyOpenCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] Skipping the open check does not skip the statement number check.
+        Initialize();
+        CreateAndPostGenJournalLine(
+            GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+            GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(true, false);
+        BindSubscription(ERMReverseBankLedger);
+        ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        Assert.AreEqual(
+            StrSubstNo(ReconciliationErr, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No."),
+            GetLastErrorText, VerifyErr);
     end;
 
     [Test]
@@ -779,6 +900,8 @@
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reverse Bank Ledger");
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
         if isInitialized then
             exit;
 
@@ -1216,6 +1339,16 @@
     begin
     end;
 
+    [MessageHandler]
+    [Scope('OnPrem')]
+    procedure ReversalMessageHandler(Message: Text[1024])
+    var
+        ExpectedMessage: Text;
+    begin
+        ExpectedMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage(ExpectedMessage, Message);
+    end;
+
     [RequestPageHandler]
     [Scope('OnPrem')]
     procedure SuggestBankAccReconLinesRPH(var SuggestBankAccReconLines: TestRequestPage "Suggest Bank Acc. Recon. Lines")
@@ -1223,6 +1356,26 @@
         LibraryVariableStorage.Enqueue(SuggestBankAccReconLines.ExcludeReversedEntries.Visible());
         LibraryVariableStorage.Enqueue(SuggestBankAccReconLines.ExcludeReversedEntries.Enabled());
         SuggestBankAccReconLines.Cancel().Invoke();
+    end;
+
+    procedure SetBankAccCheckSkipFlags(SkipOpenCheck: Boolean; SkipStatementNoCheck: Boolean)
+    begin
+        BankAccCheckSubscriberInvoked := false;
+        SkipBankAccLedgEntryOpenCheck := SkipOpenCheck;
+        SkipBankAccLedgEntryStatementNoCheck := SkipStatementNoCheck;
+    end;
+
+    procedure AssertBankAccCheckSubscriberInvoked()
+    begin
+        Assert.IsTrue(BankAccCheckSubscriberInvoked, BankAccCheckSubscriberNotInvokedErr);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Reversal Entry", 'OnBeforeCheckBankAcc', '', false, false)]
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
+    begin
+        BankAccCheckSubscriberInvoked := true;
+        SkipBankAccountLedgerEntryOpenCheck := SkipBankAccLedgEntryOpenCheck;
+        SkipBankAccountLedgerEntryStatementNoCheck := SkipBankAccLedgEntryStatementNoCheck;
     end;
 
     [RequestPageHandler]

--- a/src/Layers/W1/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/GeneralLedger/Reversal/ReversalEntry.Table.al
@@ -719,9 +719,13 @@ table 179 "Reversal Entry"
         BankAccount: Record "Bank Account";
         CheckLedgerEntry: Record "Check Ledger Entry";
         IsHandled: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
     begin
         IsHandled := false;
-        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled);
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
+        OnBeforeCheckBankAcc(BankAccountLedgerEntry, IsHandled, SkipBankAccLedgEntryOpenCheck, SkipBankAccLedgEntryStatementNoCheck);
         if IsHandled then
             exit;
 
@@ -731,10 +735,10 @@ table 179 "Reversal Entry"
         BankAccount.TestField(Blocked, false);
         if BankAccountLedgerEntry.Reversed then
             AlreadyReversedEntry(BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if not BankAccountLedgerEntry.Open then
+        if (not SkipBankAccLedgEntryOpenCheck) and (not BankAccountLedgerEntry.Open) then
             Error(
               Text006, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
-        if BankAccountLedgerEntry."Statement No." <> '' then
+        if (not SkipBankAccLedgEntryStatementNoCheck) and (BankAccountLedgerEntry."Statement No." <> '') then
             Error(
               Text007, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No.");
         CheckLedgerEntry.SetRange("Bank Account Ledger Entry No.", BankAccountLedgerEntry."Entry No.");
@@ -2333,8 +2337,10 @@ table 179 "Reversal Entry"
     /// </summary>
     /// <param name="BankAccLedgEntry">Bank account ledger entry being validated for reversal</param>
     /// <param name="IsHandled">Set to true to skip standard bank account validation</param>
+    /// <param name="SkipBankAccountLedgerEntryOpenCheck">Set to true to skip the check that the entry must be open</param>
+    /// <param name="SkipBankAccountLedgerEntryStatementNoCheck">Set to true to skip the check that the entry has no statement number</param>
     [IntegrationEvent(true, false)]
-    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean)
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/Tests/Reverse/ERMReverseBankLedger.Codeunit.al
+++ b/src/Layers/W1/Tests/Reverse/ERMReverseBankLedger.Codeunit.al
@@ -28,7 +28,12 @@
         ReconciliationErr: Label 'You cannot reverse %1 No. %2 because the entry is included in a bank account reconciliation line. The bank reconciliation has not yet been posted.', Locked = true;
         CompressErr: Label 'The transaction cannot be reversed, because the %1 has been compressed.', Locked = true;
         VerifyErr: Label 'Error must match.', Locked = true;
+        ReversalSuccessfulTxt: Label 'The entries were successfully reversed.', Locked = true;
+        BankAccCheckSubscriberNotInvokedErr: Label 'The bank account check subscriber was not invoked.', Locked = true;
         isInitialized: Boolean;
+        BankAccCheckSubscriberInvoked: Boolean;
+        SkipBankAccLedgEntryOpenCheck: Boolean;
+        SkipBankAccLedgEntryStatementNoCheck: Boolean;
         VoidType: Option "Unapply and void check","Void check only";
 
     [Test]
@@ -179,6 +184,122 @@
         ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
         // Verify: Verify Reversing Error for Bank Account Ledger Entry After Modify and Post Bank Reconciliation.
         Assert.AreEqual(StrSubstNo(ReverseErr, BankAccountLedgerEntry."Entry No."), GetLastErrorText, VerifyErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,ReversalMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ReverseClosedBankLedgerEntryWhenOpenCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] A closed bank account ledger entry can be reversed when the open check is skipped.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(true, false);
+        BindSubscription(ERMReverseBankLedger);
+        LibraryVariableStorage.Enqueue(ReversalSuccessfulTxt);
+        ReverseBankAccountLedgerEntryNoErr(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        BankAccountLedgerEntry.TestField(Reversed, true);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CannotReverseClosedBankLedgerEntryWhenOnlyStatementNoCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] Skipping the statement number check does not skip the open check.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(false, true);
+        BindSubscription(ERMReverseBankLedger);
+        ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        Assert.AreEqual(StrSubstNo(ReverseErr, BankAccountLedgerEntry."Entry No."), GetLastErrorText, VerifyErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,ReversalMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ReverseBankLedgerEntryWithStatementNoWhenStatementCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] A bank account ledger entry with a statement number can be reversed when the statement number check is skipped.
+        Initialize();
+        CreateAndPostGenJournalLine(
+          GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+          GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(false, true);
+        BindSubscription(ERMReverseBankLedger);
+        LibraryVariableStorage.Enqueue(ReversalSuccessfulTxt);
+        ReverseBankAccountLedgerEntryNoErr(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        BankAccountLedgerEntry.TestField(Reversed, true);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler')]
+    [Scope('OnPrem')]
+    procedure CannotReverseBankLedgerEntryWithStatementNoWhenOnlyOpenCheckSkipped()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        BankAccountLedgerEntry: Record "Bank Account Ledger Entry";
+        ERMReverseBankLedger: Codeunit "ERM Reverse Bank Ledger";
+    begin
+        // [SCENARIO] Skipping the open check does not skip the statement number check.
+        Initialize();
+        CreateAndPostGenJournalLine(
+            GenJournalLine, GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(),
+            GenJournalLine."Bank Payment Type"::" ", '', CreateBankAccount(), LibraryRandom.RandDec(100, 2), '');
+        BankAccountLedgerEntry.SetRange("Document No.", GenJournalLine."Document No.");
+        BankAccountLedgerEntry.FindFirst();
+        BankAccountLedgerEntry.Open := false;
+        BankAccountLedgerEntry."Statement No." := CopyStr(LibraryUtility.GenerateGUID(), 1, MaxStrLen(BankAccountLedgerEntry."Statement No."));
+        BankAccountLedgerEntry.Modify();
+
+        ERMReverseBankLedger.SetBankAccCheckSkipFlags(true, false);
+        BindSubscription(ERMReverseBankLedger);
+        ReverseBankAccountLedgerEntry(BankAccountLedgerEntry, GenJournalLine."Document No.");
+
+        ERMReverseBankLedger.AssertBankAccCheckSubscriberInvoked();
+        Assert.AreEqual(
+            StrSubstNo(ReconciliationErr, BankAccountLedgerEntry.TableCaption(), BankAccountLedgerEntry."Entry No."),
+            GetLastErrorText, VerifyErr);
     end;
 
     [Test]
@@ -780,6 +901,8 @@
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"ERM Reverse Bank Ledger");
         LibraryVariableStorage.Clear();
         LibrarySetupStorage.Restore();
+        SkipBankAccLedgEntryOpenCheck := false;
+        SkipBankAccLedgEntryStatementNoCheck := false;
         if isInitialized then
             exit;
 
@@ -1217,6 +1340,16 @@
     begin
     end;
 
+    [MessageHandler]
+    [Scope('OnPrem')]
+    procedure ReversalMessageHandler(Message: Text[1024])
+    var
+        ExpectedMessage: Text;
+    begin
+        ExpectedMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage(ExpectedMessage, Message);
+    end;
+
     [RequestPageHandler]
     [Scope('OnPrem')]
     procedure SuggestBankAccReconLinesRPH(var SuggestBankAccReconLines: TestRequestPage "Suggest Bank Acc. Recon. Lines")
@@ -1224,6 +1357,26 @@
         LibraryVariableStorage.Enqueue(SuggestBankAccReconLines.ExcludeReversedEntries.Visible());
         LibraryVariableStorage.Enqueue(SuggestBankAccReconLines.ExcludeReversedEntries.Enabled());
         SuggestBankAccReconLines.Cancel().Invoke();
+    end;
+
+    procedure SetBankAccCheckSkipFlags(SkipOpenCheck: Boolean; SkipStatementNoCheck: Boolean)
+    begin
+        BankAccCheckSubscriberInvoked := false;
+        SkipBankAccLedgEntryOpenCheck := SkipOpenCheck;
+        SkipBankAccLedgEntryStatementNoCheck := SkipStatementNoCheck;
+    end;
+
+    procedure AssertBankAccCheckSubscriberInvoked()
+    begin
+        Assert.IsTrue(BankAccCheckSubscriberInvoked, BankAccCheckSubscriberNotInvokedErr);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Reversal Entry", 'OnBeforeCheckBankAcc', '', false, false)]
+    local procedure OnBeforeCheckBankAcc(var BankAccLedgEntry: Record "Bank Account Ledger Entry"; var IsHandled: Boolean; var SkipBankAccountLedgerEntryOpenCheck: Boolean; var SkipBankAccountLedgerEntryStatementNoCheck: Boolean)
+    begin
+        BankAccCheckSubscriberInvoked := true;
+        SkipBankAccountLedgerEntryOpenCheck := SkipBankAccLedgEntryOpenCheck;
+        SkipBankAccountLedgerEntryStatementNoCheck := SkipBankAccLedgEntryStatementNoCheck;
     end;
 
     [EventSubscriber(ObjectType::Report, Report::"Suggest Bank Acc. Recon. Lines", 'OnPreDataItemBankAccount', '', false, false)]


### PR DESCRIPTION
Backport of #10630.

## What & why

This change lets extensions independently skip the Open and Statement No. validations when reversing a bank account ledger entry. The remaining standard reversal checks continue to run, avoiding the need for extensions to handle the entire validation through the existing IsHandled parameter.

The new controls are added as trailing parameters to the existing OnBeforeCheckBankAcc event, preserving compatibility with existing subscribers.

Fixes [AB#648338](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648338)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Added a test that closes a bank account ledger entry, skips only the Open check, and verifies that the entry is reversed.
- Added a test that assigns a statement number, skips only the Statement No. check, and verifies that the entry is reversed.
- Verified that the publisher and test subscriber have no AL editor diagnostics.
- The tests were not run locally because the enlistment build and test environment could not be initialized.

## Risk & compatibility

The event change is additive. The existing parameters and IntegrationEvent attributes remain unchanged, and the new Boolean parameters are appended to the event signature.

