### PR TITLE
Rename ADO sync trigger label from "Linked" to "ADO: Sync"

### DIFF
--- a/.github/workflows/WorkitemValidation.yaml
+++ b/.github/workflows/WorkitemValidation.yaml
@@ -60,12 +60,12 @@ jobs:
         run: |
           build/scripts/PullRequestValidation/ValidateInternalWorkItemForPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }}
 
-      - name: Add Linked label to PR
+      - name: Add sync label to PR
         if: github.event.pull_request.head.repo.full_name != github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels  -f "labels[]=Linked" -H "Accept: application/vnd.github.v3+json" -H "X-GitHub-Api-Version: 2022-11-28"
+          gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels  -f "labels[]=ADO: Sync" -H "Accept: application/vnd.github.v3+json" -H "X-GitHub-Api-Version: 2022-11-28"
 
       - name: Get repo version from target branch
         id: get-repo-version


### PR DESCRIPTION
## What & why

The DME `GitHubAutomations` Azure Function that creates Azure DevOps work items from GitHub activity is being renamed to trigger on the `ADO: Sync` label instead of `Linked` (DME-side change: PR #6613 in BC-EngSys-DME). This repo's `WorkItemValidationForMicrosoft` job is the producer of that trigger label on fork PRs, so it must apply the new name or the ADO-sync automation stops firing after the DME rollout.

This changes the single label-application site in `.github/workflows/WorkitemValidation.yaml`:
- Applies `ADO: Sync` instead of `Linked` (quoting preserved so the space/colon passes literally to `gh api`).
- Renames the step for clarity.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

N/A - coordinated cross-repo automation rename (DME PR #6613).

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Workflow-only change; not locally executable. Verified the diff touches only the step name and the `labels[]=` value, with quoting intact for the `ADO: Sync` value. No tests apply.

## Risk & compatibility

Must be coordinated with the DME rollout (PR #6613) and the repo must have an `ADO: Sync` label defined in settings, since `gh api ... labels[]=` fails if the label does not already exist. Ordering note: this step runs after `ValidateInternalWorkItemForPullRequest.ps1`, which throws when a PR has no `AB#` work item, so the label is only applied to fork PRs that already link an ADO work item; behavior is unchanged from before the rename.

[AB#648850](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648850)
