### PR TITLE
[Bug 646558] Stabilize remittance advice test initialization

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocRemitAdviceTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocRemitAdviceTest.Codeunit.al
@@ -614,12 +614,6 @@ codeunit 139547 "E-Doc. Remit. Advice Test"
         if BindSubscription(LibraryJobQueue) then;
         LibraryJobQueue.SetDoNotHandleCodeunitJobQueueEnqueueEvent(true);
 
-        GeneralLedgerSetup.Get();
-        if GeneralLedgerSetup."VAT Reporting Date Usage" <> GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled then begin
-            GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
-            GeneralLedgerSetup.Modify(false);
-        end;
-
         EDocumentService.DeleteAll();
 
         LibraryEDoc.SetupStandardVAT();
@@ -633,6 +627,14 @@ codeunit 139547 "E-Doc. Remit. Advice Test"
         Vendor.Modify(true);
 
         CreatePaymentJournalBatch();
+
+        GeneralLedgerSetup.Get();
+        if GeneralLedgerSetup."VAT Reporting Date Usage" <> GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled then begin
+            GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
+            GeneralLedgerSetup.Modify(false);
+        end;
+
+        Commit();
 
         IsInitialized := true;
     end;


### PR DESCRIPTION
## Why

The E-Document remittance advice tests can still fail across localization runs because shared scenario initialization may change VAT reporting date usage after it was disabled. A failed test can also roll back fixture records while the codeunit-level `IsInitialized` flag remains set, leaving later tests with inconsistent setup.

## Summary

- **Moved** VAT reporting date normalization after shared E-Document scenario initialization so localization setup cannot overwrite it.
- **Committed** initialized fixture records before setting `IsInitialized` to keep database state aligned with the codeunit flag after test rollback.

Fixes [AB#646558](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646558)
