### PR TITLE
Remove 43 unused DotNet alias declarations

### DIFF
--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -21,14 +21,6 @@ dotnet
         {
         }
 
-        type("DocumentFormat.OpenXml.EnumValue`1"; "EnumValue1")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.HexBinaryValue"; "HexBinaryValue")
-        {
-        }
-
         type("DocumentFormat.OpenXml.Int32Value"; "Int32Value")
         {
         }
@@ -108,31 +100,8 @@ dotnet
         type("DocumentFormat.OpenXml.Spreadsheet.DataBinding"; "DataBinding")
         {
         }
-        type("DocumentFormat.OpenXml.Spreadsheet.Fill"; "Fill")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.Font"; "Font")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.FontName"; "FontName")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.FontScheme"; "FontScheme")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.FontSchemeValues"; "FontSchemeValues")
-        {
-        }
 
         type("DocumentFormat.OpenXml.Spreadsheet.FontSize"; "FontSize")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.ForegroundColor"; "Spreadsheet.ForegroundColor")
         {
         }
 
@@ -149,14 +118,6 @@ dotnet
         }
 
         type("DocumentFormat.OpenXml.Spreadsheet.OrientationValues"; "OrientationValues")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.PatternFill"; "PatternFill")
-        {
-        }
-
-        type("DocumentFormat.OpenXml.Spreadsheet.PatternValues"; "PatternValues")
         {
         }
 
@@ -1082,10 +1043,6 @@ dotnet
         {
         }
 
-        type("System.Drawing.Imaging.EncoderParameter[]"; "EncoderParameterList")
-        {
-        }
-
         type("System.Drawing.Imaging.ImageCodecInfo"; "ImageCodecInfo")
         {
         }
@@ -1154,22 +1111,7 @@ dotnet
         {
         }
 
-        type("System.Security.Cryptography.Xml.SignedInfo"; "SignedInfo")
-        {
-        }
         type("System.Security.Cryptography.Xml.SignedXml"; "SignedXml")
-        {
-        }
-
-        type("System.Security.Cryptography.Xml.Transform"; "Transform")
-        {
-        }
-
-        type("System.Security.Cryptography.Xml.XmlDecryptionTransform"; "XmlDecryptionTransform")
-        {
-        }
-
-        type("System.Security.Cryptography.Xml.XmlDsigBase64Transform"; "XmlDsigBase64Transform")
         {
         }
 
@@ -1182,18 +1124,6 @@ dotnet
         }
 
         type("System.Security.Cryptography.Xml.XmlDsigExcC14NTransform"; "XmlDsigExcC14NTransform")
-        {
-        }
-
-        type("System.Security.Cryptography.Xml.XmlDsigXPathTransform"; "XmlDsigXPathTransform")
-        {
-        }
-
-        type("System.Security.Cryptography.Xml.XmlDsigXsltTransform"; "XmlDsigXsltTransform")
-        {
-        }
-
-        type("System.Security.Cryptography.Xml.XmlLicenseTransform"; "XmlLicenseTransform")
         {
         }
     }
@@ -1214,14 +1144,6 @@ dotnet
         }
 
         type("MailKit.ITransferProgress"; "ITransferProgress")
-        {
-        }
-
-        type("MailKit.CommandException"; "CommandException")
-        {
-        }
-
-        type("MailKit.Net.Smtp.SmtpCommandException"; "SmtpCommandException")
         {
         }
 
@@ -1250,10 +1172,6 @@ dotnet
         {
         }
 
-        type("MimeKit.MailboxAddress"; "MimeMailboxAddress")
-        {
-        }
-
         type("MimeKit.InternetAddressList"; "InternetAddressList")
         {
         }
@@ -1271,10 +1189,6 @@ dotnet
         }
 
         type("MimeKit.ContentType"; "MimeContentType")
-        {
-        }
-
-        type("MimeKit.MimePart"; "MimePart")
         {
         }
 
@@ -1389,15 +1303,7 @@ dotnet
         {
         }
 
-        type("System.Base64FormattingOptions"; "Base64FormattingOptions")
-        {
-        }
-
         type("System.BitConverter"; "BitConverter")
-        {
-        }
-
-        type("System.Boolean"; "Boolean")
         {
         }
 
@@ -1418,10 +1324,6 @@ dotnet
         }
 
         type("System.Collections.Hashtable"; "Hashtable")
-        {
-        }
-
-        type("System.Collections.IDictionaryEnumerator"; "IDictionaryEnumerator")
         {
         }
 
@@ -1501,14 +1403,6 @@ dotnet
         {
         }
 
-        type("System.Globalization.TextInfo"; "TextInfo")
-        {
-        }
-
-        type("System.Guid"; "Guid")
-        {
-        }
-
         type("System.Int32"; "Int32")
         {
         }
@@ -1537,10 +1431,6 @@ dotnet
         {
         }
 
-        type("System.IO.FileAttributes"; "FileAttributes")
-        {
-        }
-
         type("System.IO.FileInfo"; "FileInfo")
         {
         }
@@ -1562,10 +1452,6 @@ dotnet
         }
 
         type("System.IO.Path"; "Path")
-        {
-        }
-
-        type("System.IO.SearchOption"; "SearchOption")
         {
         }
 
@@ -1602,10 +1488,6 @@ dotnet
         }
 
         type("System.Security.Claims.Claim"; "Claim")
-        {
-        }
-
-        type(System.Security.Cryptography.SymmetricAlgorithm; "SymmetricAlgorithm")
         {
         }
 
@@ -1703,15 +1585,7 @@ dotnet
         {
         }
 
-        type("System.Reflection.FieldInfo"; "FieldInfo")
-        {
-        }
-
         type("System.Reflection.PropertyInfo"; "PropertyInfo")
-        {
-        }
-
-        type("System.Security.Cryptography.CryptoConfig"; "CryptoConfig")
         {
         }
 
@@ -1722,13 +1596,6 @@ dotnet
         {
         }
 
-        type("System.Collections.Specialized.StringCollection"; "StringCollection")
-        {
-        }
-
-        type("System.Diagnostics.FileVersionInfo"; "FileVersionInfo")
-        {
-        }
         type("System.Diagnostics.Stopwatch"; "Stopwatch")
         {
         }
@@ -1813,31 +1680,11 @@ dotnet
         {
         }
 
-        type("System.Security.Cryptography.X509Certificates.OpenFlags"; "OpenFlags")
-        {
-        }
-
-        type("System.Security.Cryptography.X509Certificates.StoreLocation"; "StoreLocation")
-        {
-        }
-
-        type("System.Security.Cryptography.X509Certificates.StoreName"; "StoreName")
-        {
-        }
-
         type("System.Security.Cryptography.X509Certificates.X509Certificate2"; "X509Certificate2")
         {
         }
 
-        type("System.Security.Cryptography.X509Certificates.X509Certificate2Collection"; "X509Certificate2Collection")
-        {
-        }
-
         type("System.Security.Cryptography.X509Certificates.X509Chain"; "X509Chain")
-        {
-        }
-
-        type("System.Security.Cryptography.X509Certificates.X509FindType"; "X509FindType")
         {
         }
 
@@ -1846,10 +1693,6 @@ dotnet
         }
 
         type("System.Security.Cryptography.X509Certificates.X509RevocationMode"; "X509RevocationMode")
-        {
-        }
-
-        type("System.Security.Cryptography.X509Certificates.X509Store"; "X509Store")
         {
         }
 
@@ -1991,10 +1834,6 @@ dotnet
         {
         }
 
-        type("System.Xml.XmlCDataSection"; "XmlCDataSection")
-        {
-        }
-
         type("System.Xml.XmlConvert"; "XmlConvert")
         {
         }
@@ -2048,10 +1887,6 @@ dotnet
         }
 
         type("System.Xml.XmlReaderSettings"; "XmlReaderSettings")
-        {
-        }
-
-        type("System.Xml.XmlText"; "XmlText")
         {
         }
 
@@ -2120,9 +1955,6 @@ dotnet
         }
 
         type("System.Collections.Generic.List`1"; "GenericList1")
-        {
-        }
-        type("System.Nullable`1"; "Nullable1")
         {
         }
 


### PR DESCRIPTION
## What & why

The `DotNet Aliases` app exists purely to publish CLR type aliases that dependent apps inherit; it contains no code, just `app.json`, `README.md` and `dotnet.al`. Over time it accumulated alias declarations that nothing consumes. This PR deletes 43 `type(...)` declarations that have zero consumers anywhere in the repository.

This is a straight deletion rather than a deprecation. DotNet interop requires `target: OnPrem` (and this app is `OnPrem`), while partner/AppSource extensions target `Cloud`, so no external extension can declare a `DotNet` variable at all and therefore cannot consume an inherited alias either. That makes these declarations first-party-internal surface with no external audience. There is also nothing to obsolete: AL does not support obsoletion metadata on `dotnet` declarations.

Deletion only. No consuming AL code, tests, or `app.json` files were touched. The diff is 168 deletions and 0 insertions in a single file.

Declarations removed per assembly:

| assembly | before | after | removed |
| --- | --- | --- | --- |
| DocumentFormat.OpenXml | 63 | 53 | 10 |
| netstandard | 198 | 177 | 21 |
| System.Security.Cryptography.Xml | 16 | 9 | 7 |
| MimeKit | 10 | 8 | 2 |
| MailKit | 7 | 5 | 2 |
| System.Drawing.Common | 15 | 14 | 1 |

Total `type()` declarations go from 517 to 474. All 49 `assembly(...)` blocks are retained and none is emptied.

## Linked work

Fixes [AB#647963](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647963)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

**I did not compile this change, and the two unchecked boxes above are accurate.** Docker Desktop is not installed on my machine and no `alc.exe` is present, so the container route in `LOCAL_DEV_ENV.md` was unavailable. Please treat compilation and runtime behavior as unverified and rely on CI plus a reviewer with a working container. Everything below is static verification only.

Zero-usage scan, run both before and after the deletion:

- Scanned all 36,684 `.al` files under `src` with `:\s*DotNet\s+"?<alias>"?\s*[;)]` for each of the 43 aliases. Result: 0 usages for all 43, both before and after.
- A deliberately looser scan, `DotNet\s+"?<alias>"?\b` across every other `.al` file, also returned no references. This catches usages outside a plain variable declaration.
- The scan was repo-wide on purpose. Aliases are inherited across app dependencies, so "unused in the declaring app" is not sufficient. For example `src\Layers\W1\Tests\TestRunner-Internal\dotnet.al` declares only `Process` and `Environment` yet uses `WindowsIdentity`, `SecurityIdentifier` and `ProcessStartInfo` inherited from `Tests-TestLibraries`.
- Each of the 43 aliases was confirmed to be declared exactly once repo-wide, so matching by alias name is unambiguous. After the change all 43 resolve to no declaration.

Structural verification:

- A structural parse of `dotnet.al` reports 0 errors and final brace depth 0 both before and after; brace counts balance at 524/524.
- `assembly(...)` block count is unchanged at 49, and the per-assembly counts in the table above were asserted programmatically.
- The diff is pure deletion: `git diff --numstat` reports `0	168`.
- Pre-existing formatting quirks in the file were preserved rather than silently normalized: the 7 "blank line after `{`" occurrences and the 1 double-blank-line remain, and no new "blank line before `}`" was introduced.

No tests were added because this removes declarations that have no consumers; there is no behavior to test, and any incorrect deletion would surface as a compile error rather than a runtime failure.

## Risk & compatibility

Low risk, but worth a careful look at three near-miss cases that were deliberately **kept**:

- **`SymmetricAlgorithm` vs `Cryptography.SymmetricAlgorithm`.** The CLR type `System.Security.Cryptography.SymmetricAlgorithm` was declared twice under different aliases. The unused `"SymmetricAlgorithm"` alias in `DotNet Aliases` is removed; the `"Cryptography.SymmetricAlgorithm"` alias in `Cryptography Management\src\dotnet.al` is untouched and still has its 10 usages and 3 public interface pins. Note this was also the single declaration in the file where the CLR name was unquoted, so a regex expecting a quoted name would have missed it.
- **`EncoderParameter[]` vs the scalar types.** Only the array form, aliased `EncoderParameterList`, is removed. `EncoderParameter` and `EncoderParameters` each have a usage and remain.
- **Backticked generic arity.** `` EnumValue`1 `` and `` Nullable`1 `` contain a literal backtick and were matched literally. The other 7 backticked generic declarations in the file are untouched.

Compatibility: because no first-party code references these aliases and no `Cloud`-target extension can consume a `DotNet` alias at all, no breaking change is expected. There is no data, upgrade, permissions, or telemetry impact.

Follow-up: a related cleanup covering 5 further dead aliases (4 in the W1/CZ test-library `dotnet.al` files, plus `SHA1Managed` in `Cryptography Management\src\dotnet.al`) is out of scope here and not included in this PR.


