### PR TITLE
[main] bug 648707 - Fix typo in Compensation CZC report paragraph label

### DIFF
--- a/src/Apps/CZ/CompensationLocalization/app/Src/Reports/CompensationCZC.Report.al
+++ b/src/Apps/CZ/CompensationLocalization/app/Src/Reports/CompensationCZC.Report.al
@@ -494,7 +494,7 @@ report 31270 "Compensation CZC"
         BusinessNameLbl: Label 'Business Name:';
         RegistrationNoLbl: Label 'Reg. No.:';
         BankConnectionLbl: Label 'Bank connection:';
-        ParagraphLbl: Label 'by reciprocally Compensation receibables by PAR. 1982-1991 of Civil Code No. 89/2012';
+        ParagraphLbl: Label 'by reciprocally Compensation receivables by PAR. 1982-1991 of Civil Code No. 89/2012';
         RemainingAmountLbl: Label 'Remaining Amount';
         CompensationAmountLbl: Label 'Compensation Amount';
         LedgerEntryRemainingAmountLbl: Label 'Ledg. Entry Remaining Amount';


### PR DESCRIPTION
## What & why

Fix typo in Compensation CZC report paragraph label

## Linked work

Fixes [AB#648707](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648707)



