### PR TITLE
[Extensibility Request] issue 30420: add service post and send events

### DIFF
--- a/src/Layers/W1/BaseApp/Service/Posting/ServicePostandSend.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Posting/ServicePostandSend.Codeunit.al
@@ -27,22 +27,33 @@ codeunit 5979 "Service-Post and Send"
     var
         TempDocumentSendingProfile: Record "Document Sending Profile" temporary;
         ServicePost: Codeunit "Service-Post";
+        ConfirmPostAndSendIsHandled: Boolean;
+        PostIsHandled: Boolean;
+        SkipPost: Boolean;
     begin
         OnBeforeCode(ServiceHeader);
 
-        case ServiceHeader."Document Type" of
-            ServiceHeader."Document Type"::Invoice,
-              ServiceHeader."Document Type"::"Credit Memo":
-                if not ConfirmPostAndSend(ServiceHeader, TempDocumentSendingProfile) then
-                    exit;
-            else
-                Error(NotSupportedDocumentTypeErr, ServiceHeader."Document Type");
-        end;
+        ConfirmPostAndSendIsHandled := false;
+        OnCodeOnBeforeConfirmPostAndSend(ServiceHeader, ConfirmPostAndSendIsHandled);
+        if ConfirmPostAndSendIsHandled or
+           (ServiceHeader."Document Type" in [ServiceHeader."Document Type"::Invoice, ServiceHeader."Document Type"::"Credit Memo"])
+        then begin
+            if not ConfirmPostAndSend(ServiceHeader, TempDocumentSendingProfile) then
+                exit;
+        end else
+            Error(NotSupportedDocumentTypeErr, ServiceHeader."Document Type");
 
         TempDocumentSendingProfile.CheckElectronicSendingEnabled();
         ValidateElectronicFormats(TempDocumentSendingProfile);
 
-        CODEUNIT.Run(CODEUNIT::"Service-Post", ServiceHeader);
+        PostIsHandled := false;
+        SkipPost := false;
+        OnCodeOnBeforePost(ServiceHeader, PostIsHandled, SkipPost);
+        if not PostIsHandled then
+            CODEUNIT.Run(CODEUNIT::"Service-Post", ServiceHeader);
+
+        if SkipPost then
+            exit;
 
         OnAfterPostAndBeforeSend(ServiceHeader);
         Commit();
@@ -111,6 +122,16 @@ codeunit 5979 "Service-Post and Send"
     end;
 
     [IntegrationEvent(false, false)]
+    local procedure OnCodeOnBeforeConfirmPostAndSend(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnCodeOnBeforePost(var ServiceHeader: Record "Service Header"; var IsHandled: Boolean; var SkipPost: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
     local procedure OnAfterCode(var ServiceHeader: Record "Service Header")
     begin
     end;
@@ -120,4 +141,3 @@ codeunit 5979 "Service-Post and Send"
     begin
     end;
 }
-


### PR DESCRIPTION
## Summary
Service integrations need to use Post & Send for Service Orders without copying codeunit 5979 or being limited to the standard Service-Post routine. This PR adds extension points that allow additional document types through confirmation and let subscribers safely replace posting or stop before sending when no posted document was created.

Source issue repository: microsoft/AlAppExtensions; issue number: 30420

## Changes Made
- `Service-Post and Send.Code()` - added pre-confirmation and pre-post integration events so extensions can support additional service document types and substitute posting while coordinating whether sending should continue.

Fixes [AB#648196](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648196)




