### PR TITLE
[Bug][SubscriptionBilling]: "Prices Including VAT" handling is incomplete — contract billing invoice treats VAT‑exclusive Subscription Line amounts as VAT‑inclusive (backport to releases/29.0)

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/CreateBillingDocuments.Codeunit.al
@@ -1,5 +1,6 @@
 namespace Microsoft.SubscriptionBilling;
 
+using Microsoft.Finance.Currency;
 using Microsoft.Foundation.ExtendedText;
 using Microsoft.Inventory.Item;
 using Microsoft.Purchases.Document;
@@ -247,6 +248,7 @@ codeunit 8060 "Create Billing Documents"
         SubContractsItemManagement: Codeunit "Sub. Contracts Item Management";
         TransferExtendedText: Codeunit "Transfer Extended Text";
         UsageBasedDocTypeConv: Codeunit "Usage Based Doc. Type Conv.";
+        UnitPrice: Decimal;
         BillingLineNo: Integer;
     begin
         ServiceObject.Get(TempBillingLine."Subscription Header No.");
@@ -274,8 +276,11 @@ codeunit 8060 "Create Billing Documents"
         if SalesLine."Unit of Measure Code" <> ServiceObject."Unit of Measure" then
             SalesLine.Validate("Unit of Measure Code", ServiceObject."Unit of Measure");
         SalesLine.Validate(Quantity, TempBillingLine.GetSign() * ServiceObject.Quantity);
+        UnitPrice := SalesLine.GetSalesDocumentSign() * TempBillingLine."Unit Price";
+        if SalesHeader."Prices Including VAT" then
+            UnitPrice := ToVATInclusiveUnitPrice(UnitPrice, SalesLine."VAT %", SalesLine."VAT Calculation Type" = SalesLine."VAT Calculation Type"::"Full VAT", SalesLine."Currency Code");
         // Unit Price is assigned directly; the following Validate("Line Discount %") recalculates the line amount.
-        SalesLine."Unit Price" := SalesLine.GetSalesDocumentSign() * TempBillingLine."Unit Price";
+        SalesLine."Unit Price" := UnitPrice;
         SalesLine.Validate("Line Discount %", TempBillingLine."Discount %");
         SalesLine.Validate("Unit Cost (LCY)", TempBillingLine."Unit Cost (LCY)");
         SalesLine."Recurring Billing from" := TempBillingLine."Billing from";
@@ -334,10 +339,28 @@ codeunit 8060 "Create Billing Documents"
         OnAfterInsertSalesLineFromBillingLine(CustomerContractLine, SalesLine);
     end;
 
+    local procedure ToVATInclusiveUnitPrice(NetUnitPrice: Decimal; VATPercent: Decimal; IsFullVAT: Boolean; CurrencyCode: Code[10]): Decimal
+    var
+        Currency: Record Currency;
+        VATFactor: Decimal;
+    begin
+        if IsFullVAT then
+            exit(NetUnitPrice);
+        VATFactor := 1 + VATPercent / 100;
+        if VATFactor = 0 then
+            exit(NetUnitPrice);
+        if CurrencyCode = '' then
+            Currency.InitRoundingPrecision()
+        else
+            Currency.Get(CurrencyCode);
+        exit(Round(NetUnitPrice * VATFactor, Currency."Unit-Amount Rounding Precision"));
+    end;
+
     local procedure SetInvoicePriceFromUsageDataBilling(var SalesLine: Record "Sales Line"; var BillingLine: Record "Billing Line")
     var
         UsageDataBilling: Record "Usage Data Billing";
         ServiceCommitment: Record "Subscription Line";
+        UnitPrice: Decimal;
     begin
         if not ServiceCommitment.Get(BillingLine."Subscription Line Entry No.") then
             exit;
@@ -359,9 +382,12 @@ codeunit 8060 "Create Billing Documents"
         UsageDataBilling.SetRange(Quantity);
         UsageDataBilling.CalcSums(Amount);
         if SalesLine.Quantity <> 0 then
-            SalesLine.Validate("Unit Price", SalesLine.GetSalesDocumentSign() * UsageDataBilling.Amount / SalesLine.Quantity)
+            UnitPrice := SalesLine.GetSalesDocumentSign() * UsageDataBilling.Amount / SalesLine.Quantity
         else
-            SalesLine.Validate("Unit Price", UsageDataBilling."Unit Price");
+            UnitPrice := UsageDataBilling."Unit Price";
+        if SalesHeader."Prices Including VAT" then
+            UnitPrice := ToVATInclusiveUnitPrice(UnitPrice, SalesLine."VAT %", SalesLine."VAT Calculation Type" = SalesLine."VAT Calculation Type"::"Full VAT", SalesLine."Currency Code");
+        SalesLine.Validate("Unit Price", UnitPrice);
         SalesLine.Validate("Line Discount %", ServiceCommitment."Discount %");
     end;
 
@@ -375,6 +401,7 @@ codeunit 8060 "Create Billing Documents"
         UsageBasedDocTypeConv: Codeunit "Usage Based Doc. Type Conv.";
         SubContractsItemManagement: Codeunit "Sub. Contracts Item Management";
         TransferExtendedText: Codeunit "Transfer Extended Text";
+        DirectUnitCost: Decimal;
         BillingLineNo: Integer;
     begin
         ServiceObject.Get(TempBillingLine."Subscription Header No.");
@@ -397,8 +424,11 @@ codeunit 8060 "Create Billing Documents"
         if PurchaseLine."Unit of Measure Code" <> ServiceObject."Unit of Measure" then
             PurchaseLine.Validate("Unit of Measure Code", ServiceObject."Unit of Measure");
         PurchaseLine.Validate(Quantity, TempBillingLine.GetSign() * ServiceObject.Quantity);
+        DirectUnitCost := PurchaseLine.GetPurchaseDocumentSign() * TempBillingLine."Unit Price";
+        if PurchaseHeader."Prices Including VAT" then
+            DirectUnitCost := ToVATInclusiveUnitPrice(DirectUnitCost, PurchaseLine."VAT %", PurchaseLine."VAT Calculation Type" = PurchaseLine."VAT Calculation Type"::"Full VAT", PurchaseLine."Currency Code");
         // Direct Unit Cost is assigned directly; the following Validate("Line Discount %") recalculates the line amount.
-        PurchaseLine."Direct Unit Cost" := PurchaseLine.GetPurchaseDocumentSign() * TempBillingLine."Unit Price";
+        PurchaseLine."Direct Unit Cost" := DirectUnitCost;
         PurchaseLine.Validate("Line Discount %", TempBillingLine."Discount %");
         PurchaseLine."Recurring Billing from" := TempBillingLine."Billing from";
         PurchaseLine."Recurring Billing to" := TempBillingLine."Billing to";
@@ -449,6 +479,7 @@ codeunit 8060 "Create Billing Documents"
     var
         UsageDataBilling: Record "Usage Data Billing";
         ServiceCommitment: Record "Subscription Line";
+        DirectUnitCost: Decimal;
     begin
         if not ServiceCommitment.Get(BillingLine."Subscription Line Entry No.") then
             exit;
@@ -470,9 +501,12 @@ codeunit 8060 "Create Billing Documents"
         UsageDataBilling.SetRange(Quantity);
         UsageDataBilling.CalcSums("Cost Amount");
         if PurchLine.Quantity <> 0 then
-            PurchLine.Validate("Direct Unit Cost", PurchLine.GetPurchaseDocumentSign() * UsageDataBilling."Cost Amount" / PurchLine.Quantity)
+            DirectUnitCost := PurchLine.GetPurchaseDocumentSign() * UsageDataBilling."Cost Amount" / PurchLine.Quantity
         else
-            PurchLine.Validate("Direct Unit Cost", 0);
+            DirectUnitCost := 0;
+        if PurchaseHeader."Prices Including VAT" then
+            DirectUnitCost := ToVATInclusiveUnitPrice(DirectUnitCost, PurchLine."VAT %", PurchLine."VAT Calculation Type" = PurchLine."VAT Calculation Type"::"Full VAT", PurchLine."Currency Code");
+        PurchLine.Validate("Direct Unit Cost", DirectUnitCost);
         PurchLine.Validate("Line Discount %", ServiceCommitment."Discount %");
     end;
 

--- a/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Billing/RecurringBillingDocsTest.Codeunit.al
@@ -1,7 +1,9 @@
 namespace Microsoft.SubscriptionBilling;
 
+using Microsoft.Finance.Currency;
 using Microsoft.Finance.GeneralLedger.Account;
 using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Item.Attribute;
@@ -715,6 +717,170 @@ codeunit 139687 "Recurring Billing Docs Test"
         // [THEN] The Sales Invoice is posted successfully
         SalesInvoiceHeader.Get(PostedDocumentNo);
         SalesInvoiceHeader.TestField("Recurring Billing", true);
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateCustomerBillingDocsContractPageHandler,MessageHandler')]
+    procedure ContractSalesInvoiceUnitPriceIsVATInclusiveWhenCustomerPricesIncludeVAT()
+    var
+        Currency: Record Currency;
+        VATPostingSetup: Record "VAT Posting Setup";
+        NetUnitPrice: Decimal;
+        ExpectedUnitPrice: Decimal;
+    begin
+        // [SCENARIO] When a Subscription Contract is billed for a customer whose prices include VAT,
+        // the resulting contract invoice sales line "Unit Price" is grossed up to a VAT-inclusive value.
+        Initialize();
+
+        // [GIVEN] A customer with "Prices Including VAT" = YES and a subscription item with a non-zero VAT rate
+        CreateCustomerContractWithVATItem(VATPostingSetup, true);
+
+        // [GIVEN] A billing proposal for the contract
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer);
+
+        // [WHEN] Billing documents are created
+        CreateBillingDocuments(false);
+
+        // [THEN] The created sales invoice has "Prices Including VAT" = YES
+        BillingLine.Reset();
+        BillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        BillingLine.SetRange(Partner, BillingTemplate.Partner);
+        BillingLine.FindFirst();
+        NetUnitPrice := SumBillingProposalUnitPrice();
+        Assert.AreNotEqual(0, NetUnitPrice, 'The net unit price should not be zero, otherwise the test is meaningless.');
+
+        SalesHeader.Get(Enum::"Sales Document Type"::Invoice, BillingLine."Document No.");
+        SalesHeader.TestField("Prices Including VAT", true);
+
+        // [THEN] The sales line unit price equals the net price grossed up by VAT
+        SalesLine.Reset();
+        FilterSalesLineOnDocumentLine(BillingLine.GetSalesDocumentTypeFromBillingDocumentType(), BillingLine."Document No.", BillingLine."Document Line No.");
+        SalesLine.FindFirst();
+        SalesLine.TestField("VAT %", VATPostingSetup."VAT %");
+
+        Currency.InitRoundingPrecision();
+        ExpectedUnitPrice := Round(NetUnitPrice * (1 + VATPostingSetup."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
+        Assert.AreEqual(ExpectedUnitPrice, SalesLine."Unit Price", 'Contract invoice unit price should be VAT-inclusive when the customer prices include VAT.');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateCustomerBillingDocsContractPageHandler,MessageHandler')]
+    procedure ContractSalesInvoiceUnitPriceIsNetWhenCustomerPricesExcludeVAT()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        NetUnitPrice: Decimal;
+    begin
+        // [SCENARIO] When a Subscription Contract is billed for a customer whose prices exclude VAT,
+        // the contract invoice sales line "Unit Price" stays net (no gross-up is applied).
+        Initialize();
+
+        // [GIVEN] A customer with "Prices Including VAT" = NO and a subscription item with a non-zero VAT rate
+        CreateCustomerContractWithVATItem(VATPostingSetup, false);
+
+        // [GIVEN] A billing proposal for the contract
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Customer);
+
+        // [WHEN] Billing documents are created
+        CreateBillingDocuments(false);
+
+        // [THEN] The created sales invoice has "Prices Including VAT" = NO
+        BillingLine.Reset();
+        BillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        BillingLine.SetRange(Partner, BillingTemplate.Partner);
+        BillingLine.FindFirst();
+        NetUnitPrice := SumBillingProposalUnitPrice();
+        Assert.AreNotEqual(0, NetUnitPrice, 'The net unit price should not be zero, otherwise the test is meaningless.');
+
+        SalesHeader.Get(Enum::"Sales Document Type"::Invoice, BillingLine."Document No.");
+        SalesHeader.TestField("Prices Including VAT", false);
+
+        // [THEN] The sales line unit price equals the net price (unchanged)
+        SalesLine.Reset();
+        FilterSalesLineOnDocumentLine(BillingLine.GetSalesDocumentTypeFromBillingDocumentType(), BillingLine."Document No.", BillingLine."Document Line No.");
+        SalesLine.FindFirst();
+        Assert.AreEqual(NetUnitPrice, SalesLine."Unit Price", 'Contract invoice unit price should stay net when the customer prices exclude VAT.');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,MessageHandler')]
+    procedure ContractPurchInvoiceUnitCostIsVATInclusiveWhenVendorPricesIncludeVAT()
+    var
+        Currency: Record Currency;
+        VATPostingSetup: Record "VAT Posting Setup";
+        NetUnitCost: Decimal;
+        ExpectedUnitCost: Decimal;
+    begin
+        // [SCENARIO] When a Vendor Subscription Contract is billed for a vendor whose prices include VAT,
+        // the resulting contract purchase invoice line "Direct Unit Cost" is grossed up to a VAT-inclusive value.
+        Initialize();
+
+        // [GIVEN] A vendor with "Prices Including VAT" = YES and a subscription item with a non-zero VAT rate
+        CreateVendorContractWithVATItem(VATPostingSetup, true);
+
+        // [GIVEN] A billing proposal for the contract
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Vendor);
+
+        // [WHEN] Billing documents are created
+        CreateBillingDocuments(false);
+
+        // [THEN] The created purchase invoice has "Prices Including VAT" = YES
+        BillingLine.Reset();
+        BillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        BillingLine.SetRange(Partner, BillingTemplate.Partner);
+        BillingLine.FindFirst();
+        NetUnitCost := SumBillingProposalUnitPrice();
+        Assert.AreNotEqual(0, NetUnitCost, 'The net unit cost should not be zero, otherwise the test is meaningless.');
+
+        PurchaseHeader.Get(Enum::"Purchase Document Type"::Invoice, BillingLine."Document No.");
+        PurchaseHeader.TestField("Prices Including VAT", true);
+
+        // [THEN] The purchase line direct unit cost equals the net cost grossed up by VAT
+        PurchaseLine.Reset();
+        FilterPurchaseLineOnDocumentLine(PurchaseHeader."Document Type", BillingLine."Document No.", BillingLine."Document Line No.");
+        PurchaseLine.FindFirst();
+        PurchaseLine.TestField("VAT %", VATPostingSetup."VAT %");
+
+        Currency.InitRoundingPrecision();
+        ExpectedUnitCost := Round(NetUnitCost * (1 + VATPostingSetup."VAT %" / 100), Currency."Unit-Amount Rounding Precision");
+        Assert.AreEqual(ExpectedUnitCost, PurchaseLine."Direct Unit Cost", 'Contract purchase invoice direct unit cost should be VAT-inclusive when the vendor prices include VAT.');
+    end;
+
+    [Test]
+    [HandlerFunctions('CreateVendorBillingDocsContractPageHandler,MessageHandler')]
+    procedure ContractPurchInvoiceUnitCostIsNetWhenVendorPricesExcludeVAT()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        NetUnitCost: Decimal;
+    begin
+        // [SCENARIO] When a Vendor Subscription Contract is billed for a vendor whose prices exclude VAT,
+        // the contract purchase invoice line "Direct Unit Cost" stays net (no gross-up is applied).
+        Initialize();
+
+        // [GIVEN] A vendor with "Prices Including VAT" = NO and a subscription item with a non-zero VAT rate
+        CreateVendorContractWithVATItem(VATPostingSetup, false);
+
+        // [GIVEN] A billing proposal for the contract
+        ContractTestLibrary.CreateBillingProposal(BillingTemplate, Enum::"Service Partner"::Vendor);
+
+        // [WHEN] Billing documents are created
+        CreateBillingDocuments(false);
+
+        // [THEN] The created purchase invoice has "Prices Including VAT" = NO
+        BillingLine.Reset();
+        BillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        BillingLine.SetRange(Partner, BillingTemplate.Partner);
+        BillingLine.FindFirst();
+        NetUnitCost := SumBillingProposalUnitPrice();
+        Assert.AreNotEqual(0, NetUnitCost, 'The net unit cost should not be zero, otherwise the test is meaningless.');
+
+        PurchaseHeader.Get(Enum::"Purchase Document Type"::Invoice, BillingLine."Document No.");
+        PurchaseHeader.TestField("Prices Including VAT", false);
+
+        // [THEN] The purchase line direct unit cost equals the net cost (unchanged)
+        PurchaseLine.Reset();
+        FilterPurchaseLineOnDocumentLine(PurchaseHeader."Document Type", BillingLine."Document No.", BillingLine."Document Line No.");
+        PurchaseLine.FindFirst();
+        Assert.AreEqual(NetUnitCost, PurchaseLine."Direct Unit Cost", 'Contract purchase invoice direct unit cost should stay net when the vendor prices exclude VAT.');
     end;
 
     [Test]
@@ -2716,6 +2882,83 @@ codeunit 139687 "Recurring Billing Docs Test"
         CustomerContractLine.SetRange("Subscription Contract No.", ContractNo);
         CustomerContractLine.FindFirst();
         CustomerContractLine.GetServiceCommitment(ServiceCommitment);
+    end;
+
+    local procedure CreateCustomerContractWithVATItem(var VATPostingSetup: Record "VAT Posting Setup"; PricesIncludingVAT: Boolean)
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+    begin
+        FindNonZeroVATPostingSetup(VATPostingSetup);
+
+        ContractTestLibrary.CreateCustomerInLCY(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Validate("Prices Including VAT", PricesIncludingVAT);
+        Customer.Modify(true);
+
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, Customer."No.");
+        ContractTestLibrary.DisableDeferralsForCustomerContract(CustomerContract, false);
+
+        // Assign the non-zero VAT rate to the invoicing item so the contract invoice line carries VAT
+        GetCustomerContractServiceCommitment(CustomerContract."No.");
+        Item.Get(ServiceCommitment."Invoicing Item No.");
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+
+        // Set a deterministic, non-zero net price on the Subscription Line
+        ServiceCommitment.Validate("Calculation Base Amount", LibraryRandom.RandDecInRange(100, 1000, 2));
+        ServiceCommitment.Validate("Calculation Base %", 100);
+        ServiceCommitment.Modify(true);
+    end;
+
+    local procedure CreateVendorContractWithVATItem(var VATPostingSetup: Record "VAT Posting Setup"; PricesIncludingVAT: Boolean)
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+    begin
+        FindNonZeroVATPostingSetup(VATPostingSetup);
+
+        ContractTestLibrary.CreateVendorInLCY(Vendor);
+        Vendor.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Vendor.Validate("Prices Including VAT", PricesIncludingVAT);
+        Vendor.Modify(true);
+
+        ContractTestLibrary.CreateVendorContractAndCreateContractLinesForItems(VendorContract, ServiceObject, Vendor."No.");
+        ContractTestLibrary.DisableDeferralsForVendorContract(VendorContract, false);
+
+        // Assign the non-zero VAT rate to the invoicing item so the contract purchase invoice line carries VAT
+        GetVendorContractServiceCommitment(VendorContract."No.");
+        Item.Get(ServiceCommitment."Invoicing Item No.");
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+
+        // Set a deterministic, non-zero net price on the Subscription Line
+        ServiceCommitment.Validate("Calculation Base Amount", LibraryRandom.RandDecInRange(100, 1000, 2));
+        ServiceCommitment.Validate("Calculation Base %", 100);
+        ServiceCommitment.Modify(true);
+    end;
+
+    local procedure FindNonZeroVATPostingSetup(var VATPostingSetup: Record "VAT Posting Setup")
+    begin
+        LibraryERM.FindVATPostingSetupInvt(VATPostingSetup);
+        if VATPostingSetup."VAT %" = 0 then begin
+            VATPostingSetup."VAT %" := LibraryRandom.RandDecInRange(10, 25, 0);
+            VATPostingSetup.Modify(false);
+        end;
+    end;
+
+    local procedure SumBillingProposalUnitPrice(): Decimal
+    var
+        LocalBillingLine: Record "Billing Line";
+        TotalUnitPrice: Decimal;
+    begin
+        LocalBillingLine.SetRange("Billing Template Code", BillingTemplate.Code);
+        LocalBillingLine.SetRange(Partner, BillingTemplate.Partner);
+        if LocalBillingLine.FindSet() then
+            repeat
+                TotalUnitPrice += LocalBillingLine."Unit Price";
+            until LocalBillingLine.Next() = 0;
+        exit(TotalUnitPrice);
     end;
 
     local procedure GetNoOfSalesInvoiceLineWithDescription(ExpectedDescriptionText: Text[100]): Integer


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

- This is a backport of PR for 30: to 29.0 https://github.com/microsoft/BCApps/pull/10093

When a Subscription Contract is billed for a customer/vendor whose prices include VAT, the contract invoice was created with the net (VAT-exclusive) amount placed onto a "Prices Including VAT" = YES document, so the platform treated that net value as gross and the resulting VAT base/amounts did not reconcile with the original order.

Add a generic helper "ToVATInclusiveUnitPrice" that grosses up a net price by the line's VAT factor (rounded to the currency's Unit-Amount Rounding Precision), and apply it at every price-assignment site when the document has "Prices Including VAT":
- Sales: standard line and usage-based path ("Unit Price")
- Purchase: standard line and usage-based path ("Direct Unit Cost")

Full VAT and zero-VAT lines are left untouched. The factor is determined before the value is validated, so each price is validated exactly once.

Add tests covering the VAT-inclusive and prices-excluding-VAT cases for both the customer (sales) and vendor (purchase) contract billing flows.

## Linked work

Fixes #8642
[AB#648227](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648227)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

This is a pure cherry-pick of the squash-merge commit of #10093 (`f2743e3`, cherry-picked with `-x`). What was verified on this backport branch:

1. The cherry-pick applied **cleanly onto `releases/29.0`, with no conflicts and no manual edits** — `git status` clean after the pick.
2. The resulting diff was compared line-by-line against `gh pr diff 10093` and is **identical** apart from the `index` blob hashes: the same two files, `+40/-6` in `CreateBillingDocuments.Codeunit.al` and `+243/-0` in `RecurringBillingDocsTest.Codeunit.al`. Even the hunk line offsets match, i.e. `releases/29.0` and `main` carry the same surrounding code in both files — including the direct-assignment form introduced by #8553, so no adaptation of the four price-assignment sites was needed.
3. `using Microsoft.Finance.Currency;` and `Currency.InitRoundingPrecision()` / `Currency."Unit-Amount Rounding Precision"` all resolve on `releases/29.0`; `app.json` was not touched.

**Not built and not tested on `releases/29.0`** — there is no 29.0 symbol cache / matching container available on my machine, so neither `alc.exe` nor the test codeunit was run against this branch. The functional validation is the one recorded on the original PR: the manual sales-order → contract → contract-invoice walkthrough plus 92/92 green in test codeunit `139687` on BC `29.0.53247`, with the VAT-inclusive assertion mutation-verified (conversion disabled → red at `157.69047` vs `143.35497`). The two new test scenarios travel with this backport and still need to be run on a 29.0 build.

## Risk & compatibility

- **Clean backport** — no conflict resolution and no adaptation was required; the change carried over byte-for-byte, so the risk profile is the same as on `main`.
- **Gated on the document header** — the gross-up runs only when `Prices Including VAT` = YES; every other document is byte-identical to before (asserted by the `…PricesExcludeVAT` tests).
- **No schema or extensibility change** — no new fields or upgrade code, helper is `local`, event signatures and firing order unchanged. Subscribers on VAT-inclusive documents now see a gross price, which is the correct value for such a document.
- **New documents only** — existing and posted documents are not corrected retroactively; contract data stays net, so a rollback leaves nothing inconsistent.
- **VAT types** — Normal, Reverse Charge and No Taxable VAT are all reversed by the base app as `/(1 + "VAT %"/100)`, so the gross-up is their exact inverse. `Full VAT` is skipped on purpose. Sales Tax is not covered (the base app reverses it via `ReverseCalculateTax`), which NA setups don't combine with `Prices Including VAT`.
- **Rounding** — grossed up once, to the currency's `Unit-Amount Rounding Precision`; a net → gross → net round trip can land one rounding step off. Inherent to VAT-inclusive documents, and the document totals stay consistent.
- **Performance-neutral** — the factor is applied before the field is written, so the price is still validated once, preserving the direct-assignment optimization from #8553 (which is already present on `releases/29.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
