### PR TITLE
[releases/29.x] Missing teaching tip on page 9852 (Effective Permissions) - an agent should be able to handle this

### DIFF
--- a/src/Layers/W1/BaseApp/System/Permissions/EffectivePermissions.Page.al
+++ b/src/Layers/W1/BaseApp/System/Permissions/EffectivePermissions.Page.al
@@ -9,6 +9,8 @@ page 9852 "Effective Permissions"
 {
     ApplicationArea = All;
     Caption = 'Effective Permissions';
+    AboutTitle = 'About Effective Permissions';
+    AboutText = 'View the permissions a user actually has in Business Central. Effective permissions combine all assigned permission sets and filters to show the final access to objects and data, helping you verify access, troubleshoot permission issues, and support audits.';
     DeleteAllowed = false;
     InsertAllowed = false;
     ModifyAllowed = false;


### PR DESCRIPTION
## Summary
Backport of bug #638696 to releases/29.x.

Fixes [AB#648898](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648898)

Original PR: #10579


