### PR TITLE
Update automation work item link from AB#539394 to AB#640900

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -160,7 +160,7 @@
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
   "templateSha": "35d89f97b4a2065f65322dbc3bd7e78cf22f45b9",
   "commitOptions": {
-    "messageSuffix": "Related to AB#539394",
+    "messageSuffix": "Related to AB#640900",
     "pullRequestAutoMerge": true,
     "pullRequestLabels": [
       "Automation"

--- a/.github/actions/RunAutomation/run.ps1
+++ b/.github/actions/RunAutomation/run.ps1
@@ -131,7 +131,7 @@ function OpenPR {
 
     git push -u origin $branch | Out-Null
 
-    $prDescription += "`n`nAB#539394" # Add link to a work item
+    $prDescription += "`n`nAB#640900" # Add link to a work item
     return New-GitHubPullRequest -Repository $Repository -BranchName $branch -TargetBranch $TargetBranch -Title $prTitle -Description $prDescription
 }
 


### PR DESCRIPTION
## What

Repoints the GitHub automation → Azure Boards work item link from **539394** to **640900** in the two (and only two) places BCApps references it:

- `.github/AL-Go-Settings.json` — `commitOptions.messageSuffix`: `"Related to [AB#539394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539394)"` → `"Related to [AB#640900](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640900)"`
- `.github/actions/RunAutomation/run.ps1` — the PR description link line: `[AB#539394](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/539394)` → `[AB#640900](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640900)`

## Why

Our automation PRs are linked to an Azure DevOps work item via the Azure Boards–GitHub integration (the `AB#<id>` mention). The currently referenced work item **539394** ("Update Packages to Latest Version") is now **Closed** and badly overloaded (~12,554 links), so every automation PR was piling another link onto a dead work item.

**640900** ("Update Packages to Latest Version - 2026-06-30") is the current **Active** shared bucket work item, which the DME repo already uses. Switching BCApps to 640900 realigns it with DME and stops attaching links to the closed item.

## Scope

Just these two edits. Verified with a whole-repo grep: zero remaining references to `539394`, and `640900` present in exactly the two changed lines.



