### PR TITLE
[Extensibility Request] issue 30433: expose consolidated calendar entry before insert

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/WorkCenter/CalculateWorkCenterCalendar.Report.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/WorkCenter/CalculateWorkCenterCalendar.Report.al
@@ -81,6 +81,7 @@ report 99001046 "Calculate Work Center Calendar"
                                             until Calendar.Next() = 0;
                                             if Calendar2.Capacity <> 0 then begin
                                                 Calendar2.Validate(Capacity);
+                                                OnWorkCenterOnAfterGetRecordOnBeforeInsertConsolidatedCalendarEntry(Calendar, Calendar2);
                                                 Calendar2.Insert();
                                             end;
                                         end;
@@ -187,5 +188,9 @@ report 99001046 "Calculate Work Center Calendar"
     local procedure OnAfterDeleteWorkCenterCalendarEntries(var WorkCenter: Record "Work Center"; StartingDate: Date; EndingDate: Date)
     begin
     end;
-}
 
+    [IntegrationEvent(false, false)]
+    local procedure OnWorkCenterOnAfterGetRecordOnBeforeInsertConsolidatedCalendarEntry(var SourceCalendarEntries: Record "Calendar Entry"; var ConsolidatedCalendarEntry: Record "Calendar Entry")
+    begin
+    end;
+}


### PR DESCRIPTION
## Summary
Extensions need to preserve source calendar metadata when consolidated work center calendar entries are generated. The standard flow currently inserts each generated entry without exposing the filtered source entries or allowing the generated record to be adjusted. This PR adds an integration event immediately before insertion so subscribers can inspect all contributing entries and modify the consolidated entry.

Source issue repository: microsoft/AlAppExtensions; issue number: 30433

## Changes Made
- `Calculate Work Center Calendar.OnAfterGetRecord` - publishes the filtered source calendar entries and generated consolidated calendar entry immediately before insertion.
- `OnWorkCenterOnAfterGetRecordOnBeforeInsertConsolidatedCalendarEntry` - adds a non-handled integration event that lets subscribers transfer or derive metadata without bypassing standard logic.


Fixes [AB#648439](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648439)



