### PR TITLE
[Extensibility Request] issue 30442: allow filtering item units during weight updates

### DIFF
--- a/src/Layers/APAC/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/APAC/BaseApp/Inventory/Item/Item.Table.al
@@ -4027,11 +4027,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/CH/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/CH/BaseApp/Inventory/Item/Item.Table.al
@@ -4055,11 +4055,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/ES/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/ES/BaseApp/Inventory/Item/Item.Table.al
@@ -4023,11 +4023,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/GB/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/GB/BaseApp/Inventory/Item/Item.Table.al
@@ -4029,11 +4029,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/IT/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/IT/BaseApp/Inventory/Item/Item.Table.al
@@ -4026,11 +4026,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/NA/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/NA/BaseApp/Inventory/Item/Item.Table.al
@@ -4072,11 +4072,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/RU/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/RU/BaseApp/Inventory/Item/Item.Table.al
@@ -4036,11 +4036,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/W1/BaseApp/Inventory/Item/Item.Table.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/Item.Table.al
@@ -4015,11 +4015,17 @@ table 27 Item
             exit;
 
         ItemUOM.SetRange("Item No.", "No.");
+        OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(Rec, ItemUOM);
         if ItemUOM.FindSet(true) then
             repeat
                 ItemUOM.CalcWeight(ItemUOM."Qty. per Unit of Measure", "Net Weight");
                 ItemUOM.Modify();
             until ItemUOM.Next() = 0;
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight(var Item: Record Item; var ItemUnitOfMeasure: Record "Item Unit of Measure")
+    begin
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
## Summary
Extensions need to exclude selected item units of measure, including the base unit, when recalculating weights from the item's net weight. The current implementation fixes the record filter immediately before processing, leaving no supported way to narrow the affected units. This PR adds an integration event that exposes the item and filtered item-unit record before recalculation begins.

Source issue repository: microsoft/AlAppExtensions; issue number: 30442

## Changes Made
- `Item.UpdateItemUnitOfMeasureWeight` - added `OnUpdateItemUnitOfMeasureWeightOnBeforeCalcWeight` before `FindSet` so subscribers can adjust the item-unit filter, propagated to all existing layer counterparts.

Fixes [AB#648438](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648438)




