### PR TITLE
[29.x] - Bug 648636: Expense Agent - Rename Enable approval workflow caption and tooltip

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetup.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetup.Page.al
@@ -220,9 +220,11 @@ page 6996 "Expense Agent Setup"
                 }
                 field("Enable Approval Workflow"; Rec."Enable Approval Workflow")
                 {
+                    Importance = Additional;
                 }
                 field(DefaultApprover; Rec."Default Approver Name")
                 {
+                    Importance = Additional;
                     DrillDown = false;
 
                     trigger OnAssistEdit()

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
@@ -431,8 +431,8 @@ table 6930 "Expense Agent Setup"
         }
         field(80; "Enable Approval Workflow"; Boolean)
         {
-            Caption = 'Enable approval workflow';
-            ToolTip = 'Specifies whether approval workflow is enabled for expense reports.';
+            Caption = 'Use traditional approval workflow';
+            ToolTip = 'Specifies whether expense reports use the traditional approval workflow instead of the Expense Agent approval experience.';
 
             trigger OnValidate()
             begin


### PR DESCRIPTION
Fixes [AB#648636](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648636)

**Issue**: The Expense Agent Setup page used the caption "Enable approval workflow", which did not clearly explain that the setting switches expense reports to the traditional approval workflow instead of the Expense Agent approval experience.

**Cause**: The field caption and tooltip were generic, and approval setup controls were grouped in a way that made the relationship between the workflow setting and related approver setup unclear.

**Solution**: Rename the caption to "Use traditional approval workflow", clarify the tooltip, and group the approval setup controls so the setting and related fields are easier to understand.





