### PR TITLE
[Master]-Bug 648538: Add mileage setup to Expense Agent wizard

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/MileageRateSetup.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/MileageRateSetup.Page.al
@@ -42,4 +42,17 @@ page 7128 "Mileage Rate Setup"
             }
         }
     }
+
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    var
+        MileageRateSetup: Record "Mileage Rate Setup";
+    begin
+        if not MileageRateSetup.IsEmpty() then
+            exit(true);
+
+        exit(Confirm(MissingMileageRateSetupQst, true));
+    end;
+
+    var
+        MissingMileageRateSetupQst: Label 'No mileage rates have been configured. The standard mileage rate will be used. Do you want to continue?';
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
@@ -710,6 +710,19 @@ page 6991 "Expense Agent Setup Wizard"
                         ConfigUpdated();
                     end;
                 }
+                field(MileageRateSetupLink; MileageRateSetupLinkTxt)
+                {
+                    ShowCaption = false;
+                    Editable = false;
+                    ToolTip = 'Specifies where to configure mileage rates by vehicle type.';
+
+                    trigger OnDrillDown()
+                    var
+                        MileageRateSetup: Page "Mileage Rate Setup";
+                    begin
+                        MileageRateSetup.RunModal();
+                    end;
+                }
             }
             group(ProjectGroup)
             {
@@ -944,6 +957,7 @@ page 6991 "Expense Agent Setup Wizard"
         RulesAppliedLinkTxt: Label 'View management rules including new defaults';
         NoSeriesLinkTxt: Label 'Preview the default number series that will be added';
         NoSeriesAppliedLinkTxt: Label 'View number series including new defaults';
+        MileageRateSetupLinkTxt: Label 'Configure mileage rates by vehicle type';
         ExpenseDashboardLinkTxt: Label 'Go to Expense app (opens in new window)';
         ExpenseDashboardUrlOnPremTxt: Label 'http://localhost:5173/', Locked = true;
         ExpenseDashboardUrlProdTxt: Label 'https://go.microsoft.com/fwlink/?LinkId=2365219', Locked = true;


### PR DESCRIPTION
Fixes [AB#648538](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648538)

Adds mileage configuration to the Expense Agent setup wizard and warns users when they close Mileage Rate Setup without configuring any mileage rates.

Changes are limited to:
- Expense Agent setup wizard mileage configuration link
- Mileage Rate Setup empty-configuration confirmation

AL build completed successfully.

