### PR TITLE
Use renamed "ADO: Sync" label in work item validation workflow

### DIFF
--- a/.github/workflows/WorkitemValidation.yaml
+++ b/.github/workflows/WorkitemValidation.yaml
@@ -60,12 +60,12 @@ jobs:
         run: |
           build/scripts/PullRequestValidation/ValidateInternalWorkItemForPullRequest.ps1 -PullRequestNumber ${{ github.event.pull_request.number }} -Repository ${{ github.repository }}
 
-      - name: Add Linked label to PR
+      - name: 'Add ADO: Sync label to PR'
         if: github.event.pull_request.head.repo.full_name != github.repository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels  -f "labels[]=Linked" -H "Accept: application/vnd.github.v3+json" -H "X-GitHub-Api-Version: 2022-11-28"
+          gh api /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels  -f "labels[]=ADO: Sync" -H "Accept: application/vnd.github.v3+json" -H "X-GitHub-Api-Version: 2022-11-28"
 
       - name: Get repo version from target branch
         id: get-repo-version


### PR DESCRIPTION
## What & why

The label `Linked` was renamed to `ADO: Sync` in the repository, but `WorkitemValidation.yaml` still posted the old name:

```yaml
-f "labels[]=Linked"
```

The GitHub labels API **creates a label on miss**. So the next fork PR to pass work item validation would have silently recreated `Linked` as a fresh, duplicate label sitting alongside `ADO: Sync` — splitting the same meaning across two labels and quietly breaking any filter or report built on either one.

This hadn't fired yet: an audit of all 321 open PRs found no PR carrying a `Linked` label, and the label no longer exists in the repo. The bug was armed but not yet triggered.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>". -->

_No tracking issue exists for the label rename — needs one added before merge, per CONTRIBUTING.md._

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings. — _N/A, workflow-only change._
- [ ] I ran the change in Business Central and confirmed it behaves as expected. — _N/A, workflow-only change._
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Parsed `WorkitemValidation.yaml` with a YAML loader after the edit; the file loads and the step name reads back as the plain string `Add ADO: Sync label to PR`.
- The step name is **quoted** in YAML. Unquoted, `name: Add ADO: Sync label to PR` contains a colon-space and would parse as a nested mapping, breaking the workflow file.
- Verified argument tokenization under `pwsh` (the workflow's configured shell) with an argument probe: `-f "labels[]=ADO: Sync"` reaches `gh` as a single argument and does not split at the space.

No tests added — this repo has no test harness for workflow YAML, and the change is a one-token string correction.

## Risk & compatibility

Low. Affects only the label applied to fork PRs after work item validation passes.

Two follow-ups found during the audit, **not** addressed here, as both need a human call on contributor PRs:

- #8577 carries `ADO: Sync` but has no `AB#` reference in its body.
- #9523 has `[AB#647953](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647953)` in its body but no label; last updated before the rename.

Also unchanged: the step's `if:` still restricts labelling to fork PRs, so the 187 open internal PRs with `AB#` links remain unlabelled. That is existing behaviour — worth revisiting only if the label becomes a reporting signal.


