### PR TITLE
[Extensibility Request] issue 30424: add prepayment update event

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -1229,6 +1229,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
         SalesHeader: Record "Sales Header";
         SalesLine: Record "Sales Line";
         Currency: Record Currency;
+        IsHandled: Boolean;
     begin
         if not SalesLine.Get(
             SalesLine."Document Type"::Order,
@@ -1242,6 +1243,11 @@ codeunit 1303 "Correct Posted Sales Invoice"
 
         SalesHeader.Get(SalesLine."Document Type"::Order, SalesLine."Document No.");
         Currency.Initialize(SalesHeader."Currency Code", true);
+
+        IsHandled := false;
+        OnUpdateSalesOrderLinePrepmtAmountOnBeforeUpdatePrepmtAmounts(SalesInvoiceLine, SalesLine, SalesHeader, Currency, IsHandled);
+        if IsHandled then
+            exit;
 
         if SalesHeader."Currency Code" <> '' then
             SalesLine.Validate(
@@ -1500,6 +1506,19 @@ codeunit 1303 "Correct Posted Sales Invoice"
     /// <param name="IsHandled">Set to true to skip default quantity update.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdateSalesOrderLineInvoicedQuantity(var SalesLine: Record "Sales Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before updating prepayment amounts on a sales order line during correction.
+    /// </summary>
+    /// <param name="SalesInvoiceLine">The sales invoice line being processed.</param>
+    /// <param name="SalesLine">The sales order line that would be updated.</param>
+    /// <param name="SalesHeader">The related sales order header.</param>
+    /// <param name="Currency">The initialized currency for the sales order.</param>
+    /// <param name="IsHandled">Set to true to skip the default prepayment amount update.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesOrderLinePrepmtAmountOnBeforeUpdatePrepmtAmounts(SalesInvoiceLine: Record "Sales Invoice Line"; var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; Currency: Record Currency; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -1212,6 +1212,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
         SalesHeader: Record "Sales Header";
         SalesLine: Record "Sales Line";
         Currency: Record Currency;
+        IsHandled: Boolean;
     begin
         if not SalesLine.Get(
             SalesLine."Document Type"::Order,
@@ -1225,6 +1226,11 @@ codeunit 1303 "Correct Posted Sales Invoice"
 
         SalesHeader.Get(SalesLine."Document Type"::Order, SalesLine."Document No.");
         Currency.Initialize(SalesHeader."Currency Code", true);
+
+        IsHandled := false;
+        OnUpdateSalesOrderLinePrepmtAmountOnBeforeUpdatePrepmtAmounts(SalesInvoiceLine, SalesLine, SalesHeader, Currency, IsHandled);
+        if IsHandled then
+            exit;
 
         if SalesHeader."Currency Code" <> '' then
             SalesLine.Validate(
@@ -1478,6 +1484,19 @@ codeunit 1303 "Correct Posted Sales Invoice"
     /// <param name="IsHandled">Set to true to skip default quantity update.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdateSalesOrderLineInvoicedQuantity(var SalesLine: Record "Sales Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before updating prepayment amounts on a sales order line during correction.
+    /// </summary>
+    /// <param name="SalesInvoiceLine">The sales invoice line being processed.</param>
+    /// <param name="SalesLine">The sales order line that would be updated.</param>
+    /// <param name="SalesHeader">The related sales order header.</param>
+    /// <param name="Currency">The initialized currency for the sales order.</param>
+    /// <param name="IsHandled">Set to true to skip the default prepayment amount update.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesOrderLinePrepmtAmountOnBeforeUpdatePrepmtAmounts(SalesInvoiceLine: Record "Sales Invoice Line"; var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; Currency: Record Currency; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/History/CorrectPostedSalesInvoice.Codeunit.al
@@ -1212,6 +1212,7 @@ codeunit 1303 "Correct Posted Sales Invoice"
         SalesHeader: Record "Sales Header";
         SalesLine: Record "Sales Line";
         Currency: Record Currency;
+        IsHandled: Boolean;
     begin
         if not SalesLine.Get(
             SalesLine."Document Type"::Order,
@@ -1225,6 +1226,11 @@ codeunit 1303 "Correct Posted Sales Invoice"
 
         SalesHeader.Get(SalesLine."Document Type"::Order, SalesLine."Document No.");
         Currency.Initialize(SalesHeader."Currency Code", true);
+
+        IsHandled := false;
+        OnUpdateSalesOrderLinePrepmtAmountOnBeforeUpdatePrepmtAmounts(SalesInvoiceLine, SalesLine, SalesHeader, Currency, IsHandled);
+        if IsHandled then
+            exit;
 
         if SalesHeader."Currency Code" <> '' then
             SalesLine.Validate(
@@ -1478,6 +1484,19 @@ codeunit 1303 "Correct Posted Sales Invoice"
     /// <param name="IsHandled">Set to true to skip default quantity update.</param>
     [IntegrationEvent(false, false)]
     local procedure OnBeforeUpdateSalesOrderLineInvoicedQuantity(var SalesLine: Record "Sales Line"; CancelledQuantity: Decimal; CancelledQtyBase: Decimal; var IsHandled: Boolean)
+    begin
+    end;
+
+    /// <summary>
+    /// Raised before updating prepayment amounts on a sales order line during correction.
+    /// </summary>
+    /// <param name="SalesInvoiceLine">The sales invoice line being processed.</param>
+    /// <param name="SalesLine">The sales order line that would be updated.</param>
+    /// <param name="SalesHeader">The related sales order header.</param>
+    /// <param name="Currency">The initialized currency for the sales order.</param>
+    /// <param name="IsHandled">Set to true to skip the default prepayment amount update.</param>
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateSalesOrderLinePrepmtAmountOnBeforeUpdatePrepmtAmounts(SalesInvoiceLine: Record "Sales Invoice Line"; var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header"; Currency: Record Currency; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## Summary
Extensions need a supported way to prevent sales order prepayment amounts from being restored when correcting a posted sales invoice. This PR adds a handled integration event after currency initialization so subscribers can skip the standard prepayment amount updates safely.

Source issue repository: microsoft/AlAppExtensions; issue number: 30424

## Changes Made
- `UpdateSalesOrderLinePrepmtAmount` - Added a handled event before prepayment amounts are updated, including the existing ES and APAC layer counterparts.

Fixes [AB#648506](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648506)


