### PR TITLE
Fix ExtRequest feedback comment detection

### DIFF
--- a/.github/workflows/bc-extrequest-triage-dispatch.yml
+++ b/.github/workflows/bc-extrequest-triage-dispatch.yml
@@ -49,11 +49,10 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
           $marker = "<!-- bc-extrequest-feedback-recorded:$env:COMMENT_ID -->"
-          $comments = gh api `
+          $comments = (gh api `
             "repos/$env:GITHUB_REPOSITORY/issues/${{ github.event.issue.number }}/comments" `
-            --paginate --slurp --jq 'add // [] | map(.body // "")' |
-            ConvertFrom-Json
-          if ($comments | Where-Object { $_.Contains($marker) }) {
+            --paginate --jq '.[].body // ""') -join "`n"
+          if ($comments.Contains($marker)) {
               Add-Content -Path $env:GITHUB_OUTPUT -Value 'process=false'
               Write-Host 'Feedback was already recorded for this comment.'
               exit 0


### PR DESCRIPTION
## Summary

Fixes `/not-accurate` feedback processing in the BC ExtRequest triage dispatcher. The duplicate-detection step combined `gh api --slurp` with `--jq`, which is unsupported and caused the job to fail before telemetry dispatch and acknowledgement.

## Changes

- Query paginated issue comment bodies with `--jq` without `--slurp`.
- Join the returned bodies before checking for the acknowledgement marker.

This addresses the failure observed in https://github.com/microsoft/BCApps/actions/runs/33275105949 after the feedback comment on #10782.

Fixes [AB#646910](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646910)


