### PR TITLE
[Extensibility Request] issue 30431: expose report sender and globals

### DIFF
--- a/src/Layers/W1/BaseApp/Projects/TimeSheet/SuggestJobJnlLines.Report.al
+++ b/src/Layers/W1/BaseApp/Projects/TimeSheet/SuggestJobJnlLines.Report.al
@@ -258,12 +258,12 @@ report 952 "Suggest Job Jnl. Lines"
     begin
     end;
 
-    [IntegrationEvent(false, false)]
+    [IntegrationEvent(true, true)]
     local procedure OnBeforeInsertTempTimeSheetLine(JobJournalLine: Record "Job Journal Line"; TimeSheetHeader: Record "Time Sheet Header"; var TempTimeSheetLine: Record "Time Sheet Line" temporary; var SkipLine: Boolean)
     begin
     end;
 
-    [IntegrationEvent(false, false)]
+    [IntegrationEvent(true, true)]
     local procedure OnAfterTransferTimeSheetDetailToJobJnlLine(var JobJournalLine: Record "Job Journal Line"; JobJournalTemplate: Record "Job Journal Template"; var TempTimeSheetLine: Record "Time Sheet Line" temporary; TimeSheetDetail: Record "Time Sheet Detail"; JobJournalBatch: Record "Job Journal Batch"; var LineNo: Integer)
     begin
     end;

--- a/src/Layers/W1/BaseApp/Projects/TimeSheet/SuggestJobJnlLines.Report.al
+++ b/src/Layers/W1/BaseApp/Projects/TimeSheet/SuggestJobJnlLines.Report.al
@@ -258,12 +258,12 @@ report 952 "Suggest Job Jnl. Lines"
     begin
     end;
 
-    [IntegrationEvent(true, true)]
+    [IntegrationEvent(true, false)]
     local procedure OnBeforeInsertTempTimeSheetLine(JobJournalLine: Record "Job Journal Line"; TimeSheetHeader: Record "Time Sheet Header"; var TempTimeSheetLine: Record "Time Sheet Line" temporary; var SkipLine: Boolean)
     begin
     end;
 
-    [IntegrationEvent(true, true)]
+    [IntegrationEvent(true, false)]
     local procedure OnAfterTransferTimeSheetDetailToJobJnlLine(var JobJournalLine: Record "Job Journal Line"; JobJournalTemplate: Record "Job Journal Template"; var TempTimeSheetLine: Record "Time Sheet Line" temporary; TimeSheetDetail: Record "Time Sheet Detail"; JobJournalBatch: Record "Job Journal Batch"; var LineNo: Integer)
     begin
     end;


### PR DESCRIPTION
## Summary
Extensions need access to report 952 and its protected global variables when subscribing to the two time sheet processing events. The events currently exclude both the sender and global variables, preventing the requested report customization. This PR enables sender and global variable access for both existing publishers.

Source issue repository: microsoft/AlAppExtensions; issue number: 30431

## Changes Made
- `OnBeforeInsertTempTimeSheetLine` - enabled sender for subscribers
- `OnAfterTransferTimeSheetDetailToJobJnlLine` - enabled sender for subscribers

Fixes [AB#647662](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647662)




