### PR TITLE
[releases/29.x] [Shopify] Role Center slow: "Unmapped Customers/Products/Companies" cues count over a lookup FlowField, degrading COUNT(*) into a full-table row-by-row scan

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyCue.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyCue.Table.al
@@ -26,13 +26,13 @@ table 30100 "Shpfy Cue"
         }
         field(2; "Unmapped Customers"; Integer)
         {
-            CalcFormula = count("Shpfy Customer" where("Customer No." = const('')));
+            CalcFormula = count("Shpfy Customer" where("Customer SystemId" = const('00000000-0000-0000-0000-000000000000')));
             Caption = 'Unmapped Customers';
             FieldClass = FlowField;
         }
         field(3; "Unmapped Products"; Integer)
         {
-            CalcFormula = count("Shpfy Product" where("Item No." = const('')));
+            CalcFormula = count("Shpfy Product" where("Item SystemId" = const('00000000-0000-0000-0000-000000000000')));
             Caption = 'Unmapped Products';
             FieldClass = FlowField;
         }
@@ -81,7 +81,7 @@ table 30100 "Shpfy Cue"
         }
         field(9; "Unmapped Companies"; Integer)
         {
-            CalcFormula = count("Shpfy Company" where("Customer No." = const('')));
+            CalcFormula = count("Shpfy Company" where("Customer SystemId" = const('00000000-0000-0000-0000-000000000000')));
             Caption = 'Unmapped Companies';
             FieldClass = FlowField;
         }

--- a/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyProduct.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Tables/ShpfyProduct.Table.al
@@ -168,6 +168,9 @@ table 30127 "Shpfy Product"
         key(Key2; "Shop Code", "Item SystemId")
         {
         }
+        key(Key3; "Item SystemId")
+        {
+        }
     }
 
     trigger OnDelete()


### PR DESCRIPTION
## Summary
Backport of bug #648153 to releases/29.x.

Fixes [AB#648900](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648900)

Original PR: #10775


