### PR TITLE
[Payables Agent] Match TTA candidates to line description

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocPurchaseDraftSubform.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocPurchaseDraftSubform.Page.al
@@ -345,7 +345,7 @@ page 6183 "E-Doc. Purchase Draft Subform"
                     {
                         ApplicationArea = All;
                         Caption = 'Text-to-Account Mappings';
-                        ToolTip = 'Opens the Text-to-Account Mapping filtered for the current vendor.';
+                        ToolTip = 'Opens Text-to-Account Mappings showing only candidates whose Mapping Text is contained in the selected line description.';
                         Image = MapAccounts;
                         Scope = Repeater;
                         Visible = AgentDrivenLineMatchingEnabled;
@@ -353,10 +353,23 @@ page 6183 "E-Doc. Purchase Draft Subform"
                         trigger OnAction()
                         var
                             TextToAccountMapping: Record "Text-to-Account Mapping";
+                            TempMapping: Record "Text-to-Account Mapping" temporary;
+                            EDocTTACandidateFilter: Codeunit "E-Doc. TTA Candidate Filter";
+                            LineNoFilter: Text;
                         begin
                             EnsureEDocumentPurchaseHeader();
                             EDocumentPurchaseHeader.TestField("[BC] Vendor No.");
-                            TextToAccountMapping.SetFilter("Vendor No.", '%1|%2', '', EDocumentPurchaseHeader."[BC] Vendor No.");
+                            EDocTTACandidateFilter.GetCandidates(Rec.Description, EDocumentPurchaseHeader."[BC] Vendor No.", TempMapping);
+                            if TempMapping.FindSet() then
+                                repeat
+                                    if LineNoFilter <> '' then
+                                        LineNoFilter += '|';
+                                    LineNoFilter += Format(TempMapping."Line No.");
+                                until TempMapping.Next() = 0;
+                            if LineNoFilter <> '' then
+                                TextToAccountMapping.SetFilter("Line No.", LineNoFilter)
+                            else
+                                TextToAccountMapping.SetRange("Line No.", -1);
                             Page.Run(Page::"Text-to-Account Mapping", TextToAccountMapping);
                         end;
                     }

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocTTACandidateFilter.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocTTACandidateFilter.Codeunit.al
@@ -1,0 +1,48 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Import.Purchase;
+
+using Microsoft.Bank.Reconciliation;
+
+/// <summary>
+/// Selects Text-to-Account Mapping candidates that are applicable to a given line description and vendor.
+/// Only records whose Mapping Text is a case-insensitive substring of the line description are returned;
+/// this prevents unrelated mappings from being presented as candidates when an invoice line is being matched.
+/// </summary>
+codeunit 6245 "E-Doc. TTA Candidate Filter"
+{
+    Access = Internal;
+    InherentPermissions = X;
+    InherentEntitlements = X;
+
+    /// <summary>
+    /// Populates TempTextToAccMapping with Text-to-Account Mapping records that satisfy both:
+    ///   1. Vendor No. is blank (global mapping) or equals VendorNo.
+    ///   2. Mapping Text is a case-insensitive substring of LineDescription.
+    /// The caller-supplied temporary table is cleared and reset before population.
+    /// </summary>
+    procedure GetCandidates(LineDescription: Text[250]; VendorNo: Code[20]; var TempTextToAccMapping: Record "Text-to-Account Mapping" temporary)
+    var
+        TextToAccMapping: Record "Text-to-Account Mapping";
+    begin
+        TempTextToAccMapping.Reset();
+        TempTextToAccMapping.DeleteAll();
+
+        if LineDescription = '' then
+            exit;
+
+        TextToAccMapping.SetFilter("Vendor No.", '%1|%2', '', VendorNo);
+        if not TextToAccMapping.FindSet() then
+            exit;
+
+        repeat
+            if TextToAccMapping."Mapping Text" <> '' then
+                if StrPos(UpperCase(LineDescription), UpperCase(TextToAccMapping."Mapping Text")) > 0 then begin
+                    TempTextToAccMapping := TextToAccMapping;
+                    TempTextToAccMapping.Insert();
+                end;
+        until TextToAccMapping.Next() = 0;
+    end;
+}

--- a/src/Apps/W1/PayablesAgent/app/.resources/Prompts/PayablesAgent-AgentInstructions-AgentDriven.md
+++ b/src/Apps/W1/PayablesAgent/app/.resources/Prompts/PayablesAgent-AgentInstructions-AgentDriven.md
@@ -191,8 +191,10 @@ For taking a decision on your next step you **MUST** follow the guidance under t
 
   #### Source B: Text-to-Account Mappings (TTA)
   - With the line selected, navigate to "Text-to-Account Mappings" from the line actions
-  - Search for the line description using letter-by-letter search
-  - Record the result: G/L Account No. from Debit Acc. No. if the Mapping Text matches, or "no match"
+  - The page already shows only candidates whose Mapping Text is contained in the currently selected line description. Do not apply additional text searches.
+  - If the page is empty: record "no match" — the application has confirmed there are no TTA candidates for this line description. Do not infer or carry over a mapping from another line.
+  - If the page shows rows: verify that the Mapping Text of the row you select is indeed contained in the current line description, then record the G/L Account No. from Debit Acc. No. as the match.
+  - **Never reuse a TTA candidate across lines**: navigate to "Text-to-Account Mappings" separately for each draft line, as the candidate list is recalculated per line description.
 
   #### Source C: Historical Purchase Lines
   - With the line selected, navigate to "Historical Purchase Lines" from the line actions


### PR DESCRIPTION
## Bug Reference

[ADO work item 648714](https://dev.azure.com/dynamicssmb2/Dynamics%20SMB/_workitems/edit/648714)

## Summary

Restricts Text-to-Account candidates to mappings whose Mapping Text occurs in the currently selected invoice-line description. This prevents the Payables Agent from assigning the first visible, unrelated mapping to multiple lines.

## Root Cause

The E-Document draft action filtered Text-to-Account Mapping only by blank/current Vendor No. The agent therefore saw unrelated records before searching and could reuse the first row across different invoice lines.

## Changes Made

- Added `E-Doc. TTA Candidate Filter` to select case-insensitive description matches within the global/current-vendor scope.
- Updated `OpenTextToAccountMappings` to expose only the selected line's candidates, or an empty page when none match.
- Strengthened the Payables Agent instructions to validate Mapping Text and never reuse candidates between lines.

## Implementation Process

- Fix iterations: 1 of 5
- Compilation: E-Document Core and Payables Agent compile successfully
- Tests: 5/5 passing

## Test Evidence

### Pre-Fix

- `UnrelatedMappingIsNotACandidate`: failed, returning 2 candidates instead of 1.
- `CandidatesAreIndependentPerLineDescription`: failed, returning both mappings for each line.
- Three vendor/global-scope tests passed.

### Post-Fix

- `UnrelatedMappingIsNotACandidate`: passed
- `MatchingCurrentVendorMappingIsCandidate`: passed
- `MatchingGlobalMappingIsCandidate`: passed
- `OtherVendorMappingIsNotACandidate`: passed
- `CandidatesAreIndependentPerLineDescription`: passed

The E-Document Core, Payables Agent, and Payables Agent Tests apps were rebuilt and published before the final test run.

## Review Notes

Review the case-insensitive substring criterion and the temporary candidate-to-Line-No. page filter.
