### PR TITLE
Use GitHub App for extensibility request implementation

### DIFF
--- a/.github/workflows/bc-extrequest-implement.yml
+++ b/.github/workflows/bc-extrequest-implement.yml
@@ -40,7 +40,7 @@ jobs:
       pull-requests: write
       id-token: write
       copilot-requests: write
-    environment: triage
+    environment: extensibility-agent
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -80,10 +80,18 @@ jobs:
         if: steps.telemetry-config.outputs.enabled == 'true' && steps.azure-login.outcome == 'failure'
         run: Write-Warning 'Azure login failed. The implementation will continue without telemetry.'
 
+      - name: Mint token for BCApps
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.EXTENSIBILITY_CLIENT_ID }}
+          private-key: ${{ secrets.EXTENSIBILITY_TRIAGE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate skill
         run: |
@@ -102,7 +110,7 @@ jobs:
       - name: Implement extensibility request
         env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ secrets.EXT_REQ_PR_CREATE }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           TELEMETRY_ENABLED: ${{ steps.telemetry-config.outputs.enabled == 'true' && steps.azure-login.outcome == 'success' }}

--- a/.github/workflows/bc-extrequest-implement.yml
+++ b/.github/workflows/bc-extrequest-implement.yml
@@ -91,7 +91,6 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate skill
         run: |

--- a/.github/workflows/bc-extrequest-implement.yml
+++ b/.github/workflows/bc-extrequest-implement.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Implement extensibility request
         env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.EXT_REQ_PR_CREATE }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           TELEMETRY_ENABLED: ${{ steps.telemetry-config.outputs.enabled == 'true' && steps.azure-login.outcome == 'success' }}


### PR DESCRIPTION
## What & why

Use the dedicated **Business Central Extensibility Bot** GitHub App for the extensibility-request implementation workflow instead of a PAT or the built-in `GITHUB_TOKEN` for pull request creation.

The workflow now:

- runs the implementation job in the protected `extensibility-agent` environment;
- mints a short-lived installation token from `EXTENSIBILITY_CLIENT_ID` and `EXTENSIBILITY_TRIAGE_APP_PRIVATE_KEY`;
- uses the App token for GitHub API operations and draft PR creation; and
- continues using the job-scoped `github.token` for Copilot requests, checkout, and branch pushes, consistent with existing BCApps automation workflows.

This allows generated pull requests to be created without enabling repository-wide PR creation for `GITHUB_TOKEN`, while avoiding a long-lived PAT.

## Configuration

The `extensibility-agent` environment must provide:

- variable `EXTENSIBILITY_CLIENT_ID`;
- secret `EXTENSIBILITY_TRIAGE_APP_PRIVATE_KEY`.

The App must be installed on `microsoft/BCApps` with the required Issues, Metadata, and Pull requests permissions. `EXTENSIBILITY_APP_ID` is not consumed because `actions/create-github-app-token` v3 uses the App client ID.

## Validation

The workflow contains no PAT reference, and the minted App token is supplied to `GH_TOKEN` for GitHub CLI operations and draft PR creation.

## Risk & compatibility

Telemetry configuration previously scoped only to the `triage` environment must also be available in `extensibility-agent` for telemetry to remain enabled. Missing telemetry configuration does not block implementation.

Fixes [AB#646910](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646910)


