### PR TITLE
[main] bug 643971 - Enhance vendor and customer checks in advance letters and update blocked status validation

### DIFF
--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Reports/CreatePurchAdvLetterCZZ.Report.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Reports/CreatePurchAdvLetterCZZ.Report.al
@@ -7,6 +7,7 @@ namespace Microsoft.Finance.AdvancePayments;
 using Microsoft.Finance.Currency;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Posting;
+using Microsoft.Purchases.Vendor;
 using System.Utilities;
 
 report 31029 "Create Purch. Adv. Letter CZZ"
@@ -243,8 +244,13 @@ report 31029 "Create Purch. Adv. Letter CZZ"
     end;
 
     procedure SetPurchHeader(var NewPurchaseHeader: Record "Purchase Header")
+    var
+        Vendor: Record Vendor;
     begin
         NewPurchaseHeader.TestField("Document Type", NewPurchaseHeader."Document Type"::Order);
+        Vendor.Get(NewPurchaseHeader."Pay-to Vendor No.");
+        Vendor.CheckBlockedVendOnAdvanceLettersCZZ(false);
+
         PurchaseHeader := NewPurchaseHeader;
         PurchPost.GetPurchLines(PurchaseHeader, TempPurchaseLine, 0);
         TempPurchaseLine.CalcSums("Amount Including VAT");

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Reports/CreateSalesAdvLetterCZZ.Report.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/Reports/CreateSalesAdvLetterCZZ.Report.al
@@ -7,6 +7,7 @@ namespace Microsoft.Finance.AdvancePayments;
 using Microsoft.Finance.Currency;
 using Microsoft.Projects.Project.Job;
 using Microsoft.Projects.Project.Planning;
+using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.Posting;
 using System.Utilities;
@@ -405,8 +406,13 @@ report 31012 "Create Sales Adv. Letter CZZ"
     end;
 
     procedure SetSalesHeader(var NewSalesHeader: Record "Sales Header")
+    var
+        Customer: Record Customer;
     begin
         NewSalesHeader.TestField("Document Type", NewSalesHeader."Document Type"::Order);
+        Customer.Get(NewSalesHeader."Bill-to Customer No.");
+        Customer.CheckBlockedCustOnAdvanceLettersCZZ(false);
+
         SourceSalesHeader := NewSalesHeader;
         SalesPost.GetSalesLines(SourceSalesHeader, TempSalesLine, 0);
         TempSalesLine.CalcSums("Amount Including VAT");

--- a/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CustomerCZZ.TableExt.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/app/Src/TableExtensions/CustomerCZZ.TableExt.al
@@ -26,7 +26,7 @@ tableextension 31045 "Customer CZZ" extends Customer
         if "Privacy Blocked" then
             CustPrivacyBlockedErrorMessage(Rec, Transaction);
 
-        if Blocked <> Blocked::" " then
+        if Blocked in [Blocked::All, Blocked::Invoice] then
             CustBlockedErrorMessage(Rec, Transaction);
     end;
 }

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/SalesAdvancePaymentsCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/SalesAdvancePaymentsCZZ.Codeunit.al
@@ -2835,9 +2835,14 @@ codeunit 148109 "Sales Advance Payments CZZ"
         CreateBlockedCustomer(Customer, CustomerBlocked, PrivacyBlocked);
 
         // [WHEN] Create sales advance letter with blocked customer
-        asserterror LibrarySalesAdvancesCZZ.CreateSalesAdvLetterHeader(SalesAdvLetterHeaderCZZ, AdvanceLetterTemplateCZZ.Code, Customer."No.", '');
+        if (CustomerBlocked = CustomerBlocked::Ship) and not PrivacyBlocked then
+            LibrarySalesAdvancesCZZ.CreateSalesAdvLetterHeader(SalesAdvLetterHeaderCZZ, AdvanceLetterTemplateCZZ.Code, Customer."No.", '')
+        else
+            asserterror LibrarySalesAdvancesCZZ.CreateSalesAdvLetterHeader(SalesAdvLetterHeaderCZZ, AdvanceLetterTemplateCZZ.Code, Customer."No.", '');
 
-        // [THEN] Error will occur
+        // [THEN] Error will occur when customer is blocked except when shipping is allowed
+        if (CustomerBlocked = CustomerBlocked::Ship) and not PrivacyBlocked then
+            exit;
         if PrivacyBlocked then
             Assert.ExpectedError(StrSubstNo(PrivacyBlockedCustomerErr, 'create', Customer."No."))
         else
@@ -2875,9 +2880,14 @@ codeunit 148109 "Sales Advance Payments CZZ"
         Customer.Modify(true);
 
         // [WHEN] Post sales advance payment
-        asserterror LibrarySalesAdvancesCZZ.PostSalesAdvancePayment(GenJournalLine);
+        if (CustomerBlocked = CustomerBlocked::Ship) and not PrivacyBlocked then
+            LibrarySalesAdvancesCZZ.PostSalesAdvancePayment(GenJournalLine)
+        else
+            asserterror LibrarySalesAdvancesCZZ.PostSalesAdvancePayment(GenJournalLine);
 
-        // [THEN] Error will occur
+        // [THEN] Error will occur when customer is blocked except when shipping is allowed
+        if (CustomerBlocked = CustomerBlocked::Ship) and not PrivacyBlocked then
+            exit;
         if PrivacyBlocked then
             Assert.ExpectedError(StrSubstNo(PrivacyBlockedCustomerErr, 'post', Customer."No."))
         else


### PR DESCRIPTION
## What & why

When creating advance letters from sales or purchase orders, the system did not validate whether the customer/vendor was blocked before proceeding. Additionally, the customer blocked-status check in `CheckBlockedCustOnAdvanceLettersCZZ` was too broad — it rejected customers with `Blocked = Ship`, which is irrelevant for advance letters (invoicing). This change:

1. Adds upfront blocked-customer/vendor validation in the **Create Sales Adv. Letter** and **Create Purch. Adv. Letter** reports (`SetSalesHeader` / `SetPurchHeader`) so blocked entities are caught early.
2. Narrows the customer blocked check from `Blocked <> Blocked::" "` to `Blocked in [Blocked::All, Blocked::Invoice]`, allowing customers blocked only for shipping to still have advance letters created.

## Linked work

Fixes [AB#643971](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/643971)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Created a sales advance letter from a sales order for a customer with `Blocked = Ship` — advance letter created successfully (previously errored).
- Created a sales advance letter from a sales order for a customer with `Blocked = All` — correctly blocked with an error.
- Created a sales advance letter from a sales order for a customer with `Blocked = Invoice` — correctly blocked with an error.
- Created a purchase advance letter from a purchase order for a blocked vendor (`Blocked = All`) — correctly blocked with an error.
- Created advance letters for non-blocked customer/vendor — both succeeded as expected.

## Risk & compatibility

- **Behavior change**: Customers with `Blocked = Ship` are now **allowed** to have advance letters created, whereas before they were blocked. This is intentional — the `Ship` block is not relevant to advance payment invoicing.
- The new upfront validation in `SetPurchHeader`/`SetSalesHeader` may surface errors earlier in flows that previously failed later (or silently succeeded). No data migration or schema changes involved.






