### PR TITLE
Bug 626576: Surface AppSource install errors instead of failing silently

### DIFF
--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -48,6 +48,8 @@ codeunit 2501 "Extension Marketplace"
         TelemetryTok: Label 'ExtensionManagementTelemetryCategoryTok', Locked = true;
         OperationResult: Option UserNotAuthorized,DeploymentFailedDueToPackage,DeploymentFailed,Successful,UserCancel,UserTimeOut;
         AppDoesntNeedSetupMsg: Label 'Your app is installed and ready to use.';
+        InstallationFailedMsg: Label 'The app could not be installed.\%1', Comment = '%1=the error that was reported by the installation';
+        InstallationFailedTelemetryTxt: Label 'AppSource app installation failed. App ID: %1. Error: %2', Comment = '%1=the app id of the extension, %2=the error that was reported by the installation';
 
     local procedure GetValue(JObject: DotNet JObject; Property: Text; ThrowError: Boolean): Text
     begin
@@ -260,20 +262,29 @@ codeunit 2501 "Extension Marketplace"
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
         MySessionSettings: SessionSettings;
         AppId: Guid;
+        InstallErrorText: Text;
     begin
         ExtensionInstallationImpl.CheckPermissions();
 
-        if not InstallAppsourceExtension(MarketplaceApplicationID, TelemetryURL) then begin // successful installation returns false
-            AppId := MapMarketplaceIdToAppId(MarketplaceApplicationID);
-            if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
-                SaveExtensionPendingSetup(AppId);
-                MySessionSettings.Init();
-                MySessionSettings.RequestSessionUpdate(false);
-            end else begin
-                ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
-                ExtensionPendingSetup.DeleteAll();
-            end;
+        // InstallAppsourceExtension is a TryFunction, so it returns false when the installation raised an error.
+        if InstallAppsourceExtension(MarketplaceApplicationID, TelemetryURL) then
+            exit;
+
+        // Capture the error before any other statement resets it.
+        InstallErrorText := GetLastErrorText();
+
+        AppId := MapMarketplaceIdToAppId(MarketplaceApplicationID);
+        if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
+            SaveExtensionPendingSetup(AppId);
+            MySessionSettings.Init();
+            MySessionSettings.RequestSessionUpdate(false);
+            exit;
         end;
+
+        ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
+        ExtensionPendingSetup.DeleteAll();
+
+        NotifyInstallationFailed(AppId, InstallErrorText);
     end;
 
     procedure InstallAppsourceExtensionWithRefreshSession(AppId: Guid; TelemetryURL: Text);
@@ -281,18 +292,39 @@ codeunit 2501 "Extension Marketplace"
         ExtensionPendingSetup: Record "Extension Pending Setup";
         ExtensionInstallationImpl: Codeunit "Extension Installation Impl";
         MySessionSettings: SessionSettings;
+        InstallErrorText: Text;
     begin
         ExtensionInstallationImpl.CheckPermissions();
 
-        if not InstallAppsourceExtension(AppId, TelemetryURL) then // successful installation returns false
-            if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
-                SaveExtensionPendingSetup(AppId);
-                MySessionSettings.Init();
-                MySessionSettings.RequestSessionUpdate(false);
-            end else begin
-                ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
-                ExtensionPendingSetup.DeleteAll();
-            end;
+        // InstallAppsourceExtension is a TryFunction, so it returns false when the installation raised an error.
+        if InstallAppsourceExtension(AppId, TelemetryURL) then
+            exit;
+
+        // Capture the error before any other statement resets it.
+        InstallErrorText := GetLastErrorText();
+
+        if ExtensionInstallationImpl.IsInstalledByAppId(AppId) then begin
+            SaveExtensionPendingSetup(AppId);
+            MySessionSettings.Init();
+            MySessionSettings.RequestSessionUpdate(false);
+            exit;
+        end;
+
+        ExtensionPendingSetup.SetRange("User Id", UserSecurityId());
+        ExtensionPendingSetup.DeleteAll();
+
+        NotifyInstallationFailed(AppId, InstallErrorText);
+    end;
+
+    local procedure NotifyInstallationFailed(AppId: Guid; InstallErrorText: Text)
+    begin
+        // An empty error text means the installation was stopped without raising an error,
+        // for example when the user declined the dependency confirmation. Nothing to report.
+        if InstallErrorText = '' then
+            exit;
+
+        Session.LogMessage('0000QAA', StrSubstNo(InstallationFailedTelemetryTxt, AppId, InstallErrorText), Verbosity::Warning, DataClassification::CustomerContent, TelemetryScope::ExtensionPublisher, 'Category', TelemetryTok);
+        Message(InstallationFailedMsg, InstallErrorText);
     end;
 
     [TryFunction]


### PR DESCRIPTION
InstallAppsourceExtensionWithRefreshSession calls InstallAppsourceExtension, which is a [TryFunction]. When the installation raised an error the TryFunction swallowed it and the caller never read GetLastErrorText(), so the install dialog just closed with nothing shown to the user.

Both overloads now capture GetLastErrorText() immediately after the TryFunction returns false and surface it via Message(), matching the existing pattern in InvokeExtensionInstallation. Also adds telemetry for the failure and corrects the misleading "successful installation returns false" comment.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes #

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<img width="1430" height="1077" alt="image" src="https://github.com/user-attachments/assets/0c23d68c-90c0-431f-bb40-39de6c26872b" />


<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


