### PR TITLE
[29.x]No Employee posting group for AT when new employee is created

### DIFF
--- a/src/Apps/AT/ContosoCoffeeDemoDatasetAT/app/DemoData/HumanResources/2. Master Data/CreateEmployeeTemplateAT.Codeunit.al
+++ b/src/Apps/AT/ContosoCoffeeDemoDatasetAT/app/DemoData/HumanResources/2. Master Data/CreateEmployeeTemplateAT.Codeunit.al
@@ -18,11 +18,12 @@ codeunit 11155 "CreateEmployee Template AT"
     [EventSubscriber(ObjectType::Table, Database::"Employee Templ.", 'OnBeforeInsertEvent', '', false, false)]
     local procedure OnBeforeInsertEmployeeTemplate(var Rec: Record "Employee Templ.")
     var
+        CreateEmployeePostingGroup: Codeunit "Create Employee Posting Group";
         CreateEmployeeTemplate: Codeunit "Create Employee Template";
     begin
         case Rec.Code of
             CreateEmployeeTemplate.AdminCode(), CreateEmployeeTemplate.ITCode():
-                Rec.Validate("Employee Posting Group", '');
+                Rec.Validate("Employee Posting Group", CreateEmployeePostingGroup.EmployeeExpenses());
         end;
     end;
 }


### PR DESCRIPTION
[Bug 648335](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648335): [all-e][29.x]No Employee posting group for AT when new employee is created

Fixes [AB#648335](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648335)


**Issue:**
The ADMINISTRATION and IT employee templates, and the demo employees created from them, did not have an Employee Posting Group assigned.

**Cause:**
The AT localization subscriber explicitly cleared the "Employee Posting Group" field while inserting these employee templates.

**Solution:**
Updated the subscriber to assign the EMPLEXP employee posting group using CreateEmployeePostingGroup.EmployeeExpenses(). Added tests to verify the posting group on both affected templates and all generated demo employees

