### PR TITLE
[ExpenseAgent] Refactor agent setup for policies

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseAgentSetupAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseAgentSetupAPI.Page.al
@@ -42,6 +42,10 @@ page 6942 "Expense Agent Setup API"
                 {
                     Caption = 'Use Rules';
                 }
+                field(submitterRunEvaluation; Rec."Submitter-run Evaluation")
+                {
+                    Caption = 'Allow Submitters to Evaluate Policies';
+                }
                 field(enableAgent; Rec."Enable Agent")
                 {
                     Caption = 'Enable Agent';

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetup.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetup.Page.al
@@ -205,6 +205,9 @@ page 6996 "Expense Agent Setup"
                         end;
                     end;
                 }
+                field("Submitter-run Evaluation"; Rec."Submitter-run Evaluation")
+                {
+                }
                 field("Do Not Allow Expenses Older Than"; Rec."Do Not Allow Exp. Older Than")
                 {
                 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
@@ -491,32 +491,6 @@ page 6991 "Expense Agent Setup Wizard"
                         end;
                     }
                 }
-
-                group(EvaluatePoliciesSection)
-                {
-                    Caption = 'Evaluate policies with AI';
-                    InstructionalText = 'Leverage AI to evaluate natural language policies defined for your organization.';
-                    field("Evaluate Policies"; Rec."Evaluate Policies")
-                    {
-                        ShowCaption = false;
-
-                        ToolTip = 'Specifies whether the agent evaluates expenses against the configured policies. Rules are evaluated by code, while policies are evaluated by AI, so enabling this consumes additional AI credits.';
-
-                        trigger OnValidate()
-                        var
-                            ExpensePoliciesPage: Page "Expense Policies";
-                        begin
-                            if Rec."Evaluate Policies" and (not xRec."Evaluate Policies") then begin
-                                if not Confirm(ActivatePolicyEvalQst, false) then
-                                    Error('');
-                                ExpensePoliciesPage.Editable(true);
-                                ExpensePoliciesPage.RunModal();
-                            end;
-                            ConfigUpdated();
-                        end;
-                    }
-                }
-
                 group(DetectOutdatedExpenseSection)
                 {
                     ShowCaption = false;
@@ -585,6 +559,60 @@ page 6991 "Expense Agent Setup Wizard"
                     }
                 }
 
+            }
+            group(EvaluatePoliciesTab)
+            {
+                Caption = 'Policy compliance';
+
+                group(EvaluatePoliciesSection)
+                {
+                    Caption = 'Evaluate compliance with AI';
+                    InstructionalText = 'Use AI to evaluate compliance according to organization guidelines.';
+                    field("Evaluate Policies"; Rec."Evaluate Policies")
+                    {
+                        ShowCaption = false;
+                        ToolTip = 'Specifies whether the agent evaluates expenses against the configured policies. Rules are evaluated by code, while policies are evaluated by AI, so enabling this consumes additional AI credits.';
+
+                        trigger OnValidate()
+                        begin
+                            if Rec."Evaluate Policies" and (not xRec."Evaluate Policies") then
+                                if not Confirm(ActivatePolicyEvalQst, false) then
+                                    Error('');
+                            ConfigUpdated();
+                        end;
+                    }
+                    field(ExpensePoliciesLink; ExpensePoliciesLinkTxt)
+                    {
+                        ShowCaption = false;
+                        Editable = false;
+                        ToolTip = 'Specifies a link that opens the expense policies.';
+
+                        trigger OnDrillDown()
+                        var
+                            ExpensePoliciesPage: Page "Expense Policies";
+                        begin
+                            ExpensePoliciesPage.Editable(true);
+                            ExpensePoliciesPage.RunModal();
+                        end;
+                    }
+                    group(SubmitterRunEvaluationSection)
+                    {
+                        Caption = 'Enable pre-submission evaluation';
+                        InstructionalText = 'Let submitters run a compliance evaluation of the expense reports.';
+                        Enabled = Rec."Evaluate Policies";
+
+                        field("Submitter-run Evaluation"; Rec."Submitter-run Evaluation")
+                        {
+                            ShowCaption = false;
+                            ToolTip = 'Specifies whether submitters can run an AI evaluation to check expense reports for compliance before submitting them.';
+
+                            trigger OnValidate()
+                            begin
+                                ConfigUpdated();
+                            end;
+                        }
+                    }
+                }
             }
             group(CommunicationGroup)
             {
@@ -942,6 +970,7 @@ page 6991 "Expense Agent Setup Wizard"
         LocationsAppliedLinkTxt: Label 'View expense locations including new defaults';
         RulesLinkTxt: Label 'Preview the default management rules that will be added';
         RulesAppliedLinkTxt: Label 'View management rules including new defaults';
+        ExpensePoliciesLinkTxt: Label 'View expense policies';
         NoSeriesLinkTxt: Label 'Preview the default number series that will be added';
         NoSeriesAppliedLinkTxt: Label 'View number series including new defaults';
         ExpenseDashboardLinkTxt: Label 'Go to Expense app (opens in new window)';

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Tables/ExpenseAgentSetup.Table.al
@@ -313,7 +313,7 @@ table 6930 "Expense Agent Setup"
         {
             Caption = 'Evaluate policies';
             DataClassification = SystemMetadata;
-            ToolTip = 'Specifies whether the agent automatically evaluates expenses against the configured policies. Enabling this consumes additional AI credits.';
+            ToolTip = 'Specifies whether the agent automatically evaluates expenses against the configured policies. This feature consumes additional AI credits.';
 
             trigger OnValidate()
             var
@@ -322,6 +322,12 @@ table 6930 "Expense Agent Setup"
                 if "Evaluate Policies" and (not xRec."Evaluate Policies") then
                     FeatureTelemetry.LogUptake('0000V3F', GetFeatureName(), Enum::"Feature Uptake Status"::Used);
             end;
+        }
+        field(32; "Submitter-run Evaluation"; Boolean)
+        {
+            Caption = 'Allow submitters to evaluate policies';
+            DataClassification = SystemMetadata;
+            ToolTip = 'Specifies whether submitters can preventively run policy evaluation before submitting expense reports. This evaluation will consume additional AI credits.';
         }
         field(34; "Expense User Nos."; Code[20])
         {


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Expense Agent admins should be able to disallow user-run policy check

## Linked work

Fixes [AB#648726](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648726)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


