### PR TITLE
Fix Expense Report Reimbursement Currency Code

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Codeunits/CreateExpenseReport.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Codeunits/CreateExpenseReport.Codeunit.al
@@ -56,7 +56,7 @@ codeunit 6983 "Create Expense Report"
         else
             Error('');
 
-        ExpenseReportHeader := GetExpenseReportHeader(ExpenseReportNo, Expense."Expense User No.", Expense."Currency Code", Expense."VAT Bus. Posting Group");
+        ExpenseReportHeader := GetExpenseReportHeader(ExpenseReportNo, Expense."Expense User No.", Expense."VAT Bus. Posting Group");
         LoopThruExpenseToAddInReport(Expense, ExpenseReportHeader);
         ShowExpenseReport(ExpenseReportHeader, ExpenseReportNo <> '');
     end;
@@ -81,7 +81,7 @@ codeunit 6983 "Create Expense Report"
         Page.Run(Page::"Expense Report", ExpenseReportHeader);
     end;
 
-    local procedure GetExpenseReportHeader(ExpenseReportNo: Code[20]; ExpenseUserNo: Code[20]; CurrencyCode: Code[10]; VATBusPostingGroup: Code[20]): Record "Expense Report Header"
+    local procedure GetExpenseReportHeader(ExpenseReportNo: Code[20]; ExpenseUserNo: Code[20]; VATBusPostingGroup: Code[20]): Record "Expense Report Header"
     var
         ExpenseReportHeader: Record "Expense Report Header";
     begin
@@ -90,7 +90,6 @@ codeunit 6983 "Create Expense Report"
 
         ExpenseReportHeader.Init();
         ExpenseReportHeader.Validate("Expense User No.", ExpenseUserNo);
-        ExpenseReportHeader.Validate("Reimbursement Currency Code", CurrencyCode);
         ExpenseReportHeader.Validate("VAT Bus. Posting Group", VATBusPostingGroup);
         ExpenseReportHeader.Insert(true);
 

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseTestII.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseTestII.Codeunit.al
@@ -358,6 +358,44 @@ codeunit 148309 "Expense Test II"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerNo,AddExpensesToExpenseReportModalPageHandler')]
+    procedure CreateExpenseReportUsesLocalCurrencyForForeignCurrencyExpense()
+    var
+        Expense: Record Expense;
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseReportLine: Record "Expense Report Line";
+        ExpenseCategory: Record "Expense Category";
+        ExpenseUser: Record "Expense User";
+        CreateExpenseReport: Codeunit "Create Expense Report";
+        CurrencyCode: Code[10];
+    begin
+        // [SCENARIO 647169] Verify that a report created from a foreign currency expense uses local currency for reimbursement.
+        Initialize();
+
+        // [GIVEN] Create a released expense in a foreign currency.
+        CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), LibraryRandom.RandDec(10, 2), LibraryRandom.RandDec(10, 2));
+        LibraryExpense.CreateExpenseUser(ExpenseUser);
+        LibraryExpense.CreateExpenseCategory(ExpenseCategory, ExpenseCategory."Reimbursement Type"::"Employee Paid", ExpenseCategory."Expense Detail Required"::" ");
+        LibraryExpense.CreateExpense(Expense, ExpenseUser."No.", ExpenseCategory.Code, '', '', true, CurrencyCode, 100);
+        Expense.PerformManualRelease();
+
+        // [GIVEN] Select a new expense report.
+        LibraryVariableStorage.Enqueue(false);
+
+        // [WHEN] Create the expense report from the expense.
+        Expense.SetRange("No.", Expense."No.");
+        CreateExpenseReport.AddExpensesToReport(Expense);
+
+        // [THEN] The report uses local currency for reimbursement and retains the foreign currency on the line.
+        Expense.Get(Expense."No.");
+        ExpenseReportHeader.Get(Expense."Expense Report No.");
+        ExpenseReportHeader.TestField("Reimbursement Currency Code", '');
+        ExpenseReportLine.SetRange("Document No.", ExpenseReportHeader."No.");
+        ExpenseReportLine.FindFirst();
+        ExpenseReportLine.TestField("Expense Currency Code", CurrencyCode);
+    end;
+
+    [Test]
     procedure ReimbursementTypeMustBeUpdatedFromPaymentMethodCodeInExpense()
     var
         ExpensePaymentMethod: Record "Expense Payment Method";


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#647169](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647169)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


