### PR TITLE
Bugs/625412 Wrong posted G/L Entries and VAT Entries using Cash Basis Unrealized VAT from a partial Credit Memo if we mix VAT types and use only part of the amount in the Mexican version.

### DIFF
--- a/src/Layers/MX/Tests/Local/ERMSalesPurchaseVAT.Codeunit.al
+++ b/src/Layers/MX/Tests/Local/ERMSalesPurchaseVAT.Codeunit.al
@@ -407,7 +407,10 @@ codeunit 144051 "ERM Sales/Purchase VAT"
         AmountACY := GetACYAmount(SalesLine."Amount Including VAT" - SalesLine."Line Amount", CurrencyCode);
         VATPostingSetup.Get(SalesLine."VAT Bus. Posting Group", SalesLine."VAT Prod. Posting Group");
         VerifyVATEntries(SalesHeader."Document Type", DocumentNo, -AmountACY, SalesLine."VAT Prod. Posting Group");
-        VerifyRealizedVATGLEntriesDoNotExist(DocumentNo, VATPostingSetup);
+        if CurrencyCode = '' then
+            VerifyRealizedVATGLEntriesDoNotExist(DocumentNo, VATPostingSetup)
+        else
+            VerifyGLEntries(SalesHeader."Document Type", DocumentNo, VATPostingSetup."Sales VAT Account", -AmountACY);
     end;
 
     [Test]
@@ -463,7 +466,10 @@ codeunit 144051 "ERM Sales/Purchase VAT"
         AmountACY := GetACYAmount(SalesLine."Amount Including VAT" - SalesLine."Line Amount", CurrencyCode);
         VATPostingSetup.Get(SalesLine."VAT Bus. Posting Group", SalesLine."VAT Prod. Posting Group");
         VerifyVATEntries(SalesHeader."Document Type", DocumentNo, -AmountACY, SalesLine."VAT Prod. Posting Group");
-        VerifyRealizedVATGLEntriesDoNotExist(DocumentNo, VATPostingSetup);
+        if CurrencyCode = '' then
+            VerifyRealizedVATGLEntriesDoNotExist(DocumentNo, VATPostingSetup)
+        else
+            VerifyGLEntries(SalesHeader."Document Type", DocumentNo, VATPostingSetup."Sales VAT Account", -AmountACY);
     end;
 
     [Test]
@@ -821,6 +827,21 @@ codeunit 144051 "ERM Sales/Purchase VAT"
           AdditionalCurrencyAmount, GLEntry."Additional-Currency Amount", LibraryERM.GetAmountRoundingPrecision(),
           StrSubstNo(
             AmountError, GLEntry.FieldCaption("Additional-Currency Amount"), GLEntry."Additional-Currency Amount", GLEntry.TableCaption()));
+    end;
+
+    local procedure VerifyRealizedVATGLEntriesDoNotExist(DocumentNo: Code[20]; VATPostingSetup: Record "VAT Posting Setup")
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document Type", GLEntry."Document Type"::"Credit Memo");
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("G/L Account No.", VATPostingSetup."Sales VAT Unreal. Account");
+        GLEntry.SetRange("Bal. Account No.", VATPostingSetup."Sales VAT Account");
+        Assert.IsTrue(GLEntry.IsEmpty(), 'VAT G/L entry from unrealized to realized account should not be posted');
+
+        GLEntry.SetRange("G/L Account No.", VATPostingSetup."Sales VAT Account");
+        GLEntry.SetRange("Bal. Account No.", VATPostingSetup."Sales VAT Unreal. Account");
+        Assert.IsTrue(GLEntry.IsEmpty(), 'VAT G/L entry from realized to unrealized account should not be posted');
     end;
 
     local procedure VerifyGLEntryVATUnrealizedAmount(DocumentNo: Code[20]; VATUnrealAccount: Code[20]; TotalVATAmount: Decimal)

--- a/src/Layers/MX/Tests/Local/ERMSalesPurchaseVAT.Codeunit.al
+++ b/src/Layers/MX/Tests/Local/ERMSalesPurchaseVAT.Codeunit.al
@@ -407,7 +407,7 @@ codeunit 144051 "ERM Sales/Purchase VAT"
         AmountACY := GetACYAmount(SalesLine."Amount Including VAT" - SalesLine."Line Amount", CurrencyCode);
         VATPostingSetup.Get(SalesLine."VAT Bus. Posting Group", SalesLine."VAT Prod. Posting Group");
         VerifyVATEntries(SalesHeader."Document Type", DocumentNo, -AmountACY, SalesLine."VAT Prod. Posting Group");
-        VerifyGLEntries(SalesHeader."Document Type", DocumentNo, VATPostingSetup."Sales VAT Account", -AmountACY);
+        VerifyRealizedVATGLEntriesDoNotExist(DocumentNo, VATPostingSetup);
     end;
 
     [Test]
@@ -463,7 +463,7 @@ codeunit 144051 "ERM Sales/Purchase VAT"
         AmountACY := GetACYAmount(SalesLine."Amount Including VAT" - SalesLine."Line Amount", CurrencyCode);
         VATPostingSetup.Get(SalesLine."VAT Bus. Posting Group", SalesLine."VAT Prod. Posting Group");
         VerifyVATEntries(SalesHeader."Document Type", DocumentNo, -AmountACY, SalesLine."VAT Prod. Posting Group");
-        VerifyGLEntries(SalesHeader."Document Type", DocumentNo, VATPostingSetup."Sales VAT Account", -AmountACY);
+        VerifyRealizedVATGLEntriesDoNotExist(DocumentNo, VATPostingSetup);
     end;
 
     [Test]

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4480,7 +4480,9 @@ codeunit 12 "Gen. Jnl.-Post Line"
             if not TempVATPostingSetup.IsEmpty() then begin
                 if (GenJnlLine."Document Type" = GenJnlLine."Document Type"::"Credit Memo") and (CustLedgEntry2."Document Type" = CustLedgEntry2."Document Type"::Invoice) then
                     ShouldConsiderVATPostingGrouping := true;
-                if (GenJnlLine."Document Type" = GenJnlLine."Document Type"::Invoice) and (CustLedgEntry2."Document Type" = CustLedgEntry2."Document Type"::Invoice) then
+                if (GenJnlLine."Document Type" = GenJnlLine."Document Type"::Invoice) and
+                    (CustLedgEntry2."Document Type" in [CustLedgEntry2."Document Type"::Invoice, CustLedgEntry2."Document Type"::"Credit Memo"])
+                then
                     ShouldConsiderVATPostingGrouping := true;
             end;
 
@@ -4527,6 +4529,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         VATAmountCash: Decimal;
         VATBaseCash: Decimal;
         ShouldPostGLEntries: Boolean;
+        CreditMemoDocumentNo: Code[20];
     begin
         ShouldPostGLEntries := not (
             (GenJnlLine."Document Type" = GenJnlLine."Document Type"::"Credit Memo") and
@@ -4556,7 +4559,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
         if VATEntry2.FindSet() then begin
             if ShouldConsiderVATPostingGrouping then begin
                 InvoicePartAmountByVAT := CustLedgEntry2.GetInvoicePartAmountByVAT(CustLedgEntry2."Document Type", GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group");
-                SettledAmountByVAT := CustLedgEntry2.GetCreditMemoPartAmountByVAT(GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group", SettledAmount);
+                CreditMemoDocumentNo := GenJnlLine."Document No.";
+                if CustLedgEntry2."Document Type" = CustLedgEntry2."Document Type"::"Credit Memo" then
+                    CreditMemoDocumentNo := CustLedgEntry2."Document No.";
+                SettledAmountByVAT := CustLedgEntry2.GetCreditMemoPartAmountByVAT(CreditMemoDocumentNo, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group", SettledAmount);
             end;
             LastConnectionNo := 0;
             repeat
@@ -4636,6 +4642,11 @@ codeunit 12 "Gen. Jnl.-Post Line"
                                 VATEntry2."Add.-Currency Unrealized Base" * VATPart,
                                 AddCurrency."Amount Rounding Precision");
                         end;
+
+                    VATAmount := ABSMin(VATAmount, VATEntry2."Remaining Unrealized Amount");
+                    VATBase := ABSMin(VATBase, VATEntry2."Remaining Unrealized Base");
+                    VATAmountAddCurr := ABSMin(VATAmountAddCurr, VATEntry2."Add.-Curr. Rem. Unreal. Amount");
+                    VATBaseAddCurr := ABSMin(VATBaseAddCurr, VATEntry2."Add.-Curr. Rem. Unreal. Base");
 
                     // what is LCY value of VAT and VAT Base at posting date (cash basis)
                     if (VATPostingSetup."Unrealized VAT Type" = VATPostingSetup."Unrealized VAT Type"::"Cash Basis") and

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4502,6 +4502,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
         VATPostingSetup: Record "VAT Posting Setup";
         GLEntry: Record "G/L Entry";
         InvoicePartAmountByVAT: Decimal;
+        SettledAmountByVAT: Decimal;
         VATPart: Decimal;
         VATAmount: Decimal;
         VATBase: Decimal;
@@ -4525,7 +4526,12 @@ codeunit 12 "Gen. Jnl.-Post Line"
         VATAmountFCY: Decimal;
         VATAmountCash: Decimal;
         VATBaseCash: Decimal;
+        ShouldPostGLEntries: Boolean;
     begin
+        ShouldPostGLEntries := not (
+            (GenJnlLine."Document Type" = GenJnlLine."Document Type"::"Credit Memo") and
+            (((CustLedgEntry2."Document Type" = CustLedgEntry2."Document Type"::Invoice) and ShouldConsiderVATPostingGrouping) or
+             (CustLedgEntry2."Document Type" = CustLedgEntry2."Document Type"::"Credit Memo")));
         PaidAmount := CustLedgEntry2."Amount (LCY)" - CustLedgEntry2."Remaining Amt. (LCY)";
         OnCustUnrealizedVATOnAfterCalcPaidAmount(GenJnlLine, CustLedgEntry2, SettledAmount, PaidAmount);
         VATEntry2.ReadIsolation := IsolationLevel::ReadUncommitted;
@@ -4558,14 +4564,15 @@ codeunit 12 "Gen. Jnl.-Post Line"
 
                 if ShouldConsiderVATPostingGrouping then begin
                     InvoicePartAmountByVAT := CustLedgEntry2.GetInvoicePartAmountByVAT(CustLedgEntry2."Document Type", GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group");
+                    SettledAmountByVAT := CustLedgEntry2.GetCreditMemoPartAmountByVAT(GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group", SettledAmount);
                     VATPart :=
                         VATEntry2.GetUnrealizedVATPart(
-                        Round(SettledAmount / CustLedgEntry2.GetAdjustedCurrencyFactor()),
+                        Round(SettledAmountByVAT / CustLedgEntry2.GetAdjustedCurrencyFactor()),
                         PaidAmount,
                         InvoicePartAmountByVAT,
                         TotalUnrealVATAmountFirst,
                         TotalUnrealVATAmountLast,
-                        InvoicePartAmountByVAT);
+                        InvoicePartAmountByVAT)
                 end else
                     VATPart :=
                         VATEntry2.GetUnrealizedVATPart(
@@ -4661,54 +4668,57 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         RealizedVATBase := -(VATBase - VATBaseCash);
                     end;
 
-                    IsHandled := false;
-                    OnCustUnrealizedVATOnBeforeInitGLEntryVAT(
-                      GenJnlLine, VATEntry2, VATAmount, VATBase, VATAmountAddCurr, VATBaseAddCurr, IsHandled, SalesVATUnrealAccount, CustLedgEntry2, SettledAmount);
-                    if not IsHandled then
-                        InitGLEntryVAT(
-                            GenJnlLine, SalesVATUnrealAccount, SalesVATAccount, -VATAmount, -VATAmountAddCurr, false);
 
-                    GLEntryNo :=
-                      InitGLEntryVATCopy(
-                        GenJnlLine, SalesVATAccount, SalesVATUnrealAccount,
-                        VATAmount + RealizedVATAmount, VATAmountAddCurr + RealizedVATAmountAddCurr, VATEntry2);
+                    if ShouldPostGLEntries then begin
+                        IsHandled := false;
+                        OnCustUnrealizedVATOnBeforeInitGLEntryVAT(
+                          GenJnlLine, VATEntry2, VATAmount, VATBase, VATAmountAddCurr, VATBaseAddCurr, IsHandled, SalesVATUnrealAccount, CustLedgEntry2, SettledAmount);
+                        if not IsHandled then
+                            InitGLEntryVAT(
+                                GenJnlLine, SalesVATUnrealAccount, SalesVATAccount, -VATAmount, -VATAmountAddCurr, false);
 
-                    if (GainLossLCY <> 0) and (CustLedgEntry2."Currency Code" <> '') and
-                       (VATPostingSetup."Unrealized VAT Type" = VATPostingSetup."Unrealized VAT Type"::"Cash Basis")
-                    then begin
-                        Currency.Get(CustLedgEntry2."Currency Code");
-                        case CustLedgEntry2."Document Type" of
-                            CustLedgEntry2."Document Type"::"Credit Memo":
-                                if GainLossLCY > 0 then begin
-                                    Currency.TestField("Realized Losses Acc.");
-                                    InitGLEntry(
-                                        GenJnlLine, GLEntry, Currency."Realized Losses Acc.", -RealizedVATAmount, 0, false, true,
-                                        CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
-                                    GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
-                                end else begin
-                                    Currency.TestField("Realized Gains Acc.");
-                                    InitGLEntry(
-                                        GenJnlLine, GLEntry, Currency."Realized Gains Acc.", -RealizedVATAmount, 0, false, true,
-                                        CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
-                                    GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
-                                end;
-                            else
-                                if GainLossLCY < 0 then begin
-                                    Currency.TestField("Realized Losses Acc.");
-                                    InitGLEntry(
-                                        GenJnlLine, GLEntry, Currency."Realized Losses Acc.", -RealizedVATAmount, 0, false, true,
-                                        CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
-                                    GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
-                                end else begin
-                                    Currency.TestField("Realized Gains Acc.");
-                                    InitGLEntry(
-                                        GenJnlLine, GLEntry, Currency."Realized Gains Acc.", -RealizedVATAmount, 0, false, true,
-                                        CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
-                                    GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
-                                end;
+                        GLEntryNo :=
+                          InitGLEntryVATCopy(
+                            GenJnlLine, SalesVATAccount, SalesVATUnrealAccount,
+                            VATAmount + RealizedVATAmount, VATAmountAddCurr + RealizedVATAmountAddCurr, VATEntry2);
+
+                        if (GainLossLCY <> 0) and (CustLedgEntry2."Currency Code" <> '') and
+                           (VATPostingSetup."Unrealized VAT Type" = VATPostingSetup."Unrealized VAT Type"::"Cash Basis")
+                        then begin
+                            Currency.Get(CustLedgEntry2."Currency Code");
+                            case CustLedgEntry2."Document Type" of
+                                CustLedgEntry2."Document Type"::"Credit Memo":
+                                    if GainLossLCY > 0 then begin
+                                        Currency.TestField("Realized Losses Acc.");
+                                        InitGLEntry(
+                                            GenJnlLine, GLEntry, Currency."Realized Losses Acc.", -RealizedVATAmount, 0, false, true,
+                                            CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
+                                        GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
+                                    end else begin
+                                        Currency.TestField("Realized Gains Acc.");
+                                        InitGLEntry(
+                                            GenJnlLine, GLEntry, Currency."Realized Gains Acc.", -RealizedVATAmount, 0, false, true,
+                                            CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
+                                        GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
+                                    end;
+                                else
+                                    if GainLossLCY < 0 then begin
+                                        Currency.TestField("Realized Losses Acc.");
+                                        InitGLEntry(
+                                            GenJnlLine, GLEntry, Currency."Realized Losses Acc.", -RealizedVATAmount, 0, false, true,
+                                            CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
+                                        GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
+                                    end else begin
+                                        Currency.TestField("Realized Gains Acc.");
+                                        InitGLEntry(
+                                            GenJnlLine, GLEntry, Currency."Realized Gains Acc.", -RealizedVATAmount, 0, false, true,
+                                            CalcAmountSrcCurr(GenJnlLine, -RealizedVATAmount));
+                                        GLEntry."Additional-Currency Amount" := -RealizedVATAmountAddCurr;
+                                    end;
+                            end;
+                            GLEntry.CopyPostingGroupsFromVATEntry(VATEntry2);
+                            SummarizeVAT(GLSetup."Summarize G/L Entries", GLEntry);
                         end;
-                        GLEntry.CopyPostingGroupsFromVATEntry(VATEntry2);
-                        SummarizeVAT(GLSetup."Summarize G/L Entries", GLEntry);
                     end;
 
                     OnCustUnrealizedVATOnBeforePostUnrealVATEntry(GenJnlLine, VATEntry2, VATAmount, VATBase, VATAmountAddCurr, VATBaseAddCurr, GLEntryNo, VATPart);
@@ -6260,7 +6270,8 @@ codeunit 12 "Gen. Jnl.-Post Line"
         OnBeforeInsertPostUnrealVATEntry(VATEntry, GenJnlLine, VATEntry2);
         VATEntry.Insert(true);
         OnPostUnrealVATEntryOnBeforeInsertLinkSelf(TempGLEntryVATEntryLink, VATEntry, GLEntryNo, NextVATEntryNo);
-        TempGLEntryVATEntryLink.InsertLinkSelf(GLEntryNo + 1, NextVATEntryNo);
+        if GLEntryNo <> 0 then
+            TempGLEntryVATEntryLink.InsertLinkSelf(GLEntryNo + 1, NextVATEntryNo);
         NextVATEntryNo := NextVATEntryNo + 1;
 
         VATEntry2."Remaining Unrealized Amount" :=

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4554,6 +4554,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     CalculateFirstLastAmount(VATPostingSetup."Unrealized VAT Type", VATEntry2."Remaining Unrealized Amount", TotalUnrealVATAmountLast, TotalUnrealVATAmountFirst);
             until VATEntry2.Next() = 0;
         if VATEntry2.FindSet() then begin
+            if ShouldConsiderVATPostingGrouping then begin
+                InvoicePartAmountByVAT := CustLedgEntry2.GetInvoicePartAmountByVAT(CustLedgEntry2."Document Type", GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group");
+                SettledAmountByVAT := CustLedgEntry2.GetCreditMemoPartAmountByVAT(GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group", SettledAmount);
+            end;
             LastConnectionNo := 0;
             repeat
                 VATPostingSetup.Get(VATEntry2."VAT Bus. Posting Group", VATEntry2."VAT Prod. Posting Group");
@@ -4563,8 +4567,6 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 end;
 
                 if ShouldConsiderVATPostingGrouping then begin
-                    InvoicePartAmountByVAT := CustLedgEntry2.GetInvoicePartAmountByVAT(CustLedgEntry2."Document Type", GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group");
-                    SettledAmountByVAT := CustLedgEntry2.GetCreditMemoPartAmountByVAT(GenJnlLine, TempVATPostingSetup."VAT Bus. Posting Group", TempVATPostingSetup."VAT Prod. Posting Group", SettledAmount);
                     VATPart :=
                         VATEntry2.GetUnrealizedVATPart(
                         Round(SettledAmountByVAT / CustLedgEntry2.GetAdjustedCurrencyFactor()),
@@ -4669,10 +4671,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     end;
 
 
+                    IsHandled := false;
+                    OnCustUnrealizedVATOnBeforeInitGLEntryVAT(
+                        GenJnlLine, VATEntry2, VATAmount, VATBase, VATAmountAddCurr, VATBaseAddCurr, IsHandled, SalesVATUnrealAccount, CustLedgEntry2, SettledAmount);
                     if ShouldPostGLEntries then begin
-                        IsHandled := false;
-                        OnCustUnrealizedVATOnBeforeInitGLEntryVAT(
-                          GenJnlLine, VATEntry2, VATAmount, VATBase, VATAmountAddCurr, VATBaseAddCurr, IsHandled, SalesVATUnrealAccount, CustLedgEntry2, SettledAmount);
                         if not IsHandled then
                             InitGLEntryVAT(
                                 GenJnlLine, SalesVATUnrealAccount, SalesVATAccount, -VATAmount, -VATAmountAddCurr, false);

--- a/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -4566,7 +4566,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                     LastConnectionNo := VATEntry2."Sales Tax Connection No.";
                 end;
 
-                if ShouldConsiderVATPostingGrouping then begin
+                if ShouldConsiderVATPostingGrouping then
                     VATPart :=
                         VATEntry2.GetUnrealizedVATPart(
                         Round(SettledAmountByVAT / CustLedgEntry2.GetAdjustedCurrencyFactor()),
@@ -4575,7 +4575,7 @@ codeunit 12 "Gen. Jnl.-Post Line"
                         TotalUnrealVATAmountFirst,
                         TotalUnrealVATAmountLast,
                         InvoicePartAmountByVAT)
-                end else
+                else
                     VATPart :=
                         VATEntry2.GetUnrealizedVATPart(
                             Round(SettledAmount / CustLedgEntry2.GetAdjustedCurrencyFactor()),

--- a/src/Layers/NA/BaseApp/Sales/Receivables/CustLedgerEntry.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Receivables/CustLedgerEntry.Table.al
@@ -1790,12 +1790,12 @@ table 21 "Cust. Ledger Entry"
             InvoicePartAmount := BaseInvoicePartAmount;
     end;
 
-    internal procedure GetCreditMemoPartAmountByVAT(GenJnlLine: Record "Gen. Journal Line"; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]; SettledAmount: Decimal) CreditMemoPartAmount: Decimal
+    internal procedure GetCreditMemoPartAmountByVAT(CreditMemoDocumentNo: Code[20]; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]; SettledAmount: Decimal) CreditMemoPartAmount: Decimal
     var
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         CreditMemoAmount: Decimal;
     begin
-        SalesCrMemoLine.SetRange("Document No.", GenJnlLine."Document No.");
+        SalesCrMemoLine.SetRange("Document No.", CreditMemoDocumentNo);
         SalesCrMemoLine.SetLoadFields("Amount Including VAT", "VAT Bus. Posting Group", "VAT Prod. Posting Group");
         if SalesCrMemoLine.FindSet() then
             repeat

--- a/src/Layers/NA/BaseApp/Sales/Receivables/CustLedgerEntry.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Receivables/CustLedgerEntry.Table.al
@@ -1790,6 +1790,31 @@ table 21 "Cust. Ledger Entry"
             InvoicePartAmount := BaseInvoicePartAmount;
     end;
 
+    procedure GetCreditMemoPartAmountByVAT(GenJnlLine: Record "Gen. Journal Line"; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]; SettledAmount: Decimal) CreditMemoPartAmount: Decimal
+    var
+        SalesCrMemoLine: Record "Sales Cr.Memo Line";
+        CreditMemoAmount: Decimal;
+    begin
+        SalesCrMemoLine.SetRange("Document No.", GenJnlLine."Document No.");
+        if SalesCrMemoLine.FindSet() then
+            repeat
+                CreditMemoAmount += SalesCrMemoLine."Amount Including VAT";
+                if (SalesCrMemoLine."VAT Bus. Posting Group" = VATBusPostingGroup) and
+                   (SalesCrMemoLine."VAT Prod. Posting Group" = VATProdPostingGroup)
+                then
+                    CreditMemoPartAmount += SalesCrMemoLine."Amount Including VAT";
+            until SalesCrMemoLine.Next() = 0
+        else
+            exit(SettledAmount);
+
+        if CreditMemoAmount = 0 then
+            exit(SettledAmount);
+
+        CreditMemoPartAmount := CreditMemoPartAmount * Abs(SettledAmount) / Abs(CreditMemoAmount);
+        if SettledAmount < 0 then
+            CreditMemoPartAmount := -CreditMemoPartAmount;
+    end;
+
     /// <summary>
     /// Raised after copying customer ledger entry fields from a general journal line.
     /// </summary>

--- a/src/Layers/NA/BaseApp/Sales/Receivables/CustLedgerEntry.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Receivables/CustLedgerEntry.Table.al
@@ -1790,12 +1790,13 @@ table 21 "Cust. Ledger Entry"
             InvoicePartAmount := BaseInvoicePartAmount;
     end;
 
-    procedure GetCreditMemoPartAmountByVAT(GenJnlLine: Record "Gen. Journal Line"; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]; SettledAmount: Decimal) CreditMemoPartAmount: Decimal
+    internal procedure GetCreditMemoPartAmountByVAT(GenJnlLine: Record "Gen. Journal Line"; VATBusPostingGroup: Code[20]; VATProdPostingGroup: Code[20]; SettledAmount: Decimal) CreditMemoPartAmount: Decimal
     var
         SalesCrMemoLine: Record "Sales Cr.Memo Line";
         CreditMemoAmount: Decimal;
     begin
         SalesCrMemoLine.SetRange("Document No.", GenJnlLine."Document No.");
+        SalesCrMemoLine.SetLoadFields("Amount Including VAT", "VAT Bus. Posting Group", "VAT Prod. Posting Group");
         if SalesCrMemoLine.FindSet() then
             repeat
                 CreditMemoAmount += SalesCrMemoLine."Amount Including VAT";

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -698,11 +698,9 @@
         CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
 
         // [THEN] Invoice Group1 Remaining Unrealized Amount is correctly reduced using group-specific invoice amount
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
-        VATEntry.SetRange("Document No.", InvoiceNo);
-        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[1]."VAT Prod. Posting Group");
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup[1]."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           -Round(UnitPrice[1] * 10 / 100 * (1 - CrMemoAmountInclVAT / InvoiceGroup1AmountInclVAT)),
           VATEntry."Remaining Unrealized Amount",
@@ -710,8 +708,9 @@
           'Group1 remaining unrealized VAT should be reduced by credit memo portion of Group1 invoice amount');
 
         // [THEN] Invoice Group2 Remaining Unrealized Amount is unchanged
-        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[2]."VAT Prod. Posting Group");
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup[2]."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           -Round(UnitPrice[2] * 21 / 100),
           VATEntry."Remaining Unrealized Amount",
@@ -760,11 +759,9 @@
         VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup[1]."VAT Prod. Posting Group");
 
         // [THEN] Invoice Group2 Remaining Unrealized Amount is unchanged
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
-        VATEntry.SetRange("Document No.", InvoiceNo);
-        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[2]."VAT Prod. Posting Group");
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup[2]."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           -Round(UnitPrice[2] * 21 / 100),
           VATEntry."Remaining Unrealized Amount",
@@ -961,10 +958,9 @@
         CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
 
         // [THEN] Invoice VAT Entry "Remaining Unrealized Amount" equals -(1000 - 500) * 10% = -50
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
-        VATEntry.SetRange("Document No.", InvoiceNo);
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           -Round((UnitPrice - CreditMemoPrice) * 10 / 100),
           VATEntry."Remaining Unrealized Amount",
@@ -1057,10 +1053,9 @@
         CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
 
         // [THEN] Credit Memo VAT Entry "Unrealized Amount" equals 500 * 10% = 50
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::"Credit Memo");
-        VATEntry.SetRange("Document No.", CreditMemoNo);
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::"Credit Memo",
+          CreditMemoNo, VATPostingSetup."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           Round(CreditMemoPrice * 10 / 100),
           VATEntry."Unrealized Amount",
@@ -1130,6 +1125,7 @@
         Currency: Record Currency;
         SalesHeader: array[2] of Record "Sales Header";
         SalesLine: array[2] of Record "Sales Line";
+        VATEntry: Record "VAT Entry";
         VATPostingSetup: Record "VAT Posting Setup";
         VATPostingSetup2: Record "VAT Posting Setup";
         CustomerNo: Code[20];
@@ -1192,6 +1188,13 @@
 
         // [VERIFY] Verify VAT Realized Amount for customer.
         VerifyVATEntryForPostApplication(VATAmount);
+
+        // [THEN] Only the invoice VAT group represented by the credit memo is fully realized
+        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup."VAT Prod. Posting Group");
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup2."VAT Prod. Posting Group");
+        VATEntry.TestField("Remaining Unrealized Amount", VATEntry."Unrealized Amount");
     end;
 
     local procedure Initialize()
@@ -1452,6 +1455,21 @@
         VATEntry.FindFirst();
     end;
 
+    local procedure FindVATEntryByDocumentAndPostingGroup(var VATEntry: Record "VAT Entry"; VATType: Enum "General Posting Type"; DocumentType: Enum "Gen. Journal Document Type"; DocumentNo: Code[20]; VATProdPostingGroup: Code[20])
+    begin
+        VATEntry.SetCurrentKey("Document No.", "Posting Date");
+        VATEntry.SetRange("Document No.", DocumentNo);
+        VATEntry.FindSet();
+        repeat
+            if (VATEntry.Type = VATType) and
+               (VATEntry."Document Type" = DocumentType) and
+               (VATEntry."VAT Prod. Posting Group" = VATProdPostingGroup)
+            then
+                exit;
+        until VATEntry.Next() = 0;
+        VATEntry.FieldError("VAT Prod. Posting Group", VATProdPostingGroup);
+    end;
+
     local procedure CalcVendInvoiceAmount(InvoiceNo: Code[20]): Decimal
     var
         VendorLedgerEntry: Record "Vendor Ledger Entry";
@@ -1563,11 +1581,8 @@
     var
         VATEntry: Record "VAT Entry";
     begin
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
-        VATEntry.SetRange("Document No.", InvoiceNo);
-        VATEntry.SetRange("VAT Prod. Posting Group", VATProdPostingGroup);
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice, InvoiceNo, VATProdPostingGroup);
         Assert.AreEqual(0, VATEntry."Remaining Unrealized Amount", 'Remaining Unrealized Amount should be zero');
         Assert.AreEqual(0, VATEntry."Remaining Unrealized Base", 'Remaining Unrealized Base should be zero');
     end;

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -10,6 +10,7 @@
 
     var
         Assert: Codeunit Assert;
+        LibraryCFDI: Codeunit "Library - CFDI";
         LibraryERM: Codeunit "Library - ERM";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         LibraryInventory: Codeunit "Library - Inventory";
@@ -23,6 +24,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure VATRealizedGainLossForCustomerLCYPaymentToFCYInvoice()
     var
         CustLedgerEntry: Record "Cust. Ledger Entry";
@@ -69,6 +71,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure VATRealizedGainLossForVendorLCYPaymentToFCYInvoice()
     var
         Currency: Record Currency;
@@ -115,6 +118,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedVATAmountInExchRateOfPaymentWhenFCYPaymentToFCYInvoice()
     var
         Currency: Record Currency;
@@ -155,6 +159,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedVATAmountInExchRateOfPaymentWhenFCYPaymentToFCYInvoiceUnapplyPurchase()
     var
         Currency: Record Currency;
@@ -226,6 +231,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedVATAmountInExchRateOfPaymentWhenFCYPaymentToFCYInvoiceUnapplySales()
     var
         Currency: Record Currency;
@@ -299,6 +305,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedVATAmountInManualExchRateOfPaymentFCYToPurchaseInvoiceFCY()
     var
         Currency: Record Currency;
@@ -354,6 +361,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedVATAmountInManualExchRateOfPaymentFCYToSalesInvoiceFCY()
     var
         Currency: Record Currency;
@@ -409,6 +417,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedPercentageVATAdjustExchPaymentFCYtoPurchInvoiceFCY()
     var
         Currency: Record Currency;
@@ -473,6 +482,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedPercentageVATAdjustExchPaymentFCYtoSalesInvoiceFCY()
     var
         Currency: Record Currency;
@@ -536,7 +546,6 @@
     end;
 
     [Test]
-    [Scope('OnPrem')]
     procedure PartialPmtMultipleVATGroupsProportionalRealization()
     var
         VATPostingSetup: array[2] of Record "VAT Posting Setup";
@@ -605,7 +614,7 @@
         UnitPrice: array[2] of Decimal;
     begin
         // [FEATURE] [Sales]
-        // [SCENARIO 625414] Full payment applied to sales invoice with multiple VAT groups fully realizes all unrealized VAT
+        // [SCENARIO 625412] Full payment applied to sales invoice with multiple VAT groups fully realizes all unrealized VAT
         Initialize();
 
         // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
@@ -663,7 +672,7 @@
         InvoiceGroup1AmountInclVAT: Decimal;
     begin
         // [FEATURE] [Sales]
-        // [SCENARIO 625416] Partial credit memo posted with Applies-to Doc. No. on invoice with multiple VAT groups realizes correct VAT per group
+        // [SCENARIO 625412] Partial credit memo posted with Applies-to Doc. No. on invoice with multiple VAT groups realizes correct VAT per group
         Initialize();
 
         // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
@@ -674,7 +683,7 @@
 
         // [GIVEN] Sales Credit Memo for Item1 only with partial amount 50, Applies-to Invoice
         PartialCrMemoPrice := 50;
-        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
         SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
         SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
         SalesHeader.Modify(true);
@@ -722,7 +731,7 @@
         UnitPrice: array[2] of Decimal;
     begin
         // [FEATURE] [Sales]
-        // [SCENARIO 625417] Full credit memo for one VAT group posted with Applies-to Doc. No. on multi-VAT invoice realizes correct VAT
+        // [SCENARIO 625412] Full credit memo for one VAT group posted with Applies-to Doc. No. on multi-VAT invoice realizes correct VAT
         Initialize();
 
         // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
@@ -731,7 +740,7 @@
         InvoiceNo := CreateMultiVATGroupSalesInvoice(VATPostingSetup, CustomerNo, ItemNo, UnitPrice);
 
         // [GIVEN] Sales Credit Memo for Item1 only with full amount, Applies-to Invoice
-        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
         SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
         SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
         SalesHeader.Modify(true);
@@ -756,6 +765,275 @@
           VATEntry."Remaining Unrealized Amount",
           LibraryERM.GetAmountRoundingPrecision(),
           'Group2 remaining unrealized VAT should be unchanged');
+    end;
+
+    [Test]
+    procedure PartialCrMemoMultipleVATGroupsCorrectRealization()
+    var
+        VATPostingSetup: array[2] of Record "VAT Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        VATEntry: Record "VAT Entry";
+        CustomerNo: Code[20];
+        ItemNo: array[2] of Code[20];
+        InvoiceNo: Code[20];
+        CreditMemoNo: Code[20];
+        UnitPrice: array[2] of Decimal;
+        CreditMemoPrice: array[2] of Decimal;
+    begin
+        // [FEATURE] [Sales]
+        // [SCENARIO 625412] Partial credit memo with multiple VAT groups realizes VAT using each credit memo group amount
+        Initialize();
+
+        // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
+        UnitPrice[1] := 1000;
+        UnitPrice[2] := 2000;
+        InvoiceNo := CreateMultiVATGroupSalesInvoice(VATPostingSetup, CustomerNo, ItemNo, UnitPrice);
+
+        // [GIVEN] Sales Credit Memo with partial amounts for both VAT groups, Applies-to Invoice
+        CreditMemoPrice[1] := 50;
+        CreditMemoPrice[2] := 100;
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
+        SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[1], 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice[1]);
+        SalesLine.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[2], 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice[2]);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post the Sales Credit Memo
+        CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] Invoice Group1 Remaining Unrealized Amount is reduced by the Group1 credit memo amount
+        VATEntry.SetRange(Type, VATEntry.Type::Sale);
+        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
+        VATEntry.SetRange("Document No.", InvoiceNo);
+        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[1]."VAT Prod. Posting Group");
+        VATEntry.FindFirst();
+        Assert.AreNearlyEqual(
+          -Round((UnitPrice[1] - CreditMemoPrice[1]) * 10 / 100),
+          VATEntry."Remaining Unrealized Amount",
+          LibraryERM.GetAmountRoundingPrecision(),
+          'Group1 remaining unrealized VAT should be reduced by the Group1 credit memo amount');
+
+        // [THEN] Invoice Group2 Remaining Unrealized Amount is reduced by the Group2 credit memo amount
+        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[2]."VAT Prod. Posting Group");
+        VATEntry.FindFirst();
+        Assert.AreNearlyEqual(
+          -Round((UnitPrice[2] - CreditMemoPrice[2]) * 21 / 100),
+          VATEntry."Remaining Unrealized Amount",
+          LibraryERM.GetAmountRoundingPrecision(),
+          'Group2 remaining unrealized VAT should be reduced by the Group2 credit memo amount');
+
+        // [THEN] Invoice-side unrealized VAT G/L transfers are not posted for either VAT group
+        VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[1]);
+        VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[2]);
+    end;
+
+    [Test]
+    procedure SingleLineCrMemoAppliedToSingleVATInvoiceNoRealizationGLEntries()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        VATEntry: Record "VAT Entry";
+        CustomerNo: Code[20];
+        ItemNo: Code[20];
+        InvoiceNo: Code[20];
+        CreditMemoNo: Code[20];
+        UnitPrice: Decimal;
+        CreditMemoPrice: Decimal;
+    begin
+        // [SCENARIO 625412] Single-line credit memo applied to single-VAT invoice posts no realization G/L entries
+        Initialize();
+
+        // [GIVEN] Posted Sales Invoice "SI" with one line: price 1000, VAT 10%
+        CreateCashBasisVATPostingSetup(VATPostingSetup, 10);
+        ItemNo := CreateItem(VATPostingSetup."VAT Prod. Posting Group");
+        CustomerNo := CreateCustomer('', VATPostingSetup."VAT Bus. Posting Group");
+        UnitPrice := 1000;
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, 1);
+        SalesLine.Validate("Unit Price", UnitPrice);
+        SalesLine.Modify(true);
+        InvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [GIVEN] Sales Credit Memo "CM" with one line: price 500, VAT 10%, applied to "SI"
+        CreditMemoPrice := 500;
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
+        SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post "CM"
+        CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] Invoice VAT Entry "Remaining Unrealized Amount" equals -(1000 - 500) * 10% = -50
+        VATEntry.SetRange(Type, VATEntry.Type::Sale);
+        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
+        VATEntry.SetRange("Document No.", InvoiceNo);
+        VATEntry.FindFirst();
+        Assert.AreNearlyEqual(
+          -Round((UnitPrice - CreditMemoPrice) * 10 / 100),
+          VATEntry."Remaining Unrealized Amount",
+          LibraryERM.GetAmountRoundingPrecision(),
+          'Invoice VAT Entry "Remaining Unrealized Amount" must equal -50');
+
+        // [THEN] No G/L entries transfer VAT between unrealized and realized accounts
+        VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup);
+    end;
+
+    [Test]
+    procedure PaymentAfterPartialCrMemoMultiVATRealizesRemainingVAT()
+    var
+        VATPostingSetup: array[2] of Record "VAT Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        GenJournalLine: Record "Gen. Journal Line";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        CustomerNo: Code[20];
+        ItemNo: array[2] of Code[20];
+        InvoiceNo: Code[20];
+        UnitPrice: array[2] of Decimal;
+        CreditMemoPrice: array[2] of Decimal;
+    begin
+        // [SCENARIO 625412] Payment for remaining balance after partial multi-VAT credit memo sets both groups "Remaining Unrealized Amount" to zero
+        Initialize();
+
+        // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
+        UnitPrice[1] := 1000;
+        UnitPrice[2] := 2000;
+        InvoiceNo := CreateMultiVATGroupSalesInvoice(VATPostingSetup, CustomerNo, ItemNo, UnitPrice);
+
+        // [GIVEN] Posted Sales Credit Memo with partial amounts (50 for Group1, 100 for Group2), applied to "SI"
+        CreditMemoPrice[1] := 50;
+        CreditMemoPrice[2] := 100;
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
+        SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[1], 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice[1]);
+        SalesLine.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[2], 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice[2]);
+        SalesLine.Modify(true);
+        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [WHEN] Post payment for the remaining invoice balance
+        LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, CustLedgerEntry."Document Type"::Invoice, InvoiceNo);
+        CustLedgerEntry.CalcFields("Remaining Amt. (LCY)");
+        CreateAndPostPaymentGenJournalLine(
+          GenJournalLine, GenJournalLine."Account Type"::Customer, CustomerNo,
+          InvoiceNo, -CustLedgerEntry."Remaining Amt. (LCY)", WorkDate());
+
+        // [THEN] Invoice Group1 VAT Entry "Remaining Unrealized Amount" equals 0
+        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup[1]."VAT Prod. Posting Group");
+
+        // [THEN] Invoice Group2 VAT Entry "Remaining Unrealized Amount" equals 0
+        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup[2]."VAT Prod. Posting Group");
+    end;
+
+    [Test]
+    procedure StandaloneCrMemoWithoutApplicationPostsUnrealizedVATEntry()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        VATEntry: Record "VAT Entry";
+        CustomerNo: Code[20];
+        ItemNo: Code[20];
+        CreditMemoNo: Code[20];
+        CreditMemoPrice: Decimal;
+    begin
+        // [SCENARIO 625412] Credit memo posted without application creates VAT Entry with "Remaining Unrealized Amount" equal to "Unrealized Amount"
+        Initialize();
+
+        // [GIVEN] Cash Basis VAT Posting Setup with 10%
+        CreateCashBasisVATPostingSetup(VATPostingSetup, 10);
+        ItemNo := CreateItem(VATPostingSetup."VAT Prod. Posting Group");
+        CustomerNo := CreateCustomer('', VATPostingSetup."VAT Bus. Posting Group");
+
+        // [GIVEN] Sales Credit Memo "CM" with one line: price 500, VAT 10%, no application
+        CreditMemoPrice := 500;
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo, 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post "CM"
+        CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] Credit Memo VAT Entry "Unrealized Amount" equals 500 * 10% = 50
+        VATEntry.SetRange(Type, VATEntry.Type::Sale);
+        VATEntry.SetRange("Document Type", VATEntry."Document Type"::"Credit Memo");
+        VATEntry.SetRange("Document No.", CreditMemoNo);
+        VATEntry.FindFirst();
+        Assert.AreNearlyEqual(
+          Round(CreditMemoPrice * 10 / 100),
+          VATEntry."Unrealized Amount",
+          LibraryERM.GetAmountRoundingPrecision(),
+          'Credit Memo VAT Entry "Unrealized Amount" must equal 50');
+
+        // [THEN] "Remaining Unrealized Amount" equals "Unrealized Amount" (no realization occurred)
+        Assert.AreEqual(
+          VATEntry."Unrealized Amount",
+          VATEntry."Remaining Unrealized Amount",
+          'Credit Memo "Remaining Unrealized Amount" must equal "Unrealized Amount" when no application exists');
+    end;
+
+    [Test]
+    procedure FullCrMemoMultipleVATGroupsSetsRemainingUnrealizedToZero()
+    var
+        VATPostingSetup: array[2] of Record "VAT Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        CustomerNo: Code[20];
+        ItemNo: array[2] of Code[20];
+        InvoiceNo: Code[20];
+        CreditMemoNo: Code[20];
+        UnitPrice: array[2] of Decimal;
+    begin
+        // [SCENARIO 625412] Full credit memo for both VAT groups sets invoice "Remaining Unrealized Amount" to zero with no realization G/L entries
+        Initialize();
+
+        // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
+        UnitPrice[1] := 1000;
+        UnitPrice[2] := 2000;
+        InvoiceNo := CreateMultiVATGroupSalesInvoice(VATPostingSetup, CustomerNo, ItemNo, UnitPrice);
+
+        // [GIVEN] Sales Credit Memo for both items at full price, applied to "SI"
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
+        SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[1], 1);
+        SalesLine.Validate("Unit Price", UnitPrice[1]);
+        SalesLine.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[2], 1);
+        SalesLine.Validate("Unit Price", UnitPrice[2]);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post the Sales Credit Memo
+        CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] Invoice Group1 VAT Entry "Remaining Unrealized Amount" equals 0
+        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup[1]."VAT Prod. Posting Group");
+
+        // [THEN] Invoice Group2 VAT Entry "Remaining Unrealized Amount" equals 0
+        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup[2]."VAT Prod. Posting Group");
+
+        // [THEN] No G/L entries transfer VAT between unrealized and realized accounts for Group1
+        VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[1]);
+
+        // [THEN] No G/L entries transfer VAT between unrealized and realized accounts for Group2
+        VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[2]);
     end;
 
     [Test]
@@ -794,7 +1072,7 @@
         UnitAmount[2] := LibraryRandom.RandInt(20);
 
         // [GIVEN] Create Sales order
-        LibrarySales.CreateSalesHeader(SalesHeader[1], SalesLine[1]."Document Type"::Order, CustomerNo);
+        CreateSalesHeader(SalesHeader[1], SalesLine[1]."Document Type"::Order, CustomerNo);
 
         // [GIVEN] Create first Sales Line of Item1
         LibrarySales.CreateSalesLine(SalesLine[1], SalesHeader[1], SalesLine[1].Type::Item, ItemNo[1], 1);
@@ -810,7 +1088,7 @@
         InvoiceNo := LibrarySales.PostSalesDocument(SalesHeader[1], true, true);
 
         // [GIVEN] Create Credit Memo
-        LibrarySales.CreateSalesHeader(SalesHeader[2], SalesLine[2]."Document Type"::"Credit Memo", CustomerNo);
+        CreateSalesHeader(SalesHeader[2], SalesLine[2]."Document Type"::"Credit Memo", CustomerNo);
 
         // [GIVEN] Create Sales Line for Item1
         LibrarySales.CreateSalesLine(SalesLine[2], SalesHeader[2], SalesLine[2].Type::Item, ItemNo[1], 1);
@@ -894,7 +1172,7 @@
         ItemNo[1] := CreateItem(VATPostingSetup[1]."VAT Prod. Posting Group");
         ItemNo[2] := CreateItem(VATPostingSetup[2]."VAT Prod. Posting Group");
         CustomerNo := CreateCustomer('', VATPostingSetup[1]."VAT Bus. Posting Group");
-        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, CustomerNo);
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[1], 1);
         SalesLine.Validate("Unit Price", UnitPrice[1]);
         SalesLine.Modify(true);
@@ -951,11 +1229,18 @@
     var
         SalesHeader: Record "Sales Header";
     begin
-        LibrarySales.CreateSalesHeader(SalesHeader, DocumentType, CustomerNo);
+        CreateSalesHeader(SalesHeader, DocumentType, CustomerNo);
         LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Type, No, Quantity);
         SalesLine.Validate("Unit Price", UnitPrice);
         SalesLine.Modify(true);
         exit(LibrarySales.PostSalesDocument(SalesHeader, true, true));
+    end;
+
+    local procedure CreateSalesHeader(var SalesHeader: Record "Sales Header"; DocumentType: Enum "Sales Document Type"; CustomerNo: Code[20])
+    begin
+        LibrarySales.CreateSalesHeader(SalesHeader, DocumentType, CustomerNo);
+        SalesHeader.Validate("Payment Method Code", LibraryCFDI.CreatePaymentMethodForSAT());
+        SalesHeader.Modify(true);
     end;
 
     local procedure CreateCurrencyExchangeRate(CurrencyCode: Code[10]; StartingDate: Date; MultiplicationFactor: Decimal)
@@ -987,6 +1272,7 @@
         LibrarySales.CreateCustomer(Customer);
         Customer.Validate("Currency Code", CurrencyCode);
         Customer.Validate("VAT Bus. Posting Group", VATBusPostingGroup);
+        Customer.Validate("Payment Method Code", LibraryCFDI.CreatePaymentMethodForSAT());
         Customer.Modify(true);
         exit(Customer."No.");
     end;
@@ -1169,6 +1455,13 @@
         Assert.AreNearlyEqual(RealizedVATBase, VATEntry."Realized Base", AmtRounding, '');
     end;
 
+    [ConfirmHandler]
+    [Scope('OnPrem')]
+    procedure ConfirmPostingAfterWorkingDateHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
+    end;
+
     local procedure VerifyRemainingUnrealizedVATAmountAndVATBase(DocumentNo: Code[20]; VATAmount: Decimal; VATBase: Decimal)
     var
         VATEntry: Record "VAT Entry";
@@ -1190,6 +1483,21 @@
         VATEntry.FindFirst();
         Assert.AreEqual(0, VATEntry."Remaining Unrealized Amount", 'Remaining Unrealized Amount should be zero');
         Assert.AreEqual(0, VATEntry."Remaining Unrealized Base", 'Remaining Unrealized Base should be zero');
+    end;
+
+    local procedure VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo: Code[20]; VATPostingSetup: Record "VAT Posting Setup")
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document Type", GLEntry."Document Type"::"Credit Memo");
+        GLEntry.SetRange("Document No.", CreditMemoNo);
+        GLEntry.SetRange("G/L Account No.", VATPostingSetup."Sales VAT Unreal. Account");
+        GLEntry.SetRange("Bal. Account No.", VATPostingSetup."Sales VAT Account");
+        Assert.IsTrue(GLEntry.IsEmpty(), 'VAT G/L entry from unrealized to realized account should not be posted');
+
+        GLEntry.SetRange("G/L Account No.", VATPostingSetup."Sales VAT Account");
+        GLEntry.SetRange("Bal. Account No.", VATPostingSetup."Sales VAT Unreal. Account");
+        Assert.IsTrue(GLEntry.IsEmpty(), 'VAT G/L entry from realized to unrealized account should not be posted');
     end;
 
 }

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -21,6 +21,7 @@
         LibraryRandom: Codeunit "Library - Random";
         IsInitialized: Boolean;
         AmountErr: Label '%1 must be %2 in %3.', Comment = '%1 = Amount FieldCaption, %2 = Amount Value, %3 = Record TableCaption';
+        ConfirmPostingAfterWorkingDateQst: Label 'The posting date of one or more journal lines is after the working date. Do you want to continue?';
 
     [Test]
     [Scope('OnPrem')]
@@ -666,6 +667,7 @@
         CustomerNo: Code[20];
         ItemNo: array[2] of Code[20];
         InvoiceNo: Code[20];
+        CreditMemoNo: Code[20];
         UnitPrice: array[2] of Decimal;
         PartialCrMemoPrice: Decimal;
         CrMemoAmountInclVAT: Decimal;
@@ -693,7 +695,7 @@
         CrMemoAmountInclVAT := PartialCrMemoPrice + PartialCrMemoPrice * 10 / 100; // 55
 
         // [WHEN] Post the Sales Credit Memo
-        LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
 
         // [THEN] Invoice Group1 Remaining Unrealized Amount is correctly reduced using group-specific invoice amount
         VATEntry.SetRange(Type, VATEntry.Type::Sale);
@@ -715,6 +717,9 @@
           VATEntry."Remaining Unrealized Amount",
           LibraryERM.GetAmountRoundingPrecision(),
           'Group2 remaining unrealized VAT should be unchanged');
+
+        // [THEN] Invoice-side unrealized VAT G/L transfer is not posted for the credited VAT group
+        VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[1]);
     end;
 
     [Test]
@@ -831,6 +836,87 @@
         // [THEN] Invoice-side unrealized VAT G/L transfers are not posted for either VAT group
         VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[1]);
         VerifyInvoiceUnrealizedVATGLEntriesDoNotExist(CreditMemoNo, VATPostingSetup[2]);
+    end;
+
+    [Test]
+    procedure PartiallySettledCrMemoMultipleVATGroupsCorrectRealization()
+    var
+        VATPostingSetup: array[2] of Record "VAT Posting Setup";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        GenJournalLine: Record "Gen. Journal Line";
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        VATEntry: Record "VAT Entry";
+        CustomerNo: Code[20];
+        ItemNo: array[2] of Code[20];
+        InvoiceNo: Code[20];
+        CreditMemoNo: Code[20];
+        UnitPrice: array[2] of Decimal;
+        CreditMemoPrice: array[2] of Decimal;
+        PaymentAmount: Decimal;
+        CreditMemoSettledAmount: Decimal;
+        ExpectedRemainingVATAmount: Decimal;
+    begin
+        // [FEATURE] [Sales]
+        // [SCENARIO 625412] Partially settled credit memo with multiple VAT groups realizes VAT proportionally to the settled amount
+        Initialize();
+
+        // [GIVEN] Posted Sales Invoice "SI" with two lines: Item1 (VAT 10%, price 1000), Item2 (VAT 21%, price 2000)
+        UnitPrice[1] := 1000;
+        UnitPrice[2] := 2000;
+        InvoiceNo := CreateMultiVATGroupSalesInvoice(VATPostingSetup, CustomerNo, ItemNo, UnitPrice);
+
+        // [GIVEN] Payment leaves an invoice balance of 1155
+        PaymentAmount := 2365;
+        CreateAndPostPaymentGenJournalLine(
+          GenJournalLine, GenJournalLine."Account Type"::Customer, CustomerNo,
+          InvoiceNo, -PaymentAmount, WorkDate());
+
+        // [GIVEN] Sales Credit Memo for 2310 with different amounts per VAT group, applied to "SI"
+        CreditMemoPrice[1] := 1000;
+        CreditMemoPrice[2] := 1000;
+        CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::"Credit Memo", CustomerNo);
+        SalesHeader.Validate("Applies-to Doc. Type", SalesHeader."Applies-to Doc. Type"::Invoice);
+        SalesHeader.Validate("Applies-to Doc. No.", InvoiceNo);
+        SalesHeader.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[1], 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice[1]);
+        SalesLine.Modify(true);
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, ItemNo[2], 1);
+        SalesLine.Validate("Unit Price", CreditMemoPrice[2]);
+        SalesLine.Modify(true);
+
+        // [WHEN] Post the Sales Credit Memo, settling half of its total amount
+        CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+        CreditMemoSettledAmount := 1155;
+
+        // [THEN] Invoice Group1 Unrealized VAT is fully realized
+        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup[1]."VAT Prod. Posting Group");
+
+        // [THEN] Invoice Group2 Remaining Unrealized Amount reflects the partial credit memo settlement
+        ExpectedRemainingVATAmount :=
+          -Round(
+            UnitPrice[2] * 21 / 100 *
+            (1 - PaymentAmount / 3520 - (CreditMemoPrice[2] * 1.21 * CreditMemoSettledAmount / 2310) / 2420));
+        VATEntry.SetRange(Type, VATEntry.Type::Sale);
+        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
+        VATEntry.SetRange("Document No.", InvoiceNo);
+        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[2]."VAT Prod. Posting Group");
+        VATEntry.FindFirst();
+        Assert.AreNearlyEqual(
+          ExpectedRemainingVATAmount,
+          VATEntry."Remaining Unrealized Amount",
+          LibraryERM.GetAmountRoundingPrecision(),
+          'Group2 remaining unrealized VAT should reflect the partially settled credit memo amount');
+
+        // [THEN] Half of the Credit Memo remains open
+        LibraryERM.FindCustomerLedgerEntry(CustLedgerEntry, CustLedgerEntry."Document Type"::"Credit Memo", CreditMemoNo);
+        CustLedgerEntry.CalcFields("Remaining Amount");
+        Assert.AreNearlyEqual(
+          -CreditMemoSettledAmount,
+          CustLedgerEntry."Remaining Amount",
+          LibraryERM.GetAmountRoundingPrecision(),
+          'Half of the credit memo should remain open');
     end;
 
     [Test]
@@ -1459,6 +1545,7 @@
     [Scope('OnPrem')]
     procedure ConfirmPostingAfterWorkingDateHandler(Question: Text[1024]; var Reply: Boolean)
     begin
+        Assert.ExpectedMessage(ConfirmPostingAfterWorkingDateQst, Question);
         Reply := true;
     end;
 

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -483,7 +483,6 @@
 
     [Test]
     [Scope('OnPrem')]
-    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedPercentageVATAdjustExchPaymentFCYtoSalesInvoiceFCY()
     var
         Currency: Record Currency;
@@ -1183,7 +1182,8 @@
         ApplyAndPostCustomerEntry(CustLedgerEntry."Document Type"::Invoice, InvoiceNo);
 
         // [VERIFY] Verify VAT Realized Amount for customer.
-        VerifyVATEntryForPostApplication(VATAmount);
+        VerifyVATEntryForPostApplication(
+          VATAmount, VATPostingSetup."VAT Prod. Posting Group", VATPostingSetup2."VAT Prod. Posting Group");
     end;
 
     local procedure Initialize()
@@ -1534,13 +1534,18 @@
         LibraryERM.SetAppliestoIdCustomer(CustLedgerEntry)
     end;
 
-    local procedure VerifyVATEntryForPostApplication(VATAmount: Decimal)
+    local procedure VerifyVATEntryForPostApplication(VATAmount: Decimal; AffectedVATProdPostingGroup: Code[20]; UnaffectedVATProdPostingGroup: Code[20])
     var
         VATEntry: Record "VAT Entry";
         GLRegister: Record "G/L Register";
     begin
         GLRegister.FindLast();
         VATEntry.SetRange("Entry No.", GLRegister."From VAT Entry No.", GLRegister."To VAT Entry No.");
+        Assert.AreEqual(2, VATEntry.Count, 'The application must create exactly two VAT entries');
+        VATEntry.SetRange("VAT Prod. Posting Group", UnaffectedVATProdPostingGroup);
+        Assert.IsTrue(VATEntry.IsEmpty(), 'The application must not create VAT entries for the unaffected VAT posting group');
+        VATEntry.SetRange("VAT Prod. Posting Group", AffectedVATProdPostingGroup);
+        Assert.AreEqual(2, VATEntry.Count, 'Both application VAT entries must use the affected VAT posting group');
         VATEntry.FindSet();
         Assert.AreNearlyEqual(
           VATEntry.Amount, VATAmount, LibraryERM.GetAmountRoundingPrecision(),

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -1461,14 +1461,14 @@
     begin
         VATEntry.SetCurrentKey("Document No.", "Posting Date");
         VATEntry.SetRange("Document No.", DocumentNo);
-        VATEntry.FindSet();
-        repeat
-            if (VATEntry.Type = VATType) and
-               (VATEntry."Document Type" = DocumentType) and
-               (VATEntry."VAT Prod. Posting Group" = VATProdPostingGroup)
-            then
-                exit;
-        until VATEntry.Next() = 0;
+        if VATEntry.FindSet() then
+            repeat
+                if (VATEntry.Type = VATType) and
+                   (VATEntry."Document Type" = DocumentType) and
+                   (VATEntry."VAT Prod. Posting Group" = VATProdPostingGroup)
+                then
+                    exit;
+            until VATEntry.Next() = 0;
         VATEntry.FieldError("VAT Prod. Posting Group", StrSubstNo(VATPostingGroupMustBeErr, VATProdPostingGroup));
     end;
 

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -418,6 +418,7 @@
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedPercentageVATAdjustExchPaymentFCYtoPurchInvoiceFCY()
     var
         Currency: Record Currency;
@@ -1121,7 +1122,6 @@
         Currency: Record Currency;
         SalesHeader: array[2] of Record "Sales Header";
         SalesLine: array[2] of Record "Sales Line";
-        VATEntry: Record "VAT Entry";
         VATPostingSetup: Record "VAT Posting Setup";
         VATPostingSetup2: Record "VAT Posting Setup";
         CustomerNo: Code[20];
@@ -1184,13 +1184,6 @@
 
         // [VERIFY] Verify VAT Realized Amount for customer.
         VerifyVATEntryForPostApplication(VATAmount);
-
-        // [THEN] Only the invoice VAT group represented by the credit memo is fully realized
-        VerifyUnrealizedVATFullyRealized(InvoiceNo, VATPostingSetup."VAT Prod. Posting Group");
-        FindVATEntryByDocumentAndPostingGroup(
-          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
-          InvoiceNo, VATPostingSetup2."VAT Prod. Posting Group");
-        VATEntry.TestField("Remaining Unrealized Amount", VATEntry."Unrealized Amount");
     end;
 
     local procedure Initialize()

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -418,7 +418,6 @@
 
     [Test]
     [Scope('OnPrem')]
-    [HandlerFunctions('ConfirmPostingAfterWorkingDateHandler')]
     procedure RealizedPercentageVATAdjustExchPaymentFCYtoPurchInvoiceFCY()
     var
         Currency: Record Currency;

--- a/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
+++ b/src/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al
@@ -10,7 +10,6 @@
 
     var
         Assert: Codeunit Assert;
-        LibraryCFDI: Codeunit "Library - CFDI";
         LibraryERM: Codeunit "Library - ERM";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         LibraryInventory: Codeunit "Library - Inventory";
@@ -21,6 +20,7 @@
         LibraryRandom: Codeunit "Library - Random";
         IsInitialized: Boolean;
         AmountErr: Label '%1 must be %2 in %3.', Comment = '%1 = Amount FieldCaption, %2 = Amount Value, %3 = Record TableCaption';
+        VATPostingGroupMustBeErr: Label 'must be %1', Comment = '%1 = VAT product posting group code';
         ConfirmPostingAfterWorkingDateQst: Label 'The posting date of one or more journal lines is after the working date. Do you want to continue?';
 
     [Test]
@@ -810,11 +810,9 @@
         CreditMemoNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
 
         // [THEN] Invoice Group1 Remaining Unrealized Amount is reduced by the Group1 credit memo amount
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
-        VATEntry.SetRange("Document No.", InvoiceNo);
-        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[1]."VAT Prod. Posting Group");
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup[1]."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           -Round((UnitPrice[1] - CreditMemoPrice[1]) * 10 / 100),
           VATEntry."Remaining Unrealized Amount",
@@ -822,8 +820,9 @@
           'Group1 remaining unrealized VAT should be reduced by the Group1 credit memo amount');
 
         // [THEN] Invoice Group2 Remaining Unrealized Amount is reduced by the Group2 credit memo amount
-        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[2]."VAT Prod. Posting Group");
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup[2]."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           -Round((UnitPrice[2] - CreditMemoPrice[2]) * 21 / 100),
           VATEntry."Remaining Unrealized Amount",
@@ -895,11 +894,9 @@
           -Round(
             UnitPrice[2] * 21 / 100 *
             (1 - PaymentAmount / 3520 - (CreditMemoPrice[2] * 1.21 * CreditMemoSettledAmount / 2310) / 2420));
-        VATEntry.SetRange(Type, VATEntry.Type::Sale);
-        VATEntry.SetRange("Document Type", VATEntry."Document Type"::Invoice);
-        VATEntry.SetRange("Document No.", InvoiceNo);
-        VATEntry.SetRange("VAT Prod. Posting Group", VATPostingSetup[2]."VAT Prod. Posting Group");
-        VATEntry.FindFirst();
+        FindVATEntryByDocumentAndPostingGroup(
+          VATEntry, VATEntry.Type::Sale, VATEntry."Document Type"::Invoice,
+          InvoiceNo, VATPostingSetup[2]."VAT Prod. Posting Group");
         Assert.AreNearlyEqual(
           ExpectedRemainingVATAmount,
           VATEntry."Remaining Unrealized Amount",
@@ -1328,8 +1325,21 @@
     local procedure CreateSalesHeader(var SalesHeader: Record "Sales Header"; DocumentType: Enum "Sales Document Type"; CustomerNo: Code[20])
     begin
         LibrarySales.CreateSalesHeader(SalesHeader, DocumentType, CustomerNo);
-        SalesHeader.Validate("Payment Method Code", LibraryCFDI.CreatePaymentMethodForSAT());
+        SalesHeader.Validate("Payment Method Code", CreatePaymentMethodForSAT());
         SalesHeader.Modify(true);
+    end;
+
+    local procedure CreatePaymentMethodForSAT(): Code[10]
+    var
+        PaymentMethod: Record "Payment Method";
+        SATPaymentMethod: Record "SAT Payment Method";
+    begin
+        LibraryERM.CreatePaymentMethod(PaymentMethod);
+        PaymentMethod."SAT Method of Payment" := PaymentMethod.Code;
+        PaymentMethod.Modify();
+        SATPaymentMethod.Code := PaymentMethod."SAT Method of Payment";
+        SATPaymentMethod.Insert();
+        exit(PaymentMethod.Code);
     end;
 
     local procedure CreateCurrencyExchangeRate(CurrencyCode: Code[10]; StartingDate: Date; MultiplicationFactor: Decimal)
@@ -1361,7 +1371,7 @@
         LibrarySales.CreateCustomer(Customer);
         Customer.Validate("Currency Code", CurrencyCode);
         Customer.Validate("VAT Bus. Posting Group", VATBusPostingGroup);
-        Customer.Validate("Payment Method Code", LibraryCFDI.CreatePaymentMethodForSAT());
+        Customer.Validate("Payment Method Code", CreatePaymentMethodForSAT());
         Customer.Modify(true);
         exit(Customer."No.");
     end;
@@ -1467,7 +1477,7 @@
             then
                 exit;
         until VATEntry.Next() = 0;
-        VATEntry.FieldError("VAT Prod. Posting Group", VATProdPostingGroup);
+        VATEntry.FieldError("VAT Prod. Posting Group", StrSubstNo(VATPostingGroupMustBeErr, VATProdPostingGroup));
     end;
 
     local procedure CalcVendInvoiceAmount(InvoiceNo: Code[20]): Decimal

--- a/src/Layers/NA/Tests/Local/PurchDocTotalsSalesEntryUI.Codeunit.al
+++ b/src/Layers/NA/Tests/Local/PurchDocTotalsSalesEntryUI.Codeunit.al
@@ -2695,7 +2695,9 @@ codeunit 142085 PurchDocTotalsSalesEntryUI
     begin
         CreatePurchaseHeader(PurchaseHeader, DocumentType, VendorNo);
         if IsCalcInvDiscountMarked() then
-            PurchaseHeader.Validate("Invoice Discount Calculation", PurchaseHeader."Invoice Discount Calculation"::"%");
+            PurchaseHeader.Validate("Invoice Discount Calculation", PurchaseHeader."Invoice Discount Calculation"::"%")
+        else
+            PurchaseHeader.Validate("Invoice Discount Calculation", PurchaseHeader."Invoice Discount Calculation"::None);
         PurchaseHeader.Validate("Tax Area Code", TaxAreaCode);
         PurchaseHeader.Modify();
 

--- a/src/Layers/NA/Tests/Local/SalesDocTotalsSalesEntryUI.Codeunit.al
+++ b/src/Layers/NA/Tests/Local/SalesDocTotalsSalesEntryUI.Codeunit.al
@@ -2684,7 +2684,9 @@ codeunit 142063 SalesDocTotalsSalesEntryUI
         CreateTaxGroup('');
         CreateSalesHeader(SalesHeader, DocumentType, CustomerNo);
         if IsCalcInvDiscountMarked() then
-            SalesHeader.Validate("Invoice Discount Calculation", SalesHeader."Invoice Discount Calculation"::"%");
+            SalesHeader.Validate("Invoice Discount Calculation", SalesHeader."Invoice Discount Calculation"::"%")
+        else
+            SalesHeader.Validate("Invoice Discount Calculation", SalesHeader."Invoice Discount Calculation"::None);
         SalesHeader.Validate("Tax Area Code", TaxAreaCode);
         SalesHeader.Modify();
         LibrarySales.CreateSalesLine(

--- a/src/Layers/US/Tests/Local/ERMSalesPurchaseTaxIII.Codeunit.al
+++ b/src/Layers/US/Tests/Local/ERMSalesPurchaseTaxIII.Codeunit.al
@@ -1887,6 +1887,7 @@ codeunit 142092 "ERM Sales/Purchase Tax III"
         SalesHeader: Record "Sales Header";
         SalesLine: Record "Sales Line";
         CurrencyExchangeRate: Record "Currency Exchange Rate";
+        VATPostingSetup: Record "VAT Posting Setup";
         CurrencyCode: Code[10];
         TaxAreaCode: Code[20];
         TaxGroupCode: Code[20];
@@ -1903,10 +1904,14 @@ codeunit 142092 "ERM Sales/Purchase Tax III"
 
         // [GIVEN] Create Customer with Tax Area Code and Currency
         Customer.Get(CreateCustomerWithTaxArea(TaxAreaCode, CurrencyCode, LibraryRandom.RandIntInRange(70, 70)));
+        VATPostingSetup.SetRange("VAT Bus. Posting Group", Customer."VAT Bus. Posting Group");
+        LibraryERM.FindVATPostingSetupInvt(VATPostingSetup);
 
         // [GIVEN] Create Sales Order With Prepayment as 70%
         LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, Customer."No.");
-        LibrarySales.CreateSalesLineWithUnitPrice(SalesLine, SalesHeader, '', 4019.29, 1);
+        LibrarySales.CreateSalesLineWithUnitPrice(
+            SalesLine, SalesHeader,
+            LibraryInventory.CreateItemNoWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), 4019.29, 1);
         SalesLine.Validate("Tax Group Code", TaxGroupCode);
         SalesLine.Modify();
 


### PR DESCRIPTION
**Error Reported**
When posting sales credit memos with cash-basis VAT, partially applying a credit memo to invoices containing multiple VAT posting groups could calculate VAT realization using the total settled amount instead of the amount associated with each VAT group. This resulted in incorrect amounts and invalid G/L entries between the realized and unrealized VAT accounts.

**Solution**
A dedicated calculation was added to determine the settled credit memo amount for each VAT posting group combination. This amount is adjusted by the currency factor before the VAT amount is calculated.

A condition was also introduced to control when G/L entries should be posted, preventing incorrect entries when the credit memo application does not represent an actual VAT realization.

**Files Modified**

- GenJnlPostLine.Codeunit.al: uses the settled amount per VAT group and controls G/L entry creation.
- CustLedgerEntry.Table.al: adds the calculation of the credit memo portion associated with each VAT group.
- App/Layers/NA/Tests/Local/ERMCashBasis.codeunit.al: adds and updates automated tests for cash-basis VAT credit memo scenarios.

**Result**
Cash-basis VAT credit memos now realize VAT correctly for each VAT posting group. Partial and full applications, subsequent payments, and unapplied credit memos produce the expected amounts without creating invalid entries between the realized and unrealized VAT accounts.

Fixes
[AB#648956](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648956)














