### PR TITLE
Remove zero-consumer DotNet alias declarations from test libraries

### DIFF
--- a/src/Layers/CZ/Tests/TestLibraries/dotnet.al
+++ b/src/Layers/CZ/Tests/TestLibraries/dotnet.al
@@ -32,17 +32,7 @@ dotnet
 
     assembly("netstandard")
     {
-        type("System.Reflection.BindingFlags"; "System.Reflection.BindingFlags")
-        {
-        }
-        type("System.UnauthorizedAccessException"; "System.UnauthorizedAccessException")
-        {
-        }
         type("System.Diagnostics.ProcessStartInfo"; "System.Diagnostics.ProcessStartInfo")
-        {
-        }
-
-        type("System.Net.Mail.MailMessage"; "System.Net.Mail.MailMessage")
         {
         }
         type("System.Net.Http.HttpRequestMessage"; "HttpRequestMessage")
@@ -57,9 +47,6 @@ dotnet
         }
 
         type("System.Xml.Schema.ValidationEventHandler"; "System.Xml.Schema.ValidationEventHandler")
-        {
-        }
-        type("System.Collections.ObjectModel.Collection`1"; "Collection1")
         {
         }
     }

--- a/src/Layers/W1/Tests/TestLibraries/dotnet.al
+++ b/src/Layers/W1/Tests/TestLibraries/dotnet.al
@@ -35,13 +35,6 @@ dotnet
 
     assembly("netstandard")
     {
-        type("System.Reflection.BindingFlags"; "System.Reflection.BindingFlags")
-        {
-        }
-
-        type("System.UnauthorizedAccessException"; "System.UnauthorizedAccessException")
-        {
-        }
         type("System.Diagnostics.ProcessStartInfo"; "System.Diagnostics.ProcessStartInfo")
         {
         }
@@ -57,9 +50,6 @@ dotnet
         }
 
         type("System.Xml.Schema.ValidationEventHandler"; "System.Xml.Schema.ValidationEventHandler")
-        {
-        }
-        type("System.Collections.ObjectModel.Collection`1"; "Collection1")
         {
         }
     }


### PR DESCRIPTION
## What & why

The W1 and CZ `Tests-TestLibraries` `dotnet.al` files declare CLR interop aliases that nothing in this repository consumes. Because an AL alias is inherited by every app that depends on the declaring app, these dead declarations keep unused .NET surface visible to roughly 220 dependent test apps, which adds noise to any future DotNet reduction work.

This deletes four such CLR types (7 declaration blocks across the 2 files). It is deletion only: no consuming AL code, test, or `app.json` was modified, and it is a no-op at runtime.

| CLR type | Alias | W1 | CZ |
| --- | --- | :-: | :-: |
| `System.Reflection.BindingFlags` | `"System.Reflection.BindingFlags"` | x | x |
| `System.UnauthorizedAccessException` | `"System.UnauthorizedAccessException"` | x | x |
| ``System.Collections.ObjectModel.Collection`1`` | `"Collection1"` | x | x |
| `System.Net.Mail.MailMessage` | `"System.Net.Mail.MailMessage"` | | x |

`System.Security.Cryptography.SHA1Managed` is also unused but is deliberately **excluded** from this PR: it lives in a shipped product module (Cryptography Management) rather than a test library, so inheritance by external extensions cannot be ruled out by a repo scan alone. It should be handled separately.

## Linked work

[AB#647963](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647963)

<!-- Tracked in ADO; no corresponding GitHub issue. -->

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

**I could not build this locally, and I would rather say so plainly than imply otherwise.** The environment this was prepared in has no `alc.exe`, no `.alpackages` symbol directories, and no Docker runtime, so the AL-Go `localDevEnv.ps1` container build was not reachable. That is why the two build/run boxes above are unchecked. This needs a compile from CI or from a reviewer with a working container before it merges.

What I did validate:

- **Zero usage, repository-wide.** Scanned all 36,684 `.al` files in the repo, not just the declaring apps, since aliases are inherited across dependencies. I searched bare distinctive tokens rather than a narrow `: DotNet "X";` pattern, so that parameter types, return types, `var` parameters and event subscriber signatures would also be caught. Before the change: 9 hits, being the 7 target declarations plus 2 false positives. After: only those same 2 false positives remain.
  - `SharePointTestLibrary.Codeunit.al:1017` - `System.UnauthorizedAccessException` inside a string literal that builds a mock JSON error body. Not a type reference.
  - `DotNet Aliases/src/dotnet.al:2141` - `HttpHeaderValueCollection1`, an unrelated alias matched only because the `Collection1` pattern was deliberately broad.
- **Structure.** Both files remain structurally valid: 12 open / 12 close braces, 8 `type(` blocks, 3 `assembly(` blocks each. No `assembly(...)` block was left empty.
- **Scope.** `git diff main...HEAD` is 23 deletions, 0 additions, exactly 2 files.

No tests were added because this removes dead declarations and introduces no behavior. The neighbouring aliases that are still in use (`HttpRequestMessage`, `System.Xml.XmlException`, `WindowsIdentity`, `SecurityIdentifier`, `ProcessStartInfo`, `XmlSchema`, `ValidationEventHandler`, `PermissionTestHelper`) were left untouched and their existing coverage is unchanged.

## Risk & compatibility

Low, but there is one thing worth a reviewer's eye.

- **Alias inheritance is where a mistake would surface.** An alias declared in `Tests-TestLibraries` is visible to every dependent app, so a missed usage would fail in a *dependent* app rather than in this one. That is why usage was checked repo-wide rather than per-app. If CI does fail, expect an unknown-type error in a dependent test app.
- **No breaking-change gate applies.** `Tests-TestLibraries` is `"target": "OnPrem"` with no sibling `AppSourceCop.json`, and DotNet alias declarations are not part of the object metadata surface that the AS0080-family rules diff against a baseline.
- **CZ is an overlay.** `src/Layers/CZ/Tests/TestLibraries` has no `app.json`; it compiles into a CZ-localized build of the same app id (`5d86850b-...`). Both layers had the same aliases removed, so no build variant is left inconsistent.
- No runtime, upgrade, data, permissions, or telemetry impact.


