### PR TITLE
[Pmt. Recon. Journal] Re-fire OnAfterGetLedgEntryInfo on proposal fast path

### DIFF
--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/AppliedPaymentEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/AppliedPaymentEntry.Table.al
@@ -895,6 +895,11 @@ table 1294 "Applied Payment Entry"
         OnAfterGetLedgEntryInfo(Rec);
     end;
 
+    internal procedure RunOnAfterGetLedgEntryInfo()
+    begin
+        OnAfterGetLedgEntryInfo(Rec);
+    end;
+
     local procedure GetCustLedgEntryInfo()
     var
         CustLedgEntry: Record "Cust. Ledger Entry";

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationProposal.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentApplicationProposal.Table.al
@@ -494,6 +494,7 @@ table 1293 "Payment Application Proposal"
         LedgerRemainingAmount: Decimal;
         IsHandled: Boolean;
         RemainingAmountHandled: Boolean;
+        LedgEntryInfoLoaded: Boolean;
     begin
         // Reads the applied ledger entry only once to populate both the informational fields and the remaining amount.
         IsHandled := false;
@@ -507,6 +508,7 @@ table 1293 "Payment Application Proposal"
         if "Applies-to Entry No." = 0 then
             exit;
 
+        LedgEntryInfoLoaded := true;
         case "Account Type" of
             "Account Type"::Customer:
                 begin
@@ -583,15 +585,31 @@ table 1293 "Payment Application Proposal"
                     "Currency Code" := BankAccLedgEntry."Currency Code";
                     LedgerRemainingAmount := BankAccLedgEntry."Remaining Amount";
                 end;
-            else
+            else begin
                 GetLedgEntryInfo();
+                LedgEntryInfoLoaded := false;
+            end;
         end;
+
+        // Re-fire the legacy OnAfterGetLedgEntryInfo extension point for the fast path without a second ledger read.
+        if LedgEntryInfoLoaded then
+            RaiseOnAfterGetLedgEntryInfoEvent();
 
         // Keep firing the legacy event so extensions that override the remaining amount still run when a proposal is created.
         RemainingAmountHandled := false;
         OnBeforeUpdateRemainingAmount(Rec, BankAccount, RemainingAmountHandled);
         if not RemainingAmountHandled then
             "Remaining Amount" := LedgerRemainingAmount;
+    end;
+
+    local procedure RaiseOnAfterGetLedgEntryInfoEvent()
+    var
+        TempAppliedPmtEntry: Record "Applied Payment Entry" temporary;
+    begin
+        // Round-trips already-loaded fields through a temp Applied Payment Entry so existing OnAfterGetLedgEntryInfo subscribers still run.
+        TempAppliedPmtEntry.TransferFields(Rec);
+        TempAppliedPmtEntry.RunOnAfterGetLedgEntryInfo();
+        TransferFields(TempAppliedPmtEntry);
     end;
 
     procedure TransferFromBankAccReconLine(BankAccReconLine: Record "Bank Acc. Reconciliation Line")


### PR DESCRIPTION
Re-firing an event that stopped firing because of a bug fix.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
The [#10498](https://github.com/microsoft/BCApps/pull/10498) perf refactor replaced GetLedgEntryInfo() with LoadLedgEntryInfoAndRemainingAmount(), which stopped raising Applied Payment Entry.OnAfterGetLedgEntryInfo for Customer/Vendor/Employee/Bank Account during proposal creation. Re-fire the legacy event via a temp round-trip (no second ledger read) so existing subscribers keep updating proposal fields.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#648382](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648382)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

Low, it re-fires an event that used to fire before a refactoring that broke it.

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


