### PR TITLE
[Master] - Slice 626305: [Excise Tax][VENDOR] Improving Excise Duty Calculation

### DIFF
--- a/src/Apps/W1/ExciseTaxes/app/src/Permissions/ExciseTaxesEdit.permissionset.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/Permissions/ExciseTaxesEdit.permissionset.al
@@ -14,7 +14,10 @@ permissionset 7452 "ExciseTaxes - Edit"
 
     Permissions =
         tabledata "Excise Tax Type" = IMD,
+#if not CLEAN30
         tabledata "Excise Tax Item/FA Rate" = IMD,
+#endif
+        tabledata "Excise Tax Rate" = IMD,
         tabledata "Item Excise Tax" = IMD,
         tabledata "Excise Tax Entry Permission" = IMD;
 }

--- a/src/Apps/W1/ExciseTaxes/app/src/Permissions/ExciseTaxesObjects.permissionset.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/Permissions/ExciseTaxesObjects.permissionset.al
@@ -12,12 +12,18 @@ permissionset 7450 "ExciseTaxes - Objects"
 
     Permissions =
         table "Excise Tax Type" = X,
+#if not CLEAN30
         table "Excise Tax Item/FA Rate" = X,
+#endif
+        table "Excise Tax Rate" = X,
         table "Item Excise Tax" = X,
         table "Excise Tax Entry Permission" = X,
         page "Excise Tax Types" = X,
         page "Excise Tax Type Card" = X,
+#if not CLEAN30
         page "Excise Tax Item/FA Rates" = X,
+#endif
+        page "Excise Tax Rates" = X,
         page "Item Excise Taxes" = X,
         page "Item Excise Tax API" = X,
         page "Excise Tax Entry Permissions" = X,

--- a/src/Apps/W1/ExciseTaxes/app/src/Permissions/ExciseTaxesRead.permissionset.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/Permissions/ExciseTaxesRead.permissionset.al
@@ -14,7 +14,10 @@ permissionset 7451 "ExciseTaxes - Read"
 
     Permissions =
         tabledata "Excise Tax Type" = R,
+#if not CLEAN30
         tabledata "Excise Tax Item/FA Rate" = R,
+#endif
+        tabledata "Excise Tax Rate" = R,
         tabledata "Item Excise Tax" = R,
         tabledata "Excise Tax Entry Permission" = R;
 }

--- a/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxCalculation.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxCalculation.Codeunit.al
@@ -285,7 +285,11 @@ codeunit 7412 "Excise Tax Calculation"
         ExciseJnlLine.Validate("Country/Region Code", ItemLedgerEntry."Country/Region Code");
         ExciseJnlLine.Validate("Source Type", ExciseJnlLine."Source Type"::Item);
         ExciseJnlLine.Validate("Source No.", ItemLedgerEntry."Item No.");
+        ExciseJnlLine.Validate("Item Category Code", ItemLedgerEntry."Item Category Code");
         ExciseJnlLine.Validate("Source Qty.", Abs(ItemLedgerEntry.Quantity));
+        if RequiresTaxableAmount(ExciseJnlLine) then
+            ExciseJnlLine.Validate("Excise Taxable Amount", GetTaxableAmountFromItemLedgerEntry(ItemLedgerEntry));
+        OnAfterUpdateExciseJournalLineFromItemLedgerEntry(ExciseJnlLine, ItemLedgerEntry);
         ExciseJnlLine."Item Ledger Entry No." := ItemLedgerEntry."Entry No.";
     end;
 
@@ -316,7 +320,40 @@ codeunit 7412 "Excise Tax Calculation"
         ExciseJnlLine.Validate("Source Type", ExciseJnlLine."Source Type"::"Fixed Asset");
         ExciseJnlLine.Validate("Source No.", FALedgerEntry."FA No.");
         ExciseJnlLine.Validate("Source Qty.", 1);
+        if RequiresTaxableAmount(ExciseJnlLine) then
+            ExciseJnlLine.Validate("Excise Taxable Amount", Abs(FALedgerEntry.Amount));
         ExciseJnlLine."FA Ledger Entry No." := FALedgerEntry."Entry No.";
+    end;
+
+    local procedure RequiresTaxableAmount(ExciseJnlLine: Record "Sust. Excise Jnl. Line"): Boolean
+    begin
+        exit(ExciseJnlLine."Excise Calculation Type" in ["Excise Calculation Type"::"Ad valorem", "Excise Calculation Type"::Hybrid]);
+    end;
+
+    // The taxable value of an item ledger entry is taken from its value entries: the invoiced sales or purchase
+    // amount when the entry has one, otherwise the inventory cost.
+    local procedure GetTaxableAmountFromItemLedgerEntry(var ItemLedgerEntry: Record "Item Ledger Entry"): Decimal
+    begin
+        case ItemLedgerEntry."Entry Type" of
+            ItemLedgerEntry."Entry Type"::Sale:
+                begin
+                    ItemLedgerEntry.CalcFields("Sales Amount (Actual)");
+                    if ItemLedgerEntry."Sales Amount (Actual)" <> 0 then
+                        exit(Abs(ItemLedgerEntry."Sales Amount (Actual)"));
+                end;
+            ItemLedgerEntry."Entry Type"::Purchase:
+                begin
+                    ItemLedgerEntry.CalcFields("Purchase Amount (Actual)");
+                    if ItemLedgerEntry."Purchase Amount (Actual)" <> 0 then
+                        exit(Abs(ItemLedgerEntry."Purchase Amount (Actual)"));
+                end;
+        end;
+
+        ItemLedgerEntry.CalcFields("Cost Amount (Actual)", "Cost Amount (Expected)");
+        if ItemLedgerEntry."Cost Amount (Actual)" <> 0 then
+            exit(Abs(ItemLedgerEntry."Cost Amount (Actual)"));
+
+        exit(Abs(ItemLedgerEntry."Cost Amount (Expected)"));
     end;
 
     local procedure UpdateExciseJournalFromPurchaseInvoice(var SustExciseJournalLine: Record "Sust. Excise Jnl. Line"; DocumentNo: Code[20])
@@ -444,6 +481,11 @@ codeunit 7412 "Excise Tax Calculation"
 
     [IntegrationEvent(false, false)]
     local procedure OnAfterInsertExciseJournalLineForItem(var ExciseJournalLine: Record "Sust. Excise Jnl. Line"; ItemLedgerEntry: Record "Item Ledger Entry")
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnAfterUpdateExciseJournalLineFromItemLedgerEntry(var ExciseJournalLine: Record "Sust. Excise Jnl. Line"; ItemLedgerEntry: Record "Item Ledger Entry")
     begin
     end;
 

--- a/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxCalculation.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxCalculation.Codeunit.al
@@ -349,10 +349,11 @@ codeunit 7412 "Excise Tax Calculation"
                 end;
         end;
 
-        ItemLedgerEntry.CalcFields("Cost Amount (Actual)", "Cost Amount (Expected)");
+        ItemLedgerEntry.CalcFields("Cost Amount (Actual)");
         if ItemLedgerEntry."Cost Amount (Actual)" <> 0 then
             exit(Abs(ItemLedgerEntry."Cost Amount (Actual)"));
 
+        ItemLedgerEntry.CalcFields("Cost Amount (Expected)");
         exit(Abs(ItemLedgerEntry."Cost Amount (Expected)"));
     end;
 

--- a/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxCalculation.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxCalculation.Codeunit.al
@@ -287,9 +287,9 @@ codeunit 7412 "Excise Tax Calculation"
         ExciseJnlLine.Validate("Source No.", ItemLedgerEntry."Item No.");
         ExciseJnlLine.Validate("Item Category Code", ItemLedgerEntry."Item Category Code");
         ExciseJnlLine.Validate("Source Qty.", Abs(ItemLedgerEntry.Quantity));
+        OnAfterUpdateExciseJournalLineFromItemLedgerEntry(ExciseJnlLine, ItemLedgerEntry);
         if RequiresTaxableAmount(ExciseJnlLine) then
             ExciseJnlLine.Validate("Excise Taxable Amount", GetTaxableAmountFromItemLedgerEntry(ItemLedgerEntry));
-        OnAfterUpdateExciseJournalLineFromItemLedgerEntry(ExciseJnlLine, ItemLedgerEntry);
         ExciseJnlLine."Item Ledger Entry No." := ItemLedgerEntry."Entry No.";
     end;
 

--- a/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxTransSubscriber.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxTransSubscriber.Codeunit.al
@@ -6,6 +6,7 @@ namespace Microsoft.ExciseTaxes;
 
 using Microsoft.FixedAssets.FixedAsset;
 using Microsoft.Inventory.Item;
+using Microsoft.Inventory.Ledger;
 using Microsoft.Sustainability.ExciseTax;
 
 codeunit 7413 "Excise Tax Trans Subscriber"
@@ -20,6 +21,10 @@ codeunit 7413 "Excise Tax Trans Subscriber"
 
         SustExciseTaxesTransactionLog."Excise Tax Type" := SustainabilityExciseJnlLine."Excise Tax Type";
         SustExciseTaxesTransactionLog."Excise Duty" := SustainabilityExciseJnlLine."Excise Duty";
+        SustExciseTaxesTransactionLog."Excise Calculation Type" := SustainabilityExciseJnlLine."Excise Calculation Type";
+        SustExciseTaxesTransactionLog."Excise Duty %" := SustainabilityExciseJnlLine."Excise Duty %";
+        SustExciseTaxesTransactionLog."Excise Taxable Amount" := SustainabilityExciseJnlLine."Excise Taxable Amount";
+        SustExciseTaxesTransactionLog."Item Category Code" := SustainabilityExciseJnlLine."Item Category Code";
         SustExciseTaxesTransactionLog."Tax Amount" := SustainabilityExciseJnlLine."Tax Amount";
         SustExciseTaxesTransactionLog."Quantity for Excise Tax" := SustainabilityExciseJnlLine."Quantity for Excise Tax";
         SustExciseTaxesTransactionLog."Excise Unit of Measure Code" := SustainabilityExciseJnlLine."Excise Unit of Measure Code";
@@ -79,7 +84,8 @@ codeunit 7413 "Excise Tax Trans Subscriber"
             ExciseJournalLine.Validate("Excise Unit of Measure Code", ItemExciseTax."Excise Unit of Measure Code");
             ExciseJournalLine.Validate("Quantity for Excise Tax", ItemExciseTax."Quantity for Excise Tax");
         end;
-        ExciseJournalLine.Validate("Excise Duty", GetExciseDutyForSource(ExciseJournalLine."Excise Tax Type", ExciseJournalLine."Source Type", ExciseJournalLine."Source No.", ExciseJournalLine."Posting Date"));
+        ExciseJournalLine.Validate("Item Category Code", Item."Item Category Code");
+        ApplyExciseRate(ExciseJournalLine, Item."Item Category Code");
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Sust. Excise Jnl. Line", OnAfterCopyFromFixedAsset, '', false, false)]
@@ -93,17 +99,55 @@ codeunit 7413 "Excise Tax Trans Subscriber"
         ExciseJournalLine.TestField("Excise Tax Type");
         ExciseJournalLine.Validate("Excise Unit of Measure Code", FixedAsset."Excise Unit of Measure Code");
         ExciseJournalLine.Validate("Quantity for Excise Tax", FixedAsset."Quantity for Excise Tax");
-        ExciseJournalLine.Validate("Excise Duty", GetExciseDutyForSource(ExciseJournalLine."Excise Tax Type", ExciseJournalLine."Source Type", ExciseJournalLine."Source No.", ExciseJournalLine."Posting Date"));
+        ApplyExciseRate(ExciseJournalLine, '');
     end;
 
-    local procedure GetExciseDutyForSource(TaxTypeCode: Code[20]; SourceType: Enum "Sust. Excise Jnl. Source Type"; SourceNo: Code[20]; EffectiveDate: Date): Decimal
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Excise Tax Calculation", OnAfterUpdateExciseJournalLineFromItemLedgerEntry, '', false, false)]
+    local procedure OnAfterUpdateExciseJournalLineFromItemLedgerEntry(var ExciseJournalLine: Record "Sust. Excise Jnl. Line"; ItemLedgerEntry: Record "Item Ledger Entry")
+    begin
+        ApplyExciseRate(ExciseJournalLine, ItemLedgerEntry."Item Category Code");
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sust. Excise Jnl.-Check", OnAfterCheckSustainabilityExciseJournalLine, '', false, false)]
+    local procedure OnAfterCheckSustainabilityExciseJournalLine(SustainabilityExciseJnlLine: Record "Sust. Excise Jnl. Line")
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
-        ExciseDuty: Decimal;
+        ExciseTaxCalculation: Codeunit "Excise Tax Calculation";
+    begin
+        if not ExciseTaxCalculation.IsExciseTaxEntry(SustainabilityExciseJnlLine) then
+            exit;
+
+        case SustainabilityExciseJnlLine."Excise Calculation Type" of
+            "Excise Calculation Type"::"Ad valorem":
+                TestAdValoremFields(SustainabilityExciseJnlLine);
+            "Excise Calculation Type"::Hybrid:
+                begin
+                    SustainabilityExciseJnlLine.TestField("Excise Duty", ErrorInfo.Create());
+                    SustainabilityExciseJnlLine.TestField("Quantity for Excise Tax", ErrorInfo.Create());
+                    TestAdValoremFields(SustainabilityExciseJnlLine);
+                end;
+        end;
+    end;
+
+    local procedure TestAdValoremFields(SustainabilityExciseJnlLine: Record "Sust. Excise Jnl. Line")
+    begin
+        SustainabilityExciseJnlLine.TestField("Excise Duty %", ErrorInfo.Create());
+        SustainabilityExciseJnlLine.TestField("Excise Taxable Amount", ErrorInfo.Create());
+    end;
+
+    local procedure ApplyExciseRate(var ExciseJournalLine: Record "Sust. Excise Jnl. Line"; ItemCategoryCode: Code[20])
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
         ExciseSourceType: Enum "Excise Source Type";
     begin
-        ExciseSourceType := ExciseTaxItemFARate.ConvertSustSourceTypeToExciseSourceType(SourceType);
-        if ExciseTaxItemFARate.GetEffectiveExciseDuty(TaxTypeCode, ExciseSourceType, SourceNo, EffectiveDate, ExciseDuty) then
-            exit(ExciseDuty);
+        ExciseSourceType := ExciseTaxRate.ConvertSustSourceTypeToExciseSourceType(ExciseJournalLine."Source Type");
+        if not ExciseTaxRate.GetEffectiveExciseRate(ExciseJournalLine."Excise Tax Type", ExciseSourceType, ExciseJournalLine."Source No.", ItemCategoryCode, ExciseJournalLine."Posting Date") then
+            Clear(ExciseTaxRate);
+
+        ExciseJournalLine.Validate("Excise Calculation Type", ExciseTaxRate."Excise Calculation Type");
+        ExciseJournalLine.Validate("Excise Duty %", ExciseTaxRate."Excise Duty %");
+        ExciseJournalLine.Validate("Excise Duty", ExciseTaxRate."Excise Duty");
+
+        if ExciseJournalLine."Excise Calculation Type" = ExciseJournalLine."Excise Calculation Type"::"Specific per Unit" then
+            ExciseJournalLine.Validate("Excise Taxable Amount", 0);
     end;
 }

--- a/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxUpgrade.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/codeunit/ExciseTaxUpgrade.Codeunit.al
@@ -17,13 +17,42 @@ codeunit 7414 "Excise Tax Upgrade"
     var
         UpgradeTag: Codeunit "Upgrade Tag";
     begin
-        if UpgradeTag.HasUpgradeTag(GetMultipleExciseTaxesPerItemUpgradeTag()) then
+        if not UpgradeTag.HasUpgradeTag(GetMultipleExciseTaxesPerItemUpgradeTag()) then begin
+            MigrateItemExciseTaxSetup();
+            UpgradeTag.SetUpgradeTag(GetMultipleExciseTaxesPerItemUpgradeTag());
+        end;
+
+#if not CLEANSCHEMA33
+        if not UpgradeTag.HasUpgradeTag(GetExciseTaxRateTableUpgradeTag()) then begin
+            MigrateExciseTaxRates();
+            UpgradeTag.SetUpgradeTag(GetExciseTaxRateTableUpgradeTag());
+        end;
+#endif
+    end;
+
+#if not CLEANSCHEMA33
+    local procedure MigrateExciseTaxRates()
+    var
+        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
+    begin
+#pragma warning disable AL0432
+        if not ExciseTaxItemFARate.FindSet() then
             exit;
 
-        MigrateItemExciseTaxSetup();
-
-        UpgradeTag.SetUpgradeTag(GetMultipleExciseTaxesPerItemUpgradeTag());
+        repeat
+            if not ExciseTaxRate.Get(ExciseTaxItemFARate."Excise Tax Type Code", ExciseTaxItemFARate."Source Type", ExciseTaxItemFARate."Source No.", '', ExciseTaxItemFARate."Effective From Date") then begin
+                ExciseTaxRate.Init();
+                ExciseTaxRate.TransferFields(ExciseTaxItemFARate);
+                ExciseTaxRate."Item Category Code" := '';
+                ExciseTaxRate."Excise Calculation Type" := ExciseTaxRate."Excise Calculation Type"::"Specific per Unit";
+                ExciseTaxRate."Excise Duty %" := 0;
+                ExciseTaxRate.Insert();
+            end;
+        until ExciseTaxItemFARate.Next() = 0;
+#pragma warning restore AL0432
     end;
+#endif
 
     local procedure MigrateItemExciseTaxSetup()
     var
@@ -65,10 +94,20 @@ codeunit 7414 "Excise Tax Upgrade"
     local procedure RegisterPerCompanyUpgradeTags(var PerCompanyUpgradeTags: List of [Code[250]])
     begin
         PerCompanyUpgradeTags.Add(GetMultipleExciseTaxesPerItemUpgradeTag());
+#if not CLEANSCHEMA33
+        PerCompanyUpgradeTags.Add(GetExciseTaxRateTableUpgradeTag());
+#endif
     end;
 
     local procedure GetMultipleExciseTaxesPerItemUpgradeTag(): Code[250]
     begin
         exit('MS-626127-MultipleExciseTaxesPerItem-20260727');
     end;
+
+#if not CLEANSCHEMA33
+    local procedure GetExciseTaxRateTableUpgradeTag(): Code[250]
+    begin
+        exit('MS-626305-ExciseTaxRate-20260902');
+    end;
+#endif
 }

--- a/src/Apps/W1/ExciseTaxes/app/src/enum/ExciseCalculationType.Enum.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/enum/ExciseCalculationType.Enum.al
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.ExciseTaxes;
+
+enum 7415 "Excise Calculation Type"
+{
+    Caption = 'Excise Calculation Type';
+    Extensible = true;
+
+    value(0; "Specific per Unit")
+    {
+        Caption = 'Specific - per unit';
+    }
+    value(1; "Ad valorem")
+    {
+        Caption = 'Ad valorem';
+    }
+    value(2; Hybrid)
+    {
+        Caption = 'Hybrid';
+    }
+}

--- a/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxItemFARates.Page.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxItemFARates.Page.al
@@ -1,3 +1,4 @@
+#if not CLEAN30
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,6 +13,9 @@ page 7412 "Excise Tax Item/FA Rates"
     DataCaptionExpression = GetCaption();
     Caption = 'Excise Duty Rates';
     DelayedInsert = true;
+    ObsoleteState = Pending;
+    ObsoleteReason = 'Replaced by the Excise Tax Rates page, which shows item category and calculation type based rates.';
+    ObsoleteTag = '30.0';
 
     layout
     {
@@ -54,3 +58,4 @@ page 7412 "Excise Tax Item/FA Rates"
         exit(StrSubstNo(EntryPermissionsCaptionLbl, Rec.TableCaption, Rec."Excise Tax Type Code"));
     end;
 }
+#endif

--- a/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxRates.Page.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxRates.Page.al
@@ -1,0 +1,101 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.ExciseTaxes;
+
+page 7418 "Excise Tax Rates"
+{
+    PageType = List;
+    ApplicationArea = All;
+    SourceTable = "Excise Tax Rate";
+    DataCaptionExpression = GetCaption();
+    Caption = 'Excise Duty Rates';
+    DelayedInsert = true;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Rates)
+            {
+                field("Excise Tax Type Code"; Rec."Excise Tax Type Code")
+                {
+                    ToolTip = 'Specifies the excise tax type code.';
+                    Editable = false;
+                    Visible = false;
+                }
+                field("Source Type"; Rec."Source Type")
+                {
+                    ToolTip = 'Specifies whether this rate applies to an Item or Fixed Asset.';
+
+                    trigger OnValidate()
+                    begin
+                        SetControlAppearance();
+                    end;
+                }
+                field("Source No."; Rec."Source No.")
+                {
+                    Visible = false;
+                    ToolTip = 'Specifies the Item or Fixed Asset number.';
+                }
+                field("Item Category Code"; Rec."Item Category Code")
+                {
+                    Enabled = ItemCategoryEnabled;
+                    ToolTip = 'Specifies the item category that this rate applies to. Leave it blank to apply the rate to all item categories.';
+                }
+                field("Excise Calculation Type"; Rec."Excise Calculation Type")
+                {
+                    ToolTip = 'Specifies whether the excise duty is calculated per unit, as a percentage of the taxable amount, or as a combination of both.';
+
+                    trigger OnValidate()
+                    begin
+                        SetControlAppearance();
+                    end;
+                }
+                field("Excise Duty"; Rec."Excise Duty")
+                {
+                    Editable = ExciseDutyRateEditable;
+                    ToolTip = 'Specifies the excise duty.';
+                }
+                field("Excise Duty %"; Rec."Excise Duty %")
+                {
+                    Editable = ExciseDutyPercentEditable;
+                    ToolTip = 'Specifies the percentage of the taxable amount that is charged as excise duty.';
+                }
+                field("Effective From Date"; Rec."Effective From Date")
+                {
+                    ToolTip = 'Specifies when this excise duty becomes effective.';
+                }
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    begin
+        SetControlAppearance();
+    end;
+
+    trigger OnNewRecord(BelowxRec: Boolean)
+    begin
+        SetControlAppearance();
+    end;
+
+    var
+        ItemCategoryEnabled: Boolean;
+        ExciseDutyRateEditable: Boolean;
+        ExciseDutyPercentEditable: Boolean;
+        EntryPermissionsCaptionLbl: Label '%1 for Tax Type: %2', Comment = '%1=Current Rec TableCaption, %2=Excise Tax Type Code';
+
+    local procedure GetCaption(): Text[100]
+    begin
+        exit(StrSubstNo(EntryPermissionsCaptionLbl, Rec.TableCaption, Rec."Excise Tax Type Code"));
+    end;
+
+    local procedure SetControlAppearance()
+    begin
+        ItemCategoryEnabled := Rec."Source Type" = Rec."Source Type"::Item;
+        ExciseDutyRateEditable := Rec."Excise Calculation Type" in [Rec."Excise Calculation Type"::"Specific per Unit", Rec."Excise Calculation Type"::Hybrid];
+        ExciseDutyPercentEditable := Rec."Excise Calculation Type" in [Rec."Excise Calculation Type"::"Ad valorem", Rec."Excise Calculation Type"::Hybrid];
+    end;
+}

--- a/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxTypeCard.Page.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxTypeCard.Page.al
@@ -63,7 +63,7 @@ page 7415 "Excise Tax Type Card"
                 Caption = 'Excise Duty Rates';
                 ToolTip = 'Configure excise duty rates for specific items and fixed assets.';
                 Image = Setup;
-                RunObject = Page "Excise Tax Item/FA Rates";
+                RunObject = Page "Excise Tax Rates";
                 RunPageLink = "Excise Tax Type Code" = field(Code);
             }
         }

--- a/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxTypes.Page.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/page/ExciseTaxTypes.Page.al
@@ -53,7 +53,7 @@ page 7414 "Excise Tax Types"
                 Caption = 'Excise Duty Rates';
                 ToolTip = 'Configure excise duty rates for specific items and fixed assets.';
                 Image = Setup;
-                RunObject = Page "Excise Tax Item/FA Rates";
+                RunObject = Page "Excise Tax Rates";
                 RunPageLink = "Excise Tax Type Code" = field(Code);
             }
         }

--- a/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseJournalLineExt.PageExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseJournalLineExt.PageExt.al
@@ -32,6 +32,12 @@ pageextension 7414 "Excise Journal Line Ext" extends "Sustainability Excise Jour
                 Visible = EnableExciseTax;
                 ToolTip = 'Specifies which entry type was used to calculate the quantity from Item Ledger Entries for this journal line.';
             }
+            field("Excise Calculation Type"; Rec."Excise Calculation Type")
+            {
+                ApplicationArea = All;
+                Visible = EnableExciseTax;
+                ToolTip = 'Specifies whether the excise duty is calculated per unit, as a percentage of the taxable amount, or as a combination of both.';
+            }
         }
         addafter("Source Unit of Measure Code")
         {
@@ -41,6 +47,12 @@ pageextension 7414 "Excise Journal Line Ext" extends "Sustainability Excise Jour
                 Visible = EnableExciseTax;
                 Editable = false;
                 ToolTip = 'Specifies the unit of measure for the excise tax quantity.';
+            }
+            field("Item Category Code"; Rec."Item Category Code")
+            {
+                ApplicationArea = All;
+                Visible = EnableExciseTax;
+                ToolTip = 'Specifies the item category copied from the item ledger entry.';
             }
         }
         addafter("Source Qty.")
@@ -59,6 +71,18 @@ pageextension 7414 "Excise Journal Line Ext" extends "Sustainability Excise Jour
                 Visible = EnableExciseTax;
                 CaptionClass = GetCaptionClass(Rec.FieldNo("Excise Duty"));
                 ToolTip = 'Specifies the excise duty applied to this journal line.';
+            }
+            field("Excise Duty %"; Rec."Excise Duty %")
+            {
+                ApplicationArea = All;
+                Visible = EnableExciseTax;
+                ToolTip = 'Specifies the percentage of the taxable amount that is charged as excise duty on this journal line.';
+            }
+            field("Excise Taxable Amount"; Rec."Excise Taxable Amount")
+            {
+                ApplicationArea = All;
+                Visible = EnableExciseTax;
+                ToolTip = 'Specifies the amount that the ad valorem part of the excise duty is calculated from.';
             }
             field("Tax Amount"; Rec."Tax Amount")
             {

--- a/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseTaxTransLogExt.PageExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/pageextension/ExciseTaxTransLogExt.PageExt.al
@@ -24,6 +24,11 @@ pageextension 7416 "Excise Tax Trans Log Ext" extends "Sust. Excise Taxes Trans.
                 ApplicationArea = All;
                 ToolTip = 'Specifies the excise entry type.';
             }
+            field("Excise Calculation Type"; Rec."Excise Calculation Type")
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies whether the excise duty was calculated per unit, as a percentage of the taxable amount, or as a combination of both.';
+            }
         }
         addafter("Source Unit of Measure Code")
         {
@@ -31,6 +36,11 @@ pageextension 7416 "Excise Tax Trans Log Ext" extends "Sust. Excise Taxes Trans.
             {
                 ApplicationArea = All;
                 ToolTip = 'Specifies the unit of measure for excise tax calculation.';
+            }
+            field("Item Category Code"; Rec."Item Category Code")
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies the item category copied from the item ledger entry.';
             }
         }
         addafter("Source Qty.")
@@ -44,6 +54,16 @@ pageextension 7416 "Excise Tax Trans Log Ext" extends "Sust. Excise Taxes Trans.
             {
                 ApplicationArea = All;
                 ToolTip = 'Specifies the excise duty.';
+            }
+            field("Excise Duty %"; Rec."Excise Duty %")
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies the percentage of the taxable amount that was charged as excise duty.';
+            }
+            field("Excise Taxable Amount"; Rec."Excise Taxable Amount")
+            {
+                ApplicationArea = All;
+                ToolTip = 'Specifies the amount that the ad valorem part of the excise duty was calculated from.';
             }
             field("Tax Amount"; Rec."Tax Amount")
             {

--- a/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxItemFARate.Table.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxItemFARate.Table.al
@@ -1,3 +1,4 @@
+#if not CLEANSCHEMA33
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -12,8 +13,18 @@ table 7413 "Excise Tax Item/FA Rate"
 {
     Caption = 'Excise Duty Rate';
     DataClassification = CustomerContent;
+#if not CLEAN30
     LookupPageId = "Excise Tax Item/FA Rates";
     DrillDownPageId = "Excise Tax Item/FA Rates";
+#endif
+    ObsoleteReason = 'Replaced by the Excise Tax Rate table, which supports item category and calculation type based rates.';
+#if not CLEAN30
+    ObsoleteState = Pending;
+    ObsoleteTag = '30.0';
+#else
+    ObsoleteState = Removed;
+    ObsoleteTag = '33.0';
+#endif
 
     fields
     {
@@ -170,3 +181,4 @@ table 7413 "Excise Tax Item/FA Rate"
         exit("Excise Source Type"::" ");
     end;
 }
+#endif

--- a/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxRate.Table.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxRate.Table.al
@@ -1,0 +1,242 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.ExciseTaxes;
+
+using Microsoft.FixedAssets.FixedAsset;
+using Microsoft.Inventory.Item;
+using Microsoft.Sustainability.ExciseTax;
+
+table 7416 "Excise Tax Rate"
+{
+    Caption = 'Excise Duty Rate';
+    DataClassification = CustomerContent;
+    LookupPageId = "Excise Tax Rates";
+    DrillDownPageId = "Excise Tax Rates";
+
+    fields
+    {
+        field(1; "Excise Tax Type Code"; Code[20])
+        {
+            Caption = 'Excise Tax Type Code';
+            TableRelation = "Excise Tax Type".Code;
+            NotBlank = true;
+        }
+        field(2; "Source Type"; Enum "Excise Source Type")
+        {
+            Caption = 'Source Type';
+            NotBlank = true;
+
+            trigger OnValidate()
+            begin
+                if "Source Type" <> "Source Type"::Item then
+                    "Item Category Code" := '';
+            end;
+        }
+        field(3; "Source No."; Code[20])
+        {
+            Caption = 'Source No.';
+            TableRelation = if ("Source Type" = const(Item)) Item
+            else
+            if ("Source Type" = const("Fixed Asset")) "Fixed Asset";
+
+            trigger OnLookup()
+            begin
+                case "Source Type" of
+                    "Source Type"::Item:
+                        LookupItem();
+                    "Source Type"::"Fixed Asset":
+                        LookupFixedAsset();
+                end;
+            end;
+
+            trigger OnValidate()
+            begin
+                if "Source No." <> '' then
+                    ValidateSourceNo();
+            end;
+        }
+        field(4; "Excise Duty"; Decimal)
+        {
+            AutoFormatType = 0;
+            Caption = 'Excise Duty Rate';
+            DecimalPlaces = 2 : 5;
+            MinValue = 0;
+
+            trigger OnValidate()
+            begin
+                if ("Excise Duty" <> 0) and ("Excise Calculation Type" = "Excise Calculation Type"::"Ad valorem") then
+                    Error(FieldNotAllowedForCalcTypeErr, FieldCaption("Excise Duty"), FieldCaption("Excise Calculation Type"), "Excise Calculation Type");
+            end;
+        }
+        field(5; "Effective From Date"; Date)
+        {
+            Caption = 'Effective From Date';
+            NotBlank = true;
+        }
+        field(7; Description; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(8; "Excise Calculation Type"; Enum "Excise Calculation Type")
+        {
+            Caption = 'Excise Calculation Type';
+
+            trigger OnValidate()
+            begin
+                case "Excise Calculation Type" of
+                    "Excise Calculation Type"::"Specific per Unit":
+                        "Excise Duty %" := 0;
+                    "Excise Calculation Type"::"Ad valorem":
+                        "Excise Duty" := 0;
+                end;
+            end;
+        }
+        field(9; "Excise Duty %"; Decimal)
+        {
+            AutoFormatType = 0;
+            Caption = 'Excise Duty %';
+            DecimalPlaces = 0 : 5;
+            MinValue = 0;
+            MaxValue = 1000;
+
+            trigger OnValidate()
+            begin
+                if ("Excise Duty %" <> 0) and ("Excise Calculation Type" = "Excise Calculation Type"::"Specific per Unit") then
+                    Error(FieldNotAllowedForCalcTypeErr, FieldCaption("Excise Duty %"), FieldCaption("Excise Calculation Type"), "Excise Calculation Type");
+            end;
+        }
+        field(10; "Item Category Code"; Code[20])
+        {
+            Caption = 'Item Category Code';
+            TableRelation = "Item Category".Code;
+
+            trigger OnValidate()
+            begin
+                if "Item Category Code" <> '' then
+                    TestField("Source Type", "Source Type"::Item);
+            end;
+        }
+    }
+
+    keys
+    {
+        key(Key1; "Excise Tax Type Code", "Source Type", "Source No.", "Item Category Code", "Effective From Date")
+        {
+            Clustered = true;
+        }
+        key(Key2; "Excise Tax Type Code")
+        {
+        }
+    }
+
+    trigger OnInsert()
+    begin
+        ValidateMandatoryFields();
+    end;
+
+    trigger OnModify()
+    begin
+        ValidateMandatoryFields();
+    end;
+
+    var
+        ItemDoesNotExistErr: Label 'Item %1 does not exist.', Comment = '%1 = Item No.';
+        FixedAssetDoesNotExistErr: Label 'Fixed Asset %1 does not exist.', Comment = '%1 = Fixed Asset No.';
+        FieldNotAllowedForCalcTypeErr: Label 'You cannot specify %1 when %2 is %3.', Comment = '%1 = Caption of the field being set, %2 = Excise Calculation Type field caption, %3 = Excise Calculation Type value';
+
+    local procedure ValidateMandatoryFields()
+    begin
+        TestField("Excise Tax Type Code");
+        TestField("Source Type");
+        TestField("Effective From Date");
+        if "Source No." <> '' then
+            ValidateSourceNo();
+        if "Source Type" <> "Source Type"::Item then
+            TestField("Item Category Code", '');
+    end;
+
+    local procedure ValidateSourceNo()
+    var
+        Item: Record Item;
+        FixedAsset: Record "Fixed Asset";
+    begin
+        case "Source Type" of
+            "Source Type"::Item:
+                if not Item.Get("Source No.") then
+                    Error(ItemDoesNotExistErr, "Source No.");
+            "Source Type"::"Fixed Asset":
+                if not FixedAsset.Get("Source No.") then
+                    Error(FixedAssetDoesNotExistErr, "Source No.");
+        end;
+    end;
+
+    local procedure LookupItem()
+    var
+        Item: Record Item;
+    begin
+        if Page.RunModal(Page::"Item List", Item) = Action::LookupOK then
+            "Source No." := Item."No.";
+    end;
+
+    local procedure LookupFixedAsset()
+    var
+        FixedAsset: Record "Fixed Asset";
+    begin
+        if Page.RunModal(Page::"Fixed Asset List", FixedAsset) = Action::LookupOK then
+            "Source No." := FixedAsset."No.";
+    end;
+
+    /// <summary>
+    /// Loads the rate line that applies to the given source, from the most specific match to the rate that applies to every source of that type.
+    /// </summary>
+    procedure GetEffectiveExciseRate(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type"; SourceNo: Code[20]; ItemCategoryCode: Code[20]; EffectiveDate: Date): Boolean
+    begin
+        if SourceType <> "Excise Source Type"::Item then
+            ItemCategoryCode := '';
+
+        if (SourceNo <> '') and (ItemCategoryCode <> '') then
+            if FindExciseRate(TaxTypeCode, SourceType, SourceNo, ItemCategoryCode, EffectiveDate) then
+                exit(true);
+
+        if SourceNo <> '' then
+            if FindExciseRate(TaxTypeCode, SourceType, SourceNo, '', EffectiveDate) then
+                exit(true);
+
+        if ItemCategoryCode <> '' then
+            if FindExciseRate(TaxTypeCode, SourceType, '', ItemCategoryCode, EffectiveDate) then
+                exit(true);
+
+        exit(FindExciseRate(TaxTypeCode, SourceType, '', '', EffectiveDate));
+    end;
+
+    local procedure FindExciseRate(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type"; SourceNo: Code[20]; ItemCategoryCode: Code[20]; EffectiveDate: Date): Boolean
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+    begin
+        ExciseTaxRate.SetCurrentKey("Excise Tax Type Code", "Source Type", "Source No.", "Item Category Code", "Effective From Date");
+        ExciseTaxRate.SetRange("Excise Tax Type Code", TaxTypeCode);
+        ExciseTaxRate.SetRange("Source Type", SourceType);
+        ExciseTaxRate.SetRange("Source No.", SourceNo);
+        ExciseTaxRate.SetRange("Item Category Code", ItemCategoryCode);
+        ExciseTaxRate.SetFilter("Effective From Date", '<=%1', EffectiveDate);
+        if not ExciseTaxRate.FindLast() then
+            exit(false);
+
+        Rec := ExciseTaxRate;
+        exit(true);
+    end;
+
+    procedure ConvertSustSourceTypeToExciseSourceType(SustSourceType: Enum "Sust. Excise Jnl. Source Type"): Enum "Excise Source Type"
+    begin
+        case SustSourceType of
+            "Sust. Excise Jnl. Source Type"::Item:
+                exit("Excise Source Type"::Item);
+            "Sust. Excise Jnl. Source Type"::"Fixed Asset":
+                exit("Excise Source Type"::"Fixed Asset");
+        end;
+
+        exit("Excise Source Type"::" ");
+    end;
+}

--- a/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxType.Table.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/table/ExciseTaxType.Table.al
@@ -47,15 +47,15 @@ table 7412 "Excise Tax Type"
     trigger OnDelete()
     var
         ExciseTaxEntryPermission: Record "Excise Tax Entry Permission";
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
         ExciseTaxEntryPermission.SetRange("Excise Tax Type Code", Code);
         if not ExciseTaxEntryPermission.IsEmpty() then
             Error(CannotDeleteTaxTypeWithRateConfigurationsErr, Code, ExciseTaxEntryPermission.TableCaption());
 
-        ExciseTaxItemFARate.SetRange("Excise Tax Type Code", Code);
-        if not ExciseTaxItemFARate.IsEmpty() then
-            Error(CannotDeleteTaxTypeWithRateConfigurationsErr, Code, ExciseTaxItemFARate.TableCaption());
+        ExciseTaxRate.SetRange("Excise Tax Type Code", Code);
+        if not ExciseTaxRate.IsEmpty() then
+            Error(CannotDeleteTaxTypeWithRateConfigurationsErr, Code, ExciseTaxRate.TableCaption());
     end;
 
     var

--- a/src/Apps/W1/ExciseTaxes/app/src/tableextension/ExciseJournalLineExt.TableExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/tableextension/ExciseJournalLineExt.TableExt.al
@@ -6,6 +6,7 @@ namespace Microsoft.ExciseTaxes;
 
 using Microsoft.FixedAssets.Ledger;
 using Microsoft.Foundation.UOM;
+using Microsoft.Inventory.Item;
 using Microsoft.Sustainability.ExciseTax;
 
 tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
@@ -27,6 +28,9 @@ tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
                     "Excise Unit of Measure Code" := '';
                     "Quantity for Excise Tax" := 0;
                     "Excise Duty" := 0;
+                    "Excise Calculation Type" := "Excise Calculation Type"::"Specific per Unit";
+                    "Excise Duty %" := 0;
+                    "Excise Taxable Amount" := 0;
                     "Tax Amount" := 0;
                 end;
 
@@ -62,7 +66,7 @@ tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
 
             trigger OnValidate()
             begin
-                Rec."Tax Amount" := CalculateTaxAmount(Rec."Excise Duty", Rec."Source Qty.", Rec."Quantity for Excise Tax");
+                UpdateTaxAmount();
             end;
         }
         field(7416; "Excise Duty"; Decimal)
@@ -79,7 +83,7 @@ tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
                 if Rec."Excise Duty" <> 0 then
                     Rec.TestField("Excise Tax Type");
 
-                Rec."Tax Amount" := CalculateTaxAmount(Rec."Excise Duty", Rec."Source Qty.", Rec."Quantity for Excise Tax");
+                UpdateTaxAmount();
             end;
         }
         field(7417; "Tax Amount"; Decimal)
@@ -90,6 +94,35 @@ tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
             DataClassification = CustomerContent;
             Editable = false;
         }
+        field(7418; "Excise Calculation Type"; Enum "Excise Calculation Type")
+        {
+            Caption = 'Excise Calculation Type';
+            DataClassification = CustomerContent;
+            Editable = false;
+
+            trigger OnValidate()
+            begin
+                UpdateTaxAmount();
+            end;
+        }
+        field(7419; "Excise Duty %"; Decimal)
+        {
+            AutoFormatType = 0;
+            Caption = 'Excise Duty %';
+            DecimalPlaces = 0 : 5;
+            MinValue = 0;
+            MaxValue = 1000;
+            DataClassification = CustomerContent;
+            Editable = false;
+
+            trigger OnValidate()
+            begin
+                if Rec."Excise Duty %" <> 0 then
+                    Rec.TestField("Excise Tax Type");
+
+                UpdateTaxAmount();
+            end;
+        }
         field(7420; "FA Ledger Entry No."; Integer)
         {
             Caption = 'FA Ledger Entry No.';
@@ -97,11 +130,34 @@ tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
             DataClassification = CustomerContent;
             Editable = false;
         }
+        field(7421; "Excise Taxable Amount"; Decimal)
+        {
+            AutoFormatType = 1;
+            AutoFormatExpression = '';
+            Caption = 'Taxable Amount';
+            MinValue = 0;
+            DataClassification = CustomerContent;
+
+            trigger OnValidate()
+            begin
+                if Rec."Excise Taxable Amount" <> 0 then
+                    Rec.TestField("Excise Tax Type");
+
+                UpdateTaxAmount();
+            end;
+        }
+        field(7422; "Item Category Code"; Code[20])
+        {
+            Caption = 'Item Category Code';
+            TableRelation = "Item Category".Code;
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
         modify("Source Qty.")
         {
             trigger OnAfterValidate()
             begin
-                Rec."Tax Amount" := CalculateTaxAmount(Rec."Excise Duty", Rec."Source Qty.", Rec."Quantity for Excise Tax");
+                UpdateTaxAmount();
             end;
         }
     }
@@ -129,11 +185,16 @@ tableextension 7413 "Excise Journal Line Ext" extends "Sust. Excise Jnl. Line"
             Error(EntryTypeNotAllowedForTaxTypeErr, "Excise Entry Type", "Excise Tax Type");
     end;
 
-    local procedure CalculateTaxAmount(ExciseDuty: Decimal; Quantity: Decimal; QtyForTax: Decimal): Decimal
+    local procedure UpdateTaxAmount()
+    var
+        TaxAmount: Decimal;
     begin
-        if (ExciseDuty = 0) or (Quantity = 0) or (QtyForTax = 0) then
-            exit(0);
+        if Rec."Excise Calculation Type" in [Rec."Excise Calculation Type"::"Specific per Unit", Rec."Excise Calculation Type"::Hybrid] then
+            TaxAmount := Rec."Excise Duty" * Rec."Source Qty." * Rec."Quantity for Excise Tax";
 
-        exit(ExciseDuty * Quantity * QtyForTax);
+        if Rec."Excise Calculation Type" in [Rec."Excise Calculation Type"::"Ad valorem", Rec."Excise Calculation Type"::Hybrid] then
+            TaxAmount += Rec."Excise Duty %" / 100 * Rec."Excise Taxable Amount";
+
+        Rec."Tax Amount" := TaxAmount;
     end;
 }

--- a/src/Apps/W1/ExciseTaxes/app/src/tableextension/ExciseTaxesTransLogExt.TableExt.al
+++ b/src/Apps/W1/ExciseTaxes/app/src/tableextension/ExciseTaxesTransLogExt.TableExt.al
@@ -6,6 +6,7 @@ namespace Microsoft.ExciseTaxes;
 
 using Microsoft.FixedAssets.Ledger;
 using Microsoft.Foundation.UOM;
+using Microsoft.Inventory.Item;
 using Microsoft.Sustainability.ExciseTax;
 
 tableextension 7414 "Excise Taxes Trans. Log Ext" extends "Sust. Excise Taxes Trans. Log"
@@ -57,10 +58,40 @@ tableextension 7414 "Excise Taxes Trans. Log Ext" extends "Sust. Excise Taxes Tr
             DataClassification = CustomerContent;
             Editable = false;
         }
+        field(7418; "Excise Calculation Type"; Enum "Excise Calculation Type")
+        {
+            Caption = 'Excise Calculation Type';
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+        field(7419; "Excise Duty %"; Decimal)
+        {
+            AutoFormatType = 0;
+            Caption = 'Excise Duty %';
+            DecimalPlaces = 0 : 5;
+            MinValue = 0;
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
         field(7420; "FA Ledger Entry No."; Integer)
         {
             Caption = 'FA Ledger Entry No.';
             TableRelation = "FA Ledger Entry"."Entry No.";
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+        field(7421; "Excise Taxable Amount"; Decimal)
+        {
+            AutoFormatType = 1;
+            AutoFormatExpression = '';
+            Caption = 'Taxable Amount';
+            DataClassification = CustomerContent;
+            Editable = false;
+        }
+        field(7422; "Item Category Code"; Code[20])
+        {
+            Caption = 'Item Category Code';
+            TableRelation = "Item Category".Code;
             DataClassification = CustomerContent;
             Editable = false;
         }

--- a/src/Apps/W1/ExciseTaxes/test/src/ExciseCalculationTypeTests.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/test/src/ExciseCalculationTypeTests.Codeunit.al
@@ -1,0 +1,375 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Test.ExciseTaxes;
+
+using Microsoft.ExciseTaxes;
+using Microsoft.Inventory.Item;
+using Microsoft.Sustainability.ExciseTax;
+
+codeunit 148352 "Excise Calculation Type Tests"
+{
+    Subtype = Test;
+    TestType = Uncategorized;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+        LibraryExciseTax: Codeunit "Library - Excise Tax";
+        LibraryRandom: Codeunit "Library - Random";
+        IsInitialized: Boolean;
+        TaxAmountMismatchLbl: Label 'Unexpected excise tax amount on the journal line';
+        CalculationTypeMismatchLbl: Label 'Unexpected excise calculation type on the journal line';
+        DutyRateMismatchLbl: Label 'Unexpected excise duty rate';
+        DutyPercentMismatchLbl: Label 'Unexpected excise duty percentage on the journal line';
+        SourceTypeMismatchLbl: Label 'Unexpected source type on the resolved excise duty rate';
+        ItemCategoryMismatchLbl: Label 'Unexpected item category on the excise duty rate';
+        RateNotFoundLbl: Label 'No effective excise duty rate was resolved';
+
+    [Test]
+    procedure SpecificRateCalculatesTaxFromQuantity()
+    var
+        Item: Record Item;
+        ExciseJnlLine: Record "Sust. Excise Jnl. Line";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ExciseDuty: Decimal;
+        SourceQty: Decimal;
+    begin
+        // [SCENARIO 626305] A specific rate charges the excise duty per unit and ignores the taxable amount.
+        Initialize();
+        ExciseDuty := LibraryRandom.RandDecInRange(1, 10, 2);
+        SourceQty := LibraryRandom.RandIntInRange(2, 20);
+
+        // [GIVEN] An item with an excise tax type that has a specific rate.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        LibraryExciseTax.CreateItemWithExciseTax(Item, TaxTypeCode);
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, Item."No.", '', "Excise Calculation Type"::"Specific per Unit", ExciseDuty, 0, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] An excise journal line is created for the item and a taxable amount is entered.
+        CreateExciseJournalLine(ExciseJnlLine, TaxTypeCode, Item."No.", SourceQty, LibraryRandom.RandDecInRange(100, 1000, 2));
+
+        // [THEN] The tax amount only reflects the specific component.
+        Assert.AreEqual("Excise Calculation Type"::"Specific per Unit", ExciseJnlLine."Excise Calculation Type", CalculationTypeMismatchLbl);
+        Assert.AreEqual(ExciseDuty * SourceQty * ExciseJnlLine."Quantity for Excise Tax", ExciseJnlLine."Tax Amount", TaxAmountMismatchLbl);
+    end;
+
+    [Test]
+    procedure AdValoremRateCalculatesTaxFromTaxableAmount()
+    var
+        Item: Record Item;
+        ExciseJnlLine: Record "Sust. Excise Jnl. Line";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ExciseDutyPct: Decimal;
+        TaxableAmount: Decimal;
+    begin
+        // [SCENARIO 626305] An ad valorem rate charges a percentage of the taxable amount.
+        Initialize();
+        ExciseDutyPct := LibraryRandom.RandDecInRange(1, 50, 2);
+        TaxableAmount := LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [GIVEN] An item with an excise tax type that has an ad valorem rate.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        LibraryExciseTax.CreateItemWithExciseTax(Item, TaxTypeCode);
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, Item."No.", '', "Excise Calculation Type"::"Ad valorem", 0, ExciseDutyPct, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] An excise journal line is created for the item with a taxable amount.
+        CreateExciseJournalLine(ExciseJnlLine, TaxTypeCode, Item."No.", LibraryRandom.RandIntInRange(2, 20), TaxableAmount);
+
+        // [THEN] The rate is applied as a percentage of the taxable amount and the per unit duty stays empty.
+        Assert.AreEqual("Excise Calculation Type"::"Ad valorem", ExciseJnlLine."Excise Calculation Type", CalculationTypeMismatchLbl);
+        Assert.AreEqual(0, ExciseJnlLine."Excise Duty", DutyRateMismatchLbl);
+        Assert.AreEqual(ExciseDutyPct, ExciseJnlLine."Excise Duty %", DutyPercentMismatchLbl);
+        Assert.AreEqual(ExciseDutyPct / 100 * TaxableAmount, ExciseJnlLine."Tax Amount", TaxAmountMismatchLbl);
+    end;
+
+    [Test]
+    procedure HybridRateAddsSpecificAndAdValoremComponents()
+    var
+        Item: Record Item;
+        ExciseJnlLine: Record "Sust. Excise Jnl. Line";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ExciseDuty: Decimal;
+        ExciseDutyPct: Decimal;
+        SourceQty: Decimal;
+        TaxableAmount: Decimal;
+    begin
+        // [SCENARIO 626305] A hybrid rate charges both a per unit duty and a percentage of the taxable amount.
+        Initialize();
+        ExciseDuty := LibraryRandom.RandDecInRange(1, 10, 2);
+        ExciseDutyPct := LibraryRandom.RandDecInRange(1, 50, 2);
+        SourceQty := LibraryRandom.RandIntInRange(2, 20);
+        TaxableAmount := LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [GIVEN] An item with an excise tax type that has a hybrid rate.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        LibraryExciseTax.CreateItemWithExciseTax(Item, TaxTypeCode);
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, Item."No.", '', "Excise Calculation Type"::Hybrid, ExciseDuty, ExciseDutyPct, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] An excise journal line is created for the item with a taxable amount.
+        CreateExciseJournalLine(ExciseJnlLine, TaxTypeCode, Item."No.", SourceQty, TaxableAmount);
+
+        // [THEN] The tax amount is the sum of both components.
+        Assert.AreEqual("Excise Calculation Type"::Hybrid, ExciseJnlLine."Excise Calculation Type", CalculationTypeMismatchLbl);
+        Assert.AreEqual(
+            ExciseDuty * SourceQty * ExciseJnlLine."Quantity for Excise Tax" + ExciseDutyPct / 100 * TaxableAmount,
+            ExciseJnlLine."Tax Amount",
+            TaxAmountMismatchLbl);
+    end;
+
+    [Test]
+    procedure ItemCategoryRateIsAppliedToItemInThatCategory()
+    var
+        Item: Record Item;
+        ExciseJnlLine: Record "Sust. Excise Jnl. Line";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ItemCategoryCode: Code[20];
+        CategoryDutyPct: Decimal;
+        TaxableAmount: Decimal;
+    begin
+        // [SCENARIO 626305] An item without its own rate is charged with the rate of its item category.
+        Initialize();
+        CategoryDutyPct := LibraryRandom.RandDecInRange(1, 50, 2);
+        TaxableAmount := LibraryRandom.RandDecInRange(100, 1000, 2);
+
+        // [GIVEN] An item that belongs to an item category which has an ad valorem rate.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ItemCategoryCode := LibraryExciseTax.CreateItemCategory();
+        LibraryExciseTax.CreateItemWithExciseTax(Item, TaxTypeCode);
+        Item.Validate("Item Category Code", ItemCategoryCode);
+        Item.Modify(true);
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, '', ItemCategoryCode, "Excise Calculation Type"::"Ad valorem", 0, CategoryDutyPct, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] An excise journal line is created for the item.
+        CreateExciseJournalLine(ExciseJnlLine, TaxTypeCode, Item."No.", LibraryRandom.RandIntInRange(2, 20), TaxableAmount);
+
+        // [THEN] The category rate is used instead of the rate that applies to all items.
+        Assert.AreEqual("Excise Calculation Type"::"Ad valorem", ExciseJnlLine."Excise Calculation Type", CalculationTypeMismatchLbl);
+        Assert.AreEqual(CategoryDutyPct, ExciseJnlLine."Excise Duty %", DutyPercentMismatchLbl);
+        Assert.AreEqual(CategoryDutyPct / 100 * TaxableAmount, ExciseJnlLine."Tax Amount", TaxAmountMismatchLbl);
+    end;
+
+    [Test]
+    procedure ItemCategoryRateTakesPriorityOverGeneralRate()
+    var
+        Item: Record Item;
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ItemCategoryCode: Code[20];
+        CategoryDuty: Decimal;
+    begin
+        // [SCENARIO 626305] A rate defined for the item category wins over the rate that applies to all items.
+        Initialize();
+        CategoryDuty := LibraryRandom.RandDecInRange(20, 30, 2);
+
+        // [GIVEN] A tax type with a rate for all items and an additional rate for one item category.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ItemCategoryCode := LibraryExciseTax.CreateItemCategory();
+        LibraryExciseTax.CreateItemWithExciseTax(Item, TaxTypeCode);
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, '', ItemCategoryCode, "Excise Calculation Type"::"Specific per Unit", CategoryDuty, 0, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] The effective rate is resolved for an item in that category.
+        Assert.IsTrue(ExciseTaxRate.GetEffectiveExciseRate(TaxTypeCode, "Excise Source Type"::Item, Item."No.", ItemCategoryCode, WorkDate()), RateNotFoundLbl);
+
+        // [THEN] The category rate is returned.
+        Assert.AreEqual(CategoryDuty, ExciseTaxRate."Excise Duty", DutyRateMismatchLbl);
+    end;
+
+    [Test]
+    procedure ItemRateTakesPriorityOverItemCategoryRate()
+    var
+        Item: Record Item;
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ItemCategoryCode: Code[20];
+        ItemDuty: Decimal;
+    begin
+        // [SCENARIO 626305] A rate defined for a specific item wins over a rate defined for its item category.
+        Initialize();
+        ItemDuty := LibraryRandom.RandDecInRange(40, 50, 2);
+
+        // [GIVEN] A tax type with a category rate and an item specific rate.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ItemCategoryCode := LibraryExciseTax.CreateItemCategory();
+        LibraryExciseTax.CreateItemWithExciseTax(Item, TaxTypeCode);
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, '', ItemCategoryCode, "Excise Calculation Type"::"Specific per Unit", LibraryRandom.RandDecInRange(20, 30, 2), 0, CalcDate('<-CY>', WorkDate()));
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, Item."No.", '', "Excise Calculation Type"::"Specific per Unit", ItemDuty, 0, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] The effective rate is resolved for that item in that category.
+        Assert.IsTrue(ExciseTaxRate.GetEffectiveExciseRate(TaxTypeCode, "Excise Source Type"::Item, Item."No.", ItemCategoryCode, WorkDate()), RateNotFoundLbl);
+
+        // [THEN] The item specific rate is returned.
+        Assert.AreEqual(ItemDuty, ExciseTaxRate."Excise Duty", DutyRateMismatchLbl);
+    end;
+
+    [Test]
+    procedure FixedAssetRateIgnoresItemCategoryRates()
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ItemCategoryCode: Code[20];
+    begin
+        // [SCENARIO 626305] Item category rates never apply to fixed assets.
+        Initialize();
+
+        // [GIVEN] A tax type with an item category rate and a rate for all fixed assets.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ItemCategoryCode := LibraryExciseTax.CreateItemCategory();
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, "Excise Source Type"::Item, '', ItemCategoryCode, "Excise Calculation Type"::"Specific per Unit", LibraryRandom.RandDecInRange(60, 70, 2), 0, CalcDate('<-CY>', WorkDate()));
+
+        // [WHEN] The effective rate is resolved for a fixed asset, passing the category along.
+        Assert.IsTrue(ExciseTaxRate.GetEffectiveExciseRate(TaxTypeCode, "Excise Source Type"::"Fixed Asset", '', ItemCategoryCode, WorkDate()), RateNotFoundLbl);
+
+        // [THEN] The fixed asset rate is returned, not the category rate.
+        Assert.AreEqual("Excise Source Type"::"Fixed Asset", ExciseTaxRate."Source Type", SourceTypeMismatchLbl);
+        Assert.AreEqual('', ExciseTaxRate."Item Category Code", ItemCategoryMismatchLbl);
+    end;
+
+    [Test]
+    procedure ChangingSourceTypeAwayFromItemClearsTheItemCategory()
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ItemCategoryCode: Code[20];
+    begin
+        // [SCENARIO 626305] The item category is cleared automatically when the rate stops applying to items.
+        Initialize();
+
+        // [GIVEN] An item rate that applies to one item category.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ItemCategoryCode := LibraryExciseTax.CreateItemCategory();
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate.Validate("Source Type", "Excise Source Type"::Item);
+        ExciseTaxRate.Validate("Item Category Code", ItemCategoryCode);
+
+        // [WHEN] The rate is changed to apply to fixed assets.
+        ExciseTaxRate.Validate("Source Type", "Excise Source Type"::"Fixed Asset");
+
+        // [THEN] The item category is cleared.
+        Assert.AreEqual('', ExciseTaxRate."Item Category Code", ItemCategoryMismatchLbl);
+    end;
+
+    [Test]
+    procedure ItemCategoryCodeIsNotAllowedForFixedAssetRates()
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+        ItemCategoryCode: Code[20];
+    begin
+        // [SCENARIO 626305] An item category cannot be assigned to a fixed asset rate.
+        Initialize();
+
+        // [GIVEN] A rate for the fixed asset source type.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ItemCategoryCode := LibraryExciseTax.CreateItemCategory();
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate.Validate("Source Type", "Excise Source Type"::"Fixed Asset");
+
+        // [WHEN] An item category is entered.
+        asserterror ExciseTaxRate.Validate("Item Category Code", ItemCategoryCode);
+
+        // [THEN] The item category is rejected.
+        Assert.ExpectedErrorCode('TestField');
+    end;
+
+    [Test]
+    procedure ExciseDutyPercentIsNotAllowedForSpecificCalculationType()
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+    begin
+        // [SCENARIO 626305] A duty percentage cannot be set when the rate is calculated per unit.
+        Initialize();
+
+        // [GIVEN] A rate that is calculated per unit.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate.Validate("Source Type", "Excise Source Type"::Item);
+        ExciseTaxRate.Validate("Excise Calculation Type", "Excise Calculation Type"::"Specific per Unit");
+
+        // [WHEN] A duty percentage is entered.
+        asserterror ExciseTaxRate.Validate("Excise Duty %", LibraryRandom.RandDecInRange(1, 50, 2));
+
+        // [THEN] The percentage is rejected.
+        Assert.ExpectedError(ExciseTaxRate.FieldCaption("Excise Duty %"));
+    end;
+
+    [Test]
+    procedure SwitchingToAdValoremClearsTheSpecificDutyRate()
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+        ExciseTaxBasis: Enum "Excise Tax Basis";
+        TaxTypeCode: Code[20];
+    begin
+        // [SCENARIO 626305] Changing the calculation type clears the rate that no longer applies.
+        Initialize();
+
+        // [GIVEN] A rate with a per unit duty.
+        TaxTypeCode := LibraryExciseTax.SetupTaxType(ExciseTaxBasis::Weight);
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate.Validate("Source Type", "Excise Source Type"::Item);
+        ExciseTaxRate.Validate("Excise Duty", LibraryRandom.RandDecInRange(1, 10, 2));
+
+        // [WHEN] The calculation type is changed to ad valorem.
+        ExciseTaxRate.Validate("Excise Calculation Type", "Excise Calculation Type"::"Ad valorem");
+
+        // [THEN] The per unit duty is cleared.
+        Assert.AreEqual(0, ExciseTaxRate."Excise Duty", DutyRateMismatchLbl);
+    end;
+
+    local procedure Initialize()
+    var
+        LibraryERMCountryData: Codeunit "Library - ERM Country Data";
+    begin
+        LibraryExciseTax.CleanupExciseTaxData();
+
+        if IsInitialized then
+            exit;
+
+        LibraryERMCountryData.UpdateGeneralLedgerSetup();
+        LibraryERMCountryData.CreateVATData();
+        LibraryERMCountryData.UpdateGeneralPostingSetup();
+        LibraryERMCountryData.CreateGeneralPostingSetupData();
+        LibraryERMCountryData.UpdatePurchasesPayablesSetup();
+        LibraryERMCountryData.UpdateJournalTemplMandatory(false);
+
+        IsInitialized := true;
+    end;
+
+    local procedure CreateExciseJournalLine(var ExciseJnlLine: Record "Sust. Excise Jnl. Line"; TaxTypeCode: Code[20]; ItemNo: Code[20]; SourceQty: Decimal; TaxableAmount: Decimal)
+    var
+        SustExciseJournalBatch: Record "Sust. Excise Journal Batch";
+        SustainabilityExciseJournalMgt: Codeunit "Sust. Excise Journal Mgt.";
+    begin
+        SustExciseJournalBatch := SustainabilityExciseJournalMgt.GetASustainabilityJournalBatch();
+        SustExciseJournalBatch.Validate(Type, SustExciseJournalBatch.Type::Excises);
+        SustExciseJournalBatch.Validate("Excise Tax Type Filter", TaxTypeCode);
+        SustExciseJournalBatch.Modify(true);
+
+        ExciseJnlLine.Init();
+        ExciseJnlLine."Journal Template Name" := SustExciseJournalBatch."Journal Template Name";
+        ExciseJnlLine."Journal Batch Name" := SustExciseJournalBatch.Name;
+        ExciseJnlLine."Line No." := 10000;
+        ExciseJnlLine."Posting Date" := WorkDate();
+        ExciseJnlLine.Validate("Excise Tax Type", TaxTypeCode);
+        ExciseJnlLine.Validate("Source Type", ExciseJnlLine."Source Type"::Item);
+        ExciseJnlLine.Validate("Source No.", ItemNo);
+        ExciseJnlLine.Validate("Source Qty.", SourceQty);
+        ExciseJnlLine.Validate("Excise Taxable Amount", TaxableAmount);
+    end;
+}
+

--- a/src/Apps/W1/ExciseTaxes/test/src/ExciseTaxCalculationTests.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/test/src/ExciseTaxCalculationTests.Codeunit.al
@@ -761,12 +761,12 @@ codeunit 148351 "Excise Tax Calculation Tests"
 
     local procedure VerifyTaxRateCreated(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type")
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
-        ExciseTaxItemFARate.SetRange("Excise Tax Type Code", TaxTypeCode);
-        ExciseTaxItemFARate.SetRange("Source Type", SourceType);
-        ExciseTaxItemFARate.FindFirst();
-        Assert.IsTrue(ExciseTaxItemFARate."Excise Tax Type Code" = TaxTypeCode, StrSubstNo(ExciseRecordNotCreatedLbl, ExciseTaxItemFARate.TableCaption()));
+        ExciseTaxRate.SetRange("Excise Tax Type Code", TaxTypeCode);
+        ExciseTaxRate.SetRange("Source Type", SourceType);
+        ExciseTaxRate.FindFirst();
+        Assert.IsTrue(ExciseTaxRate."Excise Tax Type Code" = TaxTypeCode, StrSubstNo(ExciseRecordNotCreatedLbl, ExciseTaxRate.TableCaption()));
     end;
 
     local procedure CreateFixedAssetWithSetup(FixedAsset: Record "Fixed Asset"; var DepreciationBook: Record "Depreciation Book")

--- a/src/Apps/W1/ExciseTaxes/test/src/ExciseTaxCalculationTests.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/test/src/ExciseTaxCalculationTests.Codeunit.al
@@ -420,7 +420,7 @@ codeunit 148351 "Excise Tax Calculation Tests"
 
         LibraryExciseTax.CreateFixedAssetWithExciseTax(FixedAsset, TaxTypeCode);
         // [GIVEN] Create hierarchical rate for fixed asset source type
-        LibraryExciseTax.CreateExciseTaxItemFARate(TaxTypeCode, Enum::"Excise Source Type"::"Fixed Asset", FixedAsset."No.", TaxPercentage, CalcDate('<-CY>', WorkDate()), LibraryRandom.RandText(10));
+        LibraryExciseTax.CreateExciseTaxRate(TaxTypeCode, Enum::"Excise Source Type"::"Fixed Asset", FixedAsset."No.", '', "Excise Calculation Type"::"Specific per Unit", TaxPercentage, 0, CalcDate('<-CY>', WorkDate()));
 
         // [GIVEN] Setup fixed asset depreciation and post acquisition cost
         CreateFixedAssetWithSetup(FixedAsset, DepreciationBook);

--- a/src/Apps/W1/ExciseTaxes/test/src/LibraryExciseTax.Codeunit.al
+++ b/src/Apps/W1/ExciseTaxes/test/src/LibraryExciseTax.Codeunit.al
@@ -50,49 +50,76 @@ codeunit 148350 "Library - Excise Tax"
         ExciseTaxEntryPermission.Insert(true);
     end;
 
-    procedure CreateExciseTaxItemRate(TaxTypeCode: Code[20]; ItemNo: Code[20]; ExciseDuty: Decimal; EffectiveFromDate: Date; RateDescription: Text[100]): Record "Excise Tax Item/FA Rate"
+    procedure CreateExciseTaxItemRate(TaxTypeCode: Code[20]; ItemNo: Code[20]; ExciseDuty: Decimal; EffectiveFromDate: Date; RateDescription: Text[100]): Record "Excise Tax Rate"
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
-        ExciseTaxItemFARate.Init();
-        ExciseTaxItemFARate."Excise Tax Type Code" := TaxTypeCode;
-        ExciseTaxItemFARate."Source Type" := "Excise Source Type"::Item;
-        ExciseTaxItemFARate."Source No." := ItemNo;
-        ExciseTaxItemFARate."Excise Duty" := ExciseDuty;
-        ExciseTaxItemFARate."Effective From Date" := EffectiveFromDate;
-        ExciseTaxItemFARate.Description := RateDescription;
-        ExciseTaxItemFARate.Insert(true);
-        exit(ExciseTaxItemFARate);
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate."Source Type" := "Excise Source Type"::Item;
+        ExciseTaxRate."Source No." := ItemNo;
+        ExciseTaxRate."Excise Duty" := ExciseDuty;
+        ExciseTaxRate."Effective From Date" := EffectiveFromDate;
+        ExciseTaxRate.Description := RateDescription;
+        ExciseTaxRate.Insert(true);
+        exit(ExciseTaxRate);
     end;
 
-    procedure CreateExciseTaxFARate(TaxTypeCode: Code[20]; FANo: Code[20]; ExciseDuty: Decimal; EffectiveFromDate: Date; RateDescription: Text[100]): Record "Excise Tax Item/FA Rate"
+    procedure CreateExciseTaxFARate(TaxTypeCode: Code[20]; FANo: Code[20]; ExciseDuty: Decimal; EffectiveFromDate: Date; RateDescription: Text[100]): Record "Excise Tax Rate"
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
-        ExciseTaxItemFARate.Init();
-        ExciseTaxItemFARate."Excise Tax Type Code" := TaxTypeCode;
-        ExciseTaxItemFARate."Source Type" := "Excise Source Type"::"Fixed Asset";
-        ExciseTaxItemFARate."Source No." := FANo;
-        ExciseTaxItemFARate."Excise Duty" := ExciseDuty;
-        ExciseTaxItemFARate."Effective From Date" := EffectiveFromDate;
-        ExciseTaxItemFARate.Description := RateDescription;
-        ExciseTaxItemFARate.Insert(true);
-        exit(ExciseTaxItemFARate);
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate."Source Type" := "Excise Source Type"::"Fixed Asset";
+        ExciseTaxRate."Source No." := FANo;
+        ExciseTaxRate."Excise Duty" := ExciseDuty;
+        ExciseTaxRate."Effective From Date" := EffectiveFromDate;
+        ExciseTaxRate.Description := RateDescription;
+        ExciseTaxRate.Insert(true);
+        exit(ExciseTaxRate);
     end;
 
-    procedure CreateExciseTaxItemFARate(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type"; SourceNo: Code[20]; ExciseDuty: Decimal; EffectiveFromDate: Date; RateDescription: Text[100]): Record "Excise Tax Item/FA Rate"
+    procedure CreateExciseTaxItemFARate(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type"; SourceNo: Code[20]; ExciseDuty: Decimal; EffectiveFromDate: Date; RateDescription: Text[100]): Record "Excise Tax Rate"
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
-        ExciseTaxItemFARate.Init();
-        ExciseTaxItemFARate."Excise Tax Type Code" := TaxTypeCode;
-        ExciseTaxItemFARate."Source Type" := SourceType;
-        ExciseTaxItemFARate."Source No." := SourceNo;
-        ExciseTaxItemFARate."Excise Duty" := ExciseDuty;
-        ExciseTaxItemFARate."Effective From Date" := EffectiveFromDate;
-        ExciseTaxItemFARate.Description := RateDescription;
-        ExciseTaxItemFARate.Insert(true);
-        exit(ExciseTaxItemFARate);
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate."Source Type" := SourceType;
+        ExciseTaxRate."Source No." := SourceNo;
+        ExciseTaxRate."Excise Duty" := ExciseDuty;
+        ExciseTaxRate."Effective From Date" := EffectiveFromDate;
+        ExciseTaxRate.Description := RateDescription;
+        ExciseTaxRate.Insert(true);
+        exit(ExciseTaxRate);
+    end;
+
+    procedure CreateExciseTaxRate(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type"; SourceNo: Code[20]; ItemCategoryCode: Code[20]; CalculationType: Enum "Excise Calculation Type"; ExciseDuty: Decimal; ExciseDutyPct: Decimal; EffectiveFromDate: Date): Record "Excise Tax Rate"
+    var
+        ExciseTaxRate: Record "Excise Tax Rate";
+    begin
+        ExciseTaxRate.Init();
+        ExciseTaxRate."Excise Tax Type Code" := TaxTypeCode;
+        ExciseTaxRate."Source Type" := SourceType;
+        ExciseTaxRate."Source No." := SourceNo;
+        ExciseTaxRate."Item Category Code" := ItemCategoryCode;
+        ExciseTaxRate."Excise Calculation Type" := CalculationType;
+        ExciseTaxRate."Excise Duty" := ExciseDuty;
+        ExciseTaxRate."Excise Duty %" := ExciseDutyPct;
+        ExciseTaxRate."Effective From Date" := EffectiveFromDate;
+        ExciseTaxRate.Insert(true);
+        exit(ExciseTaxRate);
+    end;
+
+    procedure CreateItemCategory(): Code[20]
+    var
+        ItemCategory: Record "Item Category";
+    begin
+        ItemCategory.Init();
+        ItemCategory.Code := LibraryUtility.GenerateRandomCode(ItemCategory.FieldNo(Code), Database::"Item Category");
+        ItemCategory.Insert(true);
+        exit(ItemCategory.Code);
     end;
 
     procedure CreateItemWithExciseTax(var Item: Record Item; TaxTypeCode: Code[20])
@@ -165,26 +192,26 @@ codeunit 148350 "Library - Excise Tax"
 
     procedure GetSourceSpecificRate(TaxTypeCode: Code[20]; SourceType: Enum "Excise Source Type"; SourceNo: Code[20]; EffectiveDate: Date): Decimal
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
-        ExciseTaxItemFARate.SetRange("Excise Tax Type Code", TaxTypeCode);
-        ExciseTaxItemFARate.SetRange("Source Type", SourceType);
-        ExciseTaxItemFARate.SetRange("Source No.", SourceNo);
-        ExciseTaxItemFARate.SetFilter("Effective From Date", '<=%1', EffectiveDate);
-        if ExciseTaxItemFARate.FindLast() then
-            exit(ExciseTaxItemFARate."Excise Duty");
+        ExciseTaxRate.SetRange("Excise Tax Type Code", TaxTypeCode);
+        ExciseTaxRate.SetRange("Source Type", SourceType);
+        ExciseTaxRate.SetRange("Source No.", SourceNo);
+        ExciseTaxRate.SetFilter("Effective From Date", '<=%1', EffectiveDate);
+        if ExciseTaxRate.FindLast() then
+            exit(ExciseTaxRate."Excise Duty");
         exit(0);
     end;
 
     procedure GetGeneralRate(TaxTypeCode: Code[20]): Decimal
     var
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
     begin
-        ExciseTaxItemFARate.SetRange("Excise Tax Type Code", TaxTypeCode);
-        ExciseTaxItemFARate.SetRange("Source Type", "Excise Source Type"::" ");
-        ExciseTaxItemFARate.SetRange("Source No.", '');
-        if ExciseTaxItemFARate.FindFirst() then
-            exit(ExciseTaxItemFARate."Excise Duty");
+        ExciseTaxRate.SetRange("Excise Tax Type Code", TaxTypeCode);
+        ExciseTaxRate.SetRange("Source Type", "Excise Source Type"::" ");
+        ExciseTaxRate.SetRange("Source No.", '');
+        if ExciseTaxRate.FindFirst() then
+            exit(ExciseTaxRate."Excise Duty");
         exit(0);
     end;
 
@@ -212,12 +239,12 @@ codeunit 148350 "Library - Excise Tax"
     var
         ExciseTaxType: Record "Excise Tax Type";
         ExciseTaxEntryPermission: Record "Excise Tax Entry Permission";
-        ExciseTaxItemFARate: Record "Excise Tax Item/FA Rate";
+        ExciseTaxRate: Record "Excise Tax Rate";
         ItemExciseTax: Record "Item Excise Tax";
     begin
         ExciseTaxType.DeleteAll();
         ExciseTaxEntryPermission.DeleteAll();
-        ExciseTaxItemFARate.DeleteAll();
+        ExciseTaxRate.DeleteAll();
         ItemExciseTax.DeleteAll();
     end;
 }


### PR DESCRIPTION
Fixes [AB#626305](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/626305)

## Issue
Excise duty calculation supported only the legacy item and fixed-asset rate model. It could not correctly calculate taxes for rate-based excise duties such as specific-per-unit, ad valorem, and hybrid rates, especially when the applicable item category changed during item ledger processing.

## Cause
The calculation flow did not have an explicit excise calculation type or a dedicated rate table for the different duty models. For item ledger entries, the taxable amount could be evaluated before the final rate and calculation type had been resolved, producing an incorrect amount. Existing rates also required migration support.

## Solution
- Added the Excise Tax Rate table, list page, and Excise Calculation Type enum for specific-per-unit, ad valorem, and hybrid rates.
- Applied the final calculation type and rate before calculating the taxable amount for item ledger entries.
- Added migration from the existing item/fixed-asset rate table.
- Updated permissions, pages, journal lines, transaction logs, and tests for the new rate model.
- Preserved the servicing-branch schema by excluding main-branch-only deprecation changes from the backport path.


