### PR TITLE
[FRA] Address French E-Document review findings

### DIFF
--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
@@ -1104,13 +1104,16 @@ codeunit 10978 "CII XML Builder"
     local procedure InitializeAmountRoundingPrecision(CurrencyCode: Code[10])
     var
         Currency: Record Currency;
+        GeneralLedgerSetup: Record "General Ledger Setup";
     begin
-        if CurrencyCode = '' then
-            Currency.InitRoundingPrecision()
-        else begin
-            Currency.Get(CurrencyCode);
-            Currency.TestField("Amount Rounding Precision");
+        GeneralLedgerSetup.Get();
+        if (CurrencyCode = '') or (CurrencyCode = GeneralLedgerSetup."LCY Code") then begin
+            AmountRoundingPrecision := GeneralLedgerSetup."Amount Rounding Precision";
+            exit;
         end;
+
+        Currency.Get(CurrencyCode);
+        Currency.TestField("Amount Rounding Precision");
         AmountRoundingPrecision := Currency."Amount Rounding Precision";
     end;
 

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
@@ -418,7 +418,7 @@ codeunit 10978 "CII XML Builder"
 
         InvoiceDiscountAmount := GetInvoiceDiscountAmount(SourceDocumentHeader, SourceDocumentLines, TaxBasisTotalAmount, LineTotalAmount);
         if InvoiceDiscountAmount = 0 then
-            InvoiceDiscountAmount := Round(LineTotalAmount - TaxBasisTotalAmount, 0.01);
+            InvoiceDiscountAmount := Round(LineTotalAmount - TaxBasisTotalAmount, GetAmountRoundingPrecision());
 
         // BG-16 Payment means (BT-81 TypeCode + BT-84 IBAN + BT-86 BIC)
         if FREDocHelpers.FindFieldByName(SourceDocumentHeader, 'Company Bank Account Code', FieldRefVar) then
@@ -545,7 +545,7 @@ codeunit 10978 "CII XML Builder"
             AllocatedDiscountTotal += DiscountAmount;
         end;
 
-        if Round(AllocatedDiscountTotal - InvoiceDiscountAmount, 0.01) <> 0 then begin
+        if Round(AllocatedDiscountTotal - InvoiceDiscountAmount, GetAmountRoundingPrecision()) <> 0 then begin
             Clear(AllocatedDiscountByKey);
             AllocateInvoiceDiscountByVATKey(InvoiceDiscountAmount, LineBaseAmounts, AllocatedDiscountByKey);
         end;
@@ -628,7 +628,7 @@ codeunit 10978 "CII XML Builder"
                             VATAmount := AmountIncludingVAT - NetBaseAmount;
                         end
                         else
-                            VATAmount := Round(NetBaseAmount * VATPercent / 100, 0.01);
+                            VATAmount := Round(NetBaseAmount * VATPercent / 100, GetAmountRoundingPrecision());
 
                         AddAmountForVATKey(VATAggregationKey, BaseAmount, LineBaseAmounts);
                         AddAmountForVATKey(VATAggregationKey, NetBaseAmount, LineNetBaseAmounts);
@@ -689,7 +689,7 @@ codeunit 10978 "CII XML Builder"
             exit;
 
         foreach VATKey in VATAggregationKeys do begin
-            AllocatedDiscountAmount := Round(InvoiceDiscountAmount * LineBaseAmounts.Get(VATKey) / TotalBaseAmount, 0.01);
+            AllocatedDiscountAmount := Round(InvoiceDiscountAmount * LineBaseAmounts.Get(VATKey) / TotalBaseAmount, GetAmountRoundingPrecision());
             AllocatedDiscountByKey.Add(VATKey, AllocatedDiscountAmount);
             TotalAllocatedDiscountAmount += AllocatedDiscountAmount;
         end;
@@ -954,12 +954,13 @@ codeunit 10978 "CII XML Builder"
         BankAccount: Record "Bank Account";
         CompanyInformation: Record "Company Information";
     begin
-        if CompanyBankAccountCode <> '' then
+        if CompanyBankAccountCode <> '' then begin
             BankAccount.SetLoadFields(IBAN, "SWIFT Code");
-        if BankAccount.Get(CompanyBankAccountCode) then begin
-            IBAN := BankAccount.IBAN;
-            SWIFTCode := BankAccount."SWIFT Code";
-            exit;
+            if BankAccount.Get(CompanyBankAccountCode) then begin
+                IBAN := BankAccount.IBAN;
+                SWIFTCode := BankAccount."SWIFT Code";
+                exit;
+            end;
         end;
 
         CompanyInformation.Get();
@@ -1055,7 +1056,7 @@ codeunit 10978 "CII XML Builder"
         end;
 
         if LineTotalAmount <> 0 then begin
-            InvoiceDiscountAmount := Round(LineTotalAmount - AmountExclVAT, 0.01);
+            InvoiceDiscountAmount := Round(LineTotalAmount - AmountExclVAT, GetAmountRoundingPrecision());
             if InvoiceDiscountAmount <> 0 then
                 exit(InvoiceDiscountAmount);
         end;
@@ -1096,6 +1097,14 @@ codeunit 10978 "CII XML Builder"
     local procedure FormatVATRate(VATPercent: Decimal): Text
     begin
         exit(Format(Round(VATPercent, 0.00001), 0, 9));
+    end;
+
+    local procedure GetAmountRoundingPrecision(): Decimal
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+    begin
+        GeneralLedgerSetup.Get();
+        exit(GeneralLedgerSetup."Amount Rounding Precision");
     end;
 
     local procedure GetVATCategoryCode(TaxCategory: Code[10]; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]): Text
@@ -1172,5 +1181,5 @@ codeunit 10978 "CII XML Builder"
         RecoveryCostNoteTok: Label 'Indemnité forfaitaire pour frais de recouvrement en cas de retard de paiement : 40 €', Locked = true;
         LatePaymentPenaltyNoteTok: Label 'Taux des pénalités de retard : taux directeur (BCE) majoré de 10 points', Locked = true;
         EarlyPaymentDiscountNoteTok: Label 'Pas d''escompte pour paiement anticipé', Locked = true;
-        VATExemptionReasonLbl: Label 'Exempt from VAT', Locked = true;
+        VATExemptionReasonLbl: Label 'Exonéré de TVA', Locked = true;
 }

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
@@ -1112,6 +1112,7 @@ codeunit 10978 "CII XML Builder"
             exit;
         end;
 
+        Currency.SetLoadFields("Amount Rounding Precision");
         Currency.Get(CurrencyCode);
         Currency.TestField("Amount Rounding Precision");
         AmountRoundingPrecision := Currency."Amount Rounding Precision";

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/CIIXMLBuilder.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.eServices.EDocument.Formats;
 
 using Microsoft.Bank.BankAccount;
 using Microsoft.eServices.EDocument;
+using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Clause;
 using Microsoft.Finance.VAT.Setup;
@@ -44,6 +45,7 @@ codeunit 10978 "CII XML Builder"
     begin
         FREDocHelpers.CheckBuyerElectronicAddress(SourceDocumentHeader);
         CompanyInformation.Get();
+        InitializeAmountRoundingPrecision(EDocument."Currency Code");
 
         XmlDoc := XmlDocument.Create();
 
@@ -1099,12 +1101,22 @@ codeunit 10978 "CII XML Builder"
         exit(Format(Round(VATPercent, 0.00001), 0, 9));
     end;
 
-    local procedure GetAmountRoundingPrecision(): Decimal
+    local procedure InitializeAmountRoundingPrecision(CurrencyCode: Code[10])
     var
-        GeneralLedgerSetup: Record "General Ledger Setup";
+        Currency: Record Currency;
     begin
-        GeneralLedgerSetup.Get();
-        exit(GeneralLedgerSetup."Amount Rounding Precision");
+        if CurrencyCode = '' then
+            Currency.InitRoundingPrecision()
+        else begin
+            Currency.Get(CurrencyCode);
+            Currency.TestField("Amount Rounding Precision");
+        end;
+        AmountRoundingPrecision := Currency."Amount Rounding Precision";
+    end;
+
+    local procedure GetAmountRoundingPrecision(): Decimal
+    begin
+        exit(AmountRoundingPrecision);
     end;
 
     local procedure GetVATCategoryCode(TaxCategory: Code[10]; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]): Text
@@ -1173,6 +1185,7 @@ codeunit 10978 "CII XML Builder"
     end;
 
     var
+        AmountRoundingPrecision: Decimal;
         RsmNamespaceTok: Label 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100', Locked = true;
         RamNamespaceTok: Label 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100', Locked = true;
         QdtNamespaceTok: Label 'urn:un:unece:uncefact:data:standard:QualifiedDataType:100', Locked = true;

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/EDocHelpers.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Core/EDocHelpers.Codeunit.al
@@ -120,10 +120,8 @@ codeunit 10991 "EDoc. Helpers"
         IsHandled: Boolean;
     begin
         OnBeforeCheckBuyerElectronicAddress(SourceDocumentHeader, EDocumentServiceCode, IsHandled);
-        if IsHandled then
-            exit;
-
-        CheckBuyerElectronicAddressCore(SourceDocumentHeader, EDocumentServiceCode);
+        if not IsHandled then
+            CheckBuyerElectronicAddressCore(SourceDocumentHeader, EDocumentServiceCode);
 
         OnAfterCheckBuyerElectronicAddress(SourceDocumentHeader, EDocumentServiceCode);
     end;
@@ -145,7 +143,7 @@ codeunit 10991 "EDoc. Helpers"
             exit;
 
         if HasServiceParticipantAddress(EDocumentServiceCode, Enum::"E-Document Source Type"::Customer, CustomerNo, ServiceParticipant) then begin
-            CheckBuyerElectronicAddressValue(ServiceParticipant."Participant Identifier", ServiceParticipant.FieldCaption("Participant Identifier"), CustomerNo);
+            CheckServiceParticipantElectronicAddressValue(ServiceParticipant, CustomerNo);
             exit;
         end;
 
@@ -168,18 +166,17 @@ codeunit 10991 "EDoc. Helpers"
         IsHandled: Boolean;
     begin
         OnBeforeGetBuyerElectronicAddress(Customer, BuyerElectronicAddress, Result, IsHandled);
-        if IsHandled then
-            exit(Result);
-
-        BuyerElectronicAddress := Customer."FR Electronic Address";
-        if BuyerElectronicAddress <> '' then
-            Result := true
-        else begin
-            BuyerElectronicAddress := CopyStr(Customer."Registration Number", 1, 9);
+        if not IsHandled then begin
+            BuyerElectronicAddress := Customer."FR Electronic Address";
             if BuyerElectronicAddress <> '' then
                 Result := true
-            else
-                Result := GetSIRENFromFrenchVATRegistrationNo(Customer."VAT Registration No.", BuyerElectronicAddress);
+            else begin
+                BuyerElectronicAddress := CopyStr(Customer."Registration Number", 1, 9);
+                if BuyerElectronicAddress <> '' then
+                    Result := true
+                else
+                    Result := GetSIRENFromFrenchVATRegistrationNo(Customer."VAT Registration No.", BuyerElectronicAddress);
+            end;
         end;
 
         OnAfterGetBuyerElectronicAddress(Customer, BuyerElectronicAddress, Result);
@@ -209,6 +206,16 @@ codeunit 10991 "EDoc. Helpers"
 
         Customer.Get(CustomerNo);
         RaiseCustomerError(StrSubstNo(BuyerElectronicAddressInvalidErr, FieldCaption, CustomerNo), Customer);
+    end;
+
+    local procedure CheckServiceParticipantElectronicAddressValue(ServiceParticipant: Record "Service Participant"; CustomerNo: Code[20])
+    begin
+        if IsValidBuyerElectronicAddress(ServiceParticipant."Participant Identifier") then
+            exit;
+
+        RaiseServiceParticipantError(
+            StrSubstNo(BuyerElectronicAddressInvalidErr, ServiceParticipant.FieldCaption("Participant Identifier"), CustomerNo),
+            ServiceParticipant);
     end;
 
     local procedure IsValidBuyerElectronicAddress(ElectronicAddress: Text): Boolean
@@ -248,6 +255,7 @@ codeunit 10991 "EDoc. Helpers"
         HasScheme := ServiceParticipant."FR Identifier Scheme" <> ServiceParticipant."FR Identifier Scheme"::" ";
         if HasIdentifier <> HasScheme then begin
             ParticipantAddressErrorInfo.Message(GetServiceParticipantAddressIncompleteError());
+            ParticipantAddressErrorInfo.DataClassification := DataClassification::SystemMetadata;
             ParticipantAddressErrorInfo.RecordId(ServiceParticipant.RecordId());
             ParticipantAddressErrorInfo.PageNo(Page::"Service Participants");
             ParticipantAddressErrorInfo.AddNavigationAction(ShowServiceParticipantLbl);
@@ -262,6 +270,7 @@ codeunit 10991 "EDoc. Helpers"
         SetupErrorInfo: ErrorInfo;
     begin
         SetupErrorInfo.Message(ErrorMessage);
+        SetupErrorInfo.DataClassification := DataClassification::SystemMetadata;
         SetupErrorInfo.RecordId(CompanyInformation.RecordId());
         SetupErrorInfo.PageNo(Page::"Company Information");
         SetupErrorInfo.AddNavigationAction(ShowCompanyInformationLbl);
@@ -273,9 +282,22 @@ codeunit 10991 "EDoc. Helpers"
         SetupErrorInfo: ErrorInfo;
     begin
         SetupErrorInfo.Message(ErrorMessage);
+        SetupErrorInfo.DataClassification := DataClassification::CustomerContent;
         SetupErrorInfo.RecordId(Customer.RecordId());
         SetupErrorInfo.PageNo(Page::"Customer Card");
         SetupErrorInfo.AddNavigationAction(ShowCustomerLbl);
+        Error(SetupErrorInfo);
+    end;
+
+    local procedure RaiseServiceParticipantError(ErrorMessage: Text; ServiceParticipant: Record "Service Participant")
+    var
+        SetupErrorInfo: ErrorInfo;
+    begin
+        SetupErrorInfo.Message(ErrorMessage);
+        SetupErrorInfo.DataClassification := DataClassification::CustomerContent;
+        SetupErrorInfo.RecordId(ServiceParticipant.RecordId());
+        SetupErrorInfo.PageNo(Page::"Service Participants");
+        SetupErrorInfo.AddNavigationAction(ShowServiceParticipantLbl);
         Error(SetupErrorInfo);
     end;
 

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/FacturXCIIXMLTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/FacturXCIIXMLTests.Codeunit.al
@@ -721,16 +721,32 @@ codeunit 148148 "Factur-X CII XML Tests"
     [Test]
     procedure FacturXSalesInvoiceUsesCompanyBankAccountWhenCodeIsBlank()
     var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
         TempBlob: Codeunit "Temp Blob";
     begin
+        // [FEATURE] [AI test]
         // [SCENARIO] A blank company bank account code falls back to Company Information payment details
         Initialize();
 
-        CreateSalesInvoiceCIIXML(TempBlob);
+        // [GIVEN] Company Information with payment details and posted sales invoice "SI" with a blank company bank account code
+        CompanyInformation.Get();
+        CompanyInformation.IBAN := 'FR7630006000011234567890189';
+        CompanyInformation."SWIFT Code" := 'AGRIFRPP';
+        CompanyInformation.Modify();
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoice());
+        SalesInvoiceHeader."Company Bank Account Code" := '';
+        SalesInvoiceHeader.Modify();
 
+        // [WHEN] Create CII XML
+        CreateSalesInvoiceCIIXMLFromHeader(SalesInvoiceHeader, TempBlob);
+
+        // [THEN] Payment account uses Company Information IBAN and BIC
         Assert.AreEqual(DelChr(CompanyInformation.IBAN, '=', ' '),
             GetCIINodeValue(TempBlob, '//ram:PayeePartyCreditorFinancialAccount/ram:IBANID'),
             StrSubstNo(IncorrectValueErr, '//ram:PayeePartyCreditorFinancialAccount/ram:IBANID'));
+        Assert.AreEqual(CompanyInformation."SWIFT Code",
+            GetCIINodeValue(TempBlob, '//ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'),
+            StrSubstNo(IncorrectValueErr, '//ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID'));
     end;
 
     [Test]
@@ -1328,7 +1344,7 @@ codeunit 148148 "Factur-X CII XML Tests"
         SourceDocumentHeader: RecordRef;
         SourceDocumentLines: RecordRef;
     begin
-        // [FEATURE] [Reminder]
+        // [FEATURE] [AI test]
         // [SCENARIO] An issued reminder line (which has no Quantity field) emits BilledQuantity = 1
         Initialize();
 
@@ -1368,7 +1384,7 @@ codeunit 148148 "Factur-X CII XML Tests"
         SourceDocumentHeader: RecordRef;
         SourceDocumentLines: RecordRef;
     begin
-        // [FEATURE] [Finance Charge Memo]
+        // [FEATURE] [AI test]
         // [SCENARIO] An issued finance charge memo line (which has no Quantity field) emits BilledQuantity = 1
         Initialize();
 

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/FacturXCIIXMLTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/FacturXCIIXMLTests.Codeunit.al
@@ -719,6 +719,21 @@ codeunit 148148 "Factur-X CII XML Tests"
     end;
 
     [Test]
+    procedure FacturXSalesInvoiceUsesCompanyBankAccountWhenCodeIsBlank()
+    var
+        TempBlob: Codeunit "Temp Blob";
+    begin
+        // [SCENARIO] A blank company bank account code falls back to Company Information payment details
+        Initialize();
+
+        CreateSalesInvoiceCIIXML(TempBlob);
+
+        Assert.AreEqual(DelChr(CompanyInformation.IBAN, '=', ' '),
+            GetCIINodeValue(TempBlob, '//ram:PayeePartyCreditorFinancialAccount/ram:IBANID'),
+            StrSubstNo(IncorrectValueErr, '//ram:PayeePartyCreditorFinancialAccount/ram:IBANID'));
+    end;
+
+    [Test]
     procedure FacturXSalesInvoiceXMLHasTaxBreakdown()
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
@@ -805,7 +820,7 @@ codeunit 148148 "Factur-X CII XML Tests"
 
         // [THEN] The category 'E' header VAT breakdown contains fallback exemption reason text
         ExemptionReasonXPath := '//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax[ram:CategoryCode="E"]/ram:ExemptionReason';
-        Assert.AreEqual('Exempt from VAT', GetCIINodeValue(TempBlob, ExemptionReasonXPath),
+        Assert.AreEqual('Exonéré de TVA', GetCIINodeValue(TempBlob, ExemptionReasonXPath),
             StrSubstNo(IncorrectValueErr, ExemptionReasonXPath));
         Assert.AreEqual(1, GetCIINodeCount(TempBlob, ExemptionReasonXPath + '/following-sibling::ram:BasisAmount'),
             StrSubstNo(IncorrectValueErr, 'ExemptionReason must precede BasisAmount'));
@@ -1798,8 +1813,10 @@ codeunit 148148 "Factur-X CII XML Tests"
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Factur-X CII XML Tests");
         EDocumentService.DeleteAll();
-        if IsInitialized then
+        if IsInitialized then begin
+            LibrarySetupStorage.Restore();
             exit;
+        end;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"Factur-X CII XML Tests");
 
         CompanyInformation.Get();

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/FacturXCIIXMLTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/FacturXCIIXMLTests.Codeunit.al
@@ -380,6 +380,36 @@ codeunit 148148 "Factur-X CII XML Tests"
     end;
 
     [Test]
+    procedure FacturXForeignCurrencyRoundingPrecisionIsUsedForInvoiceDiscountAllocation()
+    var
+        Currency: Record Currency;
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        TempBlob: Codeunit "Temp Blob";
+        AllowanceAmount: Decimal;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] Factur-X allocates an invoice discount using the foreign currency rounding precision
+        Initialize();
+
+        // [GIVEN] Posted sales invoice "SI" with mixed VAT rates and a foreign currency whose rounding precision is 1
+        LibraryERM.CreateCurrency(Currency);
+        Currency.Validate("Amount Rounding Precision", 1);
+        Currency.Modify(true);
+        SalesInvoiceHeader.Get(CreateAndPostMultiVATInvoiceWithDiscount(false));
+        SalesInvoiceHeader."Currency Code" := Currency.Code;
+        SalesInvoiceHeader."Invoice Discount Amount" := 1.4;
+        SalesInvoiceHeader.Modify();
+
+        // [WHEN] Create CII XML
+        CreateSalesInvoiceCIIXMLFromHeader(SalesInvoiceHeader, TempBlob);
+
+        // [THEN] The discount allocated to the 20% VAT breakdown is rounded from 0.56 to 1
+        AllowanceAmount := GetCIINodeDecimalValue(TempBlob,
+            '//ram:SpecifiedTradeAllowanceCharge[ram:CategoryTradeTax/ram:RateApplicablePercent="20"]/ram:ActualAmount');
+        Assert.AreEqual(1, AllowanceAmount, StrSubstNo(IncorrectValueErr, 'ActualAmount 20%'));
+    end;
+
+    [Test]
     procedure FacturXSalesInvoiceXMLHasIssueDateTimeFormat102()
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/PEPPOLBIS30XMLTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/PEPPOLBIS30XMLTests.Codeunit.al
@@ -1173,6 +1173,36 @@ codeunit 148147 "PEPPOL BIS 3.0 XML Tests"
 
         AssertExpectedDialogError(EDocHelpers.GetServiceParticipantAddressIncompleteError());
     end;
+
+    [Test]
+    procedure CheckRaisesErrorWhenParticipantIdentifierIsMalformed()
+    var
+        ServiceParticipant: Record "Service Participant";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+        CustomerNo: Code[20];
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] Check rejects a service participant identifier that does not match SIREN or SIREN_suffix format
+        Initialize();
+
+        // [GIVEN] Customer "C" with a service participant whose identifier is malformed
+        CustomerNo := CreateCustomer('buyer@example.com', "Electronic Address Scheme"::"EM");
+        ServiceParticipant.Init();
+        ServiceParticipant.Service := EDocumentService.Code;
+        ServiceParticipant."Participant Type" := ServiceParticipant."Participant Type"::Customer;
+        ServiceParticipant.Participant := CustomerNo;
+        ServiceParticipant."Participant Identifier" := 'INVALID';
+        ServiceParticipant."FR Identifier Scheme" := ServiceParticipant."FR Identifier Scheme"::"0225";
+        ServiceParticipant.Insert();
+        SalesInvoiceHeader.Get(CreateAndPostSalesInvoice(CustomerNo));
+
+        // [WHEN] Check the posted sales invoice
+        asserterror CheckInvoice(SalesInvoiceHeader);
+
+        // [THEN] The malformed participant identifier error is raised
+        AssertExpectedDialogError(EDocHelpers.GetBuyerElectronicAddressInvalidError(
+            ServiceParticipant.FieldCaption("Participant Identifier"), CustomerNo));
+    end;
     #endregion
 
     local procedure AssertExpectedDialogError(ExpectedErrorText: Text)

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/PEPPOLBIS30XMLTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/PEPPOLBIS30XMLTests.Codeunit.al
@@ -762,7 +762,7 @@ codeunit 148147 "PEPPOL BIS 3.0 XML Tests"
     end;
 
     [Test]
-    procedure ExportSalesInvUsesSellerVATFallbackWhenSIRETIsEmpty()
+    procedure ExportSalesInvUsesSellerVATFallbackWhenSIRETAndSIRENAreEmpty()
     var
         SalesInvoiceHeader: Record "Sales Invoice Header";
         XmlDoc: XmlDocument;
@@ -773,9 +773,9 @@ codeunit 148147 "PEPPOL BIS 3.0 XML Tests"
         Initialize();
 
         // [GIVEN] Company with blank SIRET No. and Registration No., and a VAT registration number
+        CompanyInformation.Get();
         OriginalSIRETNo := CompanyInformation."SIRET No.";
         OriginalRegistrationNo := CompanyInformation."Registration No.";
-        CompanyInformation.Get();
         CompanyInformation."SIRET No." := '';
         CompanyInformation."Registration No." := '';
         CompanyInformation.Modify(true);
@@ -1189,11 +1189,14 @@ codeunit 148147 "PEPPOL BIS 3.0 XML Tests"
         LibraryTestInitialize.OnTestInitialize(Codeunit::"PEPPOL BIS 3.0 XML Tests");
         ServiceParticipant.SetRange(Service, EDocumentService.Code);
         ServiceParticipant.DeleteAll();
-        InitializeCompanyIdentity();
-        if IsInitialized then
+        if IsInitialized then begin
+            LibrarySetupStorage.Restore();
+            InitializeCompanyIdentity();
             exit;
+        end;
         LibraryTestInitialize.OnBeforeTestSuiteInitialize(Codeunit::"PEPPOL BIS 3.0 XML Tests");
 
+        InitializeCompanyIdentity();
         CompanyInformation.Get();
         CompanyInformation.Name := 'Test Company FR';
         CompanyInformation.Address := '123 Rue de Paris';


### PR DESCRIPTION
## Why

Follow-up review of the French E-Document implementation identified gaps in Factur-X payment details, configurable amount rounding, localized VAT exemption output, and actionable electronic-address validation.

## Summary

- Fixed Factur-X payment details to fall back to Company Information when no company bank account code is configured.
- Updated Factur-X calculations to use the General Ledger Setup amount rounding precision and emit the French VAT exemption reason.
- Improved buyer electronic-address validation and after-event behavior.
- Added regression coverage and restored shared setup state between French E-Document tests.

Backport of #10556.

Fixes [AB#647217](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647217)
