### PR TITLE
[releases/29.x] [Shopify] Shopify Activities cue (Page 30100) slow: unindexed COUNT on "Shpfy Order Header"."Has Order State Error" causes full table scan

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Tables/ShpfyOrderHeader.Table.al
@@ -959,6 +959,9 @@ table 30118 "Shpfy Order Header"
         key(Key3; "Created At")
         {
         }
+        key(Key4; "Has Order State Error")
+        {
+        }
     }
     var
         ShopifyOrderLine: Record "Shpfy Order Line";


### PR DESCRIPTION
## Summary
Backport of bug #647742 to releases/29.x.

Fixes [AB#648902](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648902)

Original PR: #10619

