### PR TITLE
[releases/29.x] [MCP] Change the factbox title to be "Active System Tools"

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPSystemToolList.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPSystemToolList.Page.al
@@ -7,7 +7,7 @@ namespace System.MCP;
 
 page 8365 "MCP System Tool List"
 {
-    Caption = 'System Tools';
+    Caption = 'Active System Tools';
     ApplicationArea = All;
     PageType = ListPart;
     SourceTable = "MCP System Tool";


### PR DESCRIPTION
## Summary
Backport of bug #647280 to releases/29.x.

Fixes [AB#648899](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648899)

Original PR: #10432


