### PR TITLE
Expense Agent: align legacy submit cleanup with 29.0

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/APIs/ExpenseReportsAPI.Page.al
@@ -428,8 +428,8 @@ page 6928 "Expense Reports API"
         ActionContext.SetResultCode(WebServiceActionResultCode::Updated);
     end;
 
-#if not CLEAN30
-    [Obsolete('Use ReleaseAndMarkPendingApprovalExpenseReportWithComment instead.', '30.0')]
+#if not CLEAN29
+    [Obsolete('Use ReleaseAndMarkPendingApprovalExpenseReportWithComment instead.', '29.0')]
     [ServiceEnabled]
     procedure ReleaseAndMarkPendingApprovalExpenseReport(var ActionContext: WebServiceActionContext; SubmitterExpenseUserNo: Code[20])
     begin


### PR DESCRIPTION
## Summary

Align the legacy Expense Agent submit action's cleanup lifecycle on `main` with the 29.0 release where the obsoletion was introduced.

This changes the preprocessor guard from `CLEAN30` to `CLEAN29` and the obsolete tag from `30.0` to `29.0`. The compatibility action and its forwarding behavior are unchanged.

## Work item

[AB#633685](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/633685)

## Related PRs

- Original feature: #10570
- `releases/29.x` backport: #10829
- `releases/29.0` backport: #10830

Both release backports are merged and establish the `CLEAN29` / `29.0` lifecycle below `main`.



