### PR TITLE
[29.x] Hide currency fields in General Ledger Setup

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Currency/ShowCurrencyGenLedgSetup.PageExt.al
+++ b/src/Layers/W1/BaseApp/Finance/Currency/ShowCurrencyGenLedgSetup.PageExt.al
@@ -17,7 +17,8 @@ pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Show Currency';
-                importance = Additional;
+                Importance = Additional;
+                Visible = false;
 
                 trigger OnValidate()
                 begin
@@ -28,7 +29,8 @@ pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
             {
                 ApplicationArea = Basic, Suite;
                 Caption = 'Currency Symbol Position';
-                importance = Additional;
+                Importance = Additional;
+                Visible = false;
 
                 trigger OnValidate()
                 begin


### PR DESCRIPTION
## What & why

Hides the **Show Currency** and **Currency Symbol Position** fields on the General Ledger Setup page. These fields should not be exposed in the 29.x release.

## Linked work

Approved GitHub issue: [AB#648671](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648671) 

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Compared the branch with `releases/29.x`; the pull request contains one commit modifying only `ShowCurrencyGenLedgSetup.PageExt.al`.
- Ran `git diff --check` successfully.
- No automated test was added because this change only controls page field visibility.
- Local build and Business Central UI validation have not been run yet.

## Risk & compatibility

Low risk. The change only hides two existing setup fields and does not alter stored data, permissions, upgrade behavior, or public APIs.


