### PR TITLE
Ruleset hardening: promote five low-risk rules to Error

### DIFF
--- a/src/Apps/IN/INGST/app/GSTSubcontracting/src/Reports/StockRegisterforJobWork.Report.al
+++ b/src/Apps/IN/INGST/app/GSTSubcontracting/src/Reports/StockRegisterforJobWork.Report.al
@@ -220,8 +220,10 @@ report 18468 "Stock Register for Job Work"
                   "Order No." = field("Production Order No."),
                   "Order Line No." = field("Production Order Line No.");
 
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Entry Type", "Location Code", "External Document No.", "Item No.", "Order Type", "Order No.", "Order Line No.")
                         Order(Ascending) where("Order Type" = const(Production));
+#pragma warning restore AL0254
                 column(Item_Ledger_Entry_Entry_No_; "Entry No.")
                 {
                 }

--- a/src/Apps/IN/INVoucherInterface/app/src/report/VoucherRegister.report.al
+++ b/src/Apps/IN/INVoucherInterface/app/src/report/VoucherRegister.report.al
@@ -40,8 +40,10 @@ report 18933 "Voucher Register"
             }
             dataitem("G/L Entry"; "G/L Entry")
             {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Document No.", "Posting Date", Amount)
                                     order(descending);
+#pragma warning restore AL0254
 
                 column(VoucherSourceDesc; SourceDesc + VoucherLbl)
                 {

--- a/src/Apps/W1/BankDeposits/test/src/UTPageBankDeposit.Codeunit.al
+++ b/src/Apps/W1/BankDeposits/test/src/UTPageBankDeposit.Codeunit.al
@@ -113,6 +113,7 @@ codeunit 139768 "UT Page Bank Deposit"
         PostedBankDepositHeader: Record "Posted Bank Deposit Header";
         PostedBankDepositLine: Record "Posted Bank Deposit Line";
         CustLedgerEntry: Record "Cust. Ledger Entry";
+        PostedBankDeposit: TestPage "Posted Bank Deposit";
         CustomerLedgerEntries: TestPage "Customer Ledger Entries";
     begin
         // Purpose of the test is to validate AccountLedgerEntries - OnAction trigger of the Page ID: 10144, Posted Deposit Subform.
@@ -124,13 +125,16 @@ codeunit 139768 "UT Page Bank Deposit"
         CreateDetailedCustomerLedgerEntry(CustLedgerEntry."Entry No.", PostedBankDepositLine."Account No.");
 
         // Exercise: Show Account Ledger Entries.
+        OpenPostedBankDepositPage(PostedBankDeposit, PostedBankDepositHeader);
+        PostedBankDeposit.Subform.GotoRecord(PostedBankDepositLine);
         CustomerLedgerEntries.Trap();
-        PostedBankDepositLine.ShowAccountLedgerEntries();
+        PostedBankDeposit.Subform.AccountLedgerEntries.Invoke();
 
         // Verify: Verify Customer No and Amount on the Customer Ledger Entries.
         CustomerLedgerEntries."Customer No.".AssertEquals(PostedBankDepositLine."Account No.");
         CustomerLedgerEntries.Amount.AssertEquals(PostedBankDepositLine.Amount);
         CustomerLedgerEntries.Close();
+        PostedBankDeposit.Close();
     end;
 
     [Test]
@@ -139,6 +143,7 @@ codeunit 139768 "UT Page Bank Deposit"
     var
         PostedBankDepositHeader: Record "Posted Bank Deposit Header";
         PostedBankDepositLine: Record "Posted Bank Deposit Line";
+        PostedBankDeposit: TestPage "Posted Bank Deposit";
         CustomerCard: TestPage "Customer Card";
     begin
         // Purpose of the test is to validate AccountCard - OnAction trigger of the Page ID: 10144, Posted Deposit Subform.
@@ -148,12 +153,15 @@ codeunit 139768 "UT Page Bank Deposit"
         LibraryVariableStorage.Enqueue(PostedBankDepositLine."Account No.");  // Enqueue values for use in CustomerCardPageHandler.
 
         // Exercise: Show Account Card - Customer Card.
+        OpenPostedBankDepositPage(PostedBankDeposit, PostedBankDepositHeader);
+        PostedBankDeposit.Subform.GotoRecord(PostedBankDepositLine);
         CustomerCard.Trap();
-        PostedBankDepositLine.ShowAccountCard();
+        PostedBankDeposit.Subform.AccountCard.Invoke();
 
         // Verify: Verify Customer No on Customer Card.
         CustomerCard."No.".AssertEquals(PostedBankDepositLine."Account No.");
         CustomerCard.Close();
+        PostedBankDeposit.Close();
     end;
 
     [Test]

--- a/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationErrorOverview.page.al
+++ b/src/Apps/W1/HybridBC14/app/src/Errors/BC14MigrationErrorOverview.page.al
@@ -14,7 +14,9 @@ page 46863 "BC14 Migration Error Overview"
     ApplicationArea = All;
     SourceTable = "Data Migration Error";
     SourceTableTemporary = true;
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
     SourceTableView = sorting("Created On") order(descending);
+#pragma warning restore AL0254
     Caption = 'Migration Errors';
     Editable = true;
     InsertAllowed = false;

--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1666,7 +1666,9 @@ codeunit 22 "Item Jnl.-Post Line"
     begin
         ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
+#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1664,11 +1664,9 @@ codeunit 22 "Item Jnl.-Post Line"
         ReservEntry2: Record "Reservation Entry";
         ItemRec: Record Item;
     begin
-        ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
+        ReservEntry2.SetLoadFields("Source Type", "Source Subtype", "Item No.");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
-#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/APAC/BaseApp/Local/BankMgt/Deposit/DepositSlip.Report.al
+++ b/src/Layers/APAC/BaseApp/Local/BankMgt/Deposit/DepositSlip.Report.al
@@ -21,7 +21,9 @@ report 28023 "Deposit Slip"
     {
         dataitem("Gen. Journal Line"; "Gen. Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Account Type", "Account No.", "Document Type", "Document No.");
+#pragma warning restore AL0254
             RequestFilterFields = "Journal Template Name", "Journal Batch Name";
             column(FORMAT_TODAY_0_4_; Format(Today, 0, 4))
             {

--- a/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -967,7 +967,9 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -967,10 +967,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -963,12 +963,17 @@ report 412 "Purchase Prepmt. Doc. - Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -1027,6 +1032,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DocumentErrorsMgt: Codeunit "Document Errors Mgt.";
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1173,6 +1179,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
+        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
+            RequestDocumentType := NewDocumentType;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -969,6 +969,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -1006,6 +1007,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         PurchHeaderFilter := "Purchase Header".GetFilters();
 
         if DocumentType = DocumentType::Invoice then
@@ -1033,6 +1036,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1179,8 +1183,15 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
-        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
-            RequestDocumentType := NewDocumentType;
+        case NewDocumentType of
+            DocumentType::Invoice, DocumentType::"Credit Memo":
+                begin
+                    RequestDocumentType := NewDocumentType;
+                    StatisticDocumentType := false;
+                end;
+            DocumentType::Statistic:
+                StatisticDocumentType := true;
+        end;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/APAC/BaseApp/Sales/Reports/CustomerLabels.Report.al
+++ b/src/Layers/APAC/BaseApp/Sales/Reports/CustomerLabels.Report.al
@@ -223,9 +223,7 @@ report 110 "Customer - Labels"
                     {
                         ApplicationArea = Suite;
                         Caption = 'Format';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = '36 x 70 mm (3 columns),37 x 70 mm (3 columns),36 x 105 mm (2 columns),37 x 105 mm (2 columns)';
-#pragma warning restore AA0224
+                        OptionCaption = '36 x 70 mm (3 columns),37 x 70 mm (3 columns),36 x 105 mm (2 columns),37 x 105 mm (2 columns),48 x 105 mm (2 columns - Bar Code)';
                         ToolTip = 'Specifies the format of the label.';
                     }
                 }

--- a/src/Layers/APAC/BaseApp/Sales/Reports/CustomerLabels.Report.al
+++ b/src/Layers/APAC/BaseApp/Sales/Reports/CustomerLabels.Report.al
@@ -223,7 +223,9 @@ report 110 "Customer - Labels"
                     {
                         ApplicationArea = Suite;
                         Caption = 'Format';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = '36 x 70 mm (3 columns),37 x 70 mm (3 columns),36 x 105 mm (2 columns),37 x 105 mm (2 columns)';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies the format of the label.';
                     }
                 }

--- a/src/Layers/BE/BaseApp/Local/BankMgt/Payment/FileSEPA00100109Pmts.Report.al
+++ b/src/Layers/BE/BaseApp/Local/BankMgt/Payment/FileSEPA00100109Pmts.Report.al
@@ -32,7 +32,9 @@ report 2000007 "File SEPA 001.001.09 Pmts"
     {
         dataitem("Payment Journal Line"; "Payment Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Bank Account", "Beneficiary Bank Account No.", "Beneficiary IBAN", Status, "Account Type", "Account No.", "Currency Code", "Posting Date");
+#pragma warning restore AL0254
 
             trigger OnAfterGetRecord()
             var

--- a/src/Layers/BE/BaseApp/Local/BankMgt/Payment/FileSEPAPayments.Report.al
+++ b/src/Layers/BE/BaseApp/Local/BankMgt/Payment/FileSEPAPayments.Report.al
@@ -32,7 +32,9 @@ report 2000005 "File SEPA Payments"
     {
         dataitem("Payment Journal Line"; "Payment Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Bank Account", "Beneficiary Bank Account No.", "Beneficiary IBAN", Status, "Account Type", "Account No.", "Currency Code", "Posting Date");
+#pragma warning restore AL0254
 
             trigger OnAfterGetRecord()
             var

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1664,7 +1664,9 @@ codeunit 22 "Item Jnl.-Post Line"
     begin
         ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
+#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1662,11 +1662,9 @@ codeunit 22 "Item Jnl.-Post Line"
         ReservEntry2: Record "Reservation Entry";
         ItemRec: Record Item;
     begin
-        ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
+        ReservEntry2.SetLoadFields("Source Type", "Source Subtype", "Item No.");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
-#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAFile.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAFile.Report.al
@@ -23,7 +23,9 @@ report 3010541 "DTA File"
     {
         dataitem("Gen. Journal Line"; "Gen. Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Posting Date", Clearing, "Debit Bank");
+#pragma warning restore AL0254
 
             trigger OnAfterGetRecord()
             begin

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAPaymentJournal.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAPaymentJournal.Report.al
@@ -20,7 +20,9 @@ report 3010545 "DTA Payment Journal"
     {
         dataitem("Gen. Journal Line"; "Gen. Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Posting Date", Clearing, "Debit Bank");
+#pragma warning restore AL0254
             column(JournalBatchName_GenJournalLine; "Journal Batch Name")
             {
             }

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAPaymentOrder.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAPaymentOrder.Report.al
@@ -103,7 +103,9 @@ report 3010543 "DTA Payment Order"
             }
             dataitem("Gen. Journal Line"; "Gen. Journal Line")
             {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Posting Date", Clearing, "Debit Bank");
+#pragma warning restore AL0254
 
                 trigger OnAfterGetRecord()
                 begin

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/EZAGFile.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/EZAGFile.Report.al
@@ -24,7 +24,9 @@ report 3010542 "EZAG File"
     {
         dataitem("Gen. Journal Line"; "Gen. Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Posting Date", Clearing, "Debit Bank");
+#pragma warning restore AL0254
 
             trigger OnAfterGetRecord()
             begin

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/EZAGPaymentOrder.Report.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/EZAGPaymentOrder.Report.al
@@ -22,7 +22,9 @@ report 3010544 "EZAG Payment Order"
     {
         dataitem("Journal Line"; "Gen. Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Posting Date", Clearing, "Debit Bank");
+#pragma warning restore AL0254
 
             trigger OnAfterGetRecord()
             begin

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1664,7 +1664,9 @@ codeunit 22 "Item Jnl.-Post Line"
     begin
         ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
+#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1662,11 +1662,9 @@ codeunit 22 "Item Jnl.-Post Line"
         ReservEntry2: Record "Reservation Entry";
         ItemRec: Record Item;
     begin
-        ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
+        ReservEntry2.SetLoadFields("Source Type", "Source Subtype", "Item No.");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
-#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/ES/BaseApp/Local/Finance/VAT/Reporting/Make347Declaration.Report.al
+++ b/src/Layers/ES/BaseApp/Local/Finance/VAT/Reporting/Make347Declaration.Report.al
@@ -52,7 +52,9 @@ report 10707 "Make 347 Declaration"
             {
                 CalcFields = Amount;
                 DataItemLink = "Customer No." = field("No."), "VAT Reporting Date" = field("Date Filter");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Document Type", "Customer No.", "Global Dimension 1 Code", "Global Dimension 2 Code", "VAT Reporting Date", "Currency Code");
+#pragma warning restore AL0254
                 dataitem(GLEntry1; "G/L Entry")
                 {
                     DataItemLink = "Document No." = field("Document No."), "VAT Reporting Date" = field("VAT Reporting Date");
@@ -260,7 +262,9 @@ report 10707 "Make 347 Declaration"
             {
                 CalcFields = Amount;
                 DataItemLink = "Vendor No." = field("No."), "VAT Reporting Date" = field("Date Filter");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Document Type", "Vendor No.", "Global Dimension 1 Code", "Global Dimension 2 Code", "VAT Reporting Date", "Currency Code");
+#pragma warning restore AL0254
                 dataitem(GLEntry2; "G/L Entry")
                 {
                     DataItemLink = "Document No." = field("Document No."), "VAT Reporting Date" = field("VAT Reporting Date");

--- a/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -956,12 +956,17 @@ report 412 "Purchase Prepmt. Doc. - Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -1020,6 +1025,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DocumentErrorsMgt: Codeunit "Document Errors Mgt.";
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1162,6 +1168,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
+        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
+            RequestDocumentType := NewDocumentType;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -962,6 +962,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -999,6 +1000,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         PurchHeaderFilter := "Purchase Header".GetFilters();
 
         if DocumentType = DocumentType::Invoice then
@@ -1026,6 +1029,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1168,8 +1172,15 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
-        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
-            RequestDocumentType := NewDocumentType;
+        case NewDocumentType of
+            DocumentType::Invoice, DocumentType::"Credit Memo":
+                begin
+                    RequestDocumentType := NewDocumentType;
+                    StatisticDocumentType := false;
+                end;
+            DocumentType::Statistic:
+                StatisticDocumentType := true;
+        end;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -960,7 +960,9 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/ES/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -960,10 +960,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -939,7 +939,9 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -935,12 +935,17 @@ report 212 "Sales Prepmt. Document Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -1023,6 +1028,7 @@ report 212 "Sales Prepmt. Document Test"
         DimText: Text[120];
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -941,6 +941,7 @@ report 212 "Sales Prepmt. Document Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -978,6 +979,8 @@ report 212 "Sales Prepmt. Document Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         SalesHeaderFilter := "Sales Header".GetFilters();
 
         GLSetup.Get();
@@ -1029,6 +1032,7 @@ report 212 "Sales Prepmt. Document Test"
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/ES/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -939,10 +939,8 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/FR/BaseApp/Local/Purchases/Reports/VendorJournal.Report.al
+++ b/src/Layers/FR/BaseApp/Local/Purchases/Reports/VendorJournal.Report.al
@@ -128,7 +128,9 @@ report 10814 "Vendor Journal"
                 dataitem("Vendor Ledger Entry"; "Vendor Ledger Entry")
                 {
                     DataItemLink = "Source Code" = field(Code);
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                     DataItemTableView = sorting("Source Code", "Posting Date");
+#pragma warning restore AL0254
                     column(SourceCode2Code; SourceCode2.Code)
                     {
                     }

--- a/src/Layers/FR/BaseApp/Local/Sales/Reports/CustomerJournal.Report.al
+++ b/src/Layers/FR/BaseApp/Local/Sales/Reports/CustomerJournal.Report.al
@@ -131,7 +131,9 @@ report 10813 "Customer Journal"
                 dataitem("Cust. Ledger Entry"; "Cust. Ledger Entry")
                 {
                     DataItemLink = "Source Code" = field(Code);
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                     DataItemTableView = sorting("Source Code", "Posting Date");
+#pragma warning restore AL0254
                     column(SourceCode2_Code; SourceCode2.Code)
                     {
                     }

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1679,7 +1679,9 @@ codeunit 22 "Item Jnl.-Post Line"
     begin
         ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
+#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1677,11 +1677,9 @@ codeunit 22 "Item Jnl.-Post Line"
         ReservEntry2: Record "Reservation Entry";
         ItemRec: Record Item;
     begin
-        ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
+        ReservEntry2.SetLoadFields("Source Type", "Source Subtype", "Item No.");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
-#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/IT/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
@@ -126,7 +126,7 @@ codeunit 5708 "Release Transfer Document"
 #if not CLEAN28
             "WIP Quantity",
 #endif
-            "Item No.", "Variant Code");
+            "Item No.", "Variant Code", "Unit of Measure Code");
         TransLine.SetRange("Document No.", TransHeader."No.");
         TransLine.SetFilter(Quantity, '<>0');
 #if not CLEAN28
@@ -154,9 +154,7 @@ codeunit 5708 "Release Transfer Document"
             repeat
                 Item.Get(TransLine."Item No.");
                 if Item.IsInventoriableType() then
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     TransLine.TestField("Unit of Measure Code");
-#pragma warning restore AA0242
                 if Item.IsVariantMandatory() then
                     TransLine.TestField("Variant Code");
             until TransLine.Next() = 0;

--- a/src/Layers/IT/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
@@ -154,7 +154,9 @@ codeunit 5708 "Release Transfer Document"
             repeat
                 Item.Get(TransLine."Item No.");
                 if Item.IsInventoriableType() then
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     TransLine.TestField("Unit of Measure Code");
+#pragma warning restore AA0242
                 if Item.IsVariantMandatory() then
                     TransLine.TestField("Variant Code");
             until TransLine.Next() = 0;

--- a/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -924,10 +924,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -926,6 +926,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -963,6 +964,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         PurchHeaderFilter := "Purchase Header".GetFilters();
 
         if DocumentType = DocumentType::Invoice then
@@ -990,6 +993,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1130,8 +1134,15 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
-        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
-            RequestDocumentType := NewDocumentType;
+        case NewDocumentType of
+            DocumentType::Invoice, DocumentType::"Credit Memo":
+                begin
+                    RequestDocumentType := NewDocumentType;
+                    StatisticDocumentType := false;
+                end;
+            DocumentType::Statistic:
+                StatisticDocumentType := true;
+        end;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -924,7 +924,9 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/IT/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -920,12 +920,17 @@ report 412 "Purchase Prepmt. Doc. - Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -984,6 +989,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DocumentErrorsMgt: Codeunit "Document Errors Mgt.";
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1124,6 +1130,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
+        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
+            RequestDocumentType := NewDocumentType;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -906,6 +906,7 @@ report 212 "Sales Prepmt. Document Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -943,6 +944,8 @@ report 212 "Sales Prepmt. Document Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         SalesHeaderFilter := "Sales Header".GetFilters();
 
         GLSetup.Get();
@@ -994,6 +997,7 @@ report 212 "Sales Prepmt. Document Test"
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -904,7 +904,9 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -900,12 +900,17 @@ report 212 "Sales Prepmt. Document Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -988,6 +993,7 @@ report 212 "Sales Prepmt. Document Test"
         DimText: Text[120];
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/IT/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -904,10 +904,8 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/NA/BaseApp/Local/Bank/Deposit/PostedDepositSubform.Page.al
+++ b/src/Layers/NA/BaseApp/Local/Bank/Deposit/PostedDepositSubform.Page.al
@@ -127,25 +127,25 @@ page 10144 "Posted Deposit Subform"
         }
     }
 
-#pragma warning disable AL0523 // Accepted: Page wrapper method is retained for compatibility with existing callers.
+#pragma warning disable AL0523 // Accepted: Page wrapper is retained for callers and delegates to the source-table method.
     procedure ShowDimensions()
 #pragma warning restore AL0523
     begin
         Rec.ShowDimensions();
     end;
 
-#pragma warning disable AL0523 // Accepted: Page wrapper method is retained for compatibility with existing callers.
+#pragma warning disable AL0523 // Accepted: Page wrapper is retained for callers and delegates to the source-table method.
     procedure ShowAccountCard()
 #pragma warning restore AL0523
     begin
-        ShowAccountCard();
+        Rec.ShowAccountCard();
     end;
 
-#pragma warning disable AL0523 // Accepted: Page wrapper method is retained for compatibility with existing callers.
+#pragma warning disable AL0523 // Accepted: Page wrapper is retained for callers and delegates to the source-table method.
     procedure ShowAccountLedgerEntries()
 #pragma warning restore AL0523
     begin
-        ShowAccountLedgerEntries();
+        Rec.ShowAccountLedgerEntries();
     end;
 }
 

--- a/src/Layers/NA/BaseApp/Local/Bank/Deposit/PostedDepositSubform.Page.al
+++ b/src/Layers/NA/BaseApp/Local/Bank/Deposit/PostedDepositSubform.Page.al
@@ -127,17 +127,23 @@ page 10144 "Posted Deposit Subform"
         }
     }
 
+#pragma warning disable AL0523 // Accepted: Page wrapper method is retained for compatibility with existing callers.
     procedure ShowDimensions()
+#pragma warning restore AL0523
     begin
         Rec.ShowDimensions();
     end;
 
+#pragma warning disable AL0523 // Accepted: Page wrapper method is retained for compatibility with existing callers.
     procedure ShowAccountCard()
+#pragma warning restore AL0523
     begin
         ShowAccountCard();
     end;
 
+#pragma warning disable AL0523 // Accepted: Page wrapper method is retained for compatibility with existing callers.
     procedure ShowAccountLedgerEntries()
+#pragma warning restore AL0523
     begin
         ShowAccountLedgerEntries();
     end;

--- a/src/Layers/NA/BaseApp/Local/Inventory/Reports/SerialNumberStatusAging.Report.al
+++ b/src/Layers/NA/BaseApp/Local/Inventory/Reports/SerialNumberStatusAging.Report.al
@@ -103,7 +103,9 @@ report 10161 "Serial Number Status/Aging"
             dataitem("Item Ledger Entry"; "Item Ledger Entry")
             {
                 DataItemLink = "Item No." = field("No."), "Posting Date" = field("Date Filter"), "Location Code" = field("Location Filter"), "Variant Code" = field("Variant Filter"), "Global Dimension 1 Code" = field("Global Dimension 1 Filter"), "Global Dimension 2 Code" = field("Global Dimension 2 Filter");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Item No.", Open, "Variant Code", Positive, "Location Code", "Posting Date", "Expiration Date", "Lot No.", "Serial No.") where(Open = const(true));
+#pragma warning restore AL0254
                 column(Item_Ledger_Entry__Location_Code_; "Location Code")
                 {
                 }

--- a/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -951,6 +951,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -988,6 +989,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         PurchHeaderFilter := "Purchase Header".GetFilters();
 
         if DocumentType = DocumentType::Invoice then
@@ -1016,6 +1019,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1158,8 +1162,15 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
-        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
-            RequestDocumentType := NewDocumentType;
+        case NewDocumentType of
+            DocumentType::Invoice, DocumentType::"Credit Memo":
+                begin
+                    RequestDocumentType := NewDocumentType;
+                    StatisticDocumentType := false;
+                end;
+            DocumentType::Statistic:
+                StatisticDocumentType := true;
+        end;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -949,7 +949,9 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -949,10 +949,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/NA/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -945,12 +945,17 @@ report 412 "Purchase Prepmt. Doc. - Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -1010,6 +1015,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DocumentErrorsMgt: Codeunit "Document Errors Mgt.";
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1152,6 +1158,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
+        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
+            RequestDocumentType := NewDocumentType;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -922,10 +922,8 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -918,12 +918,17 @@ report 212 "Sales Prepmt. Document Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -1007,6 +1012,7 @@ report 212 "Sales Prepmt. Document Test"
         DimText: Text[120];
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -922,7 +922,9 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/NA/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -924,6 +924,7 @@ report 212 "Sales Prepmt. Document Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -961,6 +962,8 @@ report 212 "Sales Prepmt. Document Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         SalesHeaderFilter := "Sales Header".GetFilters();
 
         GLSetup.Get();
@@ -1013,6 +1016,7 @@ report 212 "Sales Prepmt. Document Test"
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -562,6 +562,9 @@ table 5222 "Employee Ledger Entry"
         key(ClosedByEntryNo; "Closed by Entry No.")
         {
         }
+        key(OpenTransactionModeCode; Open, "Transaction Mode Code")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -559,7 +559,7 @@ table 5222 "Employee Ledger Entry"
         key(PmtReconCandidates; "Document Type", Open, "Posting Date")
         {
         }
-        key(Key3; "Closed by Entry No.")
+        key(ClosedByEntryNo; "Closed by Entry No.")
         {
         }
     }

--- a/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/NL/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -559,6 +559,9 @@ table 5222 "Employee Ledger Entry"
         key(PmtReconCandidates; "Document Type", Open, "Posting Date")
         {
         }
+        key(Key3; "Closed by Entry No.")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/Docket.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/Docket.Report.al
@@ -702,9 +702,7 @@ report 11000004 Docket
                         {
                             CalcFields = Amount, "Remaining Amount";
                             DataItemLink = "Closed by Entry No." = field("Entry No.");
-#pragma warning disable AL0254 // Accepted: NL-local report sorting. "Employee Ledger Entry" has no key on "Closed by Entry No." (unlike Cust./Vendor Ledger Entry); adding one is a schema change tracked separately.
                             DataItemTableView = sorting("Closed by Entry No.");
-#pragma warning restore AL0254
                             column(DescHist_EmplLedgEntry; Description)
                             {
                             }

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/Docket.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/Docket.Report.al
@@ -702,7 +702,9 @@ report 11000004 Docket
                         {
                             CalcFields = Amount, "Remaining Amount";
                             DataItemLink = "Closed by Entry No." = field("Entry No.");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                             DataItemTableView = sorting("Closed by Entry No.");
+#pragma warning restore AL0254
                             column(DescHist_EmplLedgEntry; Description)
                             {
                             }

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/Docket.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/Docket.Report.al
@@ -702,7 +702,7 @@ report 11000004 Docket
                         {
                             CalcFields = Amount, "Remaining Amount";
                             DataItemLink = "Closed by Entry No." = field("Entry No.");
-#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
+#pragma warning disable AL0254 // Accepted: NL-local report sorting. "Employee Ledger Entry" has no key on "Closed by Entry No." (unlike Cust./Vendor Ledger Entry); adding one is a schema change tracked separately.
                             DataItemTableView = sorting("Closed by Entry No.");
 #pragma warning restore AL0254
                             column(DescHist_EmplLedgEntry; Description)

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/GetProposalEntries.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/GetProposalEntries.Report.al
@@ -128,7 +128,9 @@ report 11000000 "Get Proposal Entries"
             dataitem("Employee Ledger Entry"; "Employee Ledger Entry")
             {
                 DataItemLink = "Transaction Mode Code" = field(Code);
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting(Open, "Transaction Mode Code") where(Open = const(true));
+#pragma warning restore AL0254
                 RequestFilterFields = "Employee No.";
 
                 trigger OnAfterGetRecord()

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/GetProposalEntries.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/GetProposalEntries.Report.al
@@ -128,9 +128,7 @@ report 11000000 "Get Proposal Entries"
             dataitem("Employee Ledger Entry"; "Employee Ledger Entry")
             {
                 DataItemLink = "Transaction Mode Code" = field(Code);
-#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting(Open, "Transaction Mode Code") where(Open = const(true));
-#pragma warning restore AL0254
                 RequestFilterFields = "Employee No.";
 
                 trigger OnAfterGetRecord()

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/PaymentHistoryOverview.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/PaymentHistoryOverview.Report.al
@@ -545,9 +545,7 @@ report 11000002 "Payment History Overview"
                             {
                                 CalcFields = Amount, "Remaining Amount";
                                 DataItemLink = "Closed by Entry No." = field("Entry No.");
-#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                                 DataItemTableView = sorting("Closed by Entry No.");
-#pragma warning restore AL0254
                                 column(DescHist_EmplLedgEntry; Description)
                                 {
                                 }

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/PaymentHistoryOverview.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/PaymentHistoryOverview.Report.al
@@ -545,7 +545,9 @@ report 11000002 "Payment History Overview"
                             {
                                 CalcFields = Amount, "Remaining Amount";
                                 DataItemLink = "Closed by Entry No." = field("Entry No.");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                                 DataItemTableView = sorting("Closed by Entry No.");
+#pragma warning restore AL0254
                                 column(DescHist_EmplLedgEntry; Description)
                                 {
                                 }

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/ProposalOverview.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/ProposalOverview.Report.al
@@ -495,7 +495,9 @@ report 11000001 "Proposal Overview"
                         {
                             CalcFields = Amount, "Remaining Amount";
                             DataItemLink = "Closed by Entry No." = field("Entry No.");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                             DataItemTableView = sorting("Closed by Entry No.");
+#pragma warning restore AL0254
                             column(DescHist_EmplLedgEntry; Description)
                             {
                             }

--- a/src/Layers/NL/BaseApp/Local/Bank/Payment/ProposalOverview.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Payment/ProposalOverview.Report.al
@@ -495,9 +495,7 @@ report 11000001 "Proposal Overview"
                         {
                             CalcFields = Amount, "Remaining Amount";
                             DataItemLink = "Closed by Entry No." = field("Entry No.");
-#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                             DataItemTableView = sorting("Closed by Entry No.");
-#pragma warning restore AL0254
                             column(DescHist_EmplLedgEntry; Description)
                             {
                             }

--- a/src/Layers/NL/BaseApp/Local/Bank/Statement/CBGPostingTest.Report.al
+++ b/src/Layers/NL/BaseApp/Local/Bank/Statement/CBGPostingTest.Report.al
@@ -482,7 +482,9 @@ report 11400 "CBG Posting - Test"
                 dataitem(EmplEntryApplyID; "Employee Ledger Entry")
                 {
                     DataItemLink = "Employee No." = field("Account No.");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                     DataItemTableView = sorting("Employee No.", Open, Positive, "Currency Code") where(Open = const(true));
+#pragma warning restore AL0254
                     column(Desc_EmplEntryApplyID; Description)
                     {
                     }
@@ -544,7 +546,9 @@ report 11400 "CBG Posting - Test"
                 dataitem(EmplEntryApplyNo; "Employee Ledger Entry")
                 {
                     DataItemLink = "Employee No." = field("Account No."), "Document No." = field("Applies-to Doc. No."), "Document Type" = field("Applies-to Doc. Type");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                     DataItemTableView = sorting("Document No.");
+#pragma warning restore AL0254
                     column(Desc_EmplEntryApplyNo; Description)
                     {
                     }

--- a/src/Layers/NO/BaseApp/Local/Purchases/Payables/RemittanceTestReport.Report.al
+++ b/src/Layers/NO/BaseApp/Local/Purchases/Payables/RemittanceTestReport.Report.al
@@ -25,7 +25,9 @@ report 15000002 "Remittance Test Report"
     {
         dataitem(Transaction; "Gen. Journal Line")
         {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
             DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Remittance Agreement Code", "Remittance Type");
+#pragma warning restore AL0254
             RequestFilterFields = "Account Type", "Account No.";
             column(JnlTempName_Transaction; "Journal Template Name")
             {
@@ -131,7 +133,9 @@ report 15000002 "Remittance Test Report"
             }
             dataitem("Gen. Journal Line"; "Gen. Journal Line")
             {
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Journal Template Name", "Journal Batch Name", "Remittance Agreement Code", "Remittance Type");
+#pragma warning restore AL0254
                 column(TransactionNo; TransactionNo)
                 {
                 }

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1678,11 +1678,9 @@ codeunit 22 "Item Jnl.-Post Line"
         ReservEntry2: Record "Reservation Entry";
         ItemRec: Record Item;
     begin
-        ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
+        ReservEntry2.SetLoadFields("Source Type", "Source Subtype", "Item No.");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
-#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1680,7 +1680,9 @@ codeunit 22 "Item Jnl.-Post Line"
     begin
         ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
+#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/RU/BaseApp/Local/CustomerAccountingCard.Report.al
+++ b/src/Layers/RU/BaseApp/Local/CustomerAccountingCard.Report.al
@@ -111,7 +111,9 @@ report 12441 "Customer Accounting Card"
                     CalcFields = "Debit Amount (LCY)", "Credit Amount (LCY)";
                     DataItemLink = "Customer No." = field("No."), "Global Dimension 1 Code" = field("Global Dimension 1 Filter"), "Global Dimension 2 Code" = field("Global Dimension 2 Filter"), "Agreement No." = field("Agreement Filter"), "Posting Date" = field("Date Filter");
                     DataItemLinkReference = Customer;
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                     DataItemTableView = sorting("Customer No.", "Posting Date", "Currency Code", "Agreement No.");
+#pragma warning restore AL0254
                     column(Posting_DateCaption; Posting_DateCaptionLbl)
                     {
                     }

--- a/src/Layers/RU/BaseApp/Local/CustomerReconciliationAct.Report.al
+++ b/src/Layers/RU/BaseApp/Local/CustomerReconciliationAct.Report.al
@@ -618,7 +618,9 @@ report 14910 "Customer - Reconciliation Act"
                 dataitem(VendInvoices; "Vendor Ledger Entry")
                 {
                     DataItemLink = "Vendor No." = field("No."), "Agreement No." = field("Agreement Filter");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                     DataItemTableView = sorting("Vendor No.", "Posting Date", "Currency Code", "Agreement No.") where("Document Type" = filter(" " | Invoice | "Credit Memo"), Reversed = const(false));
+#pragma warning restore AL0254
                     dataitem(AppldVendPays2; "Integer")
                     {
                         DataItemTableView = sorting(Number) where(Number = filter(1 ..));

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransactions.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransactions.Page.al
@@ -78,7 +78,9 @@ page 615 "IC Inbox Transactions"
                 {
                     ApplicationArea = Intercompany;
                     Caption = 'Show Line Action';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                     OptionCaption = 'All,No Action,Accept,Return to IC Partner';
+#pragma warning restore AA0224
                     ToolTip = 'Specifies how you want to filter the lines shown in the window. You can choose to see all lines, or only lines with a specific option in the Line Action field.';
 
                     trigger OnValidate()

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransactions.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/Inbox/ICInboxTransactions.Page.al
@@ -78,9 +78,7 @@ page 615 "IC Inbox Transactions"
                 {
                     ApplicationArea = Intercompany;
                     Caption = 'Show Line Action';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                    OptionCaption = 'All,No Action,Accept,Return to IC Partner';
-#pragma warning restore AA0224
+                    OptionCaption = 'All,No Action,Accept,Return to IC Partner,Cancel';
                     ToolTip = 'Specifies how you want to filter the lines shown in the window. You can choose to see all lines, or only lines with a specific option in the Line Action field.';
 
                     trigger OnValidate()

--- a/src/Layers/W1/BaseApp/Finance/ReceivablesPayables/NetCustVendBalancesMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/ReceivablesPayables/NetCustVendBalancesMgt.Codeunit.al
@@ -275,7 +275,7 @@ codeunit 108 "Net Cust/Vend Balances Mgt."
 
     local procedure FailIfDuplicateLineExists(GenJournalLine: Record "Gen. Journal Line")
     begin
-        GenJournalLine.SetLoadFields("Document No.");
+        GenJournalLine.SetLoadFields("Document No.", "Applies-to Doc. Type", "Applies-to Doc. No.");
         GenJournalLine.SetRange("Account Type", GenJournalLine."Account Type");
         GenJournalLine.SetRange("Account No.", GenJournalLine."Account No.");
         GenJournalLine.SetRange("Applies-to Doc. Type", GenJournalLine."Applies-to Doc. Type");
@@ -285,9 +285,7 @@ codeunit 108 "Net Cust/Vend Balances Mgt."
                 DuplicateLineExistsErr,
                 GenJournalLine."Document No.",
                 GenJournalLine."Journal Template Name", GenJournalLine."Journal Batch Name",
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                 GenJournalLine."Applies-to Doc. Type", GenJournalLine."Applies-to Doc. No.");
-#pragma warning restore AA0242
     end;
 
     local procedure NetBalances(var VendLedgEntry: Record "Vendor Ledger Entry"; var CustLedgEntry: Record "Cust. Ledger Entry"; var VendorRemainingAmount: Decimal; var CustomerRemainingAmount: Decimal; var TempNetAmount: Decimal);

--- a/src/Layers/W1/BaseApp/Finance/ReceivablesPayables/NetCustVendBalancesMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/ReceivablesPayables/NetCustVendBalancesMgt.Codeunit.al
@@ -285,7 +285,9 @@ codeunit 108 "Net Cust/Vend Balances Mgt."
                 DuplicateLineExistsErr,
                 GenJournalLine."Document No.",
                 GenJournalLine."Journal Template Name", GenJournalLine."Journal Batch Name",
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                 GenJournalLine."Applies-to Doc. Type", GenJournalLine."Applies-to Doc. No.");
+#pragma warning restore AA0242
     end;
 
     local procedure NetBalances(var VendLedgEntry: Record "Vendor Ledger Entry"; var CustLedgEntry: Record "Cust. Ledger Entry"; var VendorRemainingAmount: Decimal; var CustomerRemainingAmount: Decimal; var TempNetAmount: Decimal);

--- a/src/Layers/W1/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -523,6 +523,9 @@ table 5222 "Employee Ledger Entry"
         key(PmtReconCandidates; "Document Type", Open, "Posting Date")
         {
         }
+        key(Key3; "Closed by Entry No.")
+        {
+        }
     }
 
     fieldgroups

--- a/src/Layers/W1/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Payables/EmployeeLedgerEntry.Table.al
@@ -523,7 +523,7 @@ table 5222 "Employee Ledger Entry"
         key(PmtReconCandidates; "Document Type", Open, "Posting Date")
         {
         }
-        key(Key3; "Closed by Entry No.")
+        key(ClosedByEntryNo; "Closed by Entry No.")
         {
         }
     }

--- a/src/Layers/W1/BaseApp/Integration/Entity/PurchaseDocumentEntity.Page.al
+++ b/src/Layers/W1/BaseApp/Integration/Entity/PurchaseDocumentEntity.Page.al
@@ -705,7 +705,9 @@ page 6404 "Purchase Document Entity"
                     ApplicationArea = All;
                     Caption = 'Posting from Whse. Ref.', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(locationFilter; Rec."Location Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Location Filter', Locked = true;

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1664,7 +1664,9 @@ codeunit 22 "Item Jnl.-Post Line"
     begin
         ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
+#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Posting/ItemJnlPostLine.Codeunit.al
@@ -1662,11 +1662,9 @@ codeunit 22 "Item Jnl.-Post Line"
         ReservEntry2: Record "Reservation Entry";
         ItemRec: Record Item;
     begin
-        ReservEntry2.SetLoadFields("Source Type", "Source Subtype");
+        ReservEntry2.SetLoadFields("Source Type", "Source Subtype", "Item No.");
         ReservEntry2.Get(ReservEntry."Entry No.", not ReservEntry.Positive);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
         if ItemRec.Get(ReservEntry2."Item No.") then
-#pragma warning restore AA0242
             if not (ItemRec."Assembly Policy" = ItemRec."Assembly Policy"::"Assemble-to-Stock") then
                 if (ReservEntry2."Source Type" = Database::"Assembly Header") and (ReservEntry2."Source Subtype" = 1)
                       and (not ItemJnlLine."Assemble to Order") then

--- a/src/Layers/W1/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
@@ -128,7 +128,9 @@ codeunit 5708 "Release Transfer Document"
             repeat
                 Item.Get(TransLine."Item No.");
                 if Item.IsInventoriableType() then
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     TransLine.TestField("Unit of Measure Code");
+#pragma warning restore AA0242
                 if Item.IsVariantMandatory() then
                     TransLine.TestField("Variant Code");
             until TransLine.Next() = 0;

--- a/src/Layers/W1/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Transfer/ReleaseTransferDocument.Codeunit.al
@@ -117,7 +117,7 @@ codeunit 5708 "Release Transfer Document"
         if IsHandled then
             exit;
 
-        TransLine.SetLoadFields("Document No.", Quantity, "Item No.", "Variant Code");
+        TransLine.SetLoadFields("Document No.", Quantity, "Item No.", "Variant Code", "Unit of Measure Code");
         TransLine.SetRange("Document No.", TransHeader."No.");
         TransLine.SetFilter(Quantity, '<>0');
         if TransLine.IsEmpty() then
@@ -128,9 +128,7 @@ codeunit 5708 "Release Transfer Document"
             repeat
                 Item.Get(TransLine."Item No.");
                 if Item.IsInventoriableType() then
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     TransLine.TestField("Unit of Measure Code");
-#pragma warning restore AA0242
                 if Item.IsVariantMandatory() then
                     TransLine.TestField("Variant Code");
             until TransLine.Next() = 0;

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
@@ -210,15 +210,11 @@ table 5405 "Production Order"
                     exit;
 
                 if Rec."Variant Code" <> '' then begin
-                    ItemVariant.SetLoadFields(Blocked);
+                    ItemVariant.SetLoadFields(Blocked, Description, "Description 2");
                     ItemVariant.Get(Rec."Source No.", Rec."Variant Code");
                     ItemVariant.TestField(Blocked, false);
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     Description := ItemVariant.Description;
-#pragma warning restore AA0242
-#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     "Description 2" := ItemVariant."Description 2";
-#pragma warning restore AA0242
                 end;
 
                 TestField("Source Type", "Source Type"::Item);

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
@@ -213,8 +213,12 @@ table 5405 "Production Order"
                     ItemVariant.SetLoadFields(Blocked);
                     ItemVariant.Get(Rec."Source No.", Rec."Variant Code");
                     ItemVariant.TestField(Blocked, false);
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     Description := ItemVariant.Description;
+#pragma warning restore AA0242
+#pragma warning disable AA0242 // Accepted: Existing partial-record access is retained; changing load behavior is outside this focused hardening.
                     "Description 2" := ItemVariant."Description 2";
+#pragma warning restore AA0242
                 end;
 
                 TestField("Source Type", "Source Type"::Item);

--- a/src/Layers/W1/BaseApp/Purchases/Document/MoveNegativePurchaseLines.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/MoveNegativePurchaseLines.Report.al
@@ -46,7 +46,9 @@ report 6698 "Move Negative Purchase Lines"
                             ApplicationArea = Basic, Suite;
                             Caption = 'To Document Type';
                             Editable = DropDownForRetOrderAndCrMemoEd;
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                             OptionCaption = ',,Order,Invoice';
+#pragma warning restore AA0224
                             ToolTip = 'Specifies which document type you want to move the negative purchase lines to.';
                         }
                     }

--- a/src/Layers/W1/BaseApp/Purchases/Document/MoveNegativePurchaseLines.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/MoveNegativePurchaseLines.Report.al
@@ -46,9 +46,7 @@ report 6698 "Move Negative Purchase Lines"
                             ApplicationArea = Basic, Suite;
                             Caption = 'To Document Type';
                             Editable = DropDownForRetOrderAndCrMemoEd;
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                             OptionCaption = ',,Order,Invoice';
-#pragma warning restore AA0224
                             ToolTip = 'Specifies which document type you want to move the negative purchase lines to.';
                         }
                     }
@@ -129,7 +127,7 @@ report 6698 "Move Negative Purchase Lines"
         ToPurchHeader: Record "Purchase Header";
         CopyDocMgt: Codeunit "Copy Document Mgt.";
         ToDocType: Option ,,"Order",Invoice,"Return Order","Credit Memo";
-        ToDocType2: Option ,,"Order",Invoice,"Return Order","Credit Memo";
+        ToDocType2: Option ,,"Order",Invoice;
         FromDocType: Option Quote,"Blanket Order","Order",Invoice,"Return Order","Credit Memo";
 #pragma warning disable AA0074
 #pragma warning disable AA0470

--- a/src/Layers/W1/BaseApp/Purchases/Document/MoveNegativePurchaseLines.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/MoveNegativePurchaseLines.Report.al
@@ -46,7 +46,7 @@ report 6698 "Move Negative Purchase Lines"
                             ApplicationArea = Basic, Suite;
                             Caption = 'To Document Type';
                             Editable = DropDownForRetOrderAndCrMemoEd;
-                            OptionCaption = ',,Order,Invoice';
+                            OptionCaption = ',,Order,Invoice,,';
                             ToolTip = 'Specifies which document type you want to move the negative purchase lines to.';
                         }
                     }
@@ -127,7 +127,7 @@ report 6698 "Move Negative Purchase Lines"
         ToPurchHeader: Record "Purchase Header";
         CopyDocMgt: Codeunit "Copy Document Mgt.";
         ToDocType: Option ,,"Order",Invoice,"Return Order","Credit Memo";
-        ToDocType2: Option ,,"Order",Invoice;
+        ToDocType2: Option ,,"Order",Invoice,"Return Order","Credit Memo";
         FromDocType: Option Quote,"Blanket Order","Order",Invoice,"Return Order","Credit Memo";
 #pragma warning disable AA0074
 #pragma warning disable AA0470

--- a/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -924,10 +924,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -926,6 +926,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -963,6 +964,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         PurchHeaderFilter := "Purchase Header".GetFilters();
 
         if DocumentType = DocumentType::Invoice then
@@ -990,6 +993,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1130,8 +1134,15 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
-        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
-            RequestDocumentType := NewDocumentType;
+        case NewDocumentType of
+            DocumentType::Invoice, DocumentType::"Credit Memo":
+                begin
+                    RequestDocumentType := NewDocumentType;
+                    StatisticDocumentType := false;
+                end;
+            DocumentType::Statistic:
+                StatisticDocumentType := true;
+        end;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -924,7 +924,9 @@ report 412 "Purchase Prepmt. Doc. - Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies the type of prepayment document: invoice or credit memo.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Reports/PurchasePrepmtDocTest.Report.al
@@ -920,12 +920,17 @@ report 412 "Purchase Prepmt. Doc. - Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -984,6 +989,7 @@ report 412 "Purchase Prepmt. Doc. - Test"
         DocumentErrorsMgt: Codeunit "Document Errors Mgt.";
         DimMgt: Codeunit DimensionManagement;
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;
@@ -1124,6 +1130,8 @@ report 412 "Purchase Prepmt. Doc. - Test"
     procedure InitializeRequest(NewDocumentType: Option; NewShowDim: Boolean)
     begin
         DocumentType := NewDocumentType;
+        if NewDocumentType in [DocumentType::Invoice, DocumentType::"Credit Memo"] then
+            RequestDocumentType := NewDocumentType;
         ShowDim := NewShowDim;
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/Document/MoveNegativeSalesLines.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/MoveNegativeSalesLines.Report.al
@@ -49,7 +49,9 @@ report 6699 "Move Negative Sales Lines"
                             ApplicationArea = ItemCharges;
                             Caption = 'To Document Type';
                             Editable = DropDownForRetOrderAndCrMemoEd;
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                             OptionCaption = ',,Order,Invoice';
+#pragma warning restore AA0224
                             ToolTip = 'Specifies which document type you want to move the negative sales lines to.';
                         }
                     }

--- a/src/Layers/W1/BaseApp/Sales/Document/MoveNegativeSalesLines.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/MoveNegativeSalesLines.Report.al
@@ -49,9 +49,7 @@ report 6699 "Move Negative Sales Lines"
                             ApplicationArea = ItemCharges;
                             Caption = 'To Document Type';
                             Editable = DropDownForRetOrderAndCrMemoEd;
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                             OptionCaption = ',,Order,Invoice';
-#pragma warning restore AA0224
                             ToolTip = 'Specifies which document type you want to move the negative sales lines to.';
                         }
                     }
@@ -144,7 +142,7 @@ report 6699 "Move Negative Sales Lines"
 
     protected var
         FromSalesHeader: Record "Sales Header";
-        ToDocType2: Option ,,"Order",Invoice,"Return Order","Credit Memo";
+        ToDocType2: Option ,,"Order",Invoice;
 
     /// <summary>
     /// Sets the source sales header from which to move negative lines.

--- a/src/Layers/W1/BaseApp/Sales/Document/MoveNegativeSalesLines.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/MoveNegativeSalesLines.Report.al
@@ -49,7 +49,7 @@ report 6699 "Move Negative Sales Lines"
                             ApplicationArea = ItemCharges;
                             Caption = 'To Document Type';
                             Editable = DropDownForRetOrderAndCrMemoEd;
-                            OptionCaption = ',,Order,Invoice';
+                            OptionCaption = ',,Order,Invoice,,';
                             ToolTip = 'Specifies which document type you want to move the negative sales lines to.';
                         }
                     }
@@ -142,7 +142,7 @@ report 6699 "Move Negative Sales Lines"
 
     protected var
         FromSalesHeader: Record "Sales Header";
-        ToDocType2: Option ,,"Order",Invoice;
+        ToDocType2: Option ,,"Order",Invoice,"Return Order","Credit Memo";
 
     /// <summary>
     /// Sets the source sales header from which to move negative lines.

--- a/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -800,7 +800,9 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
+#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
                         OptionCaption = 'Invoice,Credit Memo';
+#pragma warning restore AA0224
                         ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
                     }
                     field(ShowDimensions; ShowDim)

--- a/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -802,6 +802,7 @@ report 212 "Sales Prepmt. Document Test"
                         Caption = 'Prepayment Document Type';
                         OptionCaption = 'Invoice,Credit Memo';
                         ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+                        Visible = not StatisticDocumentType;
 
                         trigger OnValidate()
                         begin
@@ -839,6 +840,8 @@ report 212 "Sales Prepmt. Document Test"
 
     trigger OnPreReport()
     begin
+        if not StatisticDocumentType then
+            DocumentType := RequestDocumentType;
         SalesHeaderFilter := "Sales Header".GetFilters();
 
         GLSetup.Get();
@@ -890,6 +893,7 @@ report 212 "Sales Prepmt. Document Test"
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
         RequestDocumentType: Option Invoice,"Credit Memo";
+        StatisticDocumentType: Boolean;
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -800,10 +800,8 @@ report 212 "Sales Prepmt. Document Test"
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-#pragma warning disable AA0224 // Accepted: Existing option captions intentionally preserve the current request-page choices.
-                        OptionCaption = 'Invoice,Credit Memo';
-#pragma warning restore AA0224
-                        ToolTip = 'Specifies whether you want to see test documents for prepayment credit memos or prepayment invoices.';
+                        OptionCaption = 'Invoice,Credit Memo,Statistic';
+                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
                     }
                     field(ShowDimensions; ShowDim)
                     {

--- a/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
+++ b/src/Layers/W1/BaseApp/Sales/Reports/SalesPrepmtDocumentTest.Report.al
@@ -796,12 +796,17 @@ report 212 "Sales Prepmt. Document Test"
                 group(Options)
                 {
                     Caption = 'Options';
-                    field(PrepaymentDocumentType; DocumentType)
+                    field(PrepaymentDocumentType; RequestDocumentType)
                     {
                         ApplicationArea = Prepayments;
                         Caption = 'Prepayment Document Type';
-                        OptionCaption = 'Invoice,Credit Memo,Statistic';
-                        ToolTip = 'Specifies whether to test a prepayment invoice, credit memo, or statistic calculation.';
+                        OptionCaption = 'Invoice,Credit Memo';
+                        ToolTip = 'Specifies whether to test a prepayment invoice or credit memo.';
+
+                        trigger OnValidate()
+                        begin
+                            DocumentType := RequestDocumentType;
+                        end;
                     }
                     field(ShowDimensions; ShowDim)
                     {
@@ -884,6 +889,7 @@ report 212 "Sales Prepmt. Document Test"
         DimText: Text[120];
         ErrorText: array[99] of Text[250];
         DocumentType: Option Invoice,"Credit Memo",Statistic;
+        RequestDocumentType: Option Invoice,"Credit Memo";
         VATAmount: Decimal;
         VATBaseAmount: Decimal;
         ErrorCounter: Integer;

--- a/src/Layers/W1/BaseApp/Service/System/ServWorkflowCustomerEntity.PageExt.al
+++ b/src/Layers/W1/BaseApp/Service/System/ServWorkflowCustomerEntity.PageExt.al
@@ -20,7 +20,9 @@ pageextension 6491 "Serv. Workflow Customer Entity" extends "Workflow - Customer
                 ApplicationArea = All;
                 Caption = 'Contract Gain/Loss Amount', Locked = true;
             }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
             field(shipToFilter; Rec."Ship-to Filter")
+#pragma warning restore AW0007
             {
                 ApplicationArea = All;
                 Caption = 'Ship-to Filter', Locked = true;

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowCustomerEntity.Page.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowCustomerEntity.Page.al
@@ -246,17 +246,23 @@ page 6408 "Workflow - Customer Entity"
                     ApplicationArea = All;
                     Caption = 'Last Date Modified', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(dateFilter; Rec."Date Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Date Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(globalDimension1Filter; Rec."Global Dimension 1 Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Global Dimension 1 Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(globalDimension2Filter; Rec."Global Dimension 2 Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Global Dimension 2 Filter', Locked = true;
@@ -481,7 +487,9 @@ page 6408 "Workflow - Customer Entity"
                     ApplicationArea = All;
                     Caption = 'VAT Bus. Posting Group', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(currencyFilter; Rec."Currency Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Currency Filter', Locked = true;

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowItemEntity.Page.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowItemEntity.Page.al
@@ -291,22 +291,30 @@ page 6409 "Workflow - Item Entity"
                     ApplicationArea = All;
                     Caption = 'Last Time Modified', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(dateFilter; Rec."Date Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Date Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(globalDimension1Filter; Rec."Global Dimension 1 Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Global Dimension 1 Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(globalDimension2Filter; Rec."Global Dimension 2 Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Global Dimension 2 Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(locationFilter; Rec."Location Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Location Filter', Locked = true;
@@ -386,7 +394,9 @@ page 6409 "Workflow - Item Entity"
                     ApplicationArea = All;
                     Caption = 'Price Includes VAT', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(dropShipmentFilter; Rec."Drop Shipment Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Drop Shipment Filter', Locked = true;
@@ -636,12 +646,16 @@ page 6409 "Workflow - Item Entity"
                     ApplicationArea = All;
                     Caption = 'Rounding Precision', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(binFilter; Rec."Bin Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Bin Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(variantFilter; Rec."Variant Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Variant Filter', Locked = true;
@@ -781,12 +795,16 @@ page 6409 "Workflow - Item Entity"
                     ApplicationArea = All;
                     Caption = 'Expiration Calculation', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(lotNumberFilter; Rec."Lot No. Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Lot No. Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(serialNumberFilter; Rec."Serial No. Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Serial No. Filter', Locked = true;
@@ -951,12 +969,16 @@ page 6409 "Workflow - Item Entity"
                     ApplicationArea = All;
                     Caption = 'Prod. Forecast Quantity (Base)', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(productionForecastName; Rec."Production Forecast Name")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Demand Forecast Name', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(componentForecast; Rec."Component Forecast")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Component Forecast', Locked = true;

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowVendorEntity.Page.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowVendorEntity.Page.al
@@ -186,17 +186,23 @@ page 6410 "Workflow - Vendor Entity"
                     ApplicationArea = All;
                     Caption = 'Last Date Modified', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(dateFilter; Rec."Date Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Date Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(globalDimension1Filter; Rec."Global Dimension 1 Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Global Dimension 1 Filter', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(globalDimension2Filter; Rec."Global Dimension 2 Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Global Dimension 2 Filter', Locked = true;
@@ -401,7 +407,9 @@ page 6410 "Workflow - Vendor Entity"
                     ApplicationArea = All;
                     Caption = 'VAT Bus. Posting Group', Locked = true;
                 }
+#pragma warning disable AW0007 // Accepted: FlowFilter exposure is retained for API compatibility despite Web client limitations.
                 field(currencyFilter; Rec."Currency Filter")
+#pragma warning restore AW0007
                 {
                     ApplicationArea = All;
                     Caption = 'Currency Filter', Locked = true;

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -15,10 +15,6 @@
       "justification": "The application app shouldn't point at itself."
     },
     {
-      "id": "AL0254",
-      "action": "Warning"
-    },
-    {
       "id": "AL0424",
       "action": "Warning",
       "justification": "Bug 472148. The multilanguage syntax is being deprecated. Please update to the new syntax."

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -226,11 +226,6 @@
       "justification": "The OptionCaption property for must be filled in."
     },
     {
-      "id": "AA0224",
-      "action": "Warning",
-      "justification": "The count of option captions specified in the OptionCaption property is wrong."
-    },
-    {
       "id": "AA0225",
       "action": "Warning",
       "justification": ": The Caption property for must be filled in."
@@ -259,11 +254,6 @@
       "id": "AA0240",
       "action": "Warning",
       "justification": "The Label must not contain email addresses or phone numbers."
-    },
-    {
-      "id": "AA0242",
-      "action": "Warning",
-      "justification": "Field is not selected for loading and accessing it may cause a JIT load."
     },
     {
       "id": "AA0244",
@@ -305,11 +295,6 @@
       "justification": "Action should have a value for the Image property."
     },
     {
-      "id": "AW0007",
-      "action": "Warning",
-      "justification": "The FlowFilter field in the Repeater control cannot be displayed by the Web client."
-    },
-    {
       "id": "AW0009",
       "action": "Warning",
       "justification": "Using a Blob with subtype Bitmap on a page field is deprecated. "
@@ -340,10 +325,6 @@
     },
     {
       "id": "AL0603",
-      "action": "Warning"
-    },
-    {
-      "id": "AL0523",
       "action": "Warning"
     },
     {


### PR DESCRIPTION
## Summary

- Remove the global Warning overrides for `AL0254`, `AL0523`, `AA0242`, `AA0224`, and `AW0007`, allowing the base ruleset's Error default to apply.
- Convert the actionable recursion, option-model/caption, partial-record, and missing-key findings into real fixes.
- Keep tightly scoped, ID-qualified suppressions only for accepted pre-existing behavior.
- Reduce `src/rulesets/base.ruleset.json` from 81 to 76 overrides; `AL0424` remains Warning and is untouched.

The authoritative census contains 776 raw diagnostic records because projects and generated country views repeat diagnostics. Those collapse to 71 distinct generated file/line sites. The final diff changes 52 files (51 AL files) and retains 46 exact suppressions: 22 `AL0254`, 3 `AL0523`, and 21 `AW0007`. There are no `AA0242` or `AA0224` suppressions and no bare restores.

## Review fixes

- **AL0523:** retained the three public page wrappers for compatibility, fixed `ShowAccountCard()` and `ShowAccountLedgerEntries()` to delegate through `Rec`, and changed the existing unit tests to invoke the actual subform actions through TestPage.
- **AA0242:** fixed all 11 propagated source sites by adding each accessed field to the preceding `SetLoadFields` call, eliminating the JIT loads.
- **AA0224:** fixed all 13 propagated source sites. Added reachable captions, retained move-negative compatibility, and separated the visible Invoice/Credit Memo request option from the internal three-value processing option. `OnPreReport` synchronizes persisted request values for normal runs; explicit Statistic initialization hides the selector and preserves internal ordinal 2.
- **AL0254:** added descriptive Employee Ledger Entry keys for Closed by Entry No. and NL proposal sorting, then removed four now-stale suppressions.

The remaining suppressions preserve accepted report/page sorting choices, duplicate wrapper APIs, and FlowFilter API exposure without broad behavior changes.

## Validation

- `Invoke-MiSnapApp` with `RepoBranchName = 'main'`: success across all 52 changed files at `c6ecfe4758`.
- W1 BaseApp analyzer diagnostics are clear for the synchronized purchase/sales prepayment request-page changes and previously reviewed files; the Bank Deposits test source has no diagnostics.
- A full test compile/run was unavailable because this checkout has no local `.alpackages`, and global-only symbol restore returned no packages.
- BOM, CRLF, and trailing-newline behavior is unchanged in every modified AL file.

Related to [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773).

