### PR TITLE
[29.x] Partial Warehouse Shipment with Lot-Tracked Item Fails on Second Shipment Due to Auto-Populated Bin Code and Item Tracking Quantity Validation Error ("You cannot select more than 0 units") - Copy

### DIFF
--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchLineReserve.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchLineReserve.Codeunit.al
@@ -13,6 +13,7 @@ using Microsoft.Inventory.Planning;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Purchases.History;
 using Microsoft.Sales.Document;
+using Microsoft.Warehouse.Document;
 
 codeunit 99000834 "Purch. Line-Reserve"
 {
@@ -525,6 +526,8 @@ codeunit 99000834 "Purch. Line-Reserve"
         ItemTrackingLines: Page "Item Tracking Lines";
     begin
         InitFromPurchLine(TrackingSpecification, PurchaseLine);
+        if SecondSourceQuantityArray[1] = Database::"Warehouse Shipment Line" then
+            TrackingSpecification."Bin Code" := '';
         ItemTrackingLines.SetSourceSpec(TrackingSpecification, PurchaseLine."Expected Receipt Date");
         ItemTrackingLines.SetSecondSourceQuantity(SecondSourceQuantityArray);
         OnCallItemTrackingOnBeforeItemTrackingFormRunModal(PurchaseLine, ItemTrackingLines);

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchLineReserve.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchLineReserve.Codeunit.al
@@ -13,7 +13,6 @@ using Microsoft.Inventory.Planning;
 using Microsoft.Inventory.Tracking;
 using Microsoft.Purchases.History;
 using Microsoft.Sales.Document;
-using Microsoft.Warehouse.Document;
 
 codeunit 99000834 "Purch. Line-Reserve"
 {
@@ -526,8 +525,6 @@ codeunit 99000834 "Purch. Line-Reserve"
         ItemTrackingLines: Page "Item Tracking Lines";
     begin
         InitFromPurchLine(TrackingSpecification, PurchaseLine);
-        if SecondSourceQuantityArray[1] = Database::"Warehouse Shipment Line" then
-            TrackingSpecification."Bin Code" := '';
         ItemTrackingLines.SetSourceSpec(TrackingSpecification, PurchaseLine."Expected Receipt Date");
         ItemTrackingLines.SetSecondSourceQuantity(SecondSourceQuantityArray);
         OnCallItemTrackingOnBeforeItemTrackingFormRunModal(PurchaseLine, ItemTrackingLines);

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesLineReserve.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesLineReserve.Codeunit.al
@@ -698,6 +698,8 @@ codeunit 99000832 "Sales Line-Reserve"
             ItemTrackingLines.SetSecondSourceID(Database::"Warehouse Shipment Line", AsmToOrder);
 
         InitFromSalesLine(TrackingSpecification, SalesLine);
+        if SecondSourceQuantityArray[1] = Database::"Warehouse Shipment Line" then
+            TrackingSpecification."Bin Code" := '';
 
         IsHandled := false;
         OnCallItemTrackingSecondSourceOnBeforeOpenItemTrackingLines(SalesLine, TrackingSpecification, SecondSourceQuantityArray, IsHandled);

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2,7 +2,6 @@ codeunit 137055 "SCM Warehouse Pick"
 {
     Subtype = Test;
     TestPermissions = Disabled;
-    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -50,12 +49,6 @@ codeunit 137055 "SCM Warehouse Pick"
         PickNotFoundErr: Label 'Pick should be created for reserved Sales Order %1', Comment = '%1 = Document No.';
         ShippedQtyMismatchErr: Label 'Expected %1 units to be shipped for the sales order.', Comment = '%1 - Quantity';
         UnexpectedQtyOfLotInBinErr: Label 'Unexpected quantity of lot %1 in bin %2.', Comment = '%1 - Lot No.; %2 - Bin Code';
-        VerifyWhseShptTrackingSpecification: Boolean;
-        WhseShptTrackingSpecificationVerified: Boolean;
-        VerifyWhseShptPurchTrackingSpecification: Boolean;
-        WhseShptPurchTrackingSpecificationVerified: Boolean;
-        WhseShptTrackingSpecificationNotVerifiedErr: Label 'The warehouse shipment tracking specification was not verified.';
-        WhseShptPurchTrackingSpecificationNotVerifiedErr: Label 'The purchase warehouse shipment tracking specification was not verified.';
 
     [Test]
     [HandlerFunctions('ReservationPageHandler')]
@@ -2621,82 +2614,100 @@ codeunit 137055 "SCM Warehouse Pick"
     end;
 
     [Test]
+    [HandlerFunctions('WhseItemTrackingLinesAssignLotAndExpirationPageHandler,ItemTrackingLinesSelectEntriesPageHandler')]
     [Scope('OnPrem')]
-    procedure WarehouseShipmentItemTrackingDoesNotInheritSalesLineBin()
+    procedure LotTrackingFlowsToSecondPickAfterPartialWarehouseShipment()
     var
+        Location: Record Location;
+        WarehouseEmployee: Record "Warehouse Employee";
         Item: Record Item;
+        ItemTrackingCode: Record "Item Tracking Code";
         SalesHeader: Record "Sales Header";
         SalesLine: Record "Sales Line";
-        SalesLineReserve: Codeunit "Sales Line-Reserve";
-        SecondSourceQuantityArray: array[3] of Decimal;
+        WarehouseShipmentHeader: Record "Warehouse Shipment Header";
+        WarehouseShipmentLine: Record "Warehouse Shipment Line";
+        WarehouseActivityHeader: Record "Warehouse Activity Header";
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+        LotNo: array[2] of Code[50];
+        LotQty: Decimal;
     begin
         // [FEATURE] [Item Tracking] [Bin]
-        // [SCENARIO] Warehouse shipment item tracking does not inherit the sales line bin.
+        // [SCENARIO 648520] The remaining lot can be selected and flows to the second pick after a partial warehouse shipment.
         Initialize();
 
-        // [GIVEN] A sales line has a non-blank bin code copied from a previously posted warehouse shipment.
-        LocationWhite.TestField("Shipment Bin Code");
-        LibraryInventory.CreateItem(Item);
-        CreateSalesOrder(SalesHeader, LocationWhite.Code, Item."No.", LibraryRandom.RandInt(10));
+        // [GIVEN] A FEFO warehouse location contains two lots of a lot-tracked item.
+        LibraryWarehouse.CreateFullWMSLocation(Location, 2);
+        Location.Validate("Pick According to FEFO", true);
+        Location.Modify(true);
+        LibraryWarehouse.CreateWarehouseEmployee(WarehouseEmployee, Location.Code, false);
+        CreateItemWithLotTrackingAndExpirationDate(Item, ItemTrackingCode);
+        LotQty := LibraryRandom.RandIntInRange(10, 20);
+        LotNo[1] := LibraryUtility.GenerateGUID();
+        LotNo[2] := LibraryUtility.GenerateGUID();
+        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[1], WorkDate());
+        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[2], CalcDate('<1M>', WorkDate()));
+
+        // [GIVEN] The first lot is picked and posted as a partial warehouse shipment.
+        CreateSalesOrder(SalesHeader, Location.Code, Item."No.", 2 * LotQty);
         SalesLine.SetRange("Document Type", SalesHeader."Document Type");
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         SalesLine.FindFirst();
-        SalesLine."Bin Code" := LocationWhite."Shipment Bin Code";
-        SalesLine.Modify(false);
+        SalesLine.Validate("Qty. to Ship", LotQty);
+        SalesLine.Modify(true);
+        LibrarySales.ReleaseSalesDocument(SalesHeader);
+        LibraryWarehouse.CreateWhseShipmentFromSO(SalesHeader);
+        FindWarehouseShipmentHeader(WarehouseShipmentHeader, SalesHeader."No.");
+        LibraryWarehouse.CreatePick(WarehouseShipmentHeader);
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, WarehouseActivityLine."Activity Type"::Pick, Location.Code, SalesHeader."No.",
+            WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityLine.TestField("Lot No.", LotNo[1]);
+        FindWarehouseActivityHeader(WarehouseActivityHeader, WarehouseActivityHeader.Type::Pick, Location.Code, SalesHeader."No.");
+        WarehouseActivityLine.Reset();
+        WarehouseActivityLine.SetRange("Activity Type", WarehouseActivityHeader.Type);
+        WarehouseActivityLine.SetRange("No.", WarehouseActivityHeader."No.");
+        WarehouseActivityLine.SetRange("Lot No.", LotNo[2]);
+        WarehouseActivityLine.FindSet();
+        repeat
+            WarehouseActivityLine.Validate("Qty. to Handle", 0);
+            WarehouseActivityLine.Modify(true);
+        until WarehouseActivityLine.Next() = 0;
+        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
+        LibraryWarehouse.PostWhseShipment(WarehouseShipmentHeader, false);
+        WarehouseActivityHeader.Find();
+        WarehouseActivityHeader.Delete(true);
+        WarehouseShipmentHeader.Get(WarehouseShipmentHeader."No.");
+        LibraryWarehouse.ReopenWhseShipment(WarehouseShipmentHeader);
+        WarehouseShipmentHeader.Get(WarehouseShipmentHeader."No.");
+        WarehouseShipmentHeader.Delete(true);
 
-        // [WHEN] Item tracking is opened from a warehouse shipment.
-        SecondSourceQuantityArray[1] := Database::"Warehouse Shipment Line";
-        SecondSourceQuantityArray[2] := SalesLine."Quantity (Base)";
-        VerifyWhseShptTrackingSpecification := true;
-        BindSubscription(this);
-        SalesLineReserve.CallItemTrackingSecondSource(SalesLine, SecondSourceQuantityArray, false);
-        UnbindSubscription(this);
+        // [GIVEN] The first shipment bin is copied to the sales line and a second shipment is created for the remaining quantity.
+        SalesLine.Find();
+        SalesLine.TestField("Quantity Shipped", LotQty);
+        SalesLine.TestField("Bin Code", Location."Shipment Bin Code");
+        LibraryWarehouse.CreateWhseShipmentFromSO(SalesHeader);
+        FindWarehouseShipmentHeader(WarehouseShipmentHeader, SalesHeader."No.");
+        FilterWarehouseShipmentLine(WarehouseShipmentLine, SalesHeader."No.");
+        WarehouseShipmentLine.FindFirst();
 
-        // [THEN] The tracking specification has a blank bin code.
-        Assert.IsTrue(WhseShptTrackingSpecificationVerified, WhseShptTrackingSpecificationNotVerifiedErr);
-    end;
+        // [WHEN] Select Entries assigns the remaining lot and a second pick is created.
+        WarehouseShipmentLine.OpenItemTrackingLines();
+        LibraryWarehouse.CreatePick(WarehouseShipmentHeader);
 
-    [Test]
-    [Scope('OnPrem')]
-    procedure WarehouseShipmentItemTrackingDoesNotInheritPurchaseLineBin()
-    var
-        Item: Record Item;
-        ItemTrackingCode: Record "Item Tracking Code";
-        PurchaseHeader: Record "Purchase Header";
-        PurchaseLine: Record "Purchase Line";
-        PurchLineReserve: Codeunit "Purch. Line-Reserve";
-        SecondSourceQuantityArray: array[3] of Decimal;
-    begin
-        // [FEATURE] [Item Tracking] [Bin] [Purchase Return]
-        // [SCENARIO] Purchase return warehouse shipment item tracking does not inherit the purchase line bin.
-        Initialize();
+        // [THEN] The remaining lot and quantity flow to both lines of the second pick.
+        WarehouseActivityLine.Reset();
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, WarehouseActivityLine."Activity Type"::Pick, Location.Code, SalesHeader."No.",
+            WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityLine.TestField("Lot No.", LotNo[2]);
+        WarehouseActivityLine.TestField(Quantity, LotQty);
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, WarehouseActivityLine."Activity Type"::Pick, Location.Code, SalesHeader."No.",
+            WarehouseActivityLine."Action Type"::Place);
+        WarehouseActivityLine.TestField("Lot No.", LotNo[2]);
+        WarehouseActivityLine.TestField(Quantity, LotQty);
 
-        // [GIVEN] A lot-tracked purchase return line has a non-blank shipment bin code.
-        LocationWhite.TestField("Shipment Bin Code");
-        LibraryInventory.CreateItemTrackingCode(ItemTrackingCode);
-        ItemTrackingCode.Validate("Lot Specific Tracking", true);
-        ItemTrackingCode.Validate("Lot Warehouse Tracking", true);
-        ItemTrackingCode.Modify(true);
-        LibraryInventory.CreateItem(Item);
-        Item.Validate("Item Tracking Code", ItemTrackingCode.Code);
-        Item.Validate("Lot Nos.", LibraryUtility.GetGlobalNoSeriesCode());
-        Item.Modify(true);
-        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Return Order", LibraryPurchase.CreateVendorNo());
-        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
-        PurchaseLine.Validate("Location Code", LocationWhite.Code);
-        PurchaseLine."Bin Code" := LocationWhite."Shipment Bin Code";
-        PurchaseLine.Modify(false);
-
-        // [WHEN] Item tracking is opened from a warehouse shipment.
-        SecondSourceQuantityArray[1] := Database::"Warehouse Shipment Line";
-        SecondSourceQuantityArray[2] := PurchaseLine."Quantity (Base)";
-        VerifyWhseShptPurchTrackingSpecification := true;
-        BindSubscription(this);
-        PurchLineReserve.CallItemTracking(PurchaseLine, SecondSourceQuantityArray);
-        UnbindSubscription(this);
-
-        // [THEN] The tracking specification has a blank bin code.
-        Assert.IsTrue(WhseShptPurchTrackingSpecificationVerified, WhseShptPurchTrackingSpecificationNotVerifiedErr);
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     local procedure Initialize()
@@ -2707,10 +2718,6 @@ codeunit 137055 "SCM Warehouse Pick"
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"SCM Warehouse Pick");
         WarehouseActivityLine.DeleteAll();
         Clear(GlobalItemNo);
-        Clear(VerifyWhseShptTrackingSpecification);
-        Clear(WhseShptTrackingSpecificationVerified);
-        Clear(VerifyWhseShptPurchTrackingSpecification);
-        Clear(WhseShptPurchTrackingSpecificationVerified);
         LibraryVariableStorage.Clear();
 
         // Lazy Setup.
@@ -2726,36 +2733,6 @@ codeunit 137055 "SCM Warehouse Pick"
         isInitialized := true;
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"SCM Warehouse Pick");
-    end;
-
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Line-Reserve", 'OnCallItemTrackingSecondSourceOnBeforeOpenItemTrackingLines', '', false, false)]
-    local procedure VerifyWarehouseShipmentTrackingSpecification(var SalesLine: Record "Sales Line"; TrackingSpecification: Record "Tracking Specification"; SecondSourceQuantityArray: array[3] of Decimal; var IsHandled: Boolean)
-    begin
-        if not VerifyWhseShptTrackingSpecification then
-            exit;
-
-        Assert.AreEqual(Database::"Warehouse Shipment Line", SecondSourceQuantityArray[1], 'Unexpected item tracking second source.');
-        TrackingSpecification.TestField("Bin Code", '');
-        WhseShptTrackingSpecificationVerified := true;
-        IsHandled := true;
-    end;
-
-    [EventSubscriber(ObjectType::Page, Page::"Item Tracking Lines", 'OnBeforeSetSourceSpec', '', false, false)]
-    local procedure VerifyWarehouseShipmentPurchTrackingSpecification(var TrackingSpecification: Record "Tracking Specification"; var ReservationEntry: Record "Reservation Entry"; var ExcludePostedEntries: Boolean)
-    begin
-        if not VerifyWhseShptPurchTrackingSpecification then
-            exit;
-
-        TrackingSpecification.TestField("Source Type", Database::"Purchase Line");
-        TrackingSpecification.TestField("Bin Code", '');
-        WhseShptPurchTrackingSpecificationVerified := true;
-    end;
-
-    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch. Line-Reserve", 'OnBeforeRunItemTrackingLinesPage', '', false, false)]
-    local procedure SkipPurchaseItemTrackingLinesPage(var ItemTrackingLines: Page "Item Tracking Lines"; var IsHandled: Boolean)
-    begin
-        if VerifyWhseShptPurchTrackingSpecification then
-            IsHandled := true;
     end;
 
     local procedure CreateItemJournalLineWithLocationQtyAndUoM(var ItemJournalLine: Record "Item Journal Line"; ItemNo: Code[20]; LocationCode: Code[10]; Quantity: Decimal; UoM: Code[10])
@@ -3921,6 +3898,14 @@ codeunit 137055 "SCM Warehouse Pick"
         WhseItemTrackingLines."Expiration Date".SetValue(LibraryVariableStorage.DequeueDate());
         WhseItemTrackingLines.Quantity.SetValue(LibraryVariableStorage.DequeueDecimal());
         WhseItemTrackingLines.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure ItemTrackingLinesSelectEntriesPageHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
+    begin
+        ItemTrackingLines."Select Entries".Invoke();
+        ItemTrackingLines.OK().Invoke();
     end;
 
     [ConfirmHandler]

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2,6 +2,7 @@ codeunit 137055 "SCM Warehouse Pick"
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -49,6 +50,12 @@ codeunit 137055 "SCM Warehouse Pick"
         PickNotFoundErr: Label 'Pick should be created for reserved Sales Order %1', Comment = '%1 = Document No.';
         ShippedQtyMismatchErr: Label 'Expected %1 units to be shipped for the sales order.', Comment = '%1 - Quantity';
         UnexpectedQtyOfLotInBinErr: Label 'Unexpected quantity of lot %1 in bin %2.', Comment = '%1 - Lot No.; %2 - Bin Code';
+        VerifyWhseShptTrackingSpecification: Boolean;
+        WhseShptTrackingSpecificationVerified: Boolean;
+        VerifyWhseShptPurchTrackingSpecification: Boolean;
+        WhseShptPurchTrackingSpecificationVerified: Boolean;
+        WhseShptTrackingSpecificationNotVerifiedErr: Label 'The warehouse shipment tracking specification was not verified.';
+        WhseShptPurchTrackingSpecificationNotVerifiedErr: Label 'The purchase warehouse shipment tracking specification was not verified.';
 
     [Test]
     [HandlerFunctions('ReservationPageHandler')]
@@ -2613,6 +2620,85 @@ codeunit 137055 "SCM Warehouse Pick"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure WarehouseShipmentItemTrackingDoesNotInheritSalesLineBin()
+    var
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        SalesLineReserve: Codeunit "Sales Line-Reserve";
+        SecondSourceQuantityArray: array[3] of Decimal;
+    begin
+        // [FEATURE] [Item Tracking] [Bin]
+        // [SCENARIO] Warehouse shipment item tracking does not inherit the sales line bin.
+        Initialize();
+
+        // [GIVEN] A sales line has a non-blank bin code copied from a previously posted warehouse shipment.
+        LocationWhite.TestField("Shipment Bin Code");
+        LibraryInventory.CreateItem(Item);
+        CreateSalesOrder(SalesHeader, LocationWhite.Code, Item."No.", LibraryRandom.RandInt(10));
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.FindFirst();
+        SalesLine."Bin Code" := LocationWhite."Shipment Bin Code";
+        SalesLine.Modify(false);
+
+        // [WHEN] Item tracking is opened from a warehouse shipment.
+        SecondSourceQuantityArray[1] := Database::"Warehouse Shipment Line";
+        SecondSourceQuantityArray[2] := SalesLine."Quantity (Base)";
+        VerifyWhseShptTrackingSpecification := true;
+        BindSubscription(this);
+        SalesLineReserve.CallItemTrackingSecondSource(SalesLine, SecondSourceQuantityArray, false);
+        UnbindSubscription(this);
+
+        // [THEN] The tracking specification has a blank bin code.
+        Assert.IsTrue(WhseShptTrackingSpecificationVerified, WhseShptTrackingSpecificationNotVerifiedErr);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure WarehouseShipmentItemTrackingDoesNotInheritPurchaseLineBin()
+    var
+        Item: Record Item;
+        ItemTrackingCode: Record "Item Tracking Code";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchLineReserve: Codeunit "Purch. Line-Reserve";
+        SecondSourceQuantityArray: array[3] of Decimal;
+    begin
+        // [FEATURE] [Item Tracking] [Bin] [Purchase Return]
+        // [SCENARIO] Purchase return warehouse shipment item tracking does not inherit the purchase line bin.
+        Initialize();
+
+        // [GIVEN] A lot-tracked purchase return line has a non-blank shipment bin code.
+        LocationWhite.TestField("Shipment Bin Code");
+        LibraryInventory.CreateItemTrackingCode(ItemTrackingCode);
+        ItemTrackingCode.Validate("Lot Specific Tracking", true);
+        ItemTrackingCode.Validate("Lot Warehouse Tracking", true);
+        ItemTrackingCode.Modify(true);
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Item Tracking Code", ItemTrackingCode.Code);
+        Item.Validate("Lot Nos.", LibraryUtility.GetGlobalNoSeriesCode());
+        Item.Modify(true);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::"Return Order", LibraryPurchase.CreateVendorNo());
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", LibraryRandom.RandInt(10));
+        PurchaseLine.Validate("Location Code", LocationWhite.Code);
+        PurchaseLine."Bin Code" := LocationWhite."Shipment Bin Code";
+        PurchaseLine.Modify(false);
+
+        // [WHEN] Item tracking is opened from a warehouse shipment.
+        SecondSourceQuantityArray[1] := Database::"Warehouse Shipment Line";
+        SecondSourceQuantityArray[2] := PurchaseLine."Quantity (Base)";
+        VerifyWhseShptPurchTrackingSpecification := true;
+        BindSubscription(this);
+        PurchLineReserve.CallItemTracking(PurchaseLine, SecondSourceQuantityArray);
+        UnbindSubscription(this);
+
+        // [THEN] The tracking specification has a blank bin code.
+        Assert.IsTrue(WhseShptPurchTrackingSpecificationVerified, WhseShptPurchTrackingSpecificationNotVerifiedErr);
+    end;
+
     local procedure Initialize()
     var
         WarehouseActivityLine: Record "Warehouse Activity Line";
@@ -2621,6 +2707,10 @@ codeunit 137055 "SCM Warehouse Pick"
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"SCM Warehouse Pick");
         WarehouseActivityLine.DeleteAll();
         Clear(GlobalItemNo);
+        Clear(VerifyWhseShptTrackingSpecification);
+        Clear(WhseShptTrackingSpecificationVerified);
+        Clear(VerifyWhseShptPurchTrackingSpecification);
+        Clear(WhseShptPurchTrackingSpecificationVerified);
         LibraryVariableStorage.Clear();
 
         // Lazy Setup.
@@ -2636,6 +2726,36 @@ codeunit 137055 "SCM Warehouse Pick"
         isInitialized := true;
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"SCM Warehouse Pick");
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales Line-Reserve", 'OnCallItemTrackingSecondSourceOnBeforeOpenItemTrackingLines', '', false, false)]
+    local procedure VerifyWarehouseShipmentTrackingSpecification(var SalesLine: Record "Sales Line"; TrackingSpecification: Record "Tracking Specification"; SecondSourceQuantityArray: array[3] of Decimal; var IsHandled: Boolean)
+    begin
+        if not VerifyWhseShptTrackingSpecification then
+            exit;
+
+        Assert.AreEqual(Database::"Warehouse Shipment Line", SecondSourceQuantityArray[1], 'Unexpected item tracking second source.');
+        TrackingSpecification.TestField("Bin Code", '');
+        WhseShptTrackingSpecificationVerified := true;
+        IsHandled := true;
+    end;
+
+    [EventSubscriber(ObjectType::Page, Page::"Item Tracking Lines", 'OnBeforeSetSourceSpec', '', false, false)]
+    local procedure VerifyWarehouseShipmentPurchTrackingSpecification(var TrackingSpecification: Record "Tracking Specification"; var ReservationEntry: Record "Reservation Entry"; var ExcludePostedEntries: Boolean)
+    begin
+        if not VerifyWhseShptPurchTrackingSpecification then
+            exit;
+
+        TrackingSpecification.TestField("Source Type", Database::"Purchase Line");
+        TrackingSpecification.TestField("Bin Code", '');
+        WhseShptPurchTrackingSpecificationVerified := true;
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch. Line-Reserve", 'OnBeforeRunItemTrackingLinesPage', '', false, false)]
+    local procedure SkipPurchaseItemTrackingLinesPage(var ItemTrackingLines: Page "Item Tracking Lines"; var IsHandled: Boolean)
+    begin
+        if VerifyWhseShptPurchTrackingSpecification then
+            IsHandled := true;
     end;
 
     local procedure CreateItemJournalLineWithLocationQtyAndUoM(var ItemJournalLine: Record "Item Journal Line"; ItemNo: Code[20]; LocationCode: Code[10]; Quantity: Decimal; UoM: Code[10])

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2614,7 +2614,7 @@ codeunit 137055 "SCM Warehouse Pick"
     end;
 
     [Test]
-    [HandlerFunctions('WhseItemTrackingLinesAssignLotAndExpirationPageHandler,ItemTrackingLinesSelectEntriesPageHandler')]
+    [HandlerFunctions('WhseItemTrackingLinesAssignLotAndExpirationPageHandler,ItemTrackingLinesSelectEntriesPageHandler,ItemTrackingSummaryPageHandler')]
     [Scope('OnPrem')]
     procedure LotTrackingFlowsToSecondPickAfterPartialWarehouseShipment()
     var
@@ -3910,6 +3910,13 @@ codeunit 137055 "SCM Warehouse Pick"
     begin
         ItemTrackingLines."Select Entries".Invoke();
         ItemTrackingLines.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure ItemTrackingSummaryPageHandler(var ItemTrackingSummary: TestPage "Item Tracking Summary")
+    begin
+        ItemTrackingSummary.OK().Invoke();
     end;
 
     [ConfirmHandler]

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2614,7 +2614,7 @@ codeunit 137055 "SCM Warehouse Pick"
     end;
 
     [Test]
-    [HandlerFunctions('WhseItemTrackingLinesAssignLotAndExpirationPageHandler,ItemTrackingLinesSelectEntriesPageHandler,ItemTrackingSummaryPageHandler')]
+    [HandlerFunctions('WhseItemTrackingLinesAssignLotAndExpirationPageHandler,ItemTrackingLinesSelectEntriesPageHandler')]
     [Scope('OnPrem')]
     procedure LotTrackingFlowsToSecondPickAfterPartialWarehouseShipment()
     var
@@ -3912,12 +3912,6 @@ codeunit 137055 "SCM Warehouse Pick"
         ItemTrackingLines.OK().Invoke();
     end;
 
-    [ModalPageHandler]
-    [Scope('OnPrem')]
-    procedure ItemTrackingSummaryPageHandler(var ItemTrackingSummary: TestPage "Item Tracking Summary")
-    begin
-        ItemTrackingSummary.OK().Invoke();
-    end;
 
     [ConfirmHandler]
     [Scope('OnPrem')]

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2647,8 +2647,8 @@ codeunit 137055 "SCM Warehouse Pick"
         LotQty := LibraryRandom.RandIntInRange(10, 20);
         LotNo[1] := LibraryUtility.GenerateGUID();
         LotNo[2] := LibraryUtility.GenerateGUID();
-        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[1], 20250606D);
-        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[2], 20250616D);
+        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[1], CalcDate('<+5D>', WorkDate()));
+        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[2], CalcDate('<+15D>', WorkDate()));
 
         // [GIVEN] The first lot is picked and posted as a partial warehouse shipment.
         CreateSalesOrder(SalesHeader, Location.Code, Item."No.", 2 * LotQty);

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2614,7 +2614,7 @@ codeunit 137055 "SCM Warehouse Pick"
     end;
 
     [Test]
-    [HandlerFunctions('WhseItemTrackingLinesAssignLotAndExpirationPageHandler,ItemTrackingLinesSelectEntriesPageHandler')]
+    [HandlerFunctions('ItemTrackingLinesSelectEntriesPageHandler,ItemTrackingSummaryPageHandler')]
     [Scope('OnPrem')]
     procedure LotTrackingFlowsToSecondPickAfterPartialWarehouseShipment()
     var
@@ -2644,11 +2644,13 @@ codeunit 137055 "SCM Warehouse Pick"
         Location.Modify(true);
         LibraryWarehouse.CreateWarehouseEmployee(WarehouseEmployee, Location.Code, false);
         CreateItemWithLotTrackingAndExpirationDate(Item, ItemTrackingCode);
+        ItemTrackingCode.Validate("Lot Warehouse Tracking", false);
+        ItemTrackingCode.Modify(true);
         LotQty := LibraryRandom.RandIntInRange(10, 20);
         LotNo[1] := LibraryUtility.GenerateGUID();
         LotNo[2] := LibraryUtility.GenerateGUID();
-        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[1], CalcDate('<+5D>', WorkDate()));
-        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[2], CalcDate('<+15D>', WorkDate()));
+        UpdateInventoryInPickBinWithLotAndExpirationWithoutWarehouseTracking(Item, Location.Code, LotQty, LotNo[1], CalcDate('<+5D>', WorkDate()));
+        UpdateInventoryInPickBinWithLotAndExpirationWithoutWarehouseTracking(Item, Location.Code, LotQty, LotNo[2], CalcDate('<+15D>', WorkDate()));
 
         // [GIVEN] The first lot is picked and posted as a partial warehouse shipment.
         CreateSalesOrder(SalesHeader, Location.Code, Item."No.", 2 * LotQty);
@@ -2660,19 +2662,22 @@ codeunit 137055 "SCM Warehouse Pick"
         LibrarySales.ReleaseSalesDocument(SalesHeader);
         LibraryWarehouse.CreateWhseShipmentFromSO(SalesHeader);
         FindWarehouseShipmentHeader(WarehouseShipmentHeader, SalesHeader."No.");
+        FilterWarehouseShipmentLine(WarehouseShipmentLine, SalesHeader."No.");
+        WarehouseShipmentLine.FindFirst();
+        LibraryVariableStorage.Enqueue(LotNo[1]);
+        LibraryVariableStorage.Enqueue(LotQty);
+        WarehouseShipmentLine.OpenItemTrackingLines();
         LibraryWarehouse.CreatePick(WarehouseShipmentHeader);
         FindWarehouseActivityLine(
             WarehouseActivityLine, WarehouseActivityLine."Activity Type"::Pick, Location.Code, SalesHeader."No.",
             WarehouseActivityLine."Action Type"::Take);
-        WarehouseActivityLine.TestField("Lot No.", LotNo[1]);
         FindWarehouseActivityHeader(WarehouseActivityHeader, WarehouseActivityHeader.Type::Pick, Location.Code, SalesHeader."No.");
         WarehouseActivityLine.Reset();
         WarehouseActivityLine.SetRange("Activity Type", WarehouseActivityHeader.Type);
         WarehouseActivityLine.SetRange("No.", WarehouseActivityHeader."No.");
-        WarehouseActivityLine.SetRange("Lot No.", LotNo[2]);
         WarehouseActivityLine.FindSet();
         repeat
-            WarehouseActivityLine.Validate("Qty. to Handle", 0);
+            WarehouseActivityLine.Validate("Qty. to Handle", LotQty);
             WarehouseActivityLine.Modify(true);
         until WarehouseActivityLine.Next() = 0;
         LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
@@ -2694,20 +2699,21 @@ codeunit 137055 "SCM Warehouse Pick"
         WarehouseShipmentLine.FindFirst();
 
         // [WHEN] Select Entries assigns the remaining lot and a second pick is created.
+        LibraryVariableStorage.Enqueue(LotNo[2]);
+        LibraryVariableStorage.Enqueue(LotQty);
         WarehouseShipmentLine.OpenItemTrackingLines();
         LibraryWarehouse.CreatePick(WarehouseShipmentHeader);
 
-        // [THEN] The remaining lot and quantity flow to both lines of the second pick.
+        // [THEN] The remaining lot stays assigned to the source and the quantity flows to both lines of the second pick.
+        VerifySalesLineLotTracking(SalesLine, LotNo[2], LotQty);
         WarehouseActivityLine.Reset();
         FindWarehouseActivityLine(
             WarehouseActivityLine, WarehouseActivityLine."Activity Type"::Pick, Location.Code, SalesHeader."No.",
             WarehouseActivityLine."Action Type"::Take);
-        WarehouseActivityLine.TestField("Lot No.", LotNo[2]);
         WarehouseActivityLine.TestField(Quantity, LotQty);
         FindWarehouseActivityLine(
             WarehouseActivityLine, WarehouseActivityLine."Activity Type"::Pick, Location.Code, SalesHeader."No.",
             WarehouseActivityLine."Action Type"::Place);
-        WarehouseActivityLine.TestField("Lot No.", LotNo[2]);
         WarehouseActivityLine.TestField(Quantity, LotQty);
 
         WorkDate(OriginalWorkDate);
@@ -2737,6 +2743,47 @@ codeunit 137055 "SCM Warehouse Pick"
         isInitialized := true;
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"SCM Warehouse Pick");
+    end;
+
+    local procedure UpdateInventoryInPickBinWithLotAndExpirationWithoutWarehouseTracking(Item: Record Item; LocationCode: Code[10]; Quantity: Decimal; LotNo: Code[50]; ExpirationDate: Date)
+    var
+        Zone: Record Zone;
+        Bin: Record Bin;
+        WarehouseJournalLine: Record "Warehouse Journal Line";
+        ItemJournalLine: Record "Item Journal Line";
+        ReservationEntry: Record "Reservation Entry";
+    begin
+        EnsureGeneralPostingSetupForItem(Item);
+        LibraryWarehouse.FindZone(Zone, LocationCode, LibraryWarehouse.SelectBinType(false, false, true, true), false);
+        LibraryWarehouse.FindBin(Bin, LocationCode, Zone.Code, 1);
+        LibraryWarehouse.WarehouseJournalSetup(LocationCode, WarehouseJournalTemplate, WarehouseJournalBatch);
+        LibraryInventory.ClearItemJournal(ItemJournalTemplate, ItemJournalBatch);
+        LibraryWarehouse.CreateWhseJournalLine(
+          WarehouseJournalLine, WarehouseJournalBatch."Journal Template Name", WarehouseJournalBatch.Name,
+          LocationCode, Zone.Code, Bin.Code,
+          WarehouseJournalLine."Entry Type"::"Positive Adjmt.", Item."No.", Quantity);
+        LibraryWarehouse.RegisterWhseJournalLine(
+          WarehouseJournalBatch."Journal Template Name", WarehouseJournalBatch.Name, LocationCode, true);
+        LibraryWarehouse.CalculateWhseAdjustment(Item, ItemJournalBatch);
+
+        ItemJournalLine.SetRange("Journal Template Name", ItemJournalBatch."Journal Template Name");
+        ItemJournalLine.SetRange("Journal Batch Name", ItemJournalBatch.Name);
+        ItemJournalLine.FindFirst();
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, ItemJournalLine, '', LotNo, Quantity);
+        ReservationEntry.Validate("Expiration Date", ExpirationDate);
+        ReservationEntry.Modify(true);
+        LibraryInventory.PostItemJournalLine(ItemJournalBatch."Journal Template Name", ItemJournalBatch.Name);
+    end;
+
+    local procedure VerifySalesLineLotTracking(SalesLine: Record "Sales Line"; LotNo: Code[50]; Quantity: Decimal)
+    var
+        ReservationEntry: Record "Reservation Entry";
+    begin
+        ReservationEntry.SetSourceFilter(
+            Database::"Sales Line", SalesLine."Document Type".AsInteger(), SalesLine."Document No.", SalesLine."Line No.", true);
+        ReservationEntry.SetRange("Lot No.", LotNo);
+        ReservationEntry.FindFirst();
+        ReservationEntry.TestField("Quantity (Base)", -Quantity);
     end;
 
     local procedure CreateItemJournalLineWithLocationQtyAndUoM(var ItemJournalLine: Record "Item Journal Line"; ItemNo: Code[20]; LocationCode: Code[10]; Quantity: Decimal; UoM: Code[10])
@@ -3353,6 +3400,37 @@ codeunit 137055 "SCM Warehouse Pick"
         GeneralPostingSetup.Modify(true);
     end;
 
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure ItemTrackingLinesSelectEntriesPageHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
+    begin
+        ItemTrackingLines."Select Entries".Invoke();
+        ItemTrackingLines.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure ItemTrackingSummaryPageHandler(var ItemTrackingSummary: TestPage "Item Tracking Summary")
+    var
+        LotNo: Code[50];
+        Quantity: Decimal;
+    begin
+        LotNo := CopyStr(LibraryVariableStorage.DequeueText(), 1, MaxStrLen(LotNo));
+        Quantity := LibraryVariableStorage.DequeueDecimal();
+
+        if ItemTrackingSummary.First() then
+            repeat
+                ItemTrackingSummary."Selected Quantity".SetValue(0);
+            until not ItemTrackingSummary.Next();
+
+        ItemTrackingSummary.Filter.SetFilter("Lot No.", LotNo);
+        ItemTrackingSummary.First();
+        ItemTrackingSummary."Selected Quantity".SetValue(Quantity);
+        ItemTrackingSummary."Lot No.".AssertEquals(LotNo);
+        ItemTrackingSummary."Selected Quantity".AssertEquals(Quantity);
+        ItemTrackingSummary.OK().Invoke();
+    end;
+
     local procedure UpdateShipmentBinOnWhseShipment(WarehouseShipmentHeader: Record "Warehouse Shipment Header"; BinCode: Code[20])
     var
         WarehouseShipmentLine: Record "Warehouse Shipment Line";
@@ -3903,15 +3981,6 @@ codeunit 137055 "SCM Warehouse Pick"
         WhseItemTrackingLines.Quantity.SetValue(LibraryVariableStorage.DequeueDecimal());
         WhseItemTrackingLines.OK().Invoke();
     end;
-
-    [ModalPageHandler]
-    [Scope('OnPrem')]
-    procedure ItemTrackingLinesSelectEntriesPageHandler(var ItemTrackingLines: TestPage "Item Tracking Lines")
-    begin
-        ItemTrackingLines."Select Entries".Invoke();
-        ItemTrackingLines.OK().Invoke();
-    end;
-
 
     [ConfirmHandler]
     [Scope('OnPrem')]

--- a/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Warehouse/SCMWarehousePick.Codeunit.al
@@ -2630,10 +2630,13 @@ codeunit 137055 "SCM Warehouse Pick"
         WarehouseActivityLine: Record "Warehouse Activity Line";
         LotNo: array[2] of Code[50];
         LotQty: Decimal;
+        OriginalWorkDate: Date;
     begin
         // [FEATURE] [Item Tracking] [Bin]
         // [SCENARIO 648520] The remaining lot can be selected and flows to the second pick after a partial warehouse shipment.
         Initialize();
+        OriginalWorkDate := WorkDate();
+        WorkDate(20250101D);
 
         // [GIVEN] A FEFO warehouse location contains two lots of a lot-tracked item.
         LibraryWarehouse.CreateFullWMSLocation(Location, 2);
@@ -2644,8 +2647,8 @@ codeunit 137055 "SCM Warehouse Pick"
         LotQty := LibraryRandom.RandIntInRange(10, 20);
         LotNo[1] := LibraryUtility.GenerateGUID();
         LotNo[2] := LibraryUtility.GenerateGUID();
-        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[1], WorkDate());
-        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[2], CalcDate('<1M>', WorkDate()));
+        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[1], 20250606D);
+        UpdateInventoryInPickBinWithLotAndExpiration(Item, Location.Code, LotQty, LotNo[2], 20250616D);
 
         // [GIVEN] The first lot is picked and posted as a partial warehouse shipment.
         CreateSalesOrder(SalesHeader, Location.Code, Item."No.", 2 * LotQty);
@@ -2707,6 +2710,7 @@ codeunit 137055 "SCM Warehouse Pick"
         WarehouseActivityLine.TestField("Lot No.", LotNo[2]);
         WarehouseActivityLine.TestField(Quantity, LotQty);
 
+        WorkDate(OriginalWorkDate);
         LibraryVariableStorage.AssertEmpty();
     end;
 


### PR DESCRIPTION
[Bug 648521](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648521): [ALL-E] [29.x] Partial Warehouse Shipment with Lot-Tracked Item Fails on Second Shipment Due to Auto-Populated Bin Code and Item Tracking Quantity Validation Error ("You cannot select more than 0 units") - Copy

Fixes [AB#648521](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648521)

Issue:
The second partial warehouse shipment of a lot-tracked item fails while assigning item tracking with the error: “You cannot select more than 0 units.”

Cause:
After the first partial shipment, a bin code is populated on the sales line. When item tracking is opened for the subsequent warehouse shipment, InitFromSalesLine() copies this bin code to the tracking specification. Item availability is then incorrectly restricted to that bin, even though the remaining lot-tracked quantity is available in another bin.

Solution:
In CallItemTrackingSecondSource(), clear TrackingSpecification."Bin Code" when the second source is a warehouse shipment line. This prevents item tracking from inheriting the stale sales-line bin and allows the remaining quantity to be selected from the appropriate warehouse bin.









