### PR TITLE
[29.X]-Inconsistent Validation of Non-Deductible VAT % for Purchase Lines Sharing the Same VAT Identifier

### DIFF
--- a/src/Layers/AU/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
+++ b/src/Layers/AU/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
@@ -128,7 +128,7 @@ codeunit 134283 "Non-Deductible Purch. Posting"
     end;
 
     [Test]
-    procedure CombinedVATAmountLineForTwoPurchLineFirstNonDedVATSecondNormalVAT()
+    procedure SeparateVATAmountLinesForTwoPurchLineFirstNonDedVATSecondNormalVAT()
     var
         VATPostingSetup: Record "VAT Posting Setup";
         VATProductPostingGroup: Record "VAT Product Posting Group";
@@ -140,13 +140,12 @@ codeunit 134283 "Non-Deductible Purch. Posting"
         Currency: Record Currency;
         PurchPost: Codeunit "Purch.-Post";
         TotalVATAmount: Decimal;
-        VATIdentifier: Code[20];
+        NonDedVATIdentifier: Code[20];
     begin
-        // [SCENARIO 456471] Combine VAT amount line from two purchase lines (first has Non-Deductible VAT, second is not) has correct Non-Deductible VAT Base and Non-Deductible VAT Amount
-
+        // [SCENARIO 456471] Separate VAT amount lines from two purchase lines (first has Non-Deductible VAT, second is not) have correct Non-Deductible VAT Base and Non-Deductible VAT Amount
         Initialize();
         LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
-        VATIdentifier := VATPostingSetup."VAT Identifier";
+        NonDedVATIdentifier := VATPostingSetup."VAT Identifier";
         LibraryPurchase.CreatePurchHeader(
             PurchHeader, PurchHeader."Document Type"::Invoice,
             LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
@@ -154,9 +153,9 @@ codeunit 134283 "Non-Deductible Purch. Posting"
 
         LibraryERM.CreateVATProductPostingGroup(VATProductPostingGroup);
         LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Bus. Posting Group", VATProductPostingGroup.Code);
+        VATPostingSetup.Validate("VAT Identifier", VATProductPostingGroup.Code);
         VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
         VATPostingSetup.Validate("VAT %", LibraryRandom.RandIntInRange(10, 20));
-        VATPostingSetup.Validate("VAT Identifier", VATIdentifier);
         VATPostingSetup.Modify(true);
 
         CreatePurchLineItemWithVATProdPostingGroup(NormalPurchLine, PurchHeader, VATPostingSetup."VAT Prod. Posting Group");
@@ -168,12 +167,15 @@ codeunit 134283 "Non-Deductible Purch. Posting"
           TotalVATAmount, Currency, LibraryRandom.RandIntInRange(10, 50), false, 0, '', true, WorkDate());
 
         // [THEN]
-        Assert.RecordCount(TempVATAmountLine, 1);
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Base"), Format(0));
-        ClearLastError();
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Amount"), Format(0));
+        Assert.RecordCount(TempVATAmountLine, 2);
+        TempVATAmountLine.SetRange("VAT Identifier", NonDedVATIdentifier);
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
+        TempVATAmountLine.SetRange("VAT Identifier", VATPostingSetup."VAT Identifier");
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", 0);
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", 0);
     end;
 
     [Test]

--- a/src/Layers/CZ/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
+++ b/src/Layers/CZ/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
@@ -128,6 +128,57 @@ codeunit 134283 "Non-Deductible Purch. Posting"
     end;
 
     [Test]
+    procedure SeparateVATAmountLinesForTwoPurchLineFirstNonDedVATSecondNormalVAT()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        VATProductPostingGroup: Record "VAT Product Posting Group";
+        PurchHeader: Record "Purchase Header";
+        NonDedPurchLine: Record "Purchase Line";
+        NormalPurchLine: Record "Purchase Line";
+        TempPurchLine: Record "Purchase Line" temporary;
+        TempVATAmountLine: Record "VAT Amount Line" temporary;
+        Currency: Record Currency;
+        PurchPost: Codeunit "Purch.-Post";
+        TotalVATAmount: Decimal;
+        NonDedVATIdentifier: Code[20];
+    begin
+        // [SCENARIO 456471] Separate VAT amount lines from two purchase lines (first has Non-Deductible VAT, second is not) have correct Non-Deductible VAT Base and Non-Deductible VAT Amount
+        Initialize();
+        LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
+        NonDedVATIdentifier := VATPostingSetup."VAT Identifier";
+        LibraryPurchase.CreatePurchHeader(
+            PurchHeader, PurchHeader."Document Type"::Invoice,
+            LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
+        CreatePurchLineItemWithVATProdPostingGroup(NonDedPurchLine, PurchHeader, VATPostingSetup."VAT Prod. Posting Group");
+
+        LibraryERM.CreateVATProductPostingGroup(VATProductPostingGroup);
+        LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Bus. Posting Group", VATProductPostingGroup.Code);
+        VATPostingSetup.Validate("VAT Identifier", VATProductPostingGroup.Code);
+        VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
+        VATPostingSetup.Validate("VAT %", LibraryRandom.RandIntInRange(10, 20));
+        VATPostingSetup.Modify(true);
+
+        CreatePurchLineItemWithVATProdPostingGroup(NormalPurchLine, PurchHeader, VATPostingSetup."VAT Prod. Posting Group");
+        PurchPost.GetPurchLines(PurchHeader, TempPurchLine, 0);
+        NormalPurchLine.CalcVATAmountLines(0, PurchHeader, TempPurchLine, TempVATAmountLine);
+
+        // [WHEN]
+        TempVATAmountLine.UpdateLines(
+          TotalVATAmount, Currency, LibraryRandom.RandIntInRange(10, 50), false, 0, '', true, WorkDate());
+
+        // [THEN]
+        Assert.RecordCount(TempVATAmountLine, 2);
+        TempVATAmountLine.SetRange("VAT Identifier", NonDedVATIdentifier);
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
+        TempVATAmountLine.SetRange("VAT Identifier", VATPostingSetup."VAT Identifier");
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", 0);
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", 0);
+    end;
+
+    [Test]
     procedure PurchInvoiceWithPrepayment()
     var
         LineGLAccount: Record "G/L Account";

--- a/src/Layers/IT/Tests/VAT/NonDedVATMisc.Codeunit.al
+++ b/src/Layers/IT/Tests/VAT/NonDedVATMisc.Codeunit.al
@@ -1537,6 +1537,8 @@ codeunit 134284 "Non Ded. VAT Misc."
     begin
         LibraryERM.FindVATPostingSetup(VATPostingSetup, VATCalculationType);
         DeductiblePercent := GetDeductibleVATPctFromVATPostingSetup(VATPostingSetup);
+        VATPostingSetup.Validate(
+            "VAT Identifier", LibraryUtility.GenerateRandomCode(VATPostingSetup.FieldNo("VAT Identifier"), Database::"VAT Posting Setup"));
         LibraryERM.CreateGLAccount(GLAccount);
         AssignNonDeductibleVATAccount(VATPostingSetup, GLAccount."No.");
         AssignDeductibleVATPct(VATPostingSetup, LibraryRandom.RandInt(99));
@@ -1628,6 +1630,8 @@ codeunit 134284 "Non Ded. VAT Misc."
         LibraryERM.FindVATPostingSetup(VATPostingSetup, VATCalcType);
         DeductiblePercent := GetDeductibleVATPctFromVATPostingSetup(VATPostingSetup);
         NonDeductGLAccountNo := VATPostingSetup."Non-Ded. Purchase VAT Account";
+        VATPostingSetup.Validate(
+            "VAT Identifier", LibraryUtility.GenerateRandomCode(VATPostingSetup.FieldNo("VAT Identifier"), Database::"VAT Posting Setup"));
         AssignNonDeductibleVATAccount(VATPostingSetup, '');
         AssignDeductibleVATPct(VATPostingSetup, 0);
         VATPostingSetup.Modify(true);

--- a/src/Layers/IT/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
+++ b/src/Layers/IT/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
@@ -128,7 +128,7 @@ codeunit 134283 "Non-Deductible Purch. Posting"
     end;
 
     [Test]
-    procedure CombinedVATAmountLineForTwoPurchLineFirstNonDedVATSecondNormalVAT()
+    procedure SeparateVATAmountLinesForTwoPurchLineFirstNonDedVATSecondNormalVAT()
     var
         VATPostingSetup: Record "VAT Posting Setup";
         VATProductPostingGroup: Record "VAT Product Posting Group";
@@ -140,13 +140,12 @@ codeunit 134283 "Non-Deductible Purch. Posting"
         Currency: Record Currency;
         PurchPost: Codeunit "Purch.-Post";
         TotalVATAmount: Decimal;
-        VATIdentifier: Code[20];
+        NonDedVATIdentifier: Code[20];
     begin
-        // [SCENARIO 456471] Combine VAT amount line from two purchase lines (first has Non-Deductible VAT, second is not) has correct Non-Deductible VAT Base and Non-Deductible VAT Amount
-
+        // [SCENARIO 456471] Separate VAT amount lines from two purchase lines (first has Non-Deductible VAT, second is not) have correct Non-Deductible VAT Base and Non-Deductible VAT Amount
         Initialize();
         LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
-        VATIdentifier := VATPostingSetup."VAT Identifier";
+        NonDedVATIdentifier := VATPostingSetup."VAT Identifier";
         LibraryPurchase.CreatePurchHeader(
             PurchHeader, PurchHeader."Document Type"::Invoice,
             LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
@@ -156,7 +155,6 @@ codeunit 134283 "Non-Deductible Purch. Posting"
         LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Bus. Posting Group", VATProductPostingGroup.Code);
         VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
         VATPostingSetup.Validate("VAT %", LibraryRandom.RandIntInRange(10, 20));
-        VATPostingSetup.Validate("VAT Identifier", VATIdentifier);
         VATPostingSetup.Modify(true);
 
         CreatePurchLineItemWithVATProdPostingGroup(NormalPurchLine, PurchHeader, VATPostingSetup."VAT Prod. Posting Group");
@@ -168,12 +166,15 @@ codeunit 134283 "Non-Deductible Purch. Posting"
           TotalVATAmount, Currency, LibraryRandom.RandIntInRange(10, 50), false, 0, '', true, WorkDate());
 
         // [THEN]
-        Assert.RecordCount(TempVATAmountLine, 1);
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Base"), Format(0));
-        ClearLastError();
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Amount"), Format(0));
+        Assert.RecordCount(TempVATAmountLine, 2);
+        TempVATAmountLine.SetRange("VAT Identifier", NonDedVATIdentifier);
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
+        TempVATAmountLine.SetRange("VAT Identifier", VATPostingSetup."VAT Identifier");
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", 0);
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", 0);
     end;
 
     [Test]

--- a/src/Layers/RU/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
+++ b/src/Layers/RU/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
@@ -128,7 +128,7 @@ codeunit 134283 "Non-Deductible Purch. Posting"
     end;
 
     [Test]
-    procedure CombinedVATAmountLineForTwoPurchLineFirstNonDedVATSecondNormalVAT()
+    procedure SeparateVATAmountLinesForTwoPurchLineFirstNonDedVATSecondNormalVAT()
     var
         VATPostingSetup: Record "VAT Posting Setup";
         VATProductPostingGroup: Record "VAT Product Posting Group";
@@ -140,13 +140,12 @@ codeunit 134283 "Non-Deductible Purch. Posting"
         Currency: Record Currency;
         PurchPost: Codeunit "Purch.-Post";
         TotalVATAmount: Decimal;
-        VATIdentifier: Code[20];
+        NonDedVATIdentifier: Code[20];
     begin
-        // [SCENARIO 456471] Combine VAT amount line from two purchase lines (first has Non-Deductible VAT, second is not) has correct Non-Deductible VAT Base and Non-Deductible VAT Amount
-
+        // [SCENARIO 456471] Separate VAT amount lines from two purchase lines (first has Non-Deductible VAT, second is not) have correct Non-Deductible VAT Base and Non-Deductible VAT Amount
         Initialize();
         LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
-        VATIdentifier := VATPostingSetup."VAT Identifier";
+        NonDedVATIdentifier := VATPostingSetup."VAT Identifier";
         LibraryPurchase.CreatePurchHeader(
             PurchHeader, PurchHeader."Document Type"::Invoice,
             LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
@@ -154,9 +153,9 @@ codeunit 134283 "Non-Deductible Purch. Posting"
 
         LibraryERM.CreateVATProductPostingGroup(VATProductPostingGroup);
         LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Bus. Posting Group", VATProductPostingGroup.Code);
+        VATPostingSetup.Validate("VAT Identifier", VATProductPostingGroup.Code);
         VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
         VATPostingSetup.Validate("VAT %", LibraryRandom.RandIntInRange(10, 20));
-        VATPostingSetup.Validate("VAT Identifier", VATIdentifier);
         VATPostingSetup.Modify(true);
 
         CreatePurchLineItemWithVATProdPostingGroup(NormalPurchLine, PurchHeader, VATPostingSetup."VAT Prod. Posting Group");
@@ -168,12 +167,15 @@ codeunit 134283 "Non-Deductible Purch. Posting"
           TotalVATAmount, Currency, LibraryRandom.RandIntInRange(10, 50), false, 0, '', true, WorkDate(), false);
 
         // [THEN]
-        Assert.RecordCount(TempVATAmountLine, 1);
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Base"), Format(0));
-        ClearLastError();
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Amount"), Format(0));
+        Assert.RecordCount(TempVATAmountLine, 2);
+        TempVATAmountLine.SetRange("VAT Identifier", NonDedVATIdentifier);
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
+        TempVATAmountLine.SetRange("VAT Identifier", VATPostingSetup."VAT Identifier");
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", 0);
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", 0);
     end;
 
     [Test]

--- a/src/Layers/W1/BaseApp/Finance/VAT/Calculation/NonDedVATImpl.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/VAT/Calculation/NonDedVATImpl.Codeunit.al
@@ -538,8 +538,6 @@ codeunit 6201 "Non-Ded. VAT Impl."
         if IsHandled then
             exit;
 
-        if PurchaseLine."Non-Deductible VAT %" = 0 then
-            exit;
         PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type");
         PurchaseLine.SetRange("Document No.", PurchaseLine."Document No.");
         PurchaseLine.SetFilter("Line No.", '<>%1', PurchaseLine."Line No.");

--- a/src/Layers/W1/Tests/VAT/NonDedVATMisc.Codeunit.al
+++ b/src/Layers/W1/Tests/VAT/NonDedVATMisc.Codeunit.al
@@ -1591,6 +1591,8 @@ codeunit 134284 "Non Ded. VAT Misc."
     begin
         LibraryERM.FindVATPostingSetup(VATPostingSetup, VATCalculationType);
         DeductiblePercent := GetDeductibleVATPctFromVATPostingSetup(VATPostingSetup);
+        VATPostingSetup.Validate(
+            "VAT Identifier", LibraryUtility.GenerateRandomCode(VATPostingSetup.FieldNo("VAT Identifier"), Database::"VAT Posting Setup"));
         LibraryERM.CreateGLAccount(GLAccount);
         AssignNonDeductibleVATAccount(VATPostingSetup, GLAccount."No.");
         AssignDeductibleVATPct(VATPostingSetup, LibraryRandom.RandInt(99));
@@ -1682,6 +1684,8 @@ codeunit 134284 "Non Ded. VAT Misc."
         LibraryERM.FindVATPostingSetup(VATPostingSetup, VATCalcType);
         DeductiblePercent := GetDeductibleVATPctFromVATPostingSetup(VATPostingSetup);
         NonDeductGLAccountNo := VATPostingSetup."Non-Ded. Purchase VAT Account";
+        VATPostingSetup.Validate(
+            "VAT Identifier", LibraryUtility.GenerateRandomCode(VATPostingSetup.FieldNo("VAT Identifier"), Database::"VAT Posting Setup"));
         AssignNonDeductibleVATAccount(VATPostingSetup, '');
         AssignDeductibleVATPct(VATPostingSetup, 0);
         VATPostingSetup.Modify(true);

--- a/src/Layers/W1/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
+++ b/src/Layers/W1/Tests/VAT/NonDeductiblePurchPosting.Codeunit.al
@@ -128,7 +128,7 @@ codeunit 134283 "Non-Deductible Purch. Posting"
     end;
 
     [Test]
-    procedure CombinedVATAmountLineForTwoPurchLineFirstNonDedVATSecondNormalVAT()
+    procedure SeparateVATAmountLinesForTwoPurchLineFirstNonDedVATSecondNormalVAT()
     var
         VATPostingSetup: Record "VAT Posting Setup";
         VATProductPostingGroup: Record "VAT Product Posting Group";
@@ -140,13 +140,12 @@ codeunit 134283 "Non-Deductible Purch. Posting"
         Currency: Record Currency;
         PurchPost: Codeunit "Purch.-Post";
         TotalVATAmount: Decimal;
-        VATIdentifier: Code[20];
+        NonDedVATIdentifier: Code[20];
     begin
-        // [SCENARIO 456471] Combine VAT amount line from two purchase lines (first has Non-Deductible VAT, second is not) has correct Non-Deductible VAT Base and Non-Deductible VAT Amount
-
+        // [SCENARIO 456471] Separate VAT amount lines from two purchase lines (first has Non-Deductible VAT, second is not) have correct Non-Deductible VAT Base and Non-Deductible VAT Amount
         Initialize();
         LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
-        VATIdentifier := VATPostingSetup."VAT Identifier";
+        NonDedVATIdentifier := VATPostingSetup."VAT Identifier";
         LibraryPurchase.CreatePurchHeader(
             PurchHeader, PurchHeader."Document Type"::Invoice,
             LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
@@ -156,7 +155,6 @@ codeunit 134283 "Non-Deductible Purch. Posting"
         LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Bus. Posting Group", VATProductPostingGroup.Code);
         VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
         VATPostingSetup.Validate("VAT %", LibraryRandom.RandIntInRange(10, 20));
-        VATPostingSetup.Validate("VAT Identifier", VATIdentifier);
         VATPostingSetup.Modify(true);
 
         CreatePurchLineItemWithVATProdPostingGroup(NormalPurchLine, PurchHeader, VATPostingSetup."VAT Prod. Posting Group");
@@ -168,12 +166,15 @@ codeunit 134283 "Non-Deductible Purch. Posting"
           TotalVATAmount, Currency, LibraryRandom.RandIntInRange(10, 50), false, 0, '', true, WorkDate());
 
         // [THEN]
-        Assert.RecordCount(TempVATAmountLine, 1);
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Base"), Format(0));
-        ClearLastError();
-        asserterror TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
-        Assert.ExpectedTestFieldError(NonDedPurchLine.FieldCaption("Non-Deductible VAT Amount"), Format(0));
+        Assert.RecordCount(TempVATAmountLine, 2);
+        TempVATAmountLine.SetRange("VAT Identifier", NonDedVATIdentifier);
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", NonDedPurchLine."Non-Deductible VAT Base");
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", NonDedPurchLine."Non-Deductible VAT Amount");
+        TempVATAmountLine.SetRange("VAT Identifier", VATPostingSetup."VAT Identifier");
+        TempVATAmountLine.FindFirst();
+        TempVATAmountLine.TestField("Non-Deductible VAT Base", 0);
+        TempVATAmountLine.TestField("Non-Deductible VAT Amount", 0);
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/VAT/NonDeductibleUT.Codeunit.al
+++ b/src/Layers/W1/Tests/VAT/NonDeductibleUT.Codeunit.al
@@ -324,6 +324,8 @@ codeunit 134282 "Non-Deductible UT"
         // [GIVEN] Create/Modify VAT Product Posting Group and VAT Posting Setup.
         LibraryERM.CreateVATPostingSetup(VATPostingSetup, Vendor."VAT Bus. Posting Group", GLAccount."VAT Prod. Posting Group");
         VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Normal VAT");
+        if VATPostingSetup."VAT Identifier" = '' then
+            VATPostingSetup.Validate("VAT Identifier", VATPostingSetup."VAT Prod. Posting Group");
         VATPostingSetup.Validate("Allow Non-Deductible VAT", VATPostingSetup."Allow Non-Deductible VAT"::Allow);
         VATPostingSetup.Validate("VAT %", 20);
         VATPostingSetup.Validate("Non-Deductible VAT %", 100);
@@ -405,6 +407,66 @@ codeunit 134282 "Non-Deductible UT"
         ValueEntry.FindFirst();
         Assert.AreEqual(-PurchaseCost, ValueEntry."Cost Amount (Actual)",
             StrSubstNo(AmountErrorLbl, ValueEntry.FieldCaption("Cost Amount (Actual)"), -PurchaseCost));
+    end;
+
+    [Test]
+    procedure CannotSetZeroNonDedVATPercentInPurchaseLineWhenOtherLineHasNonZeroWithSameVATIdentifier()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+    begin
+        // [SCENARIO 647053] [AI test 1.0] Stan cannot set Non-Deductible VAT % to 0 in a purchase line when another line with
+        // the same VAT Identifier has a non-zero Non-Deductible VAT %, regardless of the order the lines were entered
+        Initialize();
+        // [GIVEN] VAT Posting Setup with "VAT Identifier" = "X", "Allow Non-Deductible VAT" is enabled and "Non-Deductible VAT %" = 10
+        LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
+        // [GIVEN] Purchase invoice with two lines, each with the same VAT Posting Setup and "Non-Deductible VAT %" = 10
+        LibraryPurchase.CreatePurchHeader(
+            PurchaseHeader, PurchaseHeader."Document Type"::Invoice,
+            LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
+        LibraryPurchase.CreatePurchaseLine(
+            PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item,
+            LibraryInventory.CreateItemWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), LibraryRandom.RandInt(100));
+        LibraryPurchase.CreatePurchaseLine(
+            PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item,
+            LibraryInventory.CreateItemWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), LibraryRandom.RandInt(100));
+
+        // [WHEN] Set "Non-Deductible VAT %" to 0 (deductible) in the second purchase line
+        asserterror PurchaseLine.Validate("Non-Deductible VAT %", 0);
+        // [THEN] An error message thrown that it is not possible to set different Non-Deductible VAT percents for the same VAT identifiers
+        Assert.ExpectedError(StrSubstNo(DifferentNonDedVATRatesSameVATIdentifierErr, VATPostingSetup."VAT Bus. Posting Group", VATPostingSetup."VAT Prod. Posting Group"));
+    end;
+
+    [Test]
+    procedure CannotSetNonZeroNonDedVATPercentInPurchaseLineWhenOtherLineHasZeroWithSameVATIdentifier()
+    var
+        VATPostingSetup: Record "VAT Posting Setup";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+    begin
+        // [SCENARIO 647053] Stan cannot set a non-zero Non-Deductible VAT % in a purchase line when another line with
+        // the same VAT Identifier already has Non-Deductible VAT % = 0 (reverse entry order of the previous scenario)
+        Initialize();
+        // [GIVEN] VAT Posting Setup with "VAT Identifier" = "X", "Allow Non-Deductible VAT" is enabled and "Non-Deductible VAT %" = 10
+        LibraryNonDeductibleVAT.CreateNonDeductibleNormalVATPostingSetup(VATPostingSetup);
+        // [GIVEN] Purchase invoice with a line where "Non-Deductible VAT %" is set to 0 (deductible)
+        LibraryPurchase.CreatePurchHeader(
+            PurchaseHeader, PurchaseHeader."Document Type"::Invoice,
+            LibraryPurchase.CreateVendorWithVATBusPostingGroup(VATPostingSetup."VAT Bus. Posting Group"));
+        LibraryPurchase.CreatePurchaseLine(
+            PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item,
+            LibraryInventory.CreateItemWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), LibraryRandom.RandInt(100));
+        PurchaseLine.Validate("Non-Deductible VAT %", 0);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] Add a second purchase line with the same VAT Identifier, which defaults to a non-zero "Non-Deductible VAT %"
+        asserterror
+            LibraryPurchase.CreatePurchaseLine(
+                PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item,
+                LibraryInventory.CreateItemWithVATProdPostingGroup(VATPostingSetup."VAT Prod. Posting Group"), LibraryRandom.RandInt(100));
+        // [THEN] An error message thrown that it is not possible to set different Non-Deductible VAT percents for the same VAT identifiers
+        Assert.ExpectedError(StrSubstNo(DifferentNonDedVATRatesSameVATIdentifierErr, VATPostingSetup."VAT Bus. Posting Group", VATPostingSetup."VAT Prod. Posting Group"));
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/Tests/VAT/NonDeductibleVATPostBasic.Codeunit.al
+++ b/src/Layers/W1/Tests/VAT/NonDeductibleVATPostBasic.Codeunit.al
@@ -326,6 +326,8 @@ codeunit 134285 "Non-Deductible VAT Post. Basic"
         LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Bus. Posting Group", VATProductPostingGroup.Code);
         VATPostingSetup.Validate("VAT Calculation Type", VATPostingSetup."VAT Calculation Type"::"Reverse Charge VAT");
         VATPostingSetup.Validate("VAT %", LibraryRandom.RandInt(10));
+        if VATPostingSetup."VAT Identifier" = '' then
+            VATPostingSetup.Validate("VAT Identifier", VATPostingSetup."VAT Prod. Posting Group");
         AssignDeductibleVATPct(VATPostingSetup, 0);
         VATPostingSetup.Validate("Purchase VAT Account", CreateSimpleGLAccount());
         VATPostingSetup.Validate("Reverse Chrg. VAT Acc.", CreateSimpleGLAccount());


### PR DESCRIPTION
Fixes [AB#648529](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648529)



