### PR TITLE
[29.x][ALL-E]Issues with Service Contract Invoicing and Retrospective Billing--when the second unposted Service Invoice is deleted the values on the Service Contract are no longer reset--The "Invoiced to Date" field does not resetInitial commit- #10345Initial commit

### DIFF
--- a/src/Layers/W1/BaseApp/Service/Document/ServiceHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Service/Document/ServiceHeader.Table.al
@@ -5608,14 +5608,24 @@ table 5900 "Service Header"
     local procedure CalcContractLineInvoicedToDate(var ServiceContractLine: Record "Service Contract Line"; ServiceContractHeader: Record "Service Contract Header"; ExcludeDocNo: Code[20])
     var
         ServiceLedgerEntry: Record "Service Ledger Entry";
+        ReversingServiceLedgerEntry: Record "Service Ledger Entry";
         ServContractMgt: Codeunit ServContractManagement;
+        InvoicedServiceLedgerEntryExists: Boolean;
     begin
+        ServiceLedgerEntry.SetLoadFields("Entry No.");
         ServiceLedgerEntry.SetCurrentKey("Service Contract No.");
         ServiceLedgerEntry.SetRange("Service Contract No.", ServiceContractLine."Contract No.");
         ServiceLedgerEntry.SetRange("Service Item No. (Serviced)", ServiceContractLine."Service Item No.");
         ServiceLedgerEntry.SetRange("Entry Type", ServiceLedgerEntry."Entry Type"::Sale);
         ServiceLedgerEntry.SetFilter("Document No.", '<>%1', ExcludeDocNo);
-        if ServiceLedgerEntry.IsEmpty() then
+        ServiceLedgerEntry.SetRange("Applies-to Entry No.", 0);
+        ReversingServiceLedgerEntry.SetCurrentKey("Applies-to Entry No.");
+        if ServiceLedgerEntry.FindSet() then
+            repeat
+                ReversingServiceLedgerEntry.SetRange("Applies-to Entry No.", ServiceLedgerEntry."Entry No.");
+                InvoicedServiceLedgerEntryExists := InvoicedServiceLedgerEntryExists or ReversingServiceLedgerEntry.IsEmpty();
+            until (ServiceLedgerEntry.Next() = 0) or InvoicedServiceLedgerEntryExists;
+        if not InvoicedServiceLedgerEntryExists then
             ServiceContractLine."Invoiced to Date" := 0D
         else
             ServContractMgt.CalcInvoicedToDate(ServiceContractLine, ServiceContractLine."Starting Date", ServiceContractHeader."Next Invoice Period Start" - 1);

--- a/src/Layers/W1/BaseApp/Service/Document/ServiceHeader.Table.al
+++ b/src/Layers/W1/BaseApp/Service/Document/ServiceHeader.Table.al
@@ -5608,23 +5608,33 @@ table 5900 "Service Header"
     local procedure CalcContractLineInvoicedToDate(var ServiceContractLine: Record "Service Contract Line"; ServiceContractHeader: Record "Service Contract Header"; ExcludeDocNo: Code[20])
     var
         ServiceLedgerEntry: Record "Service Ledger Entry";
-        ReversingServiceLedgerEntry: Record "Service Ledger Entry";
         ServContractMgt: Codeunit ServContractManagement;
+        OriginalServiceLedgerEntryNos: List of [Integer];
+        ReversedServiceLedgerEntryNos: Dictionary of [Integer, Boolean];
+        OriginalServiceLedgerEntryNo: Integer;
         InvoicedServiceLedgerEntryExists: Boolean;
     begin
-        ServiceLedgerEntry.SetLoadFields("Entry No.");
-        ServiceLedgerEntry.SetCurrentKey("Service Contract No.");
+        ServiceLedgerEntry.SetLoadFields("Entry No.", "Applies-to Entry No.");
+        ServiceLedgerEntry.SetCurrentKey("Service Contract No.", "Service Item No. (Serviced)", "Entry Type", "Applies-to Entry No.");
         ServiceLedgerEntry.SetRange("Service Contract No.", ServiceContractLine."Contract No.");
         ServiceLedgerEntry.SetRange("Service Item No. (Serviced)", ServiceContractLine."Service Item No.");
         ServiceLedgerEntry.SetRange("Entry Type", ServiceLedgerEntry."Entry Type"::Sale);
         ServiceLedgerEntry.SetFilter("Document No.", '<>%1', ExcludeDocNo);
-        ServiceLedgerEntry.SetRange("Applies-to Entry No.", 0);
-        ReversingServiceLedgerEntry.SetCurrentKey("Applies-to Entry No.");
         if ServiceLedgerEntry.FindSet() then
             repeat
-                ReversingServiceLedgerEntry.SetRange("Applies-to Entry No.", ServiceLedgerEntry."Entry No.");
-                InvoicedServiceLedgerEntryExists := InvoicedServiceLedgerEntryExists or ReversingServiceLedgerEntry.IsEmpty();
-            until (ServiceLedgerEntry.Next() = 0) or InvoicedServiceLedgerEntryExists;
+                if ServiceLedgerEntry."Applies-to Entry No." = 0 then
+                    OriginalServiceLedgerEntryNos.Add(ServiceLedgerEntry."Entry No.")
+                else
+                    if not ReversedServiceLedgerEntryNos.ContainsKey(ServiceLedgerEntry."Applies-to Entry No.") then
+                        ReversedServiceLedgerEntryNos.Add(ServiceLedgerEntry."Applies-to Entry No.", true);
+            until ServiceLedgerEntry.Next() = 0;
+
+        foreach OriginalServiceLedgerEntryNo in OriginalServiceLedgerEntryNos do
+            if not ReversedServiceLedgerEntryNos.ContainsKey(OriginalServiceLedgerEntryNo) then begin
+                InvoicedServiceLedgerEntryExists := true;
+                break;
+            end;
+
         if not InvoicedServiceLedgerEntryExists then
             ServiceContractLine."Invoiced to Date" := 0D
         else

--- a/src/Layers/W1/BaseApp/Service/Ledger/ServiceLedgerEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Service/Ledger/ServiceLedgerEntry.Table.al
@@ -483,6 +483,9 @@ table 5907 "Service Ledger Entry"
         key(Key9; "Service Register No.")
         {
         }
+        key(Key10; "Applies-to Entry No.")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/W1/BaseApp/Service/Ledger/ServiceLedgerEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Service/Ledger/ServiceLedgerEntry.Table.al
@@ -483,7 +483,7 @@ table 5907 "Service Ledger Entry"
         key(Key9; "Service Register No.")
         {
         }
-        key(Key10; "Applies-to Entry No.")
+        key(Key10; "Service Contract No.", "Service Item No. (Serviced)", "Entry Type", "Applies-to Entry No.")
         {
         }
     }

--- a/src/Layers/W1/Tests/SCM-Service/ServiceContractsII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Service/ServiceContractsII.Codeunit.al
@@ -63,6 +63,7 @@ codeunit 136145 "Service Contracts II"
         DescriptionMustMatchErr: Label 'Description must match.';
         WrongCountErr: Label 'Worong number of Service Line are created';
         ServiceLineStartDateErr: Label 'Service line for item C must start on its own starting date (03/01), not on the earliest new line date (02/01)';
+        ItemAInvoicedToDateErr: Label 'Item A "Invoiced to Date" must retain the posted invoice period end date after deleting the retrospective invoice.';
         ItemBInvoicedToDateErr: Label 'Item B "Invoiced to Date" must be 0D after deleting the retrospective invoice.';
         ItemCInvoicedToDateErr: Label 'Item C "Invoiced to Date" must be 0D after deleting the retrospective invoice.';
 
@@ -2341,7 +2342,7 @@ codeunit 136145 "Service Contracts II"
     end;
 
     [Test]
-    [HandlerFunctions('DequeueReplyConfirmHandler,MessageHandler')]
+    [HandlerFunctions('DequeueReplyConfirmHandler')]
     [Scope('OnPrem')]
     procedure RetrospectiveServiceLineStartDateIsPerLineNotEarliestForPrepaidContract()
     var
@@ -2371,19 +2372,20 @@ codeunit 136145 "Service Contracts II"
         MarEnd := CalcDate('<CM>', MarFirst);
         WorkDate(JanFirst);
         LibraryVariableStorage.Enqueue(false);  // "Create contract using template?" No (to allow Prepaid=true)
-        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA);
+        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA, false);
 
         // [GIVEN] Item B added at 02/01, user declines to create an invoice.
         WorkDate(FebFirst);
-        LibraryVariableStorage.Enqueue(true);   // "Do you want to open service contract...?" Yes
         LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
         LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
         LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
         AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineB);
 
         // [GIVEN] Item C added at 03/01, user declines to create an invoice.
-        // Note: Contract remains Open after declining invoice, so no confirms fire for Item C
         WorkDate(MarFirst);
+        LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
+        LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
+        LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
         AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineC);
 
         // [WHEN] At 04/01 the retrospective invoice is created covering 02/01..03/31.
@@ -2395,6 +2397,7 @@ codeunit 136145 "Service Contracts II"
             ServiceContractHeader.Modify();
         end;
         ServContractManagement.InitCodeUnit();
+        LibraryVariableStorage.Enqueue(true);  // "Create service invoice for period...?" Yes
         ServContractManagement.CreateInvoice(ServiceContractHeader);
 
         // [THEN] The service line for item C has description '03/01 - 03/31', not '02/01 - 03/31'.
@@ -2415,7 +2418,7 @@ codeunit 136145 "Service Contracts II"
     end;
 
     [Test]
-    [HandlerFunctions('DequeueReplyConfirmHandler,MessageHandler')]
+    [HandlerFunctions('DequeueReplyConfirmHandler')]
     [Scope('OnPrem')]
     procedure InvoicedToDateResetForNewPrepaidContractItemsAfterDeletingRetrospectiveInvoice()
     var
@@ -2444,19 +2447,20 @@ codeunit 136145 "Service Contracts II"
         MarEnd := CalcDate('<CM>', MarFirst);
         WorkDate(JanFirst);
         LibraryVariableStorage.Enqueue(false);  // "Create contract using template?" No (to allow Prepaid=true)
-        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA);
+        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA, false);
 
         // [GIVEN] Item B added at 02/01, user declines to create an invoice.
         WorkDate(FebFirst);
-        LibraryVariableStorage.Enqueue(true);   // "Do you want to open service contract...?" Yes
         LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
         LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
         LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
         AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineB);
 
         // [GIVEN] Item C added at 03/01, user declines to create an invoice.
-        // Note: Contract remains Open after declining invoice, so no confirms fire for Item C
         WorkDate(MarFirst);
+        LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
+        LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
+        LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
         AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineC);
 
         // [GIVEN] At 04/01 the retrospective invoice is created covering 02/01..03/31.
@@ -2468,6 +2472,7 @@ codeunit 136145 "Service Contracts II"
             ServiceContractHeader.Modify();
         end;
         ServContractManagement.InitCodeUnit();
+        LibraryVariableStorage.Enqueue(true);  // "Create service invoice for period...?" Yes
         ServContractManagement.CreateInvoice(ServiceContractHeader);
 
         // [WHEN] The retrospective invoice is deleted.
@@ -2492,7 +2497,7 @@ codeunit 136145 "Service Contracts II"
     end;
 
     [Test]
-    [HandlerFunctions('DequeueReplyConfirmHandler,MessageHandler')]
+    [HandlerFunctions('DequeueReplyConfirmHandler')]
     [Scope('OnPrem')]
     procedure InvoicedToDateResetAfterDeletingRecreatedRetrospectiveInvoiceSecondTime()
     var
@@ -2502,6 +2507,7 @@ codeunit 136145 "Service Contracts II"
         ServiceContractLineC: Record "Service Contract Line";
         ServiceHeader: Record "Service Header";
         ServContractManagement: Codeunit ServContractManagement;
+        RetrospectiveInvoiceNo: Code[20];
         Year: Integer;
         JanFirst: Date;
         FebFirst: Date;
@@ -2521,11 +2527,16 @@ codeunit 136145 "Service Contracts II"
         MarEnd := CalcDate('<CM>', MarFirst);
         WorkDate(JanFirst);
         LibraryVariableStorage.Enqueue(false);  // "Create contract using template?" No (to allow Prepaid=true)
-        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA);
+        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA, true);
+
+        // [GIVEN] The initial Q1 invoice for item A is posted.
+        ServiceHeader.SetRange("Document Type", ServiceHeader."Document Type"::Invoice);
+        ServiceHeader.SetRange("Contract No.", ServiceContractHeader."Contract No.");
+        ServiceHeader.FindFirst();
+        LibraryService.PostServiceOrder(ServiceHeader, true, false, true);
 
         // [GIVEN] Item B added at 02/01, user declines to create an invoice.
         WorkDate(FebFirst);
-        LibraryVariableStorage.Enqueue(true);   // "Do you want to open service contract...?" Yes
         LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
         LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
         LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
@@ -2533,6 +2544,9 @@ codeunit 136145 "Service Contracts II"
 
         // [GIVEN] Item C added at 03/01, user declines to create an invoice.
         WorkDate(MarFirst);
+        LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
+        LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
+        LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
         AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineC);
 
         // [GIVEN] At 04/01 the retrospective invoice covering 02/01..03/31 is created and then deleted (dates restored correctly the first time).
@@ -2543,29 +2557,27 @@ codeunit 136145 "Service Contracts II"
             ServiceContractHeader.Modify();
         end;
         ServContractManagement.InitCodeUnit();
-        ServContractManagement.CreateInvoice(ServiceContractHeader);
+        LibraryVariableStorage.Enqueue(true);  // "Create service invoice for period...?" Yes
+        RetrospectiveInvoiceNo := ServContractManagement.CreateInvoice(ServiceContractHeader);
 
-        ServiceHeader.SetRange("Document Type", ServiceHeader."Document Type"::Invoice);
-        ServiceHeader.SetRange("Contract No.", ServiceContractHeader."Contract No.");
-        ServiceHeader.FindSet();
-        repeat
-            LibraryVariableStorage.Enqueue(true);  // "Deleting will restore previous invoice dates..." Yes
-        until ServiceHeader.Next() = 0;
-        while ServiceHeader.FindLast() do
-            ServiceHeader.Delete(true);
+        ServiceHeader.Get(ServiceHeader."Document Type"::Invoice, RetrospectiveInvoiceNo);
+        LibraryVariableStorage.Enqueue(true);  // "Deleting will restore previous invoice dates..." Yes
+        ServiceHeader.Delete(true);
 
         // [GIVEN] The invoice is created a second time (Feb & Mar recalculated for items B and C).
         ServiceContractHeader.Find();
         ServContractManagement.InitCodeUnit();
-        ServContractManagement.CreateInvoice(ServiceContractHeader);
+        LibraryVariableStorage.Enqueue(true);  // "Create service invoice for period...?" Yes
+        RetrospectiveInvoiceNo := ServContractManagement.CreateInvoice(ServiceContractHeader);
 
         // [WHEN] This second, recreated retrospective invoice is also deleted.
-        ServiceHeader.FindSet();
-        repeat
-            LibraryVariableStorage.Enqueue(true);  // "Deleting will restore previous invoice dates..." Yes
-        until ServiceHeader.Next() = 0;
-        while ServiceHeader.FindLast() do
-            ServiceHeader.Delete(true);
+        ServiceHeader.Get(ServiceHeader."Document Type"::Invoice, RetrospectiveInvoiceNo);
+        LibraryVariableStorage.Enqueue(true);  // "Deleting will restore previous invoice dates..." Yes
+        ServiceHeader.Delete(true);
+
+        // [THEN] Item A retains its posted Q1 "Invoiced to Date".
+        ServiceContractLineA.Get(ServiceContractLineA."Contract Type", ServiceContractLineA."Contract No.", ServiceContractLineA."Line No.");
+        Assert.AreEqual(MarEnd, ServiceContractLineA."Invoiced to Date", ItemAInvoicedToDateErr);
 
         // [THEN] Items B and C have "Invoiced to Date" = 0D (previously stuck at 03/31).
         ServiceContractLineB.Get(ServiceContractLineB."Contract Type", ServiceContractLineB."Contract No.", ServiceContractLineB."Line No.");
@@ -3772,7 +3784,8 @@ codeunit 136145 "Service Contracts II"
 
     local procedure CreatePrepaidQuarterlyContractAndSignForBug629850(
         var ServiceContractHeader: Record "Service Contract Header";
-        var ServiceContractLine: Record "Service Contract Line")
+        var ServiceContractLine: Record "Service Contract Line";
+        CreateInitialInvoice: Boolean)
     var
         ServiceItem: Record "Service Item";
     begin
@@ -3798,6 +3811,8 @@ codeunit 136145 "Service Contracts II"
 
         UpdateAnnualAmountInServiceContract(ServiceContractHeader);
         ServiceContractHeader.Validate("Starting Date");
+        if CreateInitialInvoice then
+            ServiceContractHeader."Next Invoice Date" := CalcDate('<CQ+1D>', WorkDate());
         ServiceContractHeader.Modify(true);
 
         SignContractSilent(ServiceContractHeader);

--- a/src/Layers/W1/Tests/SCM-Service/ServiceContractsII.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Service/ServiceContractsII.Codeunit.al
@@ -2491,6 +2491,92 @@ codeunit 136145 "Service Contracts II"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [HandlerFunctions('DequeueReplyConfirmHandler,MessageHandler')]
+    [Scope('OnPrem')]
+    procedure InvoicedToDateResetAfterDeletingRecreatedRetrospectiveInvoiceSecondTime()
+    var
+        ServiceContractHeader: Record "Service Contract Header";
+        ServiceContractLineA: Record "Service Contract Line";
+        ServiceContractLineB: Record "Service Contract Line";
+        ServiceContractLineC: Record "Service Contract Line";
+        ServiceHeader: Record "Service Header";
+        ServContractManagement: Codeunit ServContractManagement;
+        Year: Integer;
+        JanFirst: Date;
+        FebFirst: Date;
+        MarFirst: Date;
+        MarEnd: Date;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 647165] Deleting the retrospective invoice a second time, after it was deleted and recreated, still resets "Invoiced to Date" to 0D for newly added prepaid contract items.
+
+        Initialize();
+
+        // [GIVEN] Quarterly prepaid contract starting Jan 1, with item A, signed silently.
+        Year := Date2DMY(WorkDate(), 3);
+        JanFirst := DMY2Date(1, 1, Year);
+        FebFirst := DMY2Date(1, 2, Year);
+        MarFirst := DMY2Date(1, 3, Year);
+        MarEnd := CalcDate('<CM>', MarFirst);
+        WorkDate(JanFirst);
+        LibraryVariableStorage.Enqueue(false);  // "Create contract using template?" No (to allow Prepaid=true)
+        CreatePrepaidQuarterlyContractAndSignForBug629850(ServiceContractHeader, ServiceContractLineA);
+
+        // [GIVEN] Item B added at 02/01, user declines to create an invoice.
+        WorkDate(FebFirst);
+        LibraryVariableStorage.Enqueue(true);   // "Do you want to open service contract...?" Yes
+        LibraryVariableStorage.Enqueue(true);   // "New lines have been added..." Yes
+        LibraryVariableStorage.Enqueue(true);   // "Next Planned Service Date is 0D" Yes
+        LibraryVariableStorage.Enqueue(false);  // "Create invoice for period...?" No
+        AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineB);
+
+        // [GIVEN] Item C added at 03/01, user declines to create an invoice.
+        WorkDate(MarFirst);
+        AddLineAndLockPrepaidContractForBug629850(ServiceContractHeader, ServiceContractLineC);
+
+        // [GIVEN] At 04/01 the retrospective invoice covering 02/01..03/31 is created and then deleted (dates restored correctly the first time).
+        WorkDate(CalcDate('<CM+1D>', MarEnd));
+        ServiceContractHeader.Find();
+        if ServiceContractHeader."Change Status" = ServiceContractHeader."Change Status"::Open then begin
+            ServiceContractHeader."Change Status" := ServiceContractHeader."Change Status"::Locked;
+            ServiceContractHeader.Modify();
+        end;
+        ServContractManagement.InitCodeUnit();
+        ServContractManagement.CreateInvoice(ServiceContractHeader);
+
+        ServiceHeader.SetRange("Document Type", ServiceHeader."Document Type"::Invoice);
+        ServiceHeader.SetRange("Contract No.", ServiceContractHeader."Contract No.");
+        ServiceHeader.FindSet();
+        repeat
+            LibraryVariableStorage.Enqueue(true);  // "Deleting will restore previous invoice dates..." Yes
+        until ServiceHeader.Next() = 0;
+        while ServiceHeader.FindLast() do
+            ServiceHeader.Delete(true);
+
+        // [GIVEN] The invoice is created a second time (Feb & Mar recalculated for items B and C).
+        ServiceContractHeader.Find();
+        ServContractManagement.InitCodeUnit();
+        ServContractManagement.CreateInvoice(ServiceContractHeader);
+
+        // [WHEN] This second, recreated retrospective invoice is also deleted.
+        ServiceHeader.FindSet();
+        repeat
+            LibraryVariableStorage.Enqueue(true);  // "Deleting will restore previous invoice dates..." Yes
+        until ServiceHeader.Next() = 0;
+        while ServiceHeader.FindLast() do
+            ServiceHeader.Delete(true);
+
+        // [THEN] Items B and C have "Invoiced to Date" = 0D (previously stuck at 03/31).
+        ServiceContractLineB.Get(ServiceContractLineB."Contract Type", ServiceContractLineB."Contract No.", ServiceContractLineB."Line No.");
+        Assert.AreEqual(0D, ServiceContractLineB."Invoiced to Date", ItemBInvoicedToDateErr);
+
+        ServiceContractLineC.Get(ServiceContractLineC."Contract Type", ServiceContractLineC."Contract No.", ServiceContractLineC."Line No.");
+        Assert.AreEqual(0D, ServiceContractLineC."Invoiced to Date", ItemCInvoicedToDateErr);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";


### PR DESCRIPTION
[Bug 648515](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648515): [29.x][ALL-E]Issues with Service Contract Invoicing and Retrospective Billing--when the second unposted Service Invoice is deleted the values on the Service Contract are no longer reset--The "Invoiced to Date" field does not reset -
Fixes [AB#648515](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648515)

**Issue :-** Issues with Service Contract Invoicing and Retrospective Billing — when the second unposted Service Invoice is deleted, the values on the Service Contract are no longer reset. The "Invoiced to Date" field stays stuck at 3/31/2026 for the newly added service items (B and C), which then blocks a correct new Service Invoice from being created.

**Cause :**- CalcContractLineInvoicedToDate in table 5900 "Service Header" (called from PrepareDeleteServiceInvoice on delete) decides whether to reset Invoiced to Date by checking if any Sale-type Service Ledger Entries exist for the contract line, excluding only the invoice being deleted ("Document No." <> ExcludeDocNo).

When an invoice is deleted, its open ledger entries are reversed (a reversing entry with "Applies-to Entry No." is inserted) but they are not removed, and they keep the first invoice's Document No.. On the second delete, those left-over entries from the already-deleted first invoice are no longer excluded (they carry a different document number), so the check finds "existing" entries and recalculates Invoiced to Date back to 3/31 instead of resetting it to 0D.

**Solution:-** Change CalcContractLineInvoicedToDate to count only real, non-reversed invoicing. It now looks at original Sale entries ("Applies-to Entry No." = 0) and treats a line as invoiced only if at least one such entry has no corresponding reversing entry. Reversed pairs (left behind by previously deleted invoices) are ignored, so Invoiced to Date correctly resets to 0D on every delete, including the second one. Genuinely posted (non-reversed) invoicing is unaffected.


