### PR TITLE
[Event Request] Codeunit 730 "Copy Item": Add price-specific before event

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Item/CopyItem.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/CopyItem.Codeunit.al
@@ -378,7 +378,13 @@ codeunit 730 "Copy Item"
     var
         NewPriceListLine: Record "Price List Line";
         PriceListLine: Record "Price List Line";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeCopyItemPriceListLines2(FromItemNo, ToItemNo, PriceType, AmountType, IsHandled);
+        if IsHandled then
+            exit;
+
         PriceListLine.SetRange("Price Type", PriceType);
         PriceListLine.SetRange("Amount Type", AmountType);
         PriceListLine.SetRange("Asset Type", PriceListLine."Asset Type"::Item);
@@ -547,6 +553,11 @@ codeunit 730 "Copy Item"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCopyItemPriceListLines(FromItemNo: Code[20]; ToItemNo: Code[20]; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCopyItemPriceListLines2(FromItemNo: Code[20]; ToItemNo: Code[20]; PriceType: Enum "Price Type"; AmountType: Enum "Price Amount Type"; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
## What & why

Adds `OnBeforeCopyItemPriceListLines2` to the price-specific `CopyItemPriceListLines` overload. The event exposes `PriceType` and `AmountType` and lets subscribers handle that individual copy operation before filters and inserts run.

The `2` suffix keeps the publisher name unique because `OnBeforeCopyItemPriceListLines` already exists for the dispatcher overload.

## Linked work
Fixes [AB#462363](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/462363)

Related to microsoft/ALAppExtensions#21991




