### PR TITLE
BC IQ - Update data sensitivities for policy history

### DIFF
--- a/src/Layers/W1/BaseApp/Utilities/DataClassificationEvalData.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Utilities/DataClassificationEvalData.Codeunit.al
@@ -3862,11 +3862,10 @@ codeunit 1751 "Data Classification Eval. Data"
         SetFieldToCompanyConfidential(40201, 7); // Entity Display Name
         SetFieldToCompanyConfidential(40201, 10); // Title
         SetFieldToCompanyConfidential(40201, 11); // Skill Text
+        SetFieldToPersonal(40201, 15); // Archived By
 
-        SetTableFieldsToNormal(40202); // "Business Skill Change Log"
-        SetFieldToPersonal(40202, 4); // Changed By
-        SetFieldToCompanyConfidential(40202, 6); // Previous Text
-        SetFieldToCompanyConfidential(40202, 7); // Skill Title
+        SetTableFieldsToNormal(40202); // "Business Skill Text Version"
+        SetFieldToCompanyConfidential(40202, 3); // Skill Text
 
         SetTableFieldsToNormal(40203); // "Business Skill Suggestion"
         SetFieldToCompanyConfidential(40203, 5); // Title


### PR DESCRIPTION
Updates the Business IQ evaluation data after Dynamics SMB/NAV PR 253367 replaced the change log with text versions and added the archived-by user identifier.

- Classifies Business Skill Archived By as Personal
- Classifies Business Skill Text Version Skill Text as Company Confidential
- Removes mappings for deleted Business Skill Change Log fields

Follow-up to #10573.

Fixes [AB#648256](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648256)




