### PR TITLE
[29.0][Expense Agent] Backport approval conversation from #10570

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
@@ -163,6 +163,11 @@ page 6928 "Expense Reports API"
                     Caption = 'Approver Comment';
                     Editable = false;
                 }
+                field(submitterComment; Rec.GetSubmitterComment())
+                {
+                    Caption = 'Submitter Comment';
+                    Editable = false;
+                }
                 field(finalApproverNo; Rec."Final Approver No.")
                 {
                     Caption = 'Final Approver No.';
@@ -423,10 +428,24 @@ page 6928 "Expense Reports API"
         ActionContext.SetResultCode(WebServiceActionResultCode::Updated);
     end;
 
+#if not CLEAN30
+    [Obsolete('Use ReleaseAndMarkPendingApprovalExpenseReportWithComment instead.', '30.0')]
     [ServiceEnabled]
     procedure ReleaseAndMarkPendingApprovalExpenseReport(var ActionContext: WebServiceActionContext; SubmitterExpenseUserNo: Code[20])
     begin
-        Rec.PerformManualReleaseAndPendingApproval(SubmitterExpenseUserNo);
+        Rec.PerformManualReleaseAndPendingApproval(SubmitterExpenseUserNo, '');
+
+        ActionContext.SetObjectType(ObjectType::Page);
+        ActionContext.SetObjectId(Page::"Expense Reports API");
+        ActionContext.AddEntityKey(Rec.FieldNo(SystemId), Rec.SystemId);
+        ActionContext.SetResultCode(WebServiceActionResultCode::Updated);
+    end;
+
+#endif
+    [ServiceEnabled]
+    procedure ReleaseAndMarkPendingApprovalExpenseReportWithComment(var ActionContext: WebServiceActionContext; SubmitterExpenseUserNo: Code[20]; SubmissionComment: Text)
+    begin
+        Rec.PerformManualReleaseAndPendingApproval(SubmitterExpenseUserNo, SubmissionComment);
 
         ActionContext.SetObjectType(ObjectType::Page);
         ActionContext.SetObjectId(Page::"Expense Reports API");

--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
@@ -428,8 +428,8 @@ page 6928 "Expense Reports API"
         ActionContext.SetResultCode(WebServiceActionResultCode::Updated);
     end;
 
-#if not CLEAN30
-    [Obsolete('Use ReleaseAndMarkPendingApprovalExpenseReportWithComment instead.', '30.0')]
+#if not CLEAN29
+    [Obsolete('Use ReleaseAndMarkPendingApprovalExpenseReportWithComment instead.', '29.0')]
     [ServiceEnabled]
     procedure ReleaseAndMarkPendingApprovalExpenseReport(var ActionContext: WebServiceActionContext; SubmitterExpenseUserNo: Code[20])
     begin

--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Codeunits/ExpenseActivityLogMgt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Codeunits/ExpenseActivityLogMgt.Codeunit.al
@@ -151,7 +151,11 @@ codeunit 6926 "Expense Activity Log Mgt."
         ExpenseActivityLogEntry."Occurred At" := OccurredAt;
         ExpenseActivityLogEntry."Initiated By" := InitiatedBy;
         ExpenseActivityLogEntry."Actor Role" := ActorRole;
-        ExpenseActivityLogEntry.Comment := CopyStr(EventComment, 1, MaxStrLen(ExpenseActivityLogEntry.Comment));
+        if StrLen(EventComment) > MaxStrLen(ExpenseActivityLogEntry.Comment) then
+            ExpenseActivityLogEntry.Comment :=
+                CopyStr(EventComment, 1, MaxStrLen(ExpenseActivityLogEntry.Comment) - 3) + '...'
+        else
+            ExpenseActivityLogEntry.Comment := CopyStr(EventComment, 1, MaxStrLen(ExpenseActivityLogEntry.Comment));
     end;
 
     local procedure InsertExpenseReportEntry(

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -77,26 +77,19 @@ codeunit 6901 "Expense Report Approval Mgmt"
     end;
 
     procedure Submit(var ExpenseReportHeader: Record "Expense Report Header")
-    var
-        ExpenseUser: Record "Expense User";
-        IsResubmission: Boolean;
     begin
         if ExpenseReportHeader.Status = ExpenseReportHeader.Status::"Pending Approval" then
             exit;
 
-        IsResubmission := ExpenseReportHeader."Submission DateTime" <> 0DT;
-        ExpenseUser.Get(GetExpenseUserNo());
-        ExpenseReportHeader.TestApprovalStatus();
-
-        ExpenseReportHeader.UpdateApproverID();
-        ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
-        RouteToInterimIfAssigned(ExpenseReportHeader);
-
-        SetApprovalStatusToPendingApprovalInExpenseReport(ExpenseReportHeader, ExpenseUser."No.", ExpenseUser."User Id For Approvals");
-        LogExpenseReportSubmission(ExpenseReportHeader, ExpenseUser."No.", IsResubmission);
+        Submit(ExpenseReportHeader, GetExpenseUserNo(), '');
     end;
 
     internal procedure Submit(var ExpenseReportHeader: Record "Expense Report Header"; SubmitterExpenseUserNo: Code[20])
+    begin
+        Submit(ExpenseReportHeader, SubmitterExpenseUserNo, '');
+    end;
+
+    internal procedure Submit(var ExpenseReportHeader: Record "Expense Report Header"; SubmitterExpenseUserNo: Code[20]; SubmissionComment: Text)
     var
         ExpenseUser: Record "Expense User";
         IsResubmission: Boolean;
@@ -107,13 +100,13 @@ codeunit 6901 "Expense Report Approval Mgmt"
         IsResubmission := ExpenseReportHeader."Submission DateTime" <> 0DT;
         ExpenseUser.Get(SubmitterExpenseUserNo);
         ExpenseReportHeader.TestApprovalStatus();
-
         ExpenseReportHeader.UpdateApproverID();
         ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
         RouteToInterimIfAssigned(ExpenseReportHeader);
 
+        UpdateSubmitterComment(ExpenseReportHeader, SubmissionComment);
         SetApprovalStatusToPendingApprovalInExpenseReport(ExpenseReportHeader, SubmitterExpenseUserNo, ExpenseUser."User Id For Approvals");
-        LogExpenseReportSubmission(ExpenseReportHeader, SubmitterExpenseUserNo, IsResubmission);
+        LogExpenseReportSubmission(ExpenseReportHeader, SubmitterExpenseUserNo, IsResubmission, SubmissionComment);
     end;
 
     procedure ReopenSubmitted(var ExpenseReportHeader: Record "Expense Report Header")
@@ -412,10 +405,18 @@ codeunit 6901 "Expense Report Approval Mgmt"
         Clear(ExpenseReportHeader."Approver Comment");
         ExpenseReportHeader."Approver Comment".CreateOutStream(OutStream, TextEncoding::UTF8);
         OutStream.WriteText(Comment);
-        ExpenseReportHeader.Modify(true);
     end;
 
-    local procedure LogExpenseReportSubmission(ExpenseReportHeader: Record "Expense Report Header"; SubmitterExpenseUserNo: Code[20]; IsResubmission: Boolean)
+    local procedure UpdateSubmitterComment(var ExpenseReportHeader: Record "Expense Report Header"; Comment: Text)
+    var
+        OutStream: OutStream;
+    begin
+        Clear(ExpenseReportHeader."Submitter Comment");
+        ExpenseReportHeader."Submitter Comment".CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText(Comment);
+    end;
+
+    local procedure LogExpenseReportSubmission(ExpenseReportHeader: Record "Expense Report Header"; SubmitterExpenseUserNo: Code[20]; IsResubmission: Boolean; EventComment: Text)
     var
         ExpenseActivityLogMgt: Codeunit "Expense Activity Log Mgt.";
         EventType: Enum "Expense Activity Event Type";
@@ -435,7 +436,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
             Enum::"Expense Activity Initiator"::User,
             Enum::"Expense Activity Actor Role"::Submitter,
             SubmitterExpenseUserNo,
-            '');
+            EventComment);
     end;
 
     local procedure LogExpenseReportEvent(

--- a/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapabilitiesProvider.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapabilitiesProvider.Codeunit.al
@@ -38,6 +38,8 @@ codeunit 6906 "Expense Capabilities Provider"
                 exit(IsAiAssistedPolicyEvaluationEnabled());
             Capability::MileageRateSetup:
                 exit(true);
+            Capability::ApprovalConversation:
+                exit(true);
         end;
         exit(false);
     end;

--- a/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapability.Enum.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Capabilities/ExpenseCapability.Enum.al
@@ -81,4 +81,12 @@ enum 6984 "Expense Capability"
     {
         Caption = 'Mileage Rate Setup', Locked = true;
     }
+
+    /// <summary>
+    /// Submitter comments can be supplied during submission, and comments can be exchanged during rejection and resubmission.
+    /// </summary>
+    value(7; ApprovalConversation)
+    {
+        Caption = 'Approval Conversation', Locked = true;
+    }
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Codeunits/ReleaseExpReportDocument.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Codeunits/ReleaseExpReportDocument.Codeunit.al
@@ -156,6 +156,11 @@ codeunit 6984 "Release Exp. Report Document"
     end;
 
     procedure PerformManualReleaseAndPendingApproval(var ExpReportHeader: Record "Expense Report Header"; SubmitterExpenseUserNo: Code[20])
+    begin
+        PerformManualReleaseAndPendingApproval(ExpReportHeader, SubmitterExpenseUserNo, '');
+    end;
+
+    procedure PerformManualReleaseAndPendingApproval(var ExpReportHeader: Record "Expense Report Header"; SubmitterExpenseUserNo: Code[20]; SubmissionComment: Text)
     var
         ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
@@ -164,7 +169,7 @@ codeunit 6984 "Release Exp. Report Document"
         ExpReportHeader.Get(ExpReportHeader."No.");
 
         CheckPendingApprovalStatus(ExpReportHeader);
-        ExpenseReportApprovalMgmt.Submit(ExpReportHeader, SubmitterExpenseUserNo);
+        ExpenseReportApprovalMgmt.Submit(ExpReportHeader, SubmitterExpenseUserNo, SubmissionComment);
     end;
 
     local procedure CheckPendingApprovalStatus(var ExpReportHeader: Record "Expense Report Header")

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
@@ -138,16 +138,37 @@ page 6910 "Expense Report"
                 }
                 group("Approver Comment")
                 {
-                    Caption = 'Approver Comment';
-                    Visible = Rec.Status = Rec.Status::Rejected;
+                    Caption = 'Approval Comments';
+
                     field(ApproverComment; ApproverComment)
                     {
                         ApplicationArea = Basic, Suite;
-                        Importance = Additional;
-                        MultiLine = true;
-                        ShowCaption = false;
+                        Caption = 'Approver Comment';
+                        DrillDown = true;
                         Editable = false;
-                        ToolTip = 'Specifies the approver comment for the expense report.';
+                        Importance = Additional;
+                        ToolTip = 'Specifies the latest comment from the approver. Drill down to view the full comment.';
+
+                        trigger OnDrillDown()
+                        begin
+                            if ApproverComment <> '' then
+                                Message(ApproverComment);
+                        end;
+                    }
+                    field(SubmitterComment; SubmitterComment)
+                    {
+                        ApplicationArea = Basic, Suite;
+                        Caption = 'Submitter Comment';
+                        DrillDown = true;
+                        Editable = false;
+                        Importance = Additional;
+                        ToolTip = 'Specifies the latest comment from the submitter. Drill down to view the full comment.';
+
+                        trigger OnDrillDown()
+                        begin
+                            if SubmitterComment <> '' then
+                                Message(SubmitterComment);
+                        end;
                     }
                 }
             }
@@ -712,6 +733,7 @@ page 6910 "Expense Report"
     begin
         SetControlVisibility();
         ApproverComment := Rec.GetApproverComment();
+        SubmitterComment := Rec.GetSubmitterComment();
     end;
 
     var
@@ -723,6 +745,7 @@ page 6910 "Expense Report"
         DocNoVisible: Boolean;
         ExpenseUserNo: Code[20];
         ApproverComment: Text;
+        SubmitterComment: Text;
         AllowVATReclaim: Boolean;
         ApprovalActionsEnabled: Boolean;
         AgentEnabled: Boolean;

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
@@ -426,7 +426,13 @@ table 6906 "Expense Report Header"
         {
             Caption = 'Approver Comment';
             DataClassification = CustomerContent;
-            ToolTip = 'Specifies the comment from approver when approving or rejecting an expense report.';
+            ToolTip = 'Specifies the latest comment from the approver when approving or rejecting an expense report.';
+        }
+        field(49; "Submitter Comment"; Blob)
+        {
+            Caption = 'Submitter Comment';
+            DataClassification = CustomerContent;
+            ToolTip = 'Specifies the latest comment from the submitter when submitting an expense report or resubmitting a rejected expense report.';
         }
         field(50; "Reimbursement Currency Factor"; Decimal)
         {
@@ -873,10 +879,20 @@ table 6906 "Expense Report Header"
     /// </summary>
     /// <param name="SubmitterExpenseUserNo">The expense user number of the submitter.</param>
     procedure PerformManualReleaseAndPendingApproval(SubmitterExpenseUserNo: Code[20])
+    begin
+        PerformManualReleaseAndPendingApproval(SubmitterExpenseUserNo, '');
+    end;
+
+    /// <summary>
+    /// Releases and submits an expense report with an optional submitter comment.
+    /// </summary>
+    /// <param name="SubmitterExpenseUserNo">The expense user number of the submitter.</param>
+    /// <param name="SubmissionComment">The optional comment supplied by the submitter.</param>
+    procedure PerformManualReleaseAndPendingApproval(SubmitterExpenseUserNo: Code[20]; SubmissionComment: Text)
     var
         ReleaseExpenseReportDoc: Codeunit "Release Exp. Report Document";
     begin
-        ReleaseExpenseReportDoc.PerformManualReleaseAndPendingApproval(Rec, SubmitterExpenseUserNo);
+        ReleaseExpenseReportDoc.PerformManualReleaseAndPendingApproval(Rec, SubmitterExpenseUserNo, SubmissionComment);
     end;
 
     /// <summary>
@@ -989,6 +1005,20 @@ table 6906 "Expense Report Header"
         Rec.CalcFields("Approver Comment");
         Rec."Approver Comment".CreateInStream(InStream, TextEncoding::UTF8);
         exit(TypeHelper.TryReadAsTextWithSepAndFieldErrMsg(InStream, TypeHelper.LFSeparator(), FieldName(Rec."Approver Comment")));
+    end;
+
+    /// <summary>
+    /// Retrieves submitter comment from the expense report header.
+    /// </summary>
+    /// <returns>Submitter comment.</returns>
+    procedure GetSubmitterComment() SubmitterComment: Text
+    var
+        TypeHelper: Codeunit "Type Helper";
+        InStream: InStream;
+    begin
+        Rec.CalcFields("Submitter Comment");
+        Rec."Submitter Comment".CreateInStream(InStream, TextEncoding::UTF8);
+        exit(TypeHelper.TryReadAsTextWithSepAndFieldErrMsg(InStream, TypeHelper.LFSeparator(), FieldName(Rec."Submitter Comment")));
     end;
 
     local procedure ConfirmUpdateAllLineDim() Confirmed: Boolean;

--- a/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseActivityLogAPITest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseActivityLogAPITest.Codeunit.al
@@ -25,9 +25,10 @@ codeunit 148343 "Expense Activity Log API Test"
         ExpenseReportsServiceNameTok: Label 'expenseReports', Locked = true;
         ExpenseUsersServiceNameTok: Label 'expenseUsers', Locked = true;
         TestDescriptionPrefixLbl: Label 'ACTIVITY API TEST ', Locked = true;
+        SubmitterCommentPropertyTxt: Label '"submitterComment":"%1"', Locked = true;
         MethodNotAllowedResponseErr: Label 'Response code is 405', Locked = true;
         BadRequestResponseErr: Label 'Response code is 400', Locked = true;
-        SubmitActionTok: Label 'Microsoft.NAV.releaseAndMarkPendingApprovalExpenseReport', Locked = true;
+        SubmitWithCommentActionTok: Label 'Microsoft.NAV.releaseAndMarkPendingApprovalExpenseReportWithComment', Locked = true;
         ApproveActionTok: Label 'Microsoft.NAV.approvedExpenseReport', Locked = true;
         RejectAndReopenActionTok: Label 'Microsoft.NAV.rejectAndReopenExpenseReport', Locked = true;
 
@@ -385,17 +386,21 @@ codeunit 148343 "Expense Activity Log API Test"
 
         // [WHEN] The report is submitted, rejected/reopened, resubmitted, and approved through API actions.
         InvokeReportAction(
-            ExpenseReportHeader.SystemId, SubmitActionTok,
-            CreateActorRequestBody('submitterExpenseUserNo', SubmitterExpenseUser."No."));
+            ExpenseReportHeader.SystemId, SubmitWithCommentActionTok,
+            CreateSubmitWithCommentRequestBody(SubmitterExpenseUser."No.", ''));
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
         InvokeReportAction(
             ExpenseReportHeader.SystemId, RejectAndReopenActionTok,
             CreateRejectRequestBody(ApproverExpenseUser."No.", 'E2E send back ' + RunToken));
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
         InvokeReportAction(
-            ExpenseReportHeader.SystemId, SubmitActionTok,
-            CreateActorRequestBody('submitterExpenseUserNo', SubmitterExpenseUser."No."));
+            ExpenseReportHeader.SystemId, SubmitWithCommentActionTok,
+            CreateSubmitWithCommentRequestBody(SubmitterExpenseUser."No.", 'E2E submitter response ' + RunToken));
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+
+        // [THEN] The report API exposes the latest submitter response.
+        VerifyReportSubmitterComment(ExpenseReportHeader.SystemId, 'E2E submitter response ' + RunToken);
+
         InvokeReportAction(
             ExpenseReportHeader.SystemId, ApproveActionTok,
             CreateActorRequestBody('approverExpenseUserNo', ApproverExpenseUser."No."));
@@ -490,6 +495,12 @@ codeunit 148343 "Expense Activity Log API Test"
         RequestBody.Add('rejectReason', RejectReason);
     end;
 
+    local procedure CreateSubmitWithCommentRequestBody(SubmitterExpenseUserNo: Code[20]; SubmissionComment: Text) RequestBody: JsonObject
+    begin
+        RequestBody.Add('submitterExpenseUserNo', SubmitterExpenseUserNo);
+        RequestBody.Add('submissionComment', SubmissionComment);
+    end;
+
     local procedure InvokeReportAction(ReportSystemID: Guid; ActionName: Text; RequestBody: JsonObject)
     var
         ResponseText: Text;
@@ -539,6 +550,20 @@ codeunit 148343 "Expense Activity Log API Test"
             0,
             StrPos(LowerCase(ResponseText), LowerCase(Format(ExpectedEventType))),
             'The report activity response does not contain the expected event type.');
+    end;
+
+    local procedure VerifyReportSubmitterComment(ReportSystemID: Guid; ExpectedComment: Text)
+    var
+        ResponseText: Text;
+        TargetURL: Text;
+    begin
+        TargetURL := LibraryGraphMgt.CreateTargetURL(
+            Format(ReportSystemID), Page::"Expense Reports API", ExpenseReportsServiceNameTok);
+        LibraryGraphMgt.GetFromWebServiceAndCheckResponseCode(ResponseText, TargetURL, 200);
+        Assert.AreNotEqual(
+            0,
+            StrPos(ResponseText, StrSubstNo(SubmitterCommentPropertyTxt, ExpectedComment)),
+            'The expense report API response must contain the latest submitter comment.');
     end;
 
     local procedure VerifyUserHistory(ExpenseUserSystemID: Guid; HistoryRole: Text; SubjectSystemID: Guid)

--- a/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseCapabilitiesAPITest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/API/ExpenseCapabilitiesAPITest.Codeunit.al
@@ -22,6 +22,7 @@ codeunit 148318 "Expense Capabilities API Test"
         IsInitialized: Boolean;
         ServiceNameTok: Label 'expenseCapabilities', Locked = true;
         ActivityLogCapabilityNameTok: Label 'activityLog', Locked = true;
+        ApprovalConversationCapabilityNameTok: Label 'approvalConversation', Locked = true;
 
     [Test]
     procedure CapabilitiesProjectsEnabledViaAPI()
@@ -75,6 +76,25 @@ codeunit 148318 "Expense Capabilities API Test"
         Assert.IsTrue(
             ResponseContainsCapabilityState(ResponseText, ActivityLogCapabilityNameTok, true),
             'Response must contain an enabled activityLog capability row.');
+    end;
+
+    [Test]
+    procedure ApprovalConversationCapabilityEnabledViaAPI()
+    var
+        TargetURL: Text;
+        ResponseText: Text;
+    begin
+        // [SCENARIO] Approval conversation is advertised when the supporting API actions are installed.
+        Initialize();
+
+        // [WHEN] The expenseCapabilities collection is fetched through the API.
+        TargetURL := LibraryGraphMgt.CreateTargetURL('', Page::"Expense Capabilities API", ServiceNameTok);
+        LibraryGraphMgt.GetFromWebServiceAndCheckResponseCode(ResponseText, TargetURL, 200);
+
+        // [THEN] ApprovalConversation is present and enabled.
+        Assert.IsTrue(
+            ResponseContainsCapabilityState(ResponseText, ApprovalConversationCapabilityNameTok, true),
+            'Response must contain an enabled approvalConversation capability row.');
     end;
 
     [Test]

--- a/src/Apps/W1/ExpenseAgent/test/src/ActivityLog/ExpenseActivityLogTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ActivityLog/ExpenseActivityLogTest.Codeunit.al
@@ -167,7 +167,7 @@ codeunit 148342 "Expense Activity Log Test"
         // [WHEN] The report is submitted, rejected, resubmitted, and approved.
         ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.");
         ExpenseReportApprovalMgt.Reject(ExpenseReportHeader, ApproverExpenseUser."No.", 'Please explain the change.');
-        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.");
+        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.", 'Updated the justification.');
         ExpenseReportApprovalMgt.Approve(ExpenseReportHeader, ApproverExpenseUser."No.");
 
         // [THEN] The report has the expected ordered activity entries.
@@ -184,9 +184,121 @@ codeunit 148342 "Expense Activity Log Test"
         Assert.AreEqual('Please explain the change.', ExpenseActivityLogEntry.Comment, 'The rejection entry must preserve the approver comment.');
         ExpenseActivityLogEntry.Next();
         Assert.AreEqual(Enum::"Expense Activity Event Type"::Resubmitted, ExpenseActivityLogEntry."Event Type", 'The fourth entry must record resubmission.');
+        Assert.AreEqual('Updated the justification.', ExpenseActivityLogEntry.Comment, 'The resubmission entry must preserve the submitter comment.');
         ExpenseActivityLogEntry.Next();
         Assert.AreEqual(Enum::"Expense Activity Event Type"::Approved, ExpenseActivityLogEntry."Event Type", 'The fifth entry must record approval.');
         Assert.AreEqual(0, ExpenseActivityLogEntry.Next(), 'No additional approval lifecycle entries are expected.');
+    end;
+
+    [Test]
+    procedure ApprovalConversationKeepsLatestHeaderValuesAndCompleteHistory()
+    var
+        SubmitterExpenseUser: Record "Expense User";
+        ApproverExpenseUser: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        ExpenseReportApprovalMgt: Codeunit "Expense Report Approval Mgmt";
+        RejectedCount: Integer;
+        ResubmittedCount: Integer;
+    begin
+        // [SCENARIO] Header comments keep the latest exchange while activity entries preserve every cycle.
+        Initialize();
+        CreateApprovalScenario(SubmitterExpenseUser, ApproverExpenseUser, ExpenseReportHeader);
+
+        // [WHEN] The report is rejected and resubmitted twice.
+        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.");
+        ExpenseReportApprovalMgt.Reject(ExpenseReportHeader, ApproverExpenseUser."No.", 'First approver comment.');
+        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.", 'First submitter response.');
+        ExpenseReportApprovalMgt.Reject(ExpenseReportHeader, ApproverExpenseUser."No.", 'Second approver comment.');
+        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.", 'Second submitter response.');
+
+        // [THEN] The header exposes only the latest value from each participant.
+        Assert.AreEqual('Second approver comment.', ExpenseReportHeader.GetApproverComment(), 'The header must keep the latest approver comment.');
+        Assert.AreEqual('Second submitter response.', ExpenseReportHeader.GetSubmitterComment(), 'The header must keep the latest submitter comment.');
+
+        // [THEN] Every comment remains in its state-change activity entry.
+        ExpenseActivityLogEntry.SetRange("Subject Table ID", Database::"Expense Report Header");
+        ExpenseActivityLogEntry.SetRange("Subject System ID", ExpenseReportHeader.SystemId);
+        ExpenseActivityLogEntry.SetCurrentKey("Entry No.");
+        ExpenseActivityLogEntry.FindSet();
+        repeat
+            case ExpenseActivityLogEntry."Event Type" of
+                ExpenseActivityLogEntry."Event Type"::Rejected:
+                    begin
+                        RejectedCount += 1;
+                        case RejectedCount of
+                            1:
+                                Assert.AreEqual('First approver comment.', ExpenseActivityLogEntry.Comment, 'The first rejection comment must remain unchanged.');
+                            2:
+                                Assert.AreEqual('Second approver comment.', ExpenseActivityLogEntry.Comment, 'The second rejection comment must be appended.');
+                        end;
+                    end;
+                ExpenseActivityLogEntry."Event Type"::Resubmitted:
+                    begin
+                        ResubmittedCount += 1;
+                        case ResubmittedCount of
+                            1:
+                                Assert.AreEqual('First submitter response.', ExpenseActivityLogEntry.Comment, 'The first submitter response must remain unchanged.');
+                            2:
+                                Assert.AreEqual('Second submitter response.', ExpenseActivityLogEntry.Comment, 'The second submitter response must be appended.');
+                        end;
+                    end;
+            end;
+        until ExpenseActivityLogEntry.Next() = 0;
+        Assert.AreEqual(2, RejectedCount, 'Exactly two rejection comments are expected.');
+        Assert.AreEqual(2, ResubmittedCount, 'Exactly two submitter responses are expected.');
+    end;
+
+    [Test]
+    procedure ResubmissionAllowsBlankComment()
+    var
+        SubmitterExpenseUser: Record "Expense User";
+        ApproverExpenseUser: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseReportApprovalMgt: Codeunit "Expense Report Approval Mgmt";
+    begin
+        // [SCENARIO] The conversation-specific submit operation accepts a blank comment.
+        Initialize();
+        CreateApprovalScenario(SubmitterExpenseUser, ApproverExpenseUser, ExpenseReportHeader);
+        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.");
+        ExpenseReportApprovalMgt.Reject(ExpenseReportHeader, ApproverExpenseUser."No.", 'Please explain the change.');
+        Commit();
+
+        // [WHEN] The submitter does not provide a response.
+        ExpenseReportApprovalMgt.Submit(ExpenseReportHeader, SubmitterExpenseUser."No.", '');
+
+        // [THEN] The report is resubmitted with an empty latest comment.
+        Assert.AreEqual(ExpenseReportHeader.Status::"Pending Approval", ExpenseReportHeader.Status, 'A blank response must not block resubmission.');
+        Assert.AreEqual('', ExpenseReportHeader.GetSubmitterComment(), 'The latest submitter comment must be empty.');
+    end;
+
+    [Test]
+    procedure ActivityCommentTruncationIncludesEllipsis()
+    var
+        ExpenseUser: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+        ExpenseActivityLogMgt: Codeunit "Expense Activity Log Mgt.";
+        EntryNo: BigInteger;
+    begin
+        // [SCENARIO] An activity comment that exceeds storage capacity is truncated with an ellipsis.
+        Initialize();
+        LibraryExpense.CreateExpenseUser(ExpenseUser);
+        LibraryExpense.CreateExpenseReport(ExpenseReportHeader, ExpenseUser."No.", '', '');
+
+        // [WHEN] An event is logged with more than 2048 characters.
+        EntryNo := ExpenseActivityLogMgt.LogExpenseReportEvent(
+            ExpenseReportHeader,
+            Enum::"Expense Activity Event Type"::Rejected,
+            Enum::"Expense Activity Initiator"::User,
+            Enum::"Expense Activity Actor Role"::Approver,
+            ExpenseUser."No.",
+            PadStr('', 2049, 'X'));
+
+        // [THEN] The stored comment fills the field and signals truncation.
+        ExpenseActivityLogEntry.Get(EntryNo);
+        Assert.AreEqual(MaxStrLen(ExpenseActivityLogEntry.Comment), StrLen(ExpenseActivityLogEntry.Comment), 'The truncated comment must fill the storage field.');
+        Assert.AreEqual('...', CopyStr(ExpenseActivityLogEntry.Comment, StrLen(ExpenseActivityLogEntry.Comment) - 2), 'The truncated comment must end with an ellipsis.');
     end;
 
     [Test]

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseReportPostingTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseReportPostingTest.Codeunit.al
@@ -3571,7 +3571,7 @@ codeunit 148302 "Expense Report Posting Test"
         CreateUserSetupsAndChainOfApprovers(CurrentUserSetup, FinalApproverUserSetup, ExpenseUser);
 
         // [WHEN] The report is released and marked Pending Approval (submitted).
-        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.");
+        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.", '');
 
         // [THEN] The report is Pending Approval.
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
@@ -3610,7 +3610,7 @@ codeunit 148302 "Expense Report Posting Test"
         CreateUserSetupsAndChainOfApprovers(CurrentUserSetup, FinalApproverUserSetup, ExpenseUser);
 
         // [WHEN] The report is released and marked Pending Approval.
-        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.");
+        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.", '');
 
         // [THEN] Submission succeeds while the line remains Stale.
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
@@ -3637,7 +3637,7 @@ codeunit 148302 "Expense Report Posting Test"
         CreateUserSetupsAndChainOfApprovers(CurrentUserSetup, FinalApproverUserSetup, ExpenseUser);
 
         // [WHEN] The report is released and marked Pending Approval.
-        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.");
+        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.", '');
 
         // [THEN] Submission succeeds while the line remains Not Evaluated.
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
@@ -3663,7 +3663,7 @@ codeunit 148302 "Expense Report Posting Test"
         ExpenseReportLine.Get(ExpenseReportLine."Document No.", ExpenseReportLine."Line No.");
         Assert.AreEqual("Expense Policy Status"::"Not Evaluated", ExpenseReportLine.GetPolicyStatus(), 'Precondition: the line must be Not Evaluated.');
         CreateUserSetupsAndChainOfApprovers(CurrentUserSetup, FinalApproverUserSetup, ExpenseUser);
-        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.");
+        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.", '');
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
         ApproverExpenseUserNo := ExpenseReportHeader."Approver Expense User No.";
         Commit();
@@ -3716,7 +3716,7 @@ codeunit 148302 "Expense Report Posting Test"
         CreateUserSetupsAndChainOfApprovers(CurrentUserSetup, FinalApproverUserSetup, ExpenseUser);
 
         // [WHEN] The report is released and marked Pending Approval.
-        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.");
+        ExpenseReportHeader.PerformManualReleaseAndPendingApproval(ExpenseUser."No.", '');
 
         // [THEN] Submit succeeds despite the stale line.
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");


### PR DESCRIPTION
## Summary

Backport the Expense Agent approval conversation from #10570 to `releases/29.0`.

This adds submitter comments for resubmission, exposes the latest approver and submitter comments through the API and Expense Report page, records immutable comment snapshots in activity history, and advertises the `approvalConversation` capability.

## Work item

[AB#633685](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633685)

## Source

- Main PR: #10570
- Expense Agent service PR: https://microsoft.ghe.com/bic/BC-ExpenseAgent/pull/2457

## Backport notes

- Rebuilt from the current `releases/29.0` tip (`1810b52`). The net diff is exactly the merged #10570 squash `2534fa5a` — 12 files, +288/-39 — and is now line-for-line identical to the `releases/29.x` backport (#10829).
- All 12 changed files belong to the Expense Agent app and tests.
- Capability ordinals match `main` and `releases/29.x`: `MileageRateSetup = 6` and `ApprovalConversation = 7`.
- Mileage Rate Setup is now implemented on `releases/29.0`, so the earlier ordinal-reservation shim and its "reserved but disabled" capability test have been dropped. `MileageRateSetup = 6` now comes from the branch itself and reports enabled; re-applying the shim would have duplicated the enum value and inverted that assertion.
- The only apply conflict was additive, in `ExpenseReport.Page.al`. It was resolved deterministically by applying the previously reviewed `releases/29.0` file patch with `git apply --3way`; the branch's `AllowVATReclaim` state and the backport's `SubmitterComment` state are both preserved.
- The legacy `releaseAndMarkPendingApprovalExpenseReport` action is retained behind `#if not CLEAN29` and tagged `[Obsolete(..., '29.0')]`. Upstream uses `CLEAN30` / `'30.0'`; this is the only intentional deviation from the source PR.
- Still a draft. The Mileage Rate Setup prerequisite that previously gated this PR is now present on `releases/29.0`.
- No behavior outside the Expense Agent approval conversation was intentionally changed.

