### PR TITLE
[29.x] Expense Agent: Improve expense activity history captions

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Pages/ExpenseActivityLogFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Pages/ExpenseActivityLogFactBox.Page.al
@@ -9,7 +9,7 @@ page 7123 "Expense Activity Log FactBox"
     PageType = ListPart;
     SourceTable = "Expense Activity Log Entry";
     SourceTableView = sorting("Source Table ID", "Source Record System ID", "Occurred At", "Entry No.") order(descending);
-    Caption = 'Activity Log';
+    Caption = 'History';
     ApplicationArea = Basic, Suite;
     Editable = false;
     InsertAllowed = false;
@@ -25,19 +25,15 @@ page 7123 "Expense Activity Log FactBox"
             {
                 field("Event Type"; Rec."Event Type")
                 {
-                    ToolTip = 'Specifies what happened to the expense report.';
                 }
                 field("Occurred At"; Rec."Occurred At")
                 {
-                    ToolTip = 'Specifies when the activity occurred.';
                 }
                 field("Actor Display Name"; Rec."Actor Display Name")
                 {
-                    ToolTip = 'Specifies the person who performed the activity, when there was one.';
                 }
                 field(Comment; Rec.Comment)
                 {
-                    ToolTip = 'Specifies the message recorded with the activity.';
                 }
             }
         }

--- a/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Tables/ExpenseActivityLogEntry.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ActivityLog/Tables/ExpenseActivityLogEntry.Table.al
@@ -60,15 +60,15 @@ table 7100 "Expense Activity Log Entry"
         }
         field(8; "Event Type"; Enum "Expense Activity Event Type")
         {
-            Caption = 'Event Type';
+            Caption = 'Activity';
             DataClassification = SystemMetadata;
-            ToolTip = 'Specifies what happened to the expense report.';
+            ToolTip = 'Specifies the activity that occurred for the expense report.';
         }
         field(9; "Occurred At"; DateTime)
         {
-            Caption = 'Occurred At';
+            Caption = 'Date and Time';
             DataClassification = SystemMetadata;
-            ToolTip = 'Specifies when the activity occurred.';
+            ToolTip = 'Specifies the date and time when the activity occurred.';
         }
         field(10; "Initiated By"; Enum "Expense Activity Initiator")
         {
@@ -99,9 +99,9 @@ table 7100 "Expense Activity Log Entry"
         }
         field(14; "Actor Display Name"; Text[100])
         {
-            Caption = 'Actor Display Name';
+            Caption = 'Performed By';
             DataClassification = EndUserIdentifiableInformation;
-            ToolTip = 'Specifies the actor name captured when the activity occurred.';
+            ToolTip = 'Specifies the name of the user or agent that performed the activity.';
         }
         field(15; "Amount (LCY)"; Decimal)
         {
@@ -158,9 +158,9 @@ table 7100 "Expense Activity Log Entry"
         }
         field(50; Comment; Text[2048])
         {
-            Caption = 'Comment';
+            Caption = 'Details';
             DataClassification = CustomerContent;
-            ToolTip = 'Specifies the message recorded with the activity.';
+            ToolTip = 'Specifies additional details recorded for the activity.';
         }
         field(51; Categories; Text[2048])
         {

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReport.Page.al
@@ -208,7 +208,7 @@ page 6980 "Manager Expense Report"
             part(Activity; "Expense Activity Log FactBox")
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Activity Log';
+                Caption = 'History';
                 SubPageLink = "Source Table ID" = const(Database::"Expense Report Header"),
                               "Source Record System ID" = field(SystemId);
                 Visible = Rec."No." <> '';

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
@@ -258,7 +258,7 @@ page 6910 "Expense Report"
             part(Activity; "Expense Activity Log FactBox")
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Activity Log';
+                Caption = 'History';
                 SubPageLink = "Source Table ID" = const(Database::"Expense Report Header"),
                               "Source Record System ID" = field(SystemId);
                 Visible = Rec."No." <> '';

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReport.Page.al
@@ -173,7 +173,7 @@ page 6998 "Posted Expense Report"
             part(Activity; "Expense Activity Log FactBox")
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Activity Log';
+                Caption = 'History';
                 SubPageLink = "Source Table ID" = const(Database::"Posted Expense Report Header"),
                               "Source Record System ID" = field(SystemId);
                 Visible = Rec."No." <> '';


### PR DESCRIPTION
## Summary

Backport of #10614 to `releases/29.x`.

- rename the Business Central activity log FactBox to **History**
- replace technical column captions with **Activity**, **Date and Time**, **Performed By**, and **Details**
- inherit field tooltips from the activity log table instead of duplicating them on the FactBox

## Validation

- deterministic backport patch matches #10614
- no conflicts or deviations
- no functional behavior or API contract changes
- build and AL tests not run

Fixes [AB#648599](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648599)
Related: [AB#647739](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647739)


