### PR TITLE
[Master]-BCApps uptake: Swiss SEPA CT Export / CT 09 Export.XMLExport_PaymentType3_Negative_BlankedSWIFT fails- #10720

### DIFF
--- a/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACT09Export.Codeunit.al
@@ -937,6 +937,7 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmHandler')]
     procedure XMLExport_PaymentType3_Negative_BlankedSWIFT()
     var
         GenJournalLine: Record "Gen. Journal Line";
@@ -4236,6 +4237,12 @@ codeunit 144354 "Swiss SEPA CT 09 Export"
     begin
         PostedPurchInvoiceUpdate."Payment Reference".SetValue(LibraryVariableStorage.DequeueText());
         PostedPurchInvoiceUpdate.OK().Invoke();
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
     end;
 }
 

--- a/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/SwissSEPACTExport.Codeunit.al
@@ -940,6 +940,7 @@ codeunit 144352 "Swiss SEPA CT Export"
 
     [Test]
     [Scope('OnPrem')]
+    [HandlerFunctions('ConfirmHandler')]
     procedure XMLExport_PaymentType3_Negative_BlankedSWIFT()
     var
         GenJournalLine: Record "Gen. Journal Line";
@@ -4398,5 +4399,11 @@ codeunit 144352 "Swiss SEPA CT Export"
     begin
         GeneralJournalTemplateList.GotoKey(LibraryVariableStorage.DequeueText());
         GeneralJournalTemplateList.OK().Invoke();
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := true;
     end;
 }


### PR DESCRIPTION
Fixes [AB#647205](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647205)

test failed due to change in

[[CH][SEPA CT] Export requires both IBAN and Clearing No. for domestic payments and refunds by dcenic · Pull Request #10136 · microsoft/BCApps](https://github.com/microsoft/BCApps/pull/10136/changes)


