### PR TITLE
Refresh country code test

### DIFF
--- a/src/Layers/AU/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/AU/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/BE/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/BE/Tests/Misc/CommonDemodata.Codeunit.al
@@ -217,7 +217,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -225,9 +225,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -337,4 +334,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/CA/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/CA/Tests/Misc/CommonDemodata.Codeunit.al
@@ -240,7 +240,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -248,9 +248,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -360,4 +357,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/CH/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/CH/Tests/Misc/CommonDemodata.Codeunit.al
@@ -205,7 +205,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -213,9 +213,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -325,4 +322,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/DE/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/DE/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/ES/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/ES/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/FI/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/FI/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/GB/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/GB/Tests/Misc/CommonDemodata.Codeunit.al
@@ -171,7 +171,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -179,9 +179,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -291,4 +288,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/IT/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/IT/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/NO/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/NO/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/NZ/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/NZ/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/SE/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/SE/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/US/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/US/Tests/Misc/CommonDemodata.Codeunit.al
@@ -240,7 +240,7 @@
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -248,9 +248,6 @@
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -360,4 +357,3 @@
         Commit();
     end;
 }
-

--- a/src/Layers/W1/Tests/Misc/CommonDemodata.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/CommonDemodata.Codeunit.al
@@ -218,7 +218,7 @@ codeunit 138500 "Common Demodata"
 
     [Test]
     [Scope('OnPrem')]
-    procedure AllCountriesHaveISOCodes()
+    procedure AllCountriesHaveCountryCodes()
     var
         CountryRegion: Record "Country/Region";
     begin
@@ -226,9 +226,6 @@ codeunit 138500 "Common Demodata"
         Initialize();
 
         CountryRegion.SetRange("ISO Code", '');
-        Assert.RecordIsEmpty(CountryRegion);
-        CountryRegion.Reset();
-        CountryRegion.SetRange("ISO Numeric Code", '');
         Assert.RecordIsEmpty(CountryRegion);
     end;
 
@@ -338,4 +335,3 @@ codeunit 138500 "Common Demodata"
         Commit();
     end;
 }
-


### PR DESCRIPTION
Removes a stale numeric-code assertion while retaining country-code coverage.

Fix [AB#641869](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641869)

