### PR TITLE
[28.5] Fix duplicate E-Reporting page extension ID

### DIFF
--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Extensions/EReportingEDocuments.PageExt.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Extensions/EReportingEDocuments.PageExt.al
@@ -6,7 +6,7 @@ namespace Microsoft.eServices.EDocument.Formats;
 
 using Microsoft.eServices.EDocument;
 
-pageextension 10974 "E-Reporting E-Documents" extends "E-Documents"
+pageextension 10976 "E-Reporting E-Documents" extends "E-Documents"
 {
     actions
     {


### PR DESCRIPTION
## Why

NAV validation fails because page extension 10974, "E-Reporting E-Documents", exists in both the inline NAV app and the BCApps backport.

## Summary

- **Updated** the BCApps page extension ID from 10974 to the free ID 10976.

#### Work Item(s)

Fixes [AB#648771](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648771)
