### PR TITLE
[Bug Fix] #295: Clarify SOA reply when a requested item variant cannot be matched

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/.resources/Prompts/SalesOrderAgent-AgentInstructions.json
+++ b/src/Apps/W1/SalesOrderAgent/app/.resources/Prompts/SalesOrderAgent-AgentInstructions.json
@@ -121,7 +121,7 @@
 							"steps": [
 								"Provide a table of all available options for each item, including their descriptions, availability level, price (incl. discount) and unit of measure.",
 								"Split the table into two based on whether the results are matching items or alternatives.",
-								"If there are item results with matching item false, distinguish a same-item variant alternative from a different-item alternative. When the result is the requested product with a different Variant Code, explain that the requested variant is unavailable and offer the result as an alternative variant; do not say that the product itself was not found. Otherwise, indicate that the queried item was not found and that alternative items are available.",
+								"If there are item results with matching item false, distinguish a same-item variant alternative from a different-item alternative. When the result is the requested product with a different Variant Code, make clear that the product itself was found; then explain that either the specific variant requested is unavailable or no specific variant could be determined from the customer's request, and offer the result as an available variant; do not say that the product was not found or was not found in a variant. Otherwise, indicate that the queried item was not found and that alternative items are available.",
 								{
 									"name": "capable_to_promise",
 									"value": "Provide a table listing all items that are currently unavailable but can be shipped on a later date, including their descriptions, earliest shipment date, price (incl. discount) and unit of measure."


### PR DESCRIPTION
## Bug Reference
Fixes microsoft/BCAppsBugFix#295 (Work item microsoft/BCAppsBugFix#295 / [AB#647058](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647058))

## Summary
The Sales Order Agent produced confusing customer-facing wording ("The requested BERLIN Guest Chair was not found in the searched variant.") when a customer asked about an item without pinning a specific variant. This reworded one instruction in the agent prompt so the reply makes clear the item itself was found and only the specific variant could not be determined/matched, then offers an alternative variant.

## Root Cause
The customer email reply is generated by AOAI, guided by the prompt resource `src/Apps/W1/SalesOrderAgent/app/.resources/Prompts/SalesOrderAgent-AgentInstructions.json` (the issue named a `.md` path that does not exist). In the "Send Items Request to Customer" step, the same-item variant-alternative instruction only covered the case where the customer requested a specific variant that was unavailable. It did not cover the case where the customer did not pin a specific variant (e.g. "I would like to buy 5 BERLIN Guest Chairs. what colors are available?"), so the model still described the item itself as "not found in" a variant.

## Changes Made
- `src/Apps/W1/SalesOrderAgent/app/.resources/Prompts/SalesOrderAgent-AgentInstructions.json`: Reworded the same-item variant-alternative instruction so the model (a) states the product itself was found, (b) covers both the specific-variant-unavailable case and the no-specific-variant-determined case, (c) offers the result as an available/alternative variant, and (d) never phrases it as the item being "not found in" a variant. The different-item branch is unchanged.

## Implementation Process

- Fix iterations: Not applicable - tests not required
- Compilation: ✅ All projects compile successfully
- Publish: ✅ Modified app published successfully
- Validation: Tests not required by the approved plan

## Validation Evidence

### No-Test Validation Evidence

- **Tests required by plan**: No
- **Rationale**: The confusing text is an AOAI-generated natural-language customer email produced from a prompt resource, not a deterministic AL Label or code branch. An AL automated test cannot meaningfully reproduce or assert the model's phrasing, and no existing AL test covers this wording.
- **Compilation**: ✅ All modified projects compiled successfully (full al_build of `src/Apps/W1/SalesOrderAgent/app`)
- **Publish**: ✅ Modified app published successfully to the BC container
- **Manual/external validation approach**: Full al_build of the Sales Order Agent app (which embeds the prompt JSON resource), then al_publish of the built app. Manual review confirms the reworded instruction directs the model to state the item was found, state the requested variant could not be determined/matched (covering the no-specific-variant case), and offer the alternative variant, without ever saying the item was "not found in" a variant.

## Validation Coverage

- [x] Automated tests: Not applicable per approved Test Strategy
- [x] Build and publish validation completed
- [ ] Manual/external validation: Send the Sales Order Agent a request for an item without pinning a variant (e.g. "I would like to buy 5 BERLIN Guest Chairs. what colors are available?") and confirm the reply no longer says the item was "not found in" a variant.

## Miapp Propagation

- **Layers propagated to**: None - the fix touched no propagated path (W1-only prompt resource with no country-layer counterparts)
- **Files changed by propagation**: 0
- **VerifyMiappSync**: ✅ No files still need to be integrated

## Review Notes
The change is confined to natural-language instruction text in a JSON prompt resource; no AL objects, control flow, or public APIs are affected.

🤖 Generated by the bc-fix-bug skill

---
Promoted from microsoft/BCAppsBugFix#331: https://github.com/microsoft/BCAppsBugFix/pull/331

Fixes [AB#647058](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647058)



