### PR TITLE
[29.x] planning worksheet requires second run of calculate regenerative plan

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Inventory/Location/MfgStockkeepingUnit.TableExt.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Inventory/Location/MfgStockkeepingUnit.TableExt.al
@@ -66,6 +66,7 @@ tableextension 99000759 "Mfg. Stockkeeping Unit" extends "Stockkeeping Unit"
                 MfgSetup: Record "Manufacturing Setup";
                 ProdBOMHeader: Record "Production BOM Header";
                 CalculateLowLevelCode: Codeunit "Calculate Low-Level Code";
+                xLowLevelCode: Integer;
             begin
                 if ("Production BOM No." <> '') and ("Production BOM No." <> xRec."Production BOM No.") then begin
                     ProdBOMHeader.Get("Production BOM No.");
@@ -74,7 +75,10 @@ tableextension 99000759 "Mfg. Stockkeeping Unit" extends "Stockkeeping Unit"
                         MfgSetup.Get();
                         Item.Get("Item No.");
                         if MfgSetup."Dynamic Low-Level Code" then begin
+                            xLowLevelCode := Item."Low-Level Code";
                             Item."Low-Level Code" := CalculateLowLevelCode.CalcLevels(1, Item."No.", 0, 0);
+                            if Item."Low-Level Code" <> xLowLevelCode then
+                                Item.Modify();
                             CalculateLowLevelCode.SetRecursiveLevelsOnBOM(ProdBOMHeader, Item."Low-Level Code" + 1, false);
                         end;
                     end;

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/CalculateLowLevelCode.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/CalculateLowLevelCode.Codeunit.al
@@ -7,11 +7,13 @@ namespace Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Inventory.BOM;
 using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.Setup;
+using Microsoft.Inventory.Location;
 
 codeunit 99000793 "Calculate Low-Level Code"
 {
     Permissions = TableData Item = rm,
-                  TableData "Manufacturing Setup" = r;
+                  TableData "Manufacturing Setup" = r,
+                    TableData "Stockkeeping Unit" = r;
     TableNo = Item;
 
     trigger OnRun()
@@ -24,6 +26,7 @@ codeunit 99000793 "Calculate Low-Level Code"
         Item2."Low-Level Code" := CalcLevels(1, Item2."No.", 0, 0);
         if ProdBOM.Get(Item."Production BOM No.") then
             SetRecursiveLevelsOnBOM(ProdBOM, Item2."Low-Level Code" + 1, false);
+        RecalcSKULowerLevels(Item2."No.", Item2."Low-Level Code" + 1, false);
         OnBeforeItemModify(Item2);
         Item2.Modify();
         Rec.Copy(Item2);
@@ -42,6 +45,8 @@ codeunit 99000793 "Calculate Low-Level Code"
         Item2: Record Item;
         ProdBOMLine: Record "Production BOM Line";
         AsmBOMComp: Record "BOM Component";
+        SKU: Record "Stockkeeping Unit";
+        ProcessedItemNos: List of [Code[20]];
         ActLevel: Integer;
         TotalLevels: Integer;
         CalculateDeeperLevel: Boolean;
@@ -68,6 +73,18 @@ codeunit 99000793 "Calculate Low-Level Code"
                             if ActLevel > TotalLevels then
                                 TotalLevels := ActLevel;
                         until Item2.Next() = 0;
+
+                    SKU.SetCurrentKey("Production BOM No.");
+                    SKU.SetRange("Production BOM No.", No);
+                    if SKU.FindSet() then
+                        repeat
+                            if not ProcessedItemNos.Contains(SKU."Item No.") then begin
+                                ProcessedItemNos.Add(SKU."Item No.");
+                                ActLevel := CalcLevels(Type::Item, SKU."Item No.", Level + 1, LevelDepth + 1);
+                                if ActLevel > TotalLevels then
+                                    TotalLevels := ActLevel;
+                            end;
+                        until SKU.Next() = 0;
                     OnCalcLevelsForProdBOM(Item2, No, Level, LevelDepth, TotalLevels);
                 end;
             Type::Assembly:
@@ -152,6 +169,36 @@ codeunit 99000793 "Calculate Low-Level Code"
             until ProdBOMLine.Next() = 0;
     end;
 
+    local procedure RecalcSKULowerLevels(ItemNo: Code[20]; LowLevelCode: Integer; IgnoreMissingItemsOrBOMs: Boolean)
+    var
+        SKU: Record "Stockkeeping Unit";
+        CompBOM: Record "Production BOM Header";
+        TempCompBOM: Record "Production BOM Header" temporary;
+        EntityPresent: Boolean;
+    begin
+        if LowLevelCode > 50 then
+            Error(ProdBomErr, 50, Item."No.", ItemNo, LowLevelCode);
+        SKU.SetCurrentKey("Item No.");
+        SKU.SetRange("Item No.", ItemNo);
+        SKU.SetFilter("Production BOM No.", '<>%1', '');
+        if SKU.FindSet() then
+            repeat
+                if not TempCompBOM.Get(SKU."Production BOM No.") then begin
+                    EntityPresent := CompBOM.Get(SKU."Production BOM No.");
+                    if EntityPresent or (not IgnoreMissingItemsOrBOMs) then begin
+                        SetRecursiveLevelsOnBOM(CompBOM, LowLevelCode, IgnoreMissingItemsOrBOMs);
+                        if EntityPresent then
+                            TempCompBOM := CompBOM
+                        else begin
+                            TempCompBOM.Init();
+                            TempCompBOM."No." := SKU."Production BOM No.";
+                        end;
+                        TempCompBOM.Insert();
+                    end;
+                end;
+            until SKU.Next() = 0;
+    end;
+
     procedure RecalcAsmLowerLevels(ParentItemNo: Code[20]; LowLevelCode: Integer; IgnoreMissingItemsOrBOMs: Boolean)
     var
         CompItem: Record Item;
@@ -196,6 +243,8 @@ codeunit 99000793 "Calculate Low-Level Code"
                 if EntityPresent or (not IgnoreMissingItemsOrBOMs) then
                     SetRecursiveLevelsOnBOM(CompBOM, CompItem."Low-Level Code" + 1, IgnoreMissingItemsOrBOMs);
             end;
+
+            RecalcSKULowerLevels(CompItem."No.", CompItem."Low-Level Code" + 1, IgnoreMissingItemsOrBOMs);
             OnSetRecursiveLevelsOnItemOnBeforeCompItemModify(CompItem, IgnoreMissingItemsOrBOMs);
             CompItem.Modify();
         end;

--- a/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/CalculateLowLevelCode.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/ProductionBOM/CalculateLowLevelCode.Codeunit.al
@@ -6,8 +6,8 @@ namespace Microsoft.Manufacturing.ProductionBOM;
 
 using Microsoft.Inventory.BOM;
 using Microsoft.Inventory.Item;
-using Microsoft.Manufacturing.Setup;
 using Microsoft.Inventory.Location;
+using Microsoft.Manufacturing.Setup;
 
 codeunit 99000793 "Calculate Low-Level Code"
 {

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufLowLevelCode.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufLowLevelCode.Codeunit.al
@@ -5,9 +5,9 @@
 namespace Microsoft.Manufacturing.Test;
 
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Location;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Setup;
-using Microsoft.Inventory.Location;
 
 codeunit 137039 "SCM Manuf Low Level Code"
 {

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufLowLevelCode.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufLowLevelCode.Codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.Manufacturing.Test;
 using Microsoft.Inventory.Item;
 using Microsoft.Manufacturing.ProductionBOM;
 using Microsoft.Manufacturing.Setup;
+using Microsoft.Inventory.Location;
 
 codeunit 137039 "SCM Manuf Low Level Code"
 {
@@ -22,6 +23,7 @@ codeunit 137039 "SCM Manuf Low Level Code"
         ManufacturingSetup: Record "Manufacturing Setup";
         LibraryInventory: Codeunit "Library - Inventory";
         LibraryManufacturing: Codeunit "Library - Manufacturing";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         isInitialized: Boolean;
 
@@ -190,6 +192,148 @@ codeunit 137039 "SCM Manuf Low Level Code"
         RestoreManufacturingSetup(TempManufacturingSetup);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure LowLevelCodeWithSKULevelProductionBOM()
+    var
+        CompItem: Record Item;
+        SemiItem: Record Item;
+        FinishedItem: Record Item;
+        TempManufacturingSetup: Record "Manufacturing Setup" temporary;
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        LocationCode: Code[10];
+    begin
+        // [SCENARIO 648732] [AI] 0.2 Multi-level BOMs assigned on Stockkeeping Units must get correct Low-Level Codes in a single pass.
+        // [GIVEN] Dynamic Low-Level Code enabled.
+        Initialize();
+        UpdateManufacturingSetup(TempManufacturingSetup, true);
+        LocationCode := CreateLocation();
+
+        // [GIVEN] Three items: Component, Semi-finished and Finished, none carrying an Item-card Production BOM.
+        LibraryInventory.CreateItem(CompItem);
+        LibraryInventory.CreateItem(SemiItem);
+        LibraryInventory.CreateItem(FinishedItem);
+
+        // [GIVEN] Semi-finished item has a certified BOM (with the Component) assigned on its SKU.
+        CreateProdBOM(ProductionBOMHeader, ProductionBOMLine.Type::Item, CompItem."No.", '', SemiItem."Base Unit of Measure", false);
+        CreateSKUWithProdBOM(SemiItem."No.", LocationCode, ProductionBOMHeader."No.");
+
+        // [GIVEN] Finished item has a certified BOM (with the Semi-finished item) assigned on its SKU.
+        CreateProdBOM(ProductionBOMHeader, ProductionBOMLine.Type::Item, SemiItem."No.", '', FinishedItem."Base Unit of Measure", false);
+        CreateSKUWithProdBOM(FinishedItem."No.", LocationCode, ProductionBOMHeader."No.");
+
+        // [THEN] Low-Level Codes reflect the full multi-level SKU BOM structure without a second calculation.
+        VerifyLowLevelCode(FinishedItem."No.", '', 0);
+        VerifyLowLevelCode(SemiItem."No.", '', 1);
+        VerifyLowLevelCode(CompItem."No.", '', 2);
+
+        // Tear Down: Dynamic Low-Level Code set to Default in Manufacturing setup.
+        RestoreManufacturingSetup(TempManufacturingSetup);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure RecalculateLowLevelCodeWithExistingSKULevelProductionBOM()
+    var
+        CompItem: Record Item;
+        SemiItem: Record Item;
+        FinishedItem: Record Item;
+        TempManufacturingSetup: Record "Manufacturing Setup" temporary;
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        LocationCode: Code[10];
+        SemiBOMNo: Code[20];
+        FinishedBOMNo: Code[20];
+    begin
+        // [SCENARIO 648732] [AI] 0.2 Recalculating an item through Calculate Low-Level Code must resolve the full multi-level chain when the BOMs already exist on Stockkeeping Units.
+        // [GIVEN] Dynamic Low-Level Code enabled and a 3-level SKU-only BOM structure (Finished -> Semi -> Component).
+        Initialize();
+        UpdateManufacturingSetup(TempManufacturingSetup, true);
+        LocationCode := CreateLocation();
+
+        LibraryInventory.CreateItem(CompItem);
+        LibraryInventory.CreateItem(SemiItem);
+        LibraryInventory.CreateItem(FinishedItem);
+
+        CreateProdBOM(ProductionBOMHeader, ProductionBOMLine.Type::Item, CompItem."No.", '', SemiItem."Base Unit of Measure", false);
+        SemiBOMNo := ProductionBOMHeader."No.";
+        CreateSKUWithProdBOM(SemiItem."No.", LocationCode, SemiBOMNo);
+
+        CreateProdBOM(ProductionBOMHeader, ProductionBOMLine.Type::Item, SemiItem."No.", '', FinishedItem."Base Unit of Measure", false);
+        FinishedBOMNo := ProductionBOMHeader."No.";
+        CreateSKUWithProdBOM(FinishedItem."No.", LocationCode, FinishedBOMNo);
+
+        // [GIVEN] All low-level codes are reset, simulating a recalculation over pre-existing data.
+        ResetItemLowLevelCode(CompItem."No.");
+        ResetItemLowLevelCode(SemiItem."No.");
+        ResetItemLowLevelCode(FinishedItem."No.");
+        ResetProdBOMLowLevelCode(SemiBOMNo);
+        ResetProdBOMLowLevelCode(FinishedBOMNo);
+
+        // [WHEN] Calculate Low-Level Code is run for the finished item (OnRun -> RecalcSKULowerLevels cascades down through SKU-level BOMs).
+        RunCalculateLowLevelCode(FinishedItem."No.");
+
+        // [THEN] The whole chain is recalculated through the SKU-level BOMs in a single pass.
+        VerifyLowLevelCode(FinishedItem."No.", '', 0);
+        VerifyLowLevelCode(SemiItem."No.", '', 1);
+        VerifyLowLevelCode(CompItem."No.", '', 2);
+
+        // [WHEN] Only the component is reset and recalculated (CalcLevels walks up through the SKU-level parents).
+        ResetItemLowLevelCode(CompItem."No.");
+        RunCalculateLowLevelCode(CompItem."No.");
+
+        // [THEN] The component still resolves to level 2 by traversing its SKU-level BOM parents.
+        VerifyLowLevelCode(CompItem."No.", '', 2);
+
+        // Tear Down: Dynamic Low-Level Code set to Default in Manufacturing setup.
+        RestoreManufacturingSetup(TempManufacturingSetup);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure LowLevelCodeWithMultipleSKUsForSameItemAndBOM()
+    var
+        CompItem: Record Item;
+        ParentItem: Record Item;
+        TempManufacturingSetup: Record "Manufacturing Setup" temporary;
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionBOMLine: Record "Production BOM Line";
+        FirstLocationCode: Code[10];
+        SecondLocationCode: Code[10];
+        ParentBOMNo: Code[20];
+    begin
+        // [SCENARIO 648732] [AI] 0.2 Calculate Low-Level Code must resolve correctly and process the item only once when several SKUs of the same item share the same production BOM.
+        // [GIVEN] Dynamic Low-Level Code enabled and two locations.
+        Initialize();
+        UpdateManufacturingSetup(TempManufacturingSetup, true);
+        FirstLocationCode := CreateLocation();
+        SecondLocationCode := CreateLocation();
+
+        // [GIVEN] A component item and a parent item, with the parent's certified BOM (containing the component) assigned to two SKUs of the same parent item.
+        LibraryInventory.CreateItem(CompItem);
+        LibraryInventory.CreateItem(ParentItem);
+        CreateProdBOM(ProductionBOMHeader, ProductionBOMLine.Type::Item, CompItem."No.", '', ParentItem."Base Unit of Measure", false);
+        ParentBOMNo := ProductionBOMHeader."No.";
+        CreateSKUWithProdBOM(ParentItem."No.", FirstLocationCode, ParentBOMNo);
+        CreateSKUWithProdBOM(ParentItem."No.", SecondLocationCode, ParentBOMNo);
+
+        // [GIVEN] All low-level codes are reset, simulating a recalculation over pre-existing data.
+        ResetItemLowLevelCode(CompItem."No.");
+        ResetItemLowLevelCode(ParentItem."No.");
+        ResetProdBOMLowLevelCode(ParentBOMNo);
+
+        // [WHEN] Calculate Low-Level Code is run for the component (CalcLevels walks up through both SKUs pointing to the same BOM).
+        RunCalculateLowLevelCode(CompItem."No.");
+
+        // [THEN] The codes resolve correctly regardless of the number of duplicate SKUs pointing to the same BOM.
+        VerifyLowLevelCode(ParentItem."No.", '', 0);
+        VerifyLowLevelCode(CompItem."No.", '', 1);
+
+        // Tear Down: Dynamic Low-Level Code set to Default in Manufacturing setup.
+        RestoreManufacturingSetup(TempManufacturingSetup);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -257,6 +401,49 @@ codeunit 137039 "SCM Manuf Low Level Code"
         Item.Get(ItemNo);
         Item.Validate("Production BOM No.", ProductionBOMNo);
         Item.Modify(true);
+    end;
+
+    local procedure CreateLocation(): Code[10]
+    var
+        Location: Record Location;
+    begin
+        exit(LibraryWarehouse.CreateLocationWithInventoryPostingSetup(Location));
+    end;
+
+    local procedure CreateSKUWithProdBOM(ItemNo: Code[20]; LocationCode: Code[10]; ProductionBOMNo: Code[20])
+    var
+        StockkeepingUnit: Record "Stockkeeping Unit";
+    begin
+        LibraryInventory.CreateStockkeepingUnitForLocationAndVariant(StockkeepingUnit, LocationCode, ItemNo, '');
+        StockkeepingUnit.Validate("Production BOM No.", ProductionBOMNo);
+        StockkeepingUnit.Modify(true);
+    end;
+
+    local procedure ResetItemLowLevelCode(ItemNo: Code[20])
+    var
+        Item: Record Item;
+    begin
+        Item.Get(ItemNo);
+        Item."Low-Level Code" := 0;
+        Item.Modify();
+    end;
+
+    local procedure ResetProdBOMLowLevelCode(ProductionBOMNo: Code[20])
+    var
+        ProductionBOMHeader: Record "Production BOM Header";
+    begin
+        ProductionBOMHeader.Get(ProductionBOMNo);
+        ProductionBOMHeader."Low-Level Code" := 0;
+        ProductionBOMHeader.Modify();
+    end;
+
+    local procedure RunCalculateLowLevelCode(ItemNo: Code[20])
+    var
+        Item: Record Item;
+        CalculateLowLevelCode: Codeunit "Calculate Low-Level Code";
+    begin
+        Item.Get(ItemNo);
+        CalculateLowLevelCode.Run(Item);
     end;
 
     local procedure UpdateProductionBom(var ProductionBOMHeader: Record "Production BOM Header"; ItemNo: Code[20])


### PR DESCRIPTION
Fixes: [AB#648732](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648732)

**Issue :-**
Planning Worksheet needs a second Calculate Regenerative Plan run to generate all planning lines for multi-level BOMs when the Production BOMs are assigned at the SKU level (item card blank). The first run plans only the top two levels; the component's transfer/purchase supply appears only on the second run.

**Root cause :-**
Planning processes items once, ordered by stored Low-Level Code. The dynamic engine (codeunit 99000793 Calculate Low-Level Code) only walked item-card BOMs, not SKU-level BOMs, so a SKU-only component got the same code as its parent instead of a higher one. Also, the SKU Production BOM No. OnValidate computed the item's code but never saved it. With equal codes, the component was processed before its demand existed → second run needed.

**Solutions :-**
CalculateLowLevelCode.Codeunit.al: made the engine SKU-aware — CalcLevels now traverses upward through SKUs referencing a BOM, and a new RecalcSKULowerLevels propagates codes downward through SKU-level BOMs (called from OnRun and SetRecursiveLevelsOnItem).
MfgStockkeepingUnit.TableExt.al: SKU Production BOM No. OnValidate now persists the recalculated item low-level code.
SCMManufLowLevelCode.Codeunit.al: added test LowLevelCodeWithSKULevelProductionBOM (SKU-only 3-level chain → Finished=0, Semi=1, Component=2).




