### PR TITLE
Backport #10990: [29.0] Add Expense VAT settings to Contoso demo tool

### DIFF
--- a/src/Apps/W1/ExpenseAgent/demo data/Demo Data/ExpenseAgentContosoModule.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/demo data/Demo Data/ExpenseAgentContosoModule.Codeunit.al
@@ -37,6 +37,7 @@ codeunit 8202 "Expense Agent Contoso Module" implements "Contoso Demo Data Modul
         CreateExpenseCountryData: Codeunit "Create Expense Country Data";
     begin
         CreateExpenseCountryData.CreateMasterData();
+        Codeunit.Run(Codeunit::"Create Expense VAT Rates");
     end;
 
     procedure CreateTransactionalData()


### PR DESCRIPTION
Backport of #10990 to `releases/29.0`.

Original change: Add Expense VAT settings to the Contoso demo tool.

Bug [AB#648895](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648895)


