### PR TITLE
[Extensibility Request] issue 30434: add purchase prepayment amount event

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1502,8 +1502,15 @@ codeunit 444 "Purchase-Post Prepayments"
         OnAfterApplyFilter(PurchLine, PurchHeader, DocumentType);
     end;
 
-    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic): Decimal
+    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic) Result: Decimal
+    var
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforePrepmtAmount(PurchLine, DocumentType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case DocumentType of
             DocumentType::Statistic:
                 exit(PurchLine."Prepmt. Line Amount");
@@ -2590,6 +2597,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBuildInvLineBufferOnPrepmtAmountZero(PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line"; var PrepaymentInvLineBuffer2: Record "Prepayment Inv. Line Buffer"; var PrepaymentInvLineBuffer: Record "Prepayment Inv. Line Buffer"; var TempPurchaseLineSource: Record "Purchase Line" temporary);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePrepmtAmount(var PurchaseLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; var Result: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1160,8 +1160,15 @@ codeunit 444 "Purchase-Post Prepayments"
         OnAfterApplyFilter(PurchLine, PurchHeader, DocumentType);
     end;
 
-    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic): Decimal
+    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic) Result: Decimal
+    var
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforePrepmtAmount(PurchLine, DocumentType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case DocumentType of
             DocumentType::Statistic:
                 exit(PurchLine."Prepmt. Line Amount");
@@ -2087,6 +2094,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBuildInvLineBufferOnPrepmtAmountZero(PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line"; var PrepaymentInvLineBuffer2: Record "Prepayment Inv. Line Buffer"; var PrepaymentInvLineBuffer: Record "Prepayment Inv. Line Buffer"; var TempPurchaseLineSource: Record "Purchase Line" temporary);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePrepmtAmount(var PurchaseLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; var Result: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/IT/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1225,8 +1225,15 @@ codeunit 444 "Purchase-Post Prepayments"
         OnAfterApplyFilter(PurchLine, PurchHeader, DocumentType);
     end;
 
-    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic): Decimal
+    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic) Result: Decimal
+    var
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforePrepmtAmount(PurchLine, DocumentType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case DocumentType of
             DocumentType::Statistic:
                 exit(PurchLine."Prepmt. Line Amount");
@@ -2198,6 +2205,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBuildInvLineBufferOnPrepmtAmountZero(PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line"; var PrepaymentInvLineBuffer2: Record "Prepayment Inv. Line Buffer"; var PrepaymentInvLineBuffer: Record "Prepayment Inv. Line Buffer"; var TempPurchaseLineSource: Record "Purchase Line" temporary);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePrepmtAmount(var PurchaseLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; var Result: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NA/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1192,10 +1192,16 @@ codeunit 444 "Purchase-Post Prepayments"
         exit(PrepmtAmount(PurchLine, DocumentType, PurchaseHeader."Prepmt. Include Tax"));
     end;
 
-    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; IncludeTax: Boolean): Decimal
+    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; IncludeTax: Boolean) Result: Decimal
     var
         PrepmtAmt: Decimal;
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforePrepmtAmount(PurchLine, DocumentType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case DocumentType of
             DocumentType::Statistic:
                 PrepmtAmt := PurchLine."Prepmt. Line Amount";
@@ -2113,6 +2119,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBuildInvLineBufferOnPrepmtAmountZero(PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line"; var PrepaymentInvLineBuffer2: Record "Prepayment Inv. Line Buffer"; var PrepaymentInvLineBuffer: Record "Prepayment Inv. Line Buffer"; var TempPurchaseLineSource: Record "Purchase Line" temporary);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePrepmtAmount(var PurchaseLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; var Result: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/NL/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/NL/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1154,8 +1154,15 @@ codeunit 444 "Purchase-Post Prepayments"
         OnAfterApplyFilter(PurchLine, PurchHeader, DocumentType);
     end;
 
-    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic): Decimal
+    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic) Result: Decimal
+    var
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforePrepmtAmount(PurchLine, DocumentType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case DocumentType of
             DocumentType::Statistic:
                 exit(PurchLine."Prepmt. Line Amount");
@@ -2049,6 +2056,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBuildInvLineBufferOnPrepmtAmountZero(PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line"; var PrepaymentInvLineBuffer2: Record "Prepayment Inv. Line Buffer"; var PrepaymentInvLineBuffer: Record "Prepayment Inv. Line Buffer"; var TempPurchaseLineSource: Record "Purchase Line" temporary);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePrepmtAmount(var PurchaseLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; var Result: Decimal; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Posting/PurchasePostPrepayments.Codeunit.al
@@ -1154,8 +1154,15 @@ codeunit 444 "Purchase-Post Prepayments"
         OnAfterApplyFilter(PurchLine, PurchHeader, DocumentType);
     end;
 
-    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic): Decimal
+    procedure PrepmtAmount(PurchLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic) Result: Decimal
+    var
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforePrepmtAmount(PurchLine, DocumentType, Result, IsHandled);
+        if IsHandled then
+            exit(Result);
+
         case DocumentType of
             DocumentType::Statistic:
                 exit(PurchLine."Prepmt. Line Amount");
@@ -2047,6 +2054,11 @@ codeunit 444 "Purchase-Post Prepayments"
 
     [IntegrationEvent(false, false)]
     local procedure OnBuildInvLineBufferOnPrepmtAmountZero(PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line"; var PrepaymentInvLineBuffer2: Record "Prepayment Inv. Line Buffer"; var PrepaymentInvLineBuffer: Record "Prepayment Inv. Line Buffer"; var TempPurchaseLineSource: Record "Purchase Line" temporary);
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforePrepmtAmount(var PurchaseLine: Record "Purchase Line"; DocumentType: Option Invoice,"Credit Memo",Statistic; var Result: Decimal; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions cannot currently override the prepayment amount calculated for purchase documents, even though the equivalent sales calculation is extensible. This change adds a handled event before the purchase prepayment calculation so subscribers can provide the result when standard logic does not meet their requirements.

Source issue repository: microsoft/AlAppExtensions; issue number: 30434

## Changes Made
- `Purchase-Post Prepayments.PrepmtAmount` - added `OnBeforePrepmtAmount` with an overridable result and propagated the event to all existing layer counterparts while preserving localized calculation logic

Fixes [AB#647921](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647921)



