### PR TITLE
[Main]-Test disabled after BCApps uptake: Reminder Automation Tests.TestReminderAutomationLogsInteractionWithIssuedReminderNumber fails (CZ)

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Reports/ReminderCZL.Report.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Reports/ReminderCZL.Report.al
@@ -485,7 +485,7 @@ report 31182 "Reminder CZL"
 
                 if LogInteraction and not IsReportInPreviewMode() then
                     SegManagement.LogDocument(
-                      8, "No.", 0, 0, Database::Customer, "Customer No.", '', '', "Posting Description", '');
+                                            8, "No.", 0, 0, Database::Customer, "Customer No.", '', '', GetLogInteractionDescription(), '');
 
                 if "Currency Code" = '' then
                     "Currency Code" := "General Ledger Setup"."LCY Code";


### PR DESCRIPTION
Workitem [Bug 642684](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642684): [All-e]Test disabled after BCApps uptake: Reminder Automation Tests.TestReminderAutomationLogsInteractionWithIssuedReminderNumber fails (IT + CZ)

Fixes [AB#642684](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642684)

This Pull Request is created to enable disabled TestReminderAutomationLogsInteractionWithIssuedReminderNumber fails which is failing in CZ.




