### PR TITLE
Bug 648371: [internal] github code review agent sprinkles wrong ownership teams on some PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -212,6 +212,9 @@
 # single owner. This line has no owner on purpose: it releases demo data
 # from the localization wildcard above without naming anyone.
 /src/Apps/*/*ContosoCoffeeDemoDataset*/
+/src/DemoTool/*/
+/src/Layers/*/DemoTool/*/
+
 
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets


### PR DESCRIPTION
Added directives for (old) demotool, pointing to nil (no team)
Fixes [AB#648371](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648371)



