### PR TITLE
[29.0] bug 648733 - Add integration event for updating original document VAT date in General Ledger Setup CZL

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/GeneralLedgerSetupCZL.TableExt.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/GeneralLedgerSetupCZL.TableExt.al
@@ -180,6 +180,7 @@ tableextension 11713 "General Ledger Setup CZL" extends "General Ledger Setup"
     begin
         if ("Def. Orig. Doc. VAT Date CZL" = DefaultOrigDocVATDate) then
             OriginalDocumentVATDate := NewDate;
+        OnAfterUpdateOriginalDocumentVATDateCZL(NewDate, DefaultOrigDocVATDate, OriginalDocumentVATDate);
     end;
 
     procedure GetOriginalDocumentVATDateCZL(PostingDate: Date; VATDate: Date; DocumentDate: Date): Date
@@ -233,6 +234,11 @@ tableextension 11713 "General Ledger Setup CZL" extends "General Ledger Setup"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterInitVATDateCZL()
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterUpdateOriginalDocumentVATDateCZL(NewDate: Date; DefaultOrigDocVATDate: Enum "Default Orig.Doc. VAT Date CZL"; var OriginalDocumentVATDate: Date)
     begin
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/GeneralLedgerSetupCZL.TableExt.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/TableExtensions/GeneralLedgerSetupCZL.TableExt.al
@@ -238,7 +238,7 @@ tableextension 11713 "General Ledger Setup CZL" extends "General Ledger Setup"
     end;
 
     [IntegrationEvent(false, false)]
-    local procedure OnAfterUpdateOriginalDocumentVATDateCZL(NewDate: Date; DefaultOrigDocVATDate: Enum "Default Orig.Doc. VAT Date CZL"; var OriginalDocumentVATDate: Date)
+    local procedure OnAfterUpdateOriginalDocumentVATDateCZL(NewDate: Date; DefaultOriginalDocumentVATDate: Enum "Default Orig.Doc. VAT Date CZL"; var OriginalDocumentVATDate: Date)
     begin
     end;
 }


### PR DESCRIPTION
## What & why

The UpdateOriginalDocumentVATDateCZL procedure in the "General Ledger Setup" table currently does not allow extension with custom logic. This procedure is called from handlers in Codeunit 11744 when source fields change (posting date, document date, VAT date) and sets the value of the "Original Doc. VAT Date CZL" field in Purchase Header based on the "Default Orig.Doc. VAT Date CZL" setting. The call chain handler → UpdateOriginalDocumentVATDateCZL → validation provides no extensibility point to modify the behavior.

The integration event for updating original document VAT date in General Ledger Setup CZL has been added

## Linked work

Fixes [AB#648733](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648733)

