### PR TITLE
[29.x]User is unable to filter the Deferral Summary-GL Report Not Filtering Totals by Global Dimensions.

### DIFF
--- a/src/Layers/ES/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTimeSheet: Codeunit "Library - Time Sheet";
         LibraryJournals: Codeunit "Library - Journals";
+        LibraryDimension: Codeunit "Library - Dimension";
         DeferralUtilities: Codeunit "Deferral Utilities";
         CalcMethod: Enum "Deferral Calculation Method";
         DeferralDocType: Option Purchase,Sales,"G/L";
@@ -2263,6 +2264,22 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         VerifyDeferralSchedule("Deferral Document Type"::Purchase, PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension1()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 1 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension2()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 2 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(2);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";
@@ -2882,6 +2899,80 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
                 DeferralHeader."Document Type", DeferralHeader."Document No.", DeferralHeader."Line No.");
         DeferralLine.SetFilter(Amount, '<>%1', 0);
         Assert.RecordIsEmpty(DeferralLine);
+    end;
+
+    local procedure VerifyGLDeferralSummaryReportFiltersByGlobalDimension(GlobalDimensionNo: Integer)
+    var
+        DimensionValue: array[2] of Record "Dimension Value";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: array[2] of Record "Gen. Journal Line";
+        GLAccount: Record "G/L Account";
+        PostedDeferralHeader: Record "Posted Deferral Header";
+        DeferralSummaryGL: Report "Deferral Summary - G/L";
+        DimensionCode: Code[20];
+    begin
+        Initialize();
+
+        // [GIVEN] Two posted deferrals with different values for the selected global dimension
+        GeneralLedgerSetup.Get();
+        case GlobalDimensionNo of
+            1:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 1 Code";
+            2:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 2 Code";
+        end;
+        LibraryDimension.CreateDimensionValue(DimensionValue[1], DimensionCode);
+        LibraryDimension.CreateDimensionValue(DimensionValue[2], DimensionCode);
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Default Deferral Template Code", CreateEqual5Periods());
+        GLAccount.Modify(true);
+        CreateGeneralJournalBatch(GenJournalBatch);
+        UpdateSourceCodeInGenJournalTemplate(GenJournalBatch);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[1], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[1].Code);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[2], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[2].Code);
+
+        // [WHEN] Run Deferral Summary - G/L filtered by the first dimension value
+        GLAccount.SetRecFilter();
+        case GlobalDimensionNo of
+            1:
+                GLAccount.SetRange("Global Dimension 1 Filter", DimensionValue[1].Code);
+            2:
+                GLAccount.SetRange("Global Dimension 2 Filter", DimensionValue[1].Code);
+        end;
+        PostedDeferralHeader.SetRange("Deferral Doc. Type", PostedDeferralHeader."Deferral Doc. Type"::"G/L");
+        PostedDeferralHeader.SetRange("Account No.", GLAccount."No.");
+        Clear(DeferralSummaryGL);
+        DeferralSummaryGL.SetTableView(GLAccount);
+        DeferralSummaryGL.SetTableView(PostedDeferralHeader);
+        DeferralSummaryGL.Run();
+
+        // [THEN] The report includes the matching deferral and excludes the other deferral
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists('GenJnlDocNo', GenJournalLine[1]."Document No.");
+        LibraryReportDataset.AssertElementWithValueNotExist('GenJnlDocNo', GenJournalLine[2]."Document No.");
+    end;
+
+    local procedure CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(var GenJournalLine: Record "Gen. Journal Line"; GenJournalBatch: Record "Gen. Journal Batch"; GLAccountNo: Code[20]; GlobalDimensionNo: Integer; DimensionValueCode: Code[20])
+    begin
+        CreateGenJournalLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", GLAccountNo,
+            GenJournalBatch."Bal. Account Type", GenJournalBatch."Bal. Account No.", LibraryRandom.RandDec(1000, 2));
+        case GlobalDimensionNo of
+            1:
+                GenJournalLine.Validate("Shortcut Dimension 1 Code", DimensionValueCode);
+            2:
+                GenJournalLine.Validate("Shortcut Dimension 2 Code", DimensionValueCode);
+        end;
+        GenJournalLine.Validate("Deferral Code");
+        GenJournalLine.Modify(true);
+        Commit();
+
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/FR/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
+++ b/src/Layers/FR/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTimeSheet: Codeunit "Library - Time Sheet";
         LibraryJournals: Codeunit "Library - Journals";
+        LibraryDimension: Codeunit "Library - Dimension";
         DeferralUtilities: Codeunit "Deferral Utilities";
         CalcMethod: Enum "Deferral Calculation Method";
         DeferralDocType: Option Purchase,Sales,"G/L";
@@ -2263,6 +2264,22 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         VerifyDeferralSchedule("Deferral Document Type"::Purchase, PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension1()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 1 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension2()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 2 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(2);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";
@@ -2882,6 +2899,80 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
                 DeferralHeader."Document Type", DeferralHeader."Document No.", DeferralHeader."Line No.");
         DeferralLine.SetFilter(Amount, '<>%1', 0);
         Assert.RecordIsEmpty(DeferralLine);
+    end;
+
+    local procedure VerifyGLDeferralSummaryReportFiltersByGlobalDimension(GlobalDimensionNo: Integer)
+    var
+        DimensionValue: array[2] of Record "Dimension Value";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: array[2] of Record "Gen. Journal Line";
+        GLAccount: Record "G/L Account";
+        PostedDeferralHeader: Record "Posted Deferral Header";
+        DeferralSummaryGL: Report "Deferral Summary - G/L";
+        DimensionCode: Code[20];
+    begin
+        Initialize();
+
+        // [GIVEN] Two posted deferrals with different values for the selected global dimension
+        GeneralLedgerSetup.Get();
+        case GlobalDimensionNo of
+            1:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 1 Code";
+            2:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 2 Code";
+        end;
+        LibraryDimension.CreateDimensionValue(DimensionValue[1], DimensionCode);
+        LibraryDimension.CreateDimensionValue(DimensionValue[2], DimensionCode);
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Default Deferral Template Code", CreateEqual5Periods());
+        GLAccount.Modify(true);
+        CreateGeneralJournalBatch(GenJournalBatch);
+        UpdateSourceCodeInGenJournalTemplate(GenJournalBatch);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[1], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[1].Code);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[2], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[2].Code);
+
+        // [WHEN] Run Deferral Summary - G/L filtered by the first dimension value
+        GLAccount.SetRecFilter();
+        case GlobalDimensionNo of
+            1:
+                GLAccount.SetRange("Global Dimension 1 Filter", DimensionValue[1].Code);
+            2:
+                GLAccount.SetRange("Global Dimension 2 Filter", DimensionValue[1].Code);
+        end;
+        PostedDeferralHeader.SetRange("Deferral Doc. Type", PostedDeferralHeader."Deferral Doc. Type"::"G/L");
+        PostedDeferralHeader.SetRange("Account No.", GLAccount."No.");
+        Clear(DeferralSummaryGL);
+        DeferralSummaryGL.SetTableView(GLAccount);
+        DeferralSummaryGL.SetTableView(PostedDeferralHeader);
+        DeferralSummaryGL.Run();
+
+        // [THEN] The report includes the matching deferral and excludes the other deferral
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists('GenJnlDocNo', GenJournalLine[1]."Document No.");
+        LibraryReportDataset.AssertElementWithValueNotExist('GenJnlDocNo', GenJournalLine[2]."Document No.");
+    end;
+
+    local procedure CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(var GenJournalLine: Record "Gen. Journal Line"; GenJournalBatch: Record "Gen. Journal Batch"; GLAccountNo: Code[20]; GlobalDimensionNo: Integer; DimensionValueCode: Code[20])
+    begin
+        CreateGenJournalLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", GLAccountNo,
+            GenJournalBatch."Bal. Account Type", GenJournalBatch."Bal. Account No.", LibraryRandom.RandDec(1000, 2));
+        case GlobalDimensionNo of
+            1:
+                GenJournalLine.Validate("Shortcut Dimension 1 Code", DimensionValueCode);
+            2:
+                GenJournalLine.Validate("Shortcut Dimension 2 Code", DimensionValueCode);
+        end;
+        GenJournalLine.Validate("Deferral Code");
+        GenJournalLine.Modify(true);
+        Commit();
+
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/GB/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
+++ b/src/Layers/GB/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTimeSheet: Codeunit "Library - Time Sheet";
         LibraryJournals: Codeunit "Library - Journals";
+        LibraryDimension: Codeunit "Library - Dimension";
         DeferralUtilities: Codeunit "Deferral Utilities";
         CalcMethod: Enum "Deferral Calculation Method";
         DeferralDocType: Option Purchase,Sales,"G/L";
@@ -2325,6 +2326,22 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         VerifyDeferralSchedule("Deferral Document Type"::Purchase, PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension1()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 1 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension2()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 2 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(2);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";
@@ -2944,6 +2961,80 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
                 DeferralHeader."Document Type", DeferralHeader."Document No.", DeferralHeader."Line No.");
         DeferralLine.SetFilter(Amount, '<>%1', 0);
         Assert.RecordIsEmpty(DeferralLine);
+    end;
+
+    local procedure VerifyGLDeferralSummaryReportFiltersByGlobalDimension(GlobalDimensionNo: Integer)
+    var
+        DimensionValue: array[2] of Record "Dimension Value";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: array[2] of Record "Gen. Journal Line";
+        GLAccount: Record "G/L Account";
+        PostedDeferralHeader: Record "Posted Deferral Header";
+        DeferralSummaryGL: Report "Deferral Summary - G/L";
+        DimensionCode: Code[20];
+    begin
+        Initialize();
+
+        // [GIVEN] Two posted deferrals with different values for the selected global dimension
+        GeneralLedgerSetup.Get();
+        case GlobalDimensionNo of
+            1:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 1 Code";
+            2:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 2 Code";
+        end;
+        LibraryDimension.CreateDimensionValue(DimensionValue[1], DimensionCode);
+        LibraryDimension.CreateDimensionValue(DimensionValue[2], DimensionCode);
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Default Deferral Template Code", CreateEqual5Periods());
+        GLAccount.Modify(true);
+        CreateGeneralJournalBatch(GenJournalBatch);
+        UpdateSourceCodeInGenJournalTemplate(GenJournalBatch);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[1], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[1].Code);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[2], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[2].Code);
+
+        // [WHEN] Run Deferral Summary - G/L filtered by the first dimension value
+        GLAccount.SetRecFilter();
+        case GlobalDimensionNo of
+            1:
+                GLAccount.SetRange("Global Dimension 1 Filter", DimensionValue[1].Code);
+            2:
+                GLAccount.SetRange("Global Dimension 2 Filter", DimensionValue[1].Code);
+        end;
+        PostedDeferralHeader.SetRange("Deferral Doc. Type", PostedDeferralHeader."Deferral Doc. Type"::"G/L");
+        PostedDeferralHeader.SetRange("Account No.", GLAccount."No.");
+        Clear(DeferralSummaryGL);
+        DeferralSummaryGL.SetTableView(GLAccount);
+        DeferralSummaryGL.SetTableView(PostedDeferralHeader);
+        DeferralSummaryGL.Run();
+
+        // [THEN] The report includes the matching deferral and excludes the other deferral
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists('GenJnlDocNo', GenJournalLine[1]."Document No.");
+        LibraryReportDataset.AssertElementWithValueNotExist('GenJnlDocNo', GenJournalLine[2]."Document No.");
+    end;
+
+    local procedure CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(var GenJournalLine: Record "Gen. Journal Line"; GenJournalBatch: Record "Gen. Journal Batch"; GLAccountNo: Code[20]; GlobalDimensionNo: Integer; DimensionValueCode: Code[20])
+    begin
+        CreateGenJournalLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", GLAccountNo,
+            GenJournalBatch."Bal. Account Type", GenJournalBatch."Bal. Account No.", LibraryRandom.RandDec(1000, 2));
+        case GlobalDimensionNo of
+            1:
+                GenJournalLine.Validate("Shortcut Dimension 1 Code", DimensionValueCode);
+            2:
+                GenJournalLine.Validate("Shortcut Dimension 2 Code", DimensionValueCode);
+        end;
+        GenJournalLine.Validate("Deferral Code");
+        GenJournalLine.Modify(true);
+        Commit();
+
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/IT/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTimeSheet: Codeunit "Library - Time Sheet";
         LibraryJournals: Codeunit "Library - Journals";
+        LibraryDimension: Codeunit "Library - Dimension";
         DeferralUtilities: Codeunit "Deferral Utilities";
         CalcMethod: Enum "Deferral Calculation Method";
         DeferralDocType: Option Purchase,Sales,"G/L";
@@ -2132,6 +2133,22 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         VerifyDeferralSchedule("Deferral Document Type"::Purchase, PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension1()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 1 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension2()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 2 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(2);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";
@@ -2751,6 +2768,80 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
                 DeferralHeader."Document Type", DeferralHeader."Document No.", DeferralHeader."Line No.");
         DeferralLine.SetFilter(Amount, '<>%1', 0);
         Assert.RecordIsEmpty(DeferralLine);
+    end;
+
+    local procedure VerifyGLDeferralSummaryReportFiltersByGlobalDimension(GlobalDimensionNo: Integer)
+    var
+        DimensionValue: array[2] of Record "Dimension Value";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: array[2] of Record "Gen. Journal Line";
+        GLAccount: Record "G/L Account";
+        PostedDeferralHeader: Record "Posted Deferral Header";
+        DeferralSummaryGL: Report "Deferral Summary - G/L";
+        DimensionCode: Code[20];
+    begin
+        Initialize();
+
+        // [GIVEN] Two posted deferrals with different values for the selected global dimension
+        GeneralLedgerSetup.Get();
+        case GlobalDimensionNo of
+            1:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 1 Code";
+            2:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 2 Code";
+        end;
+        LibraryDimension.CreateDimensionValue(DimensionValue[1], DimensionCode);
+        LibraryDimension.CreateDimensionValue(DimensionValue[2], DimensionCode);
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Default Deferral Template Code", CreateEqual5Periods());
+        GLAccount.Modify(true);
+        CreateGeneralJournalBatch(GenJournalBatch);
+        UpdateSourceCodeInGenJournalTemplate(GenJournalBatch);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[1], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[1].Code);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[2], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[2].Code);
+
+        // [WHEN] Run Deferral Summary - G/L filtered by the first dimension value
+        GLAccount.SetRecFilter();
+        case GlobalDimensionNo of
+            1:
+                GLAccount.SetRange("Global Dimension 1 Filter", DimensionValue[1].Code);
+            2:
+                GLAccount.SetRange("Global Dimension 2 Filter", DimensionValue[1].Code);
+        end;
+        PostedDeferralHeader.SetRange("Deferral Doc. Type", PostedDeferralHeader."Deferral Doc. Type"::"G/L");
+        PostedDeferralHeader.SetRange("Account No.", GLAccount."No.");
+        Clear(DeferralSummaryGL);
+        DeferralSummaryGL.SetTableView(GLAccount);
+        DeferralSummaryGL.SetTableView(PostedDeferralHeader);
+        DeferralSummaryGL.Run();
+
+        // [THEN] The report includes the matching deferral and excludes the other deferral
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists('GenJnlDocNo', GenJournalLine[1]."Document No.");
+        LibraryReportDataset.AssertElementWithValueNotExist('GenJnlDocNo', GenJournalLine[2]."Document No.");
+    end;
+
+    local procedure CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(var GenJournalLine: Record "Gen. Journal Line"; GenJournalBatch: Record "Gen. Journal Batch"; GLAccountNo: Code[20]; GlobalDimensionNo: Integer; DimensionValueCode: Code[20])
+    begin
+        CreateGenJournalLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", GLAccountNo,
+            GenJournalBatch."Bal. Account Type", GenJournalBatch."Bal. Account No.", LibraryRandom.RandDec(1000, 2));
+        case GlobalDimensionNo of
+            1:
+                GenJournalLine.Validate("Shortcut Dimension 1 Code", DimensionValueCode);
+            2:
+                GenJournalLine.Validate("Shortcut Dimension 2 Code", DimensionValueCode);
+        end;
+        GenJournalLine.Validate("Deferral Code");
+        GenJournalLine.Modify(true);
+        Commit();
+
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/NA/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTimeSheet: Codeunit "Library - Time Sheet";
         LibraryJournals: Codeunit "Library - Journals";
+        LibraryDimension: Codeunit "Library - Dimension";
         DeferralUtilities: Codeunit "Deferral Utilities";
         CalcMethod: Enum "Deferral Calculation Method";
         DeferralDocType: Option Purchase,Sales,"G/L";
@@ -2263,6 +2264,22 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         VerifyDeferralSchedule("Deferral Document Type"::Purchase, PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension1()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 1 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension2()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 2 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(2);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";
@@ -2887,6 +2904,80 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
                 DeferralHeader."Document Type", DeferralHeader."Document No.", DeferralHeader."Line No.");
         DeferralLine.SetFilter(Amount, '<>%1', 0);
         Assert.RecordIsEmpty(DeferralLine);
+    end;
+
+    local procedure VerifyGLDeferralSummaryReportFiltersByGlobalDimension(GlobalDimensionNo: Integer)
+    var
+        DimensionValue: array[2] of Record "Dimension Value";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: array[2] of Record "Gen. Journal Line";
+        GLAccount: Record "G/L Account";
+        PostedDeferralHeader: Record "Posted Deferral Header";
+        DeferralSummaryGL: Report "Deferral Summary - G/L";
+        DimensionCode: Code[20];
+    begin
+        Initialize();
+
+        // [GIVEN] Two posted deferrals with different values for the selected global dimension
+        GeneralLedgerSetup.Get();
+        case GlobalDimensionNo of
+            1:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 1 Code";
+            2:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 2 Code";
+        end;
+        LibraryDimension.CreateDimensionValue(DimensionValue[1], DimensionCode);
+        LibraryDimension.CreateDimensionValue(DimensionValue[2], DimensionCode);
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Default Deferral Template Code", CreateEqual5Periods());
+        GLAccount.Modify(true);
+        CreateGeneralJournalBatch(GenJournalBatch);
+        UpdateSourceCodeInGenJournalTemplate(GenJournalBatch);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[1], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[1].Code);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[2], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[2].Code);
+
+        // [WHEN] Run Deferral Summary - G/L filtered by the first dimension value
+        GLAccount.SetRecFilter();
+        case GlobalDimensionNo of
+            1:
+                GLAccount.SetRange("Global Dimension 1 Filter", DimensionValue[1].Code);
+            2:
+                GLAccount.SetRange("Global Dimension 2 Filter", DimensionValue[1].Code);
+        end;
+        PostedDeferralHeader.SetRange("Deferral Doc. Type", PostedDeferralHeader."Deferral Doc. Type"::"G/L");
+        PostedDeferralHeader.SetRange("Account No.", GLAccount."No.");
+        Clear(DeferralSummaryGL);
+        DeferralSummaryGL.SetTableView(GLAccount);
+        DeferralSummaryGL.SetTableView(PostedDeferralHeader);
+        DeferralSummaryGL.Run();
+
+        // [THEN] The report includes the matching deferral and excludes the other deferral
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists('GenJnlDocNo', GenJournalLine[1]."Document No.");
+        LibraryReportDataset.AssertElementWithValueNotExist('GenJnlDocNo', GenJournalLine[2]."Document No.");
+    end;
+
+    local procedure CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(var GenJournalLine: Record "Gen. Journal Line"; GenJournalBatch: Record "Gen. Journal Batch"; GLAccountNo: Code[20]; GlobalDimensionNo: Integer; DimensionValueCode: Code[20])
+    begin
+        CreateGenJournalLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", GLAccountNo,
+            GenJournalBatch."Bal. Account Type", GenJournalBatch."Bal. Account No.", LibraryRandom.RandDec(1000, 2));
+        case GlobalDimensionNo of
+            1:
+                GenJournalLine.Validate("Shortcut Dimension 1 Code", DimensionValueCode);
+            2:
+                GenJournalLine.Validate("Shortcut Dimension 2 Code", DimensionValueCode);
+        end;
+        GenJournalLine.Validate("Deferral Code");
+        GenJournalLine.Modify(true);
+        Commit();
+
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/W1/BaseApp/Finance/Deferral/DeferralSummaryGL.Report.al
+++ b/src/Layers/W1/BaseApp/Finance/Deferral/DeferralSummaryGL.Report.al
@@ -24,7 +24,7 @@ report 1700 "Deferral Summary - G/L"
     {
         dataitem(GLAccount; "G/L Account")
         {
-            RequestFilterFields = "No.";
+            RequestFilterFields = "No.", "Global Dimension 1 Filter", "Global Dimension 2 Filter";
             // RDLC only
             column(CompanyName; COMPANYPROPERTY.DisplayName())
             {
@@ -143,6 +143,9 @@ report 1700 "Deferral Summary - G/L"
                     GLEntry: Record "G/L Entry";
                     LinesFound: Boolean;
                 begin
+                    if not EntryMatchesGlobalDimFilters("Entry No.") then
+                        CurrReport.Skip();
+
                     PreviousAccount := WorkingAccount;
                     if GLAccount.Get("Account No.") then begin
                         AccountName := GLAccount.Name;
@@ -330,6 +333,8 @@ report 1700 "Deferral Summary - G/L"
     trigger OnPreReport()
     begin
         PostedDeferralFilter := "Posted Deferral Header".GetFilters();
+        GlobalDim1Filter := GLAccount.GetFilter("Global Dimension 1 Filter");
+        GlobalDim2Filter := GLAccount.GetFilter("Global Dimension 2 Filter");
         if HideZeroRemainingAmounts then
             "Posted Deferral Header".CalculatePeriodFilter(BalanceAsOfDateFilter, PeriodStartDate, PeriodEndDate);
     end;
@@ -365,6 +370,8 @@ report 1700 "Deferral Summary - G/L"
         PeriodStartDate: Date;
         PeriodEndDate: Date;
         LineCount: Integer;
+        GlobalDim1Filter: Text;
+        GlobalDim2Filter: Text;
         // RDLC Only layout field captions. To be removed in a future release along with the RDLC layout.
         PageCaptionLbl: Label 'Page';
         BalanceCaptionLbl: Label 'This also includes general ledger accounts that only have a balance.';
@@ -386,5 +393,20 @@ report 1700 "Deferral Summary - G/L"
     begin
         PrintOnlyOnePerPage := NewPrintOnlyOnePerPage;
         BalanceAsOfDateFilter := NewBalanceAsOfDateFilter;
+    end;
+
+    local procedure EntryMatchesGlobalDimFilters(GLEntryNo: Integer): Boolean
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        if (GlobalDim1Filter = '') and (GlobalDim2Filter = '') then
+            exit(true);
+
+        GLEntry.SetRange("Entry No.", GLEntryNo);
+        if GlobalDim1Filter <> '' then
+            GLEntry.SetFilter("Global Dimension 1 Code", GlobalDim1Filter);
+        if GlobalDim2Filter <> '' then
+            GLEntry.SetFilter("Global Dimension 2 Code", GlobalDim2Filter);
+        exit(not GLEntry.IsEmpty());
     end;
 }

--- a/src/Layers/W1/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/TestREDSetupGenJnl.Codeunit.al
@@ -21,6 +21,7 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTimeSheet: Codeunit "Library - Time Sheet";
         LibraryJournals: Codeunit "Library - Journals";
+        LibraryDimension: Codeunit "Library - Dimension";
         DeferralUtilities: Codeunit "Deferral Utilities";
         CalcMethod: Enum "Deferral Calculation Method";
         DeferralDocType: Option Purchase,Sales,"G/L";
@@ -2263,6 +2264,22 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
         VerifyDeferralSchedule("Deferral Document Type"::Purchase, PurchaseLine."Document Type".AsInteger(), PurchaseLine."Document No.", PurchaseLine."Line No.");
     end;
 
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension1()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 1 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(1);
+    end;
+
+    [Test]
+    [HandlerFunctions('GLDeferralSummaryReportHandler')]
+    procedure GLDeferralSummaryReportFiltersByGlobalDimension2()
+    begin
+        // [SCENARIO 647585] Deferral Summary - G/L respects the Global Dimension 2 filter
+        VerifyGLDeferralSummaryReportFiltersByGlobalDimension(2);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";
@@ -2882,6 +2899,80 @@ codeunit 134803 "Test RED Setup Gen. Jnl."
                 DeferralHeader."Document Type", DeferralHeader."Document No.", DeferralHeader."Line No.");
         DeferralLine.SetFilter(Amount, '<>%1', 0);
         Assert.RecordIsEmpty(DeferralLine);
+    end;
+
+    local procedure VerifyGLDeferralSummaryReportFiltersByGlobalDimension(GlobalDimensionNo: Integer)
+    var
+        DimensionValue: array[2] of Record "Dimension Value";
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        GenJournalBatch: Record "Gen. Journal Batch";
+        GenJournalLine: array[2] of Record "Gen. Journal Line";
+        GLAccount: Record "G/L Account";
+        PostedDeferralHeader: Record "Posted Deferral Header";
+        DeferralSummaryGL: Report "Deferral Summary - G/L";
+        DimensionCode: Code[20];
+    begin
+        Initialize();
+
+        // [GIVEN] Two posted deferrals with different values for the selected global dimension
+        GeneralLedgerSetup.Get();
+        case GlobalDimensionNo of
+            1:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 1 Code";
+            2:
+                DimensionCode := GeneralLedgerSetup."Global Dimension 2 Code";
+        end;
+        LibraryDimension.CreateDimensionValue(DimensionValue[1], DimensionCode);
+        LibraryDimension.CreateDimensionValue(DimensionValue[2], DimensionCode);
+
+        LibraryERM.CreateGLAccount(GLAccount);
+        GLAccount.Validate("Default Deferral Template Code", CreateEqual5Periods());
+        GLAccount.Modify(true);
+        CreateGeneralJournalBatch(GenJournalBatch);
+        UpdateSourceCodeInGenJournalTemplate(GenJournalBatch);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[1], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[1].Code);
+        CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(
+            GenJournalLine[2], GenJournalBatch, GLAccount."No.", GlobalDimensionNo, DimensionValue[2].Code);
+
+        // [WHEN] Run Deferral Summary - G/L filtered by the first dimension value
+        GLAccount.SetRecFilter();
+        case GlobalDimensionNo of
+            1:
+                GLAccount.SetRange("Global Dimension 1 Filter", DimensionValue[1].Code);
+            2:
+                GLAccount.SetRange("Global Dimension 2 Filter", DimensionValue[1].Code);
+        end;
+        PostedDeferralHeader.SetRange("Deferral Doc. Type", PostedDeferralHeader."Deferral Doc. Type"::"G/L");
+        PostedDeferralHeader.SetRange("Account No.", GLAccount."No.");
+        Clear(DeferralSummaryGL);
+        DeferralSummaryGL.SetTableView(GLAccount);
+        DeferralSummaryGL.SetTableView(PostedDeferralHeader);
+        DeferralSummaryGL.Run();
+
+        // [THEN] The report includes the matching deferral and excludes the other deferral
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists('GenJnlDocNo', GenJournalLine[1]."Document No.");
+        LibraryReportDataset.AssertElementWithValueNotExist('GenJnlDocNo', GenJournalLine[2]."Document No.");
+    end;
+
+    local procedure CreateAndPostGenJournalLineWithDeferralAndGlobalDimension(var GenJournalLine: Record "Gen. Journal Line"; GenJournalBatch: Record "Gen. Journal Batch"; GLAccountNo: Code[20]; GlobalDimensionNo: Integer; DimensionValueCode: Code[20])
+    begin
+        CreateGenJournalLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::" ", GenJournalLine."Account Type"::"G/L Account", GLAccountNo,
+            GenJournalBatch."Bal. Account Type", GenJournalBatch."Bal. Account No.", LibraryRandom.RandDec(1000, 2));
+        case GlobalDimensionNo of
+            1:
+                GenJournalLine.Validate("Shortcut Dimension 1 Code", DimensionValueCode);
+            2:
+                GenJournalLine.Validate("Shortcut Dimension 2 Code", DimensionValueCode);
+        end;
+        GenJournalLine.Validate("Deferral Code");
+        GenJournalLine.Modify(true);
+        Commit();
+
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
Fixes [AB#648519](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648519)
Workitem : [Bug 648519](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648519): [29.x][All-e][FTE][SaaS] User is unable to filter the Deferral Summary-GL Report Not Filtering Totals by Global Dimensions.





