### PR TITLE
[29.x] Route Expense Agent app family reviews to dedicated team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -213,6 +213,10 @@
 # from the localization wildcard above without naming anyone.
 /src/Apps/*/*ContosoCoffeeDemoDataset*/
 
+# Dedicated application reviewers. These review-routing overrides intentionally
+# differ from the functional ownership labels generated above.
+/src/Apps/W1/ExpenseAgent/ @microsoft/d365-bc-app-expense-agent
+
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,8 @@
 # To change ownership, edit ownership-rules.js in BCAppsTriage and regenerate.
 # Do not hand-edit the block below; hand edits will be lost and will silently
 # diverge from issue and pull request triage.
+# Apps with dedicated reviewer teams are intentionally omitted from this block
+# and listed once in the dedicated application reviewers section below.
 #
 # The specialized cross-cutting rules at the bottom of this file (App Security,
 # App Permissions, app.json, AL-Go and build files, Developer Experience, Code
@@ -134,8 +136,6 @@
 /src/Apps/W1/EssentialBusinessHeadlines/ @microsoft/d365-bc-integrations
 /src/Apps/W1/ExcelReports/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/ExciseTaxes/ @microsoft/d365-bc-finance-1
-/src/Apps/W1/ExpenseAgent/ @microsoft/d365-bc-finance-1
-/src/Apps/W1/ExpenseWithholdingTax/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/External\ File\ Storage\ -\ Azure\ Blob\ Service\ Connector/ @microsoft/d365-bc-integrations
 /src/Apps/W1/External\ File\ Storage\ -\ Azure\ File\ Service\ Connector/ @microsoft/d365-bc-integrations
 /src/Apps/W1/External\ File\ Storage\ -\ SFTP\ Connector/ @microsoft/d365-bc-integrations
@@ -213,9 +213,10 @@
 # from the localization wildcard above without naming anyone.
 /src/Apps/*/*ContosoCoffeeDemoDataset*/
 
-# Dedicated application reviewers. These review-routing overrides intentionally
-# differ from the functional ownership labels generated above.
-/src/Apps/W1/ExpenseAgent/ @microsoft/d365-bc-app-expense-agent
+# Expense Agent application family. These review routes intentionally differ
+# from the Finance functional ownership labels used by triage.
+/src/Apps/*/ExpenseAgent*/ @microsoft/d365-bc-app-expense-agent
+/src/Apps/*/ExpenseWithholdingTax*/ @microsoft/d365-bc-app-expense-agent
 
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets


### PR DESCRIPTION
Backports the CODEOWNERS review-routing change from https://github.com/microsoft/BCApps/pull/10811 to `releases/29.x`.

The net change is limited to `CODEOWNERS` and routes the Expense Agent application family to the dedicated reviewer team.

Fixes [AB#647288](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647288)

