### PR TITLE
[29.x] Promote Excise Taxes action on Item card

### DIFF
--- a/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseItemCardExt.PageExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseItemCardExt.PageExt.al
@@ -62,7 +62,7 @@ pageextension 7415 "Excise Item Card Ext" extends "Item Card"
                 RunPageLink = "Item No." = field("No.");
             }
         }
-        addlast(Category_Process)
+        addlast(Category_Category4)
         {
             actionref("Excise Taxes_Promoted"; "Excise Taxes")
             {

--- a/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseItemCardExt.PageExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseItemCardExt.PageExt.al
@@ -62,5 +62,11 @@ pageextension 7415 "Excise Item Card Ext" extends "Item Card"
                 RunPageLink = "Item No." = field("No.");
             }
         }
+        addafter(ApplyTemplate_Promoted)
+        {
+            actionref("Excise Taxes_Promoted"; "Excise Taxes")
+            {
+            }
+        }
     }
 }

--- a/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseItemCardExt.PageExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseItemCardExt.PageExt.al
@@ -62,7 +62,7 @@ pageextension 7415 "Excise Item Card Ext" extends "Item Card"
                 RunPageLink = "Item No." = field("No.");
             }
         }
-        addafter(ApplyTemplate_Promoted)
+        addlast(Category_Process)
         {
             actionref("Excise Taxes_Promoted"; "Excise Taxes")
             {


### PR DESCRIPTION
## Description
Backport of the Item Card action promotion for Excise Taxes.

## Work item
- [AB#648828](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648828)

## Reference
- [Bug 648828](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648828): [29.x] Promote Excise Taxes action on Item card




