### PR TITLE
[Master]-Bug 645041: Expense Agent - Rename Enable approval workflow caption and tooltip

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetup.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetup.Page.al
@@ -220,9 +220,11 @@ page 6996 "Expense Agent Setup"
                 }
                 field("Enable Approval Workflow"; Rec."Enable Approval Workflow")
                 {
+                    Importance = Additional;
                 }
                 field(DefaultApprover; Rec."Default Approver Name")
                 {
+                    Importance = Additional;
                     DrillDown = false;
 
                     trigger OnAssistEdit()

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
@@ -433,8 +433,8 @@ table 6930 "Expense Agent Setup"
         }
         field(80; "Enable Approval Workflow"; Boolean)
         {
-            Caption = 'Enable approval workflow';
-            ToolTip = 'Specifies whether approval workflow is enabled for expense reports.';
+            Caption = 'Use traditional approval workflow';
+            ToolTip = 'Specifies whether expense reports use the traditional approval workflow instead of the Expense Agent approval experience.';
 
             trigger OnValidate()
             begin


### PR DESCRIPTION
Fixes [AB#645041](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/645041)

**Issue**: On the Expense Agent Setup page the "Enable approval workflow" toggle had a generic caption and tooltip that did not make clear it switches expense reports to the traditional approval workflow instead of the Expense Agent approval experience, and it sat at standard importance among unrelated controls.

**Cause**: The field was labelled "Enable approval workflow" with a tooltip that only stated approval workflow is enabled, and used default Importance, so its purpose relative to the Expense Agent experience was ambiguous on the page.

**Solution**: Renamed the caption to "Use traditional approval workflow" and updated the tooltip to "Specifies whether expense reports use the traditional approval workflow instead of the Expense Agent approval experience." Set this field and the related Default Approver field to Importance = Additional so they surface only when relevant, per review feedback on the work item.








