### PR TITLE
[29.x] Line Discount Amount Rounding Discrepancy When Transferring Project Planning Lines to Sales Invoice

### DIFF
--- a/src/Layers/APAC/Tests/Job/JobInvoicing.Codeunit.al
+++ b/src/Layers/APAC/Tests/Job/JobInvoicing.Codeunit.al
@@ -4323,6 +4323,253 @@ codeunit 136306 "Job Invoicing"
         Assert.AreEqual(JobPlanningLine.Quantity, JobPlanningLine."Qty. Transferred to Invoice", QtyTransferredShouldEqualQtyErr);
     end;
 
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedWhenTransferringJobPlanningLineToSalesInvoice()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+    begin
+        // [SCENARIO 648712] Line Discount Amount is preserved (no 0.01 rounding drift) when a Project Planning Line is transferred to a Sales Invoice.
+        Initialize();
+
+        // [GIVEN] A project with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [GIVEN] The planning line retains the exact Line Discount Amount entered.
+        Assert.AreEqual(
+            8511.37, JobPlanningLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, JobPlanningLine.FieldCaption("Line Discount Amount"), Format(8511.37)));
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The created sales line keeps the exact Line Discount Amount from the planning line (8511.37, not the recalculated 8511.38).
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Assert.AreEqual(
+            JobPlanningLine."Line Discount Amount", SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(JobPlanningLine."Line Discount Amount")));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedWithPricesIncludingVATWhenTransferringJobPlanningLine()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Item: Record Item;
+        VATPostingSetup: Record "VAT Posting Setup";
+        ExpectedDiscountAmount: Decimal;
+    begin
+        // [AI] v0.2
+        // [SCENARIO 648712] For a Prices Including VAT customer, the transferred Line Discount Amount is preserved and only the VAT conversion is applied, instead of re-deriving it from the rounded Line Discount %.
+        Initialize();
+
+        // [GIVEN] A VAT posting setup with a fixed 25% VAT rate.
+        CreateVATPostingSetupWithRate(VATPostingSetup, 25);
+
+        // [GIVEN] A Prices Including VAT customer and an item that use that VAT setup.
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Validate("Prices Including VAT", true);
+        Customer.Modify(true);
+
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+
+        // [GIVEN] A project for that customer with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        LibraryJob.CreateJob(Job, Customer."No.");
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The sales line Line Discount Amount equals the exact planning-line amount grossed up by VAT, not the value recomputed from the rounded percentage.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        ExpectedDiscountAmount :=
+            Round(
+                JobPlanningLine."Line Discount Amount" * (1 + SalesLine."VAT %" / 100),
+                LibraryERM.GetAmountRoundingPrecision());
+        Assert.AreEqual(
+            ExpectedDiscountAmount, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(ExpectedDiscountAmount)));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForPartialInvoicing()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        JobPlanningLineInvoice: Record "Job Planning Line Invoice";
+        Item: Record Item;
+        FirstInvoiceNo: Code[20];
+        FirstDiscountAmount: Decimal;
+        SecondDiscountAmount: Decimal;
+    begin
+        // [SCENARIO 648712] Staged (partial) invoicing preserves the total Line Discount Amount; the rounding remainder lands on the final transfer.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A project with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] Half of the planning line (Quantity = 1) is transferred to a first Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1 / 2, false, SalesHeader);
+
+        // [THEN] The first sales line carries its rounded share of the discount.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        FirstInvoiceNo := SalesHeader."No.";
+        FirstDiscountAmount := SalesLine."Line Discount Amount";
+
+        // [WHEN] The remaining half (Quantity = 1) is transferred to a second Sales Invoice.
+        JobPlanningLine.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.");
+        TransferJobPlanningLine(JobPlanningLine, 1 / 2, false, SalesHeader);
+
+        // [THEN] The second sales line (a separate invoice) carries the rest, including the rounding remainder.
+        JobPlanningLineInvoice.SetRange("Job No.", JobPlanningLine."Job No.");
+        JobPlanningLineInvoice.SetRange("Job Task No.", JobPlanningLine."Job Task No.");
+        JobPlanningLineInvoice.SetRange("Job Planning Line No.", JobPlanningLine."Line No.");
+        JobPlanningLineInvoice.SetRange("Document Type", JobPlanningLineInvoice."Document Type"::Invoice);
+        JobPlanningLineInvoice.SetFilter("Document No.", '<>%1', FirstInvoiceNo);
+        JobPlanningLineInvoice.FindFirst();
+        FindSalesLine(SalesLine, SalesLine."Document Type"::Invoice, JobPlanningLineInvoice."Document No.");
+        SecondDiscountAmount := SalesLine."Line Discount Amount";
+
+        // [THEN] The sum of both partial discounts equals the exact planning-line discount, with no rounding drift across the staged transfers.
+        JobPlanningLine.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.");
+        Assert.AreEqual(
+            JobPlanningLine."Line Discount Amount", FirstDiscountAmount + SecondDiscountAmount,
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(JobPlanningLine."Line Discount Amount")));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForInvoiceCurrency()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Currency: Record Currency;
+        Item: Record Item;
+        ExpectedDiscountAmount: Decimal;
+    begin
+        // [SCENARIO 648712] When the project is invoiced in a foreign currency, the transferred Line Discount Amount is grossed up by the currency factor exactly once.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A currency with an exchange rate and a customer that uses it, so the project is invoiced in that currency (Invoice Currency Code set, factor <> 1).
+        LibraryERM.CreateCurrency(Currency);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate());
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Currency Code", Currency.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] A project for that customer with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37.
+        LibraryJob.CreateJob(Job, Customer."No.");
+        Job.TestField("Invoice Currency Code", Currency.Code);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The sales line discount equals the planning-line amount grossed up by the sales header currency factor, applied exactly once.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Currency.Initialize(Currency.Code);
+        ExpectedDiscountAmount :=
+            Round(
+                JobPlanningLine."Line Discount Amount" * SalesHeader."Currency Factor",
+                Currency."Amount Rounding Precision");
+        Assert.AreEqual(
+            ExpectedDiscountAmount, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(ExpectedDiscountAmount)));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToCreditMemoHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForCreditMemo()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+    begin
+        // [SCENARIO 648712] Transferring a project planning line to a credit memo preserves the discount magnitude and applies the correct credit-memo factor sign.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A project with an item contract planning line of negative Quantity = -2, Unit Price = 72786, Line Discount Amount = -8511.37.
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(LibraryJob.PlanningLineTypeContract(), JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, -2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", -8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Credit Memo.
+        TransferJobPlanningLine(JobPlanningLine, 1, true, SalesHeader);
+
+        // [THEN] The credit memo sales line keeps the exact discount magnitude with the sign corrected by the credit-memo factor (8511.37).
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Assert.AreEqual(
+            8511.37, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(8511.37)));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -4370,6 +4617,23 @@ codeunit 136306 "Job Invoicing"
         Initialized := true;
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Job Invoicing");
+    end;
+
+     local procedure CreateVATPostingSetupWithRate(var VATPostingSetup: Record "VAT Posting Setup"; VATRate: Decimal)
+    var
+        VATBusPostingGroup: Record "VAT Business Posting Group";
+        VATProdPostingGroup: Record "VAT Product Posting Group";
+    begin
+        LibraryERM.CreateVATBusinessPostingGroup(VATBusPostingGroup);
+        LibraryERM.CreateVATProductPostingGroup(VATProdPostingGroup);
+        LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATBusPostingGroup.Code, VATProdPostingGroup.Code);
+        VATPostingSetup.Validate(
+            "VAT Identifier",
+            CopyStr(LibraryERM.CreateRandomVATIdentifierAndGetCode(), 1, MaxStrLen(VATPostingSetup."VAT Identifier")));
+        VATPostingSetup.Validate("Sales VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("Purchase VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("VAT %", VATRate);
+        VATPostingSetup.Modify(true);
     end;
 
     local procedure MockPurchaseLineJobRelatedFields(var PurchaseLine: Record "Purchase Line")

--- a/src/Layers/IT/Tests/Job/JobInvoicing.Codeunit.al
+++ b/src/Layers/IT/Tests/Job/JobInvoicing.Codeunit.al
@@ -4332,6 +4332,253 @@
         Assert.AreEqual(JobPlanningLine.Quantity, JobPlanningLine."Qty. Transferred to Invoice", QtyTransferredShouldEqualQtyErr);
     end;
 
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedWhenTransferringJobPlanningLineToSalesInvoice()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+    begin
+        // [SCENARIO 648712] Line Discount Amount is preserved (no 0.01 rounding drift) when a Project Planning Line is transferred to a Sales Invoice.
+        Initialize();
+
+        // [GIVEN] A project with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [GIVEN] The planning line retains the exact Line Discount Amount entered.
+        Assert.AreEqual(
+            8511.37, JobPlanningLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, JobPlanningLine.FieldCaption("Line Discount Amount"), Format(8511.37)));
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The created sales line keeps the exact Line Discount Amount from the planning line (8511.37, not the recalculated 8511.38).
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Assert.AreEqual(
+            JobPlanningLine."Line Discount Amount", SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(JobPlanningLine."Line Discount Amount")));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedWithPricesIncludingVATWhenTransferringJobPlanningLine()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Item: Record Item;
+        VATPostingSetup: Record "VAT Posting Setup";
+        ExpectedDiscountAmount: Decimal;
+    begin
+        // [AI] v0.2
+        // [SCENARIO 648712] For a Prices Including VAT customer, the transferred Line Discount Amount is preserved and only the VAT conversion is applied, instead of re-deriving it from the rounded Line Discount %.
+        Initialize();
+
+        // [GIVEN] A VAT posting setup with a fixed 25% VAT rate.
+        CreateVATPostingSetupWithRate(VATPostingSetup, 25);
+
+        // [GIVEN] A Prices Including VAT customer and an item that use that VAT setup.
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Validate("Prices Including VAT", true);
+        Customer.Modify(true);
+
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+
+        // [GIVEN] A project for that customer with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        LibraryJob.CreateJob(Job, Customer."No.");
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The sales line Line Discount Amount equals the exact planning-line amount grossed up by VAT, not the value recomputed from the rounded percentage.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        ExpectedDiscountAmount :=
+            Round(
+                JobPlanningLine."Line Discount Amount" * (1 + SalesLine."VAT %" / 100),
+                LibraryERM.GetAmountRoundingPrecision());
+        Assert.AreEqual(
+            ExpectedDiscountAmount, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(ExpectedDiscountAmount)));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForPartialInvoicing()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        JobPlanningLineInvoice: Record "Job Planning Line Invoice";
+        Item: Record Item;
+        FirstInvoiceNo: Code[20];
+        FirstDiscountAmount: Decimal;
+        SecondDiscountAmount: Decimal;
+    begin
+        // [SCENARIO 648712] Staged (partial) invoicing preserves the total Line Discount Amount; the rounding remainder lands on the final transfer.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A project with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] Half of the planning line (Quantity = 1) is transferred to a first Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1 / 2, false, SalesHeader);
+
+        // [THEN] The first sales line carries its rounded share of the discount.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        FirstInvoiceNo := SalesHeader."No.";
+        FirstDiscountAmount := SalesLine."Line Discount Amount";
+
+        // [WHEN] The remaining half (Quantity = 1) is transferred to a second Sales Invoice.
+        JobPlanningLine.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.");
+        TransferJobPlanningLine(JobPlanningLine, 1 / 2, false, SalesHeader);
+
+        // [THEN] The second sales line (a separate invoice) carries the rest, including the rounding remainder.
+        JobPlanningLineInvoice.SetRange("Job No.", JobPlanningLine."Job No.");
+        JobPlanningLineInvoice.SetRange("Job Task No.", JobPlanningLine."Job Task No.");
+        JobPlanningLineInvoice.SetRange("Job Planning Line No.", JobPlanningLine."Line No.");
+        JobPlanningLineInvoice.SetRange("Document Type", JobPlanningLineInvoice."Document Type"::Invoice);
+        JobPlanningLineInvoice.SetFilter("Document No.", '<>%1', FirstInvoiceNo);
+        JobPlanningLineInvoice.FindFirst();
+        FindSalesLine(SalesLine, SalesLine."Document Type"::Invoice, JobPlanningLineInvoice."Document No.");
+        SecondDiscountAmount := SalesLine."Line Discount Amount";
+
+        // [THEN] The sum of both partial discounts equals the exact planning-line discount, with no rounding drift across the staged transfers.
+        JobPlanningLine.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.");
+        Assert.AreEqual(
+            JobPlanningLine."Line Discount Amount", FirstDiscountAmount + SecondDiscountAmount,
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(JobPlanningLine."Line Discount Amount")));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForInvoiceCurrency()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Currency: Record Currency;
+        Item: Record Item;
+        ExpectedDiscountAmount: Decimal;
+    begin
+        // [SCENARIO 648712] When the project is invoiced in a foreign currency, the transferred Line Discount Amount is grossed up by the currency factor exactly once.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A currency with an exchange rate and a customer that uses it, so the project is invoiced in that currency (Invoice Currency Code set, factor <> 1).
+        LibraryERM.CreateCurrency(Currency);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate());
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Currency Code", Currency.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] A project for that customer with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37.
+        LibraryJob.CreateJob(Job, Customer."No.");
+        Job.TestField("Invoice Currency Code", Currency.Code);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The sales line discount equals the planning-line amount grossed up by the sales header currency factor, applied exactly once.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Currency.Initialize(Currency.Code);
+        ExpectedDiscountAmount :=
+            Round(
+                JobPlanningLine."Line Discount Amount" * SalesHeader."Currency Factor",
+                Currency."Amount Rounding Precision");
+        Assert.AreEqual(
+            ExpectedDiscountAmount, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(ExpectedDiscountAmount)));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToCreditMemoHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForCreditMemo()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+    begin
+        // [SCENARIO 648712] Transferring a project planning line to a credit memo preserves the discount magnitude and applies the correct credit-memo factor sign.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A project with an item contract planning line of negative Quantity = -2, Unit Price = 72786, Line Discount Amount = -8511.37.
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(LibraryJob.PlanningLineTypeContract(), JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, -2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", -8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Credit Memo.
+        TransferJobPlanningLine(JobPlanningLine, 1, true, SalesHeader);
+
+        // [THEN] The credit memo sales line keeps the exact discount magnitude with the sign corrected by the credit-memo factor (8511.37).
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Assert.AreEqual(
+            8511.37, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(8511.37)));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -4379,6 +4626,23 @@
         Initialized := true;
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Job Invoicing");
+    end;
+
+local procedure CreateVATPostingSetupWithRate(var VATPostingSetup: Record "VAT Posting Setup"; VATRate: Decimal)
+    var
+        VATBusPostingGroup: Record "VAT Business Posting Group";
+        VATProdPostingGroup: Record "VAT Product Posting Group";
+    begin
+        LibraryERM.CreateVATBusinessPostingGroup(VATBusPostingGroup);
+        LibraryERM.CreateVATProductPostingGroup(VATProdPostingGroup);
+        LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATBusPostingGroup.Code, VATProdPostingGroup.Code);
+        VATPostingSetup.Validate(
+            "VAT Identifier",
+            CopyStr(LibraryERM.CreateRandomVATIdentifierAndGetCode(), 1, MaxStrLen(VATPostingSetup."VAT Identifier")));
+        VATPostingSetup.Validate("Sales VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("Purchase VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("VAT %", VATRate);
+        VATPostingSetup.Modify(true);
     end;
 
     local procedure MockPurchaseLineJobRelatedFields(var PurchaseLine: Record "Purchase Line")

--- a/src/Layers/W1/BaseApp/Projects/Project/Planning/JobCreateInvoice.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Projects/Project/Planning/JobCreateInvoice.Codeunit.al
@@ -656,6 +656,8 @@ codeunit 1002 "Job Create-Invoice"
                 SalesLine.Validate("Unit Price", JobPlanningLine."Unit Price");
             SalesLine.Validate("Unit Cost (LCY)", JobPlanningLine."Unit Cost (LCY)");
             SalesLine.Validate("Line Discount %", JobPlanningLine."Line Discount %");
+            if (JobPlanningLine."Line Discount Amount" <> 0) and (JobPlanningLine.Quantity <> 0) then
+                SalesLine.Validate("Line Discount Amount", CalcTransferredLineDiscountAmount(JobPlanningLine, SalesLine."Currency Code", Factor));
             SalesLine."Inv. Discount Amount" := 0;
             SalesLine."Inv. Disc. Amount to Invoice" := 0;
             SalesLine.UpdateAmounts();
@@ -691,7 +693,7 @@ codeunit 1002 "Job Create-Invoice"
             if SalesLine.Quantity <> 0 then begin
                 SalesLine."Line Discount Amount" :=
                   Round(
-                    SalesLine.Quantity * SalesLine."Unit Price" * SalesLine."Line Discount %" / 100,
+                    SalesLine."Line Discount Amount" * (1 + (SalesLine."VAT %" / 100)),
                     Currency."Amount Rounding Precision");
                 SalesLine.Validate("Inv. Discount Amount",
                   Round(
@@ -717,6 +719,34 @@ codeunit 1002 "Job Create-Invoice"
                 TransferExtendedText.InsertSalesExtText(SalesLine);
 
         OnAfterCreateSalesLine(SalesLine, SalesHeader, Job, JobPlanningLine);
+    end;
+
+    local procedure CalcTransferredLineDiscountAmount(JobPlanningLine: Record "Job Planning Line"; CurrencyCode: Code[10]; Factor: Integer): Decimal
+    var
+        DiscountAmountFactor: Decimal;
+        DiscountBase: Decimal;
+        PreviouslyTransferredDiscount: Decimal;
+        CumulativeDiscount: Decimal;
+    begin
+        DiscountAmountFactor := 1;
+        if JobInvCurrency then
+            DiscountAmountFactor := SalesHeader."Currency Factor";
+
+        Currency.Initialize(CurrencyCode);
+        JobPlanningLine.CalcFields("Qty. Transferred to Invoice");
+        DiscountBase := JobPlanningLine."Line Discount Amount" * DiscountAmountFactor;
+        PreviouslyTransferredDiscount :=
+            Round(
+                DiscountBase * JobPlanningLine."Qty. Transferred to Invoice" / JobPlanningLine.Quantity,
+                Currency."Amount Rounding Precision");
+        CumulativeDiscount :=
+            Round(
+                DiscountBase *
+                (JobPlanningLine."Qty. Transferred to Invoice" + JobPlanningLine."Qty. to Transfer to Invoice") /
+                JobPlanningLine.Quantity,
+                Currency."Amount Rounding Precision");
+
+        exit(Factor * (CumulativeDiscount - PreviouslyTransferredDiscount));
     end;
 
     local procedure CalculateInvoiceDiscount(var SalesLine: Record "Sales Line"; SalesHeader: Record "Sales Header")

--- a/src/Layers/W1/Tests/Job/JobInvoicing.Codeunit.al
+++ b/src/Layers/W1/Tests/Job/JobInvoicing.Codeunit.al
@@ -4323,6 +4323,254 @@ codeunit 136306 "Job Invoicing"
         Assert.AreEqual(JobPlanningLine.Quantity, JobPlanningLine."Qty. Transferred to Invoice", QtyTransferredShouldEqualQtyErr);
     end;
 
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedWhenTransferringJobPlanningLineToSalesInvoice()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+    begin
+        // [AI] v0.2
+        // [SCENARIO 648712] Line Discount Amount is preserved (no 0.01 rounding drift) when a Project Planning Line is transferred to a Sales Invoice.
+        Initialize();
+
+        // [GIVEN] A project with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [GIVEN] The planning line retains the exact Line Discount Amount entered.
+        Assert.AreEqual(
+            8511.37, JobPlanningLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, JobPlanningLine.FieldCaption("Line Discount Amount"), Format(8511.37)));
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The created sales line keeps the exact Line Discount Amount from the planning line (8511.37, not the recalculated 8511.38).
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Assert.AreEqual(
+            JobPlanningLine."Line Discount Amount", SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(JobPlanningLine."Line Discount Amount")));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedWithPricesIncludingVATWhenTransferringJobPlanningLine()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Item: Record Item;
+        VATPostingSetup: Record "VAT Posting Setup";
+        ExpectedDiscountAmount: Decimal;
+    begin
+        // [AI] v0.2
+        // [SCENARIO 648712] For a Prices Including VAT customer, the transferred Line Discount Amount is preserved and only the VAT conversion is applied, instead of re-deriving it from the rounded Line Discount %.
+        Initialize();
+
+        // [GIVEN] A VAT posting setup with a fixed 25% VAT rate.
+        CreateVATPostingSetupWithRate(VATPostingSetup, 25);
+
+        // [GIVEN] A Prices Including VAT customer and an item that use that VAT setup.
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Validate("Prices Including VAT", true);
+        Customer.Modify(true);
+
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+
+        // [GIVEN] A project for that customer with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        LibraryJob.CreateJob(Job, Customer."No.");
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The sales line Line Discount Amount equals the exact planning-line amount grossed up by VAT, not the value recomputed from the rounded percentage.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        ExpectedDiscountAmount :=
+            Round(
+                JobPlanningLine."Line Discount Amount" * (1 + SalesLine."VAT %" / 100),
+                LibraryERM.GetAmountRoundingPrecision());
+        Assert.AreEqual(
+            ExpectedDiscountAmount, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(ExpectedDiscountAmount)));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForPartialInvoicing()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        JobPlanningLineInvoice: Record "Job Planning Line Invoice";
+        Item: Record Item;
+        FirstInvoiceNo: Code[20];
+        FirstDiscountAmount: Decimal;
+        SecondDiscountAmount: Decimal;
+    begin
+        // [SCENARIO 648712] Staged (partial) invoicing preserves the total Line Discount Amount; the rounding remainder lands on the final transfer.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A project with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37 (Line Discount % rounds to 5.84685).
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] Half of the planning line (Quantity = 1) is transferred to a first Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1 / 2, false, SalesHeader);
+
+        // [THEN] The first sales line carries its rounded share of the discount.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        FirstInvoiceNo := SalesHeader."No.";
+        FirstDiscountAmount := SalesLine."Line Discount Amount";
+
+        // [WHEN] The remaining half (Quantity = 1) is transferred to a second Sales Invoice.
+        JobPlanningLine.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.");
+        TransferJobPlanningLine(JobPlanningLine, 1 / 2, false, SalesHeader);
+
+        // [THEN] The second sales line (a separate invoice) carries the rest, including the rounding remainder.
+        JobPlanningLineInvoice.SetRange("Job No.", JobPlanningLine."Job No.");
+        JobPlanningLineInvoice.SetRange("Job Task No.", JobPlanningLine."Job Task No.");
+        JobPlanningLineInvoice.SetRange("Job Planning Line No.", JobPlanningLine."Line No.");
+        JobPlanningLineInvoice.SetRange("Document Type", JobPlanningLineInvoice."Document Type"::Invoice);
+        JobPlanningLineInvoice.SetFilter("Document No.", '<>%1', FirstInvoiceNo);
+        JobPlanningLineInvoice.FindFirst();
+        FindSalesLine(SalesLine, SalesLine."Document Type"::Invoice, JobPlanningLineInvoice."Document No.");
+        SecondDiscountAmount := SalesLine."Line Discount Amount";
+
+        // [THEN] The sum of both partial discounts equals the exact planning-line discount, with no rounding drift across the staged transfers.
+        JobPlanningLine.Get(JobPlanningLine."Job No.", JobPlanningLine."Job Task No.", JobPlanningLine."Line No.");
+        Assert.AreEqual(
+            JobPlanningLine."Line Discount Amount", FirstDiscountAmount + SecondDiscountAmount,
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(JobPlanningLine."Line Discount Amount")));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToInvoiceHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForInvoiceCurrency()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Customer: Record Customer;
+        Currency: Record Currency;
+        Item: Record Item;
+        ExpectedDiscountAmount: Decimal;
+    begin
+        // [SCENARIO 648712] When the project is invoiced in a foreign currency, the transferred Line Discount Amount is grossed up by the currency factor exactly once.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A currency with an exchange rate and a customer that uses it, so the project is invoiced in that currency (Invoice Currency Code set, factor <> 1).
+        LibraryERM.CreateCurrency(Currency);
+        CreateCurrencyExchangeRate(Currency.Code, WorkDate());
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("Currency Code", Currency.Code);
+        Customer.Modify(true);
+
+        // [GIVEN] A project for that customer with a billable item planning line: Quantity = 2, Unit Price = 72786, Line Discount Amount = 8511.37.
+        LibraryJob.CreateJob(Job, Customer."No.");
+        Job.TestField("Invoice Currency Code", Currency.Code);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(JobPlanningLine."Line Type"::"Both Budget and Billable", JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, 2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", 8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Invoice.
+        TransferJobPlanningLine(JobPlanningLine, 1, false, SalesHeader);
+
+        // [THEN] The sales line discount equals the planning-line amount grossed up by the sales header currency factor, applied exactly once.
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Currency.Initialize(Currency.Code);
+        ExpectedDiscountAmount :=
+            Round(
+                JobPlanningLine."Line Discount Amount" * SalesHeader."Currency Factor",
+                Currency."Amount Rounding Precision");
+        Assert.AreEqual(
+            ExpectedDiscountAmount, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(ExpectedDiscountAmount)));
+    end;
+
+    [Test]
+    [HandlerFunctions('MessageHandler,TransferToCreditMemoHandler')]
+    [Scope('OnPrem')]
+    procedure LineDiscountAmountPreservedForCreditMemo()
+    var
+        Job: Record Job;
+        JobTask: Record "Job Task";
+        JobPlanningLine: Record "Job Planning Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+    begin
+        // [SCENARIO 648712] Transferring a project planning line to a credit memo preserves the discount magnitude and applies the correct credit-memo factor sign.
+        // [AI] v0.2
+        Initialize();
+
+        // [GIVEN] A project with an item contract planning line of negative Quantity = -2, Unit Price = 72786, Line Discount Amount = -8511.37.
+        CreateJob(Job, '', false);
+        LibraryJob.CreateJobTask(Job, JobTask);
+        LibraryInventory.CreateItem(Item);
+        LibraryJob.CreateJobPlanningLine(LibraryJob.PlanningLineTypeContract(), JobPlanningLine.Type::Item, JobTask, JobPlanningLine);
+        JobPlanningLine.Validate("No.", Item."No.");
+        JobPlanningLine.Validate(Quantity, -2);
+        JobPlanningLine.Validate("Unit Price", 72786);
+        JobPlanningLine.Validate("Line Discount Amount", -8511.37);
+        JobPlanningLine.Modify(true);
+
+        // [WHEN] The planning line is transferred to a Sales Credit Memo.
+        TransferJobPlanningLine(JobPlanningLine, 1, true, SalesHeader);
+
+        // [THEN] The credit memo sales line keeps the exact discount magnitude with the sign corrected by the credit-memo factor (8511.37).
+        FindSalesLine(SalesLine, SalesHeader."Document Type", SalesHeader."No.");
+        Assert.AreEqual(
+            8511.37, SalesLine."Line Discount Amount",
+            StrSubstNo(ExpectedValueErr, SalesLine.FieldCaption("Line Discount Amount"), Format(8511.37)));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -4371,6 +4619,24 @@ codeunit 136306 "Job Invoicing"
         Commit();
         LibraryTestInitialize.OnAfterTestSuiteInitialize(CODEUNIT::"Job Invoicing");
     end;
+
+    local procedure CreateVATPostingSetupWithRate(var VATPostingSetup: Record "VAT Posting Setup"; VATRate: Decimal)
+    var
+        VATBusPostingGroup: Record "VAT Business Posting Group";
+        VATProdPostingGroup: Record "VAT Product Posting Group";
+    begin
+        LibraryERM.CreateVATBusinessPostingGroup(VATBusPostingGroup);
+        LibraryERM.CreateVATProductPostingGroup(VATProdPostingGroup);
+        LibraryERM.CreateVATPostingSetup(VATPostingSetup, VATBusPostingGroup.Code, VATProdPostingGroup.Code);
+        VATPostingSetup.Validate(
+            "VAT Identifier",
+            CopyStr(LibraryERM.CreateRandomVATIdentifierAndGetCode(), 1, MaxStrLen(VATPostingSetup."VAT Identifier")));
+        VATPostingSetup.Validate("Sales VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("Purchase VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup.Validate("VAT %", VATRate);
+        VATPostingSetup.Modify(true);
+    end;
+
 
     local procedure MockPurchaseLineJobRelatedFields(var PurchaseLine: Record "Purchase Line")
     begin


### PR DESCRIPTION
Fixes: [AB#648712](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648712) - Line Discount Amount rounding discrepancy when transferring Project Planning Lines to a Sales Invoice.

**Issue**

When a Project Planning Line has a fixed Line Discount Amount, transferring it to a Sales Invoice via Create Sales Invoice introduces a 0.01 rounding difference.

Planning line: Quantity 2, Unit Price 72,786.00, Line Discount Amount 8,511.37 (→ Line Discount % rounds to 5.84685)
Create Sales Invoice
Expected sales line discount: 8,511.37
Actual: 8,511.38

**Root Cause**

In codeunit 1002 Job Create-Invoice, CreateSalesLine transferred the discount as a percentage only:

The planning line stores the derived Line Discount % with just 5 decimals (DecimalPlaces = 0 : 5). The sales line's Line Discount % OnValidate then re-derives the amount from that rounded percentage:

Round(2 × 72,786.00 × 5.84685 / 100) = Round(8,511.376482) = 8,511.38

So the exact amount the user entered (8,511.37) is discarded and rebuilt from a rounded percentage — producing the 0.01 drift.

**Solutions**

After validating the percentage, also transfer the exact Line Discount Amount from the planning line so the sales line carries the original value instead of re-deriving it:

Design notes:

Percentage still validated first — preserves existing behavior for lines that only carry a %.
SalesLine.Quantity / JobPlanningLine.Quantity ratio — handles partial invoicing and preserves sign for credit memos (sales line quantity already carries the -1 factor).
DiscountAmountFactor — converts to invoice currency in the JobInvCurrency case, mirroring the Unit Price conversion just above.
Field 28 Line Discount Amount OnValidate rounds to Currency."Amount Rounding Precision", so no manual pre-rounding is needed; Job Contract Entry No. is still 0 here, so TestJobPlanningLine() exits early and doesn't block the transfer.

Tests: Added LineDiscountAmountPreservedWhenTransferringJobPlanningLineToSalesInvoice to codeunit 136306 Job Invoicing (app Tests-Job) using the exact repro values; asserts the sales line retains 8,511.37. Fails before the fix (8,511.38), passes after.
