### PR TITLE
[releases/29.x] Let the agent update invoice due dates

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Profile/PageCustomizations/PAEDocPurchaseDraft.PageCust.al
+++ b/src/Apps/W1/PayablesAgent/app/Profile/PageCustomizations/PAEDocPurchaseDraft.PageCust.al
@@ -27,6 +27,10 @@ pagecustomization "PA E-Doc. Purchase Draft" customizes "E-Document Purchase Dra
         {
             Visible = true;
         }
+        modify("Due Date")
+        {
+            Visible = true;
+        }
         modify(Record)
         {
             Visible = true;


### PR DESCRIPTION
Backport of #10084.

The Payables Agent could not update the due date when a user requested the correction during draft review because the field was hidden by the agent's page customization.

This makes the existing editable Due Date field visible to the agent so it can apply the correction and return the updated draft for review.

Fixes [AB#648606](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648606)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app locally with no new warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Before the change, I asked the agent to update the Due Date during draft review. The agent reported that the field was unavailable for editing.
- After exposing the field, I repeated the scenario. The agent updated the Due Date and returned the draft for review without finalizing it.

## Risk & compatibility

Low. This only exposes the existing editable Due Date control to the Payables Agent profile. It does not change the underlying field behavior, data model, permissions, or upgrade logic.



