### PR TITLE
Bug 648577: [IT] Subcontracting migration does not precheck bin-mandatory locations

### DIFF
--- a/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
@@ -1,6 +1,7 @@
 #if not CLEAN28
 namespace Microsoft.Manufacturing.Subcontracting.Migration;
 
+using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Transfer;
 using Microsoft.Manufacturing.Document;
 using Microsoft.Manufacturing.Routing;
@@ -41,6 +42,7 @@ codeunit 149951 "IT Subc. Migration"
 #if not CLEAN28
         LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
 #endif
+        CheckSubcontractingLocations();
         UIAllowed := ShowDialog and GuiAllowed();
         if UIAllowed then begin
             ConfirmDisableLegacySubcontracting();
@@ -573,6 +575,66 @@ codeunit 149951 "IT Subc. Migration"
         PurchaseHeader.SetFilter("Subcontracting Location Code", '<>%1', '');
     end;
 
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    internal procedure CheckSubcontractingLocations()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        Location: Record Location;
+        LegacySubcontractingLocations: Dictionary of [Code[10], Boolean];
+        LocationCode: Code[10];
+        UnsupportedWarehouseSettings: Text;
+    begin
+        SetVendorMigrationFilters(Vendor);
+        Vendor.SetLoadFields("Subcontracting Location Code");
+        if Vendor.FindSet() then
+            repeat
+                AddLegacySubcontractingLocation(LegacySubcontractingLocations, Vendor."Subcontracting Location Code");
+            until Vendor.Next() = 0;
+
+        SetPurchaseHeaderMigrationFilters(PurchaseHeader);
+        PurchaseHeader.SetLoadFields("Subcontracting Location Code");
+        if PurchaseHeader.FindSet() then
+            repeat
+                AddLegacySubcontractingLocation(LegacySubcontractingLocations, PurchaseHeader."Subcontracting Location Code");
+            until PurchaseHeader.Next() = 0;
+
+        foreach LocationCode in LegacySubcontractingLocations.Keys() do begin
+            Location.Get(LocationCode);
+            UnsupportedWarehouseSettings := GetUnsupportedWarehouseSettings(Location);
+            if UnsupportedWarehouseSettings <> '' then
+                Error(UnsupportedSubcontractingLocationErr, Location.Code, UnsupportedWarehouseSettings);
+        end;
+    end;
+
+    local procedure AddLegacySubcontractingLocation(var LegacySubcontractingLocations: Dictionary of [Code[10], Boolean]; LocationCode: Code[10])
+    begin
+        if not LegacySubcontractingLocations.ContainsKey(LocationCode) then
+            LegacySubcontractingLocations.Add(LocationCode, true);
+    end;
+
+    local procedure GetUnsupportedWarehouseSettings(Location: Record Location): Text
+    var
+        UnsupportedWarehouseSettings: Text;
+    begin
+        AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Bin Mandatory", Location.FieldCaption("Bin Mandatory"));
+        AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Pick", Location.FieldCaption("Require Pick"));
+        AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Put-away", Location.FieldCaption("Require Put-away"));
+        AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Receive", Location.FieldCaption("Require Receive"));
+        AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Shipment", Location.FieldCaption("Require Shipment"));
+        exit(UnsupportedWarehouseSettings);
+    end;
+
+    local procedure AddUnsupportedWarehouseSetting(var UnsupportedWarehouseSettings: Text; IsEnabled: Boolean; WarehouseSettingCaption: Text)
+    begin
+        if not IsEnabled then
+            exit;
+
+        if UnsupportedWarehouseSettings <> '' then
+            UnsupportedWarehouseSettings += ', ';
+        UnsupportedWarehouseSettings += WarehouseSettingCaption;
+    end;
+
     local procedure VerifyMigration()
     var
         TransferLine: Record "Transfer Line";
@@ -658,6 +720,7 @@ codeunit 149951 "IT Subc. Migration"
         VerifyingPhaseLbl: Label 'Verifying migration...';
         VerifyingProgressEntityLbl: Label 'Verification step';
         MigrationVerificationFailedErr: Label 'Migration verification failed for %1: expected %2 record(s) but found %3 after migration.', Comment = '%1 = entity name, %2 = pre-migration count, %3 = post-migration count';
+        UnsupportedSubcontractingLocationErr: Label 'Migration can''t start because subcontracting location %1 uses unsupported warehouse settings: %2. Update the location or subcontracting setup, and then run the precheck again.', Comment = '%1 = location code, %2 = unsupported warehouse settings';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Legacy Subc. Feature Handler", 'OnMigrationSubcontractingData', '', false, false)]
     local procedure MigrateSubconOnMigrationSubcontractingData()

--- a/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
@@ -584,6 +584,9 @@ codeunit 149951 "IT Subc. Migration"
         LegacySubcontractingLocations: Dictionary of [Code[10], Boolean];
         LocationCode: Code[10];
         UnsupportedWarehouseSettings: Text;
+        CollectedErrors: List of [ErrorInfo];
+        CollectedError: ErrorInfo;
+        BlockingErrorText: Text;
     begin
         SetVendorMigrationFilters(Vendor);
         Vendor.SetLoadFields("Subcontracting Location Code");
@@ -604,6 +607,13 @@ codeunit 149951 "IT Subc. Migration"
             UnsupportedWarehouseSettings := GetUnsupportedWarehouseSettings(Location);
             if UnsupportedWarehouseSettings <> '' then
                 Error(UnsupportedSubcontractingLocationErr, Location.Code, UnsupportedWarehouseSettings);
+        end;
+
+        if HasCollectedErrors() then begin
+            CollectedErrors := GetCollectedErrors(true);
+            foreach CollectedError in CollectedErrors do
+                BlockingErrorText += CollectedError.Message() + '\';
+            Error(ErrorInfo.Create(BlockingErrorText, false));
         end;
     end;
 

--- a/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
@@ -42,6 +42,7 @@ codeunit 149951 "IT Subc. Migration"
 #if not CLEAN28
         LegacySubcFeatureHandler.CheckCanDisableLegacySubcontracting();
 #endif
+        // Validate before confirmation for prompt feedback, then repeat under locks to prevent concurrent changes.
         CheckSubcontractingLocations();
         UIAllowed := ShowDialog and GuiAllowed();
         if UIAllowed then begin
@@ -51,6 +52,7 @@ codeunit 149951 "IT Subc. Migration"
 
         LockTables();
         Clear(PreMigrationCounts);
+        // This authoritative validation covers changes made by other sessions while confirmation was pending.
         CheckSubcontractingLocations();
         RunMigration();
 

--- a/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
@@ -51,6 +51,7 @@ codeunit 149951 "IT Subc. Migration"
 
         LockTables();
         Clear(PreMigrationCounts);
+        CheckSubcontractingLocations();
         RunMigration();
 
         if UIAllowed then
@@ -443,6 +444,7 @@ codeunit 149951 "IT Subc. Migration"
         RoutingLine: Record "Routing Line";
         Vendor: Record Vendor;
         PurchaseHeader: Record "Purchase Header";
+        Location: Record Location;
 #pragma warning disable AL0432
         LegacySubcontractorPrice: Record "Subcontractor Prices";
 #pragma warning restore AL0432
@@ -457,6 +459,7 @@ codeunit 149951 "IT Subc. Migration"
         RoutingLine.LockTable();
         Vendor.LockTable();
         PurchaseHeader.LockTable();
+        Location.LockTable();
         LegacySubcontractorPrice.LockTable();
         SubcontractorPrice.LockTable();
         ManufacturingSetup.LockTable();
@@ -586,6 +589,7 @@ codeunit 149951 "IT Subc. Migration"
         UnsupportedWarehouseSettings: Text;
         CollectedErrors: List of [ErrorInfo];
         CollectedError: ErrorInfo;
+        BlockingError: ErrorInfo;
         BlockingErrorText: Text;
     begin
         SetVendorMigrationFilters(Vendor);
@@ -602,18 +606,30 @@ codeunit 149951 "IT Subc. Migration"
                 AddLegacySubcontractingLocation(LegacySubcontractingLocations, PurchaseHeader."Subcontracting Location Code");
             until PurchaseHeader.Next() = 0;
 
-        foreach LocationCode in LegacySubcontractingLocations.Keys() do begin
-            Location.Get(LocationCode);
-            UnsupportedWarehouseSettings := GetUnsupportedWarehouseSettings(Location);
-            if UnsupportedWarehouseSettings <> '' then
-                Error(UnsupportedSubcontractingLocationErr, Location.Code, UnsupportedWarehouseSettings);
-        end;
+        Location.SetLoadFields(
+            "Bin Mandatory",
+            "Require Pick",
+            "Require Put-away",
+            "Require Receive",
+            "Require Shipment");
+        foreach LocationCode in LegacySubcontractingLocations.Keys() do
+            if not Location.Get(LocationCode) then
+                Error(MissingSubcontractingLocationErr, LocationCode)
+            else begin
+                UnsupportedWarehouseSettings := GetUnsupportedWarehouseSettings(Location);
+                if UnsupportedWarehouseSettings <> '' then
+                    Error(UnsupportedSubcontractingLocationErr, Location.Code, UnsupportedWarehouseSettings);
+            end;
 
         if HasCollectedErrors() then begin
             CollectedErrors := GetCollectedErrors(true);
             foreach CollectedError in CollectedErrors do
                 BlockingErrorText += CollectedError.Message() + '\';
-            Error(ErrorInfo.Create(BlockingErrorText, false));
+            BlockingError.Message := BlockingErrorText;
+            BlockingError.DataClassification := DataClassification::CustomerContent;
+            BlockingError.ErrorType := ErrorType::Client;
+            BlockingError.Collectible := false;
+            Error(BlockingError);
         end;
     end;
 
@@ -731,6 +747,7 @@ codeunit 149951 "IT Subc. Migration"
         VerifyingProgressEntityLbl: Label 'Verification step';
         MigrationVerificationFailedErr: Label 'Migration verification failed for %1: expected %2 record(s) but found %3 after migration.', Comment = '%1 = entity name, %2 = pre-migration count, %3 = post-migration count';
         UnsupportedSubcontractingLocationErr: Label 'Migration can''t start because subcontracting location %1 uses unsupported warehouse settings: %2. Update the location or subcontracting setup, and then run the precheck again.', Comment = '%1 = location code, %2 = unsupported warehouse settings';
+        MissingSubcontractingLocationErr: Label 'Migration can''t start because legacy subcontracting data references location %1, but that location doesn''t exist. Update the legacy vendor or purchase document, and then run the precheck again.', Comment = '%1 = location code';
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Legacy Subc. Feature Handler", 'OnMigrationSubcontractingData', '', false, false)]
     local procedure MigrateSubconOnMigrationSubcontractingData()

--- a/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
@@ -613,7 +613,8 @@ codeunit 149951 "IT Subc. Migration"
             "Require Pick",
             "Require Put-away",
             "Require Receive",
-            "Require Shipment");
+            "Require Shipment",
+            "Use As In-Transit");
         foreach LocationCode in LegacySubcontractingLocations.Keys() do
             if not Location.Get(LocationCode) then
                 Error(ErrorInfo.Create(StrSubstNo(MissingSubcontractingLocationErr, LocationCode), true))
@@ -650,6 +651,7 @@ codeunit 149951 "IT Subc. Migration"
         AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Put-away", Location.FieldCaption("Require Put-away"));
         AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Receive", Location.FieldCaption("Require Receive"));
         AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Require Shipment", Location.FieldCaption("Require Shipment"));
+        AddUnsupportedWarehouseSetting(UnsupportedWarehouseSettings, Location."Use As In-Transit", Location.FieldCaption("Use As In-Transit"));
         exit(UnsupportedWarehouseSettings);
     end;
 

--- a/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/App/src/ITSubcMigration.Codeunit.al
@@ -590,7 +590,7 @@ codeunit 149951 "IT Subc. Migration"
         CollectedErrors: List of [ErrorInfo];
         CollectedError: ErrorInfo;
         BlockingError: ErrorInfo;
-        BlockingErrorText: Text;
+        BlockingErrorTextBuilder: TextBuilder;
     begin
         SetVendorMigrationFilters(Vendor);
         Vendor.SetLoadFields("Subcontracting Location Code");
@@ -614,18 +614,18 @@ codeunit 149951 "IT Subc. Migration"
             "Require Shipment");
         foreach LocationCode in LegacySubcontractingLocations.Keys() do
             if not Location.Get(LocationCode) then
-                Error(MissingSubcontractingLocationErr, LocationCode)
+                Error(ErrorInfo.Create(StrSubstNo(MissingSubcontractingLocationErr, LocationCode), true))
             else begin
                 UnsupportedWarehouseSettings := GetUnsupportedWarehouseSettings(Location);
                 if UnsupportedWarehouseSettings <> '' then
-                    Error(UnsupportedSubcontractingLocationErr, Location.Code, UnsupportedWarehouseSettings);
+                    Error(ErrorInfo.Create(StrSubstNo(UnsupportedSubcontractingLocationErr, Location.Code, UnsupportedWarehouseSettings), true));
             end;
 
         if HasCollectedErrors() then begin
             CollectedErrors := GetCollectedErrors(true);
             foreach CollectedError in CollectedErrors do
-                BlockingErrorText += CollectedError.Message() + '\';
-            BlockingError.Message := BlockingErrorText;
+                BlockingErrorTextBuilder.AppendLine(CollectedError.Message());
+            BlockingError.Message := StrSubstNo(SubcontractingLocationsBlockedErr, BlockingErrorTextBuilder.ToText());
             BlockingError.DataClassification := DataClassification::CustomerContent;
             BlockingError.ErrorType := ErrorType::Client;
             BlockingError.Collectible := false;
@@ -746,6 +746,7 @@ codeunit 149951 "IT Subc. Migration"
         VerifyingPhaseLbl: Label 'Verifying migration...';
         VerifyingProgressEntityLbl: Label 'Verification step';
         MigrationVerificationFailedErr: Label 'Migration verification failed for %1: expected %2 record(s) but found %3 after migration.', Comment = '%1 = entity name, %2 = pre-migration count, %3 = post-migration count';
+        SubcontractingLocationsBlockedErr: Label 'Migration can''t start because one or more subcontracting locations are invalid. Resolve the following issues and run the precheck again:\%1', Comment = '%1 = detailed location validation errors';
         UnsupportedSubcontractingLocationErr: Label 'Migration can''t start because subcontracting location %1 uses unsupported warehouse settings: %2. Update the location or subcontracting setup, and then run the precheck again.', Comment = '%1 = location code, %2 = unsupported warehouse settings';
         MissingSubcontractingLocationErr: Label 'Migration can''t start because legacy subcontracting data references location %1, but that location doesn''t exist. Update the legacy vendor or purchase document, and then run the precheck again.', Comment = '%1 = location code';
 

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
@@ -33,6 +33,7 @@ codeunit 149956 "IT Subc. Migration Tests"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryUtility: Codeunit "Library - Utility";
         Initialized: Boolean;
+        UnsupportedSubcontractingLocationErr: Label 'Migration can''t start because subcontracting location %1 uses unsupported warehouse settings: %2. Update the location or subcontracting setup, and then run the precheck again.', Comment = '%1 = location code, %2 = unsupported warehouse settings';
 
     [Test]
     [Scope('OnPrem')]
@@ -829,6 +830,108 @@ codeunit 149956 "IT Subc. Migration Tests"
     end;
 
     [Test]
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    [Scope('OnPrem')]
+    procedure CheckSubcontractingLocations_ReportsEveryLocationAndSetting()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        VendorLocation: Record Location;
+        PurchaseLocation: Record Location;
+        ITSubcMigration: Codeunit "IT Subc. Migration";
+        CollectedErrors: List of [ErrorInfo];
+    begin
+        // [SCENARIO] The migration precheck reports every incompatible location and its unsupported warehouse settings
+        Initialize();
+
+        // [GIVEN] A vendor whose legacy subcontracting location requires bins and picks
+        LibraryWarehouse.CreateLocation(VendorLocation);
+        VendorLocation."Bin Mandatory" := true;
+        VendorLocation."Require Pick" := true;
+        VendorLocation.Modify(false);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor."Subcontracting Location Code" := VendorLocation.Code;
+        Vendor.Modify(false);
+
+        // [GIVEN] A purchase header with a different legacy location that requires warehouse handling
+        LibraryWarehouse.CreateLocation(PurchaseLocation);
+        PurchaseLocation."Require Put-away" := true;
+        PurchaseLocation."Require Receive" := true;
+        PurchaseLocation."Require Shipment" := true;
+        PurchaseLocation.Modify(false);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        PurchaseHeader."Subcontracting Location Code" := PurchaseLocation.Code;
+        PurchaseHeader.Modify(false);
+
+        // [WHEN] The subcontracting location precheck runs
+        ITSubcMigration.CheckSubcontractingLocations();
+
+        // [THEN] One error per incompatible location identifies every unsupported setting
+        CollectedErrors := GetCollectedErrors(true);
+        Assert.AreEqual(2, CollectedErrors.Count, 'The precheck should report every incompatible subcontracting location.');
+        AssertCollectedError(
+            CollectedErrors,
+            StrSubstNo(
+                UnsupportedSubcontractingLocationErr,
+                VendorLocation.Code,
+                'Bin Mandatory, Require Pick'));
+        AssertCollectedError(
+            CollectedErrors,
+            StrSubstNo(
+                UnsupportedSubcontractingLocationErr,
+                PurchaseLocation.Code,
+                'Require Put-away, Require Receive, Require Shipment'));
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure StartDisableLegacySubcontracting_BlocksUnsupportedLocationBeforeMigration()
+    var
+        Vendor: Record Vendor;
+        Location: Record Location;
+        TransferLine: Record "Transfer Line";
+        PurchaseLine: Record "Purchase Line";
+        ITSubcMigration: Codeunit "IT Subc. Migration";
+    begin
+        // [SCENARIO] Disabling legacy subcontracting stops before migration when a location has unsupported warehouse settings
+        Initialize();
+
+        // [GIVEN] No open WIP transfers or purchase orders
+        TransferLine.SetRange("WIP Item", true);
+        if not TransferLine.IsEmpty() then
+            TransferLine.DeleteAll();
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+#pragma warning disable AL0432
+        PurchaseLine.SetRange("WIP Item", true);
+#pragma warning restore AL0432
+        if not PurchaseLine.IsEmpty() then
+            PurchaseLine.DeleteAll();
+
+        // [GIVEN] A vendor with an unmigrated legacy subcontracting location that requires bins
+        LibraryWarehouse.CreateLocation(Location);
+        Location."Bin Mandatory" := true;
+        Location.Modify(false);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor."Subcontracting Location Code" := Location.Code;
+        Vendor."Subc. Location Code" := '';
+        Vendor.Modify(false);
+
+        // [WHEN] Legacy subcontracting is disabled
+        asserterror ITSubcMigration.StartDisableLegacySubcontracting(false);
+
+        // [THEN] The precheck reports the incompatible location
+        Assert.ExpectedError(
+            StrSubstNo(
+                UnsupportedSubcontractingLocationErr,
+                Location.Code,
+                'Bin Mandatory'));
+
+        // [THEN] Migration has not changed the vendor
+        Vendor.Get(Vendor."No.");
+        Assert.AreEqual('', Vendor."Subc. Location Code", 'The vendor must not be migrated when the precheck fails.');
+    end;
+
+    [Test]
     [HandlerFunctions('ConfirmHandlerReturnFalse')]
     [Scope('OnPrem')]
     procedure StartDisableLegacySubcontracting_NotConfirmedNothingHappens()
@@ -993,6 +1096,17 @@ codeunit 149956 "IT Subc. Migration Tests"
             StrSubstNo('ManufacturingSetup."Legacy Subcontracting" should be %1.', ExpectedValue));
 #pragma warning restore AA0217
 #pragma warning restore AA0233
+    end;
+
+    local procedure AssertCollectedError(CollectedErrors: List of [ErrorInfo]; ExpectedMessage: Text)
+    var
+        CollectedError: ErrorInfo;
+    begin
+        foreach CollectedError in CollectedErrors do
+            if CollectedError.Message = ExpectedMessage then
+                exit;
+
+        Error('Expected collected error was not found: %1', ExpectedMessage);
     end;
 
     local procedure ActivateLegacySubcontracting()

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
@@ -830,7 +830,6 @@ codeunit 149956 "IT Subc. Migration Tests"
     end;
 
     [Test]
-    [ErrorBehavior(ErrorBehavior::Collect)]
     [Scope('OnPrem')]
     procedure CheckSubcontractingLocations_ReportsEveryLocationAndSetting()
     var
@@ -839,7 +838,7 @@ codeunit 149956 "IT Subc. Migration Tests"
         VendorLocation: Record Location;
         PurchaseLocation: Record Location;
         ITSubcMigration: Codeunit "IT Subc. Migration";
-        CollectedErrors: List of [ErrorInfo];
+        BlockingError: Text;
     begin
         // [SCENARIO] The migration precheck reports every incompatible location and its unsupported warehouse settings
         Initialize();
@@ -864,23 +863,24 @@ codeunit 149956 "IT Subc. Migration Tests"
         PurchaseHeader.Modify(false);
 
         // [WHEN] The subcontracting location precheck runs
-        ITSubcMigration.CheckSubcontractingLocations();
+        asserterror ITSubcMigration.CheckSubcontractingLocations();
 
-        // [THEN] One error per incompatible location identifies every unsupported setting
-        CollectedErrors := GetCollectedErrors(true);
-        Assert.AreEqual(2, CollectedErrors.Count, 'The precheck should report every incompatible subcontracting location.');
-        AssertCollectedError(
-            CollectedErrors,
-            StrSubstNo(
-                UnsupportedSubcontractingLocationErr,
-                VendorLocation.Code,
-                'Bin Mandatory, Require Pick'));
-        AssertCollectedError(
-            CollectedErrors,
-            StrSubstNo(
-                UnsupportedSubcontractingLocationErr,
-                PurchaseLocation.Code,
-                'Require Put-away, Require Receive, Require Shipment'));
+        // [THEN] The blocking error reports every incompatible location and its unsupported settings
+        BlockingError := GetLastErrorText();
+        Assert.IsTrue(
+            BlockingError.Contains(
+                StrSubstNo(
+                    UnsupportedSubcontractingLocationErr,
+                    VendorLocation.Code,
+                    'Bin Mandatory, Require Pick')),
+            'The precheck should report the vendor location and its unsupported settings.');
+        Assert.IsTrue(
+            BlockingError.Contains(
+                StrSubstNo(
+                    UnsupportedSubcontractingLocationErr,
+                    PurchaseLocation.Code,
+                    'Require Put-away, Require Receive, Require Shipment')),
+            'The precheck should report the purchase location and its unsupported settings.');
     end;
 
     [Test]
@@ -1096,17 +1096,6 @@ codeunit 149956 "IT Subc. Migration Tests"
             StrSubstNo('ManufacturingSetup."Legacy Subcontracting" should be %1.', ExpectedValue));
 #pragma warning restore AA0217
 #pragma warning restore AA0233
-    end;
-
-    local procedure AssertCollectedError(CollectedErrors: List of [ErrorInfo]; ExpectedMessage: Text)
-    var
-        CollectedError: ErrorInfo;
-    begin
-        foreach CollectedError in CollectedErrors do
-            if CollectedError.Message = ExpectedMessage then
-                exit;
-
-        Error('Expected collected error was not found: %1', ExpectedMessage);
     end;
 
     local procedure ActivateLegacySubcontracting()

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
@@ -33,6 +33,7 @@ codeunit 149956 "IT Subc. Migration Tests"
         LibraryWarehouse: Codeunit "Library - Warehouse";
         LibraryUtility: Codeunit "Library - Utility";
         Initialized: Boolean;
+        SubcontractingLocationsBlockedErr: Label 'Migration can''t start because one or more subcontracting locations are invalid.';
         UnsupportedSubcontractingLocationErr: Label 'Migration can''t start because subcontracting location %1 uses unsupported warehouse settings: %2. Update the location or subcontracting setup, and then run the precheck again.', Comment = '%1 = location code, %2 = unsupported warehouse settings';
         MissingSubcontractingLocationErr: Label 'Migration can''t start because legacy subcontracting data references location %1, but that location doesn''t exist. Update the legacy vendor or purchase document, and then run the precheck again.', Comment = '%1 = location code';
 
@@ -865,6 +866,7 @@ codeunit 149956 "IT Subc. Migration Tests"
 
         // [WHEN] The subcontracting location precheck runs
         asserterror ITSubcMigration.CheckSubcontractingLocations();
+        Assert.ExpectedError(SubcontractingLocationsBlockedErr);
 
         // [THEN] The blocking error reports every incompatible location and its unsupported settings
         BlockingError := GetLastErrorText();
@@ -916,6 +918,7 @@ codeunit 149956 "IT Subc. Migration Tests"
 
         // [WHEN] The subcontracting location precheck runs
         asserterror ITSubcMigration.CheckSubcontractingLocations();
+        Assert.ExpectedError(SubcontractingLocationsBlockedErr);
 
         // [THEN] The blocking error reports both legacy location problems
         BlockingError := GetLastErrorText();

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
@@ -34,6 +34,7 @@ codeunit 149956 "IT Subc. Migration Tests"
         LibraryUtility: Codeunit "Library - Utility";
         Initialized: Boolean;
         UnsupportedSubcontractingLocationErr: Label 'Migration can''t start because subcontracting location %1 uses unsupported warehouse settings: %2. Update the location or subcontracting setup, and then run the precheck again.', Comment = '%1 = location code, %2 = unsupported warehouse settings';
+        MissingSubcontractingLocationErr: Label 'Migration can''t start because legacy subcontracting data references location %1, but that location doesn''t exist. Update the legacy vendor or purchase document, and then run the precheck again.', Comment = '%1 = location code';
 
     [Test]
     [Scope('OnPrem')]
@@ -885,6 +886,50 @@ codeunit 149956 "IT Subc. Migration Tests"
 
     [Test]
     [Scope('OnPrem')]
+    procedure CheckSubcontractingLocations_ReportsMissingAndUnsupportedLegacyLocations()
+    var
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        MissingLocation: Record Location;
+        UnsupportedLocation: Record Location;
+        ITSubcMigration: Codeunit "IT Subc. Migration";
+        BlockingError: Text;
+    begin
+        // [SCENARIO] The migration precheck aggregates missing and unsupported legacy subcontracting locations
+        Initialize();
+
+        // [GIVEN] A vendor whose legacy subcontracting location references a deleted location
+        LibraryWarehouse.CreateLocation(MissingLocation);
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor."Subcontracting Location Code" := MissingLocation.Code;
+        Vendor.Modify(false);
+        MissingLocation.Delete(false);
+
+        // [GIVEN] A purchase header whose legacy subcontracting location requires bins
+        LibraryWarehouse.CreateLocation(UnsupportedLocation);
+        UnsupportedLocation."Bin Mandatory" := true;
+        UnsupportedLocation.Modify(false);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, Vendor."No.");
+        PurchaseHeader."Subcontracting Location Code" := UnsupportedLocation.Code;
+        PurchaseHeader.Modify(false);
+        Commit();
+
+        // [WHEN] The subcontracting location precheck runs
+        asserterror ITSubcMigration.CheckSubcontractingLocations();
+
+        // [THEN] The blocking error reports both legacy location problems
+        BlockingError := GetLastErrorText();
+        Assert.IsTrue(
+            BlockingError.Contains(StrSubstNo(MissingSubcontractingLocationErr, MissingLocation.Code)),
+            'The precheck should report the missing legacy location.');
+        Assert.IsTrue(
+            BlockingError.Contains(
+                StrSubstNo(UnsupportedSubcontractingLocationErr, UnsupportedLocation.Code, 'Bin Mandatory')),
+            'The precheck should continue and report the unsupported legacy location.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure StartDisableLegacySubcontracting_BlocksUnsupportedLocationBeforeMigration()
     var
         Vendor: Record Vendor;
@@ -915,6 +960,7 @@ codeunit 149956 "IT Subc. Migration Tests"
         Vendor."Subcontracting Location Code" := Location.Code;
         Vendor."Subc. Location Code" := '';
         Vendor.Modify(false);
+        Commit();
 
         // [WHEN] Legacy subcontracting is disabled
         asserterror ITSubcMigration.StartDisableLegacySubcontracting(false);

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
@@ -938,7 +938,7 @@ codeunit 149956 "IT Subc. Migration Tests"
 
     [Test]
     [Scope('OnPrem')]
-    procedure StartDisableLegacySubcontracting_BlocksUnsupportedLocationBeforeMigration()
+    procedure StartDisableLegacySubcontracting_BlocksInTransitLocationBeforeMigration()
     var
         Vendor: Record Vendor;
         Location: Record Location;
@@ -946,7 +946,7 @@ codeunit 149956 "IT Subc. Migration Tests"
         PurchaseLine: Record "Purchase Line";
         ITSubcMigration: Codeunit "IT Subc. Migration";
     begin
-        // [SCENARIO] Disabling legacy subcontracting stops before migration when a location has unsupported warehouse settings
+        // [SCENARIO] Disabling legacy subcontracting stops before migration when a location is used as in-transit
         Initialize();
 
         // [GIVEN] No open WIP transfers or purchase orders
@@ -960,9 +960,9 @@ codeunit 149956 "IT Subc. Migration Tests"
         if not PurchaseLine.IsEmpty() then
             PurchaseLine.DeleteAll();
 
-        // [GIVEN] A vendor with an unmigrated legacy subcontracting location that requires bins
+        // [GIVEN] A vendor with an unmigrated legacy subcontracting location used as in-transit
         LibraryWarehouse.CreateLocation(Location);
-        Location."Bin Mandatory" := true;
+        Location."Use As In-Transit" := true;
         Location.Modify(false);
         LibraryPurchase.CreateVendor(Vendor);
         Vendor."Subcontracting Location Code" := Location.Code;
@@ -978,7 +978,7 @@ codeunit 149956 "IT Subc. Migration Tests"
             StrSubstNo(
                 UnsupportedSubcontractingLocationErr,
                 Location.Code,
-                Location.FieldCaption("Bin Mandatory")));
+                Location.FieldCaption("Use As In-Transit")));
 
         // [THEN] Migration has not changed the vendor
         Vendor.Get(Vendor."No.");

--- a/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
+++ b/src/Apps/IT/SubcontractingMigrationIT/Test/src/ITSubcMigrationTests.Codeunit.al
@@ -875,14 +875,16 @@ codeunit 149956 "IT Subc. Migration Tests"
                 StrSubstNo(
                     UnsupportedSubcontractingLocationErr,
                     VendorLocation.Code,
-                    'Bin Mandatory, Require Pick')),
+                    VendorLocation.FieldCaption("Bin Mandatory") + ', ' + VendorLocation.FieldCaption("Require Pick"))),
             'The precheck should report the vendor location and its unsupported settings.');
         Assert.IsTrue(
             BlockingError.Contains(
                 StrSubstNo(
                     UnsupportedSubcontractingLocationErr,
                     PurchaseLocation.Code,
-                    'Require Put-away, Require Receive, Require Shipment')),
+                    PurchaseLocation.FieldCaption("Require Put-away") + ', ' +
+                    PurchaseLocation.FieldCaption("Require Receive") + ', ' +
+                    PurchaseLocation.FieldCaption("Require Shipment"))),
             'The precheck should report the purchase location and its unsupported settings.');
     end;
 
@@ -927,7 +929,10 @@ codeunit 149956 "IT Subc. Migration Tests"
             'The precheck should report the missing legacy location.');
         Assert.IsTrue(
             BlockingError.Contains(
-                StrSubstNo(UnsupportedSubcontractingLocationErr, UnsupportedLocation.Code, 'Bin Mandatory')),
+                StrSubstNo(
+                    UnsupportedSubcontractingLocationErr,
+                    UnsupportedLocation.Code,
+                    UnsupportedLocation.FieldCaption("Bin Mandatory"))),
             'The precheck should continue and report the unsupported legacy location.');
     end;
 
@@ -973,7 +978,7 @@ codeunit 149956 "IT Subc. Migration Tests"
             StrSubstNo(
                 UnsupportedSubcontractingLocationErr,
                 Location.Code,
-                'Bin Mandatory'));
+                Location.FieldCaption("Bin Mandatory")));
 
         // [THEN] Migration has not changed the vendor
         Vendor.Get(Vendor."No.");


### PR DESCRIPTION
## What
- Block IT subcontracting migration when legacy vendor or purchase-header locations use unsupported warehouse settings.
- Report every incompatible location and list each enabled setting.
- Keep migration data untouched when the precheck fails.

## Why
The migration copied legacy location codes directly into the new subcontracting fields, bypassing the target validation and leaving migrated records in an unsupported state.

## Tests
- Added coverage for multiple locations and all unsupported warehouse settings.
- Added integration coverage proving migration stops before vendor data is copied.

## Review
- al-review (BCQuality, Branch mode, High): the ErrorBehavior::Collect precheck now handles its collected errors explicitly and raises a single deliberate blocking error instead of relying on the platform concatenated dialog.

ADO bug: [648577](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648577)

[AB#648577](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648577)














