### PR TITLE
[Quality Management] Add public rule engine facade for automatic inspection creation

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
+++ b/src/Apps/W1/Quality Management/app/src/Document/QltyInspectionCreate.Codeunit.al
@@ -246,6 +246,112 @@ codeunit 20404 "Qlty. Inspection - Create"
     end;
 
     /// <summary>
+    /// Creates or reuses an inspection for the supplied records through the generation rule engine, with the same
+    /// automatic semantics as the app's own triggered creation paths. Intended for extensions that need to create
+    /// inspections at a moment the app does not trigger itself, for example from an event subscriber on a document
+    /// or posting routine.
+    ///
+    /// Automatic semantics:
+    /// - Only generation rules with an activation trigger of "Manual or Automatic" or "Automatic only" are considered.
+    /// - The filters on TempFiltersQltyInspectionGenRule are applied to the rule search, in the same way the app's own
+    ///   triggers filter on their trigger field (for example "Warehouse Receipt Trigger"). Pass an unfiltered temporary
+    ///   record to consider every automatic rule for the source table.
+    /// - No inspection page is opened and no inspection-created notification is raised. The caller receives the
+    ///   resolved inspection and decides whether to surface it. Workflow and integration events raised by inspection
+    ///   creation fire as for any automatic creation.
+    /// - No error is raised when no generation rule matches. The procedure returns false when no rule matches, when
+    ///   Quality Management Setup is missing, or when a subscriber to OnBeforeCreateInspection handles the creation.
+    ///
+    /// Up to four records can be supplied. The engine promotes each supplied record to primary in turn until an
+    /// inspection is resolved, and applies the source configuration of every supplied record to the inspection, so the
+    /// inspection may be created from a record other than the first. Unused slots can be left as unassigned variants.
+    /// A temporary "Tracking Specification" record positioned on one tracking line can be passed in any slot to supply
+    /// lot, serial and package information.
+    ///
+    /// Whether an existing inspection is reused or a new one is created follows the "Inspection Creation Option" and
+    /// "Inspection Search Criteria" in Quality Management Setup.
+    /// </summary>
+    /// <param name="PrimaryRecordVariant">The record to create the inspection for (Record, RecordRef, or RecordId).</param>
+    /// <param name="OptionalRelated2Variant">An optional related record used for rule matching and source field mapping, or an unassigned variant.</param>
+    /// <param name="OptionalRelated3Variant">An optional related record used for rule matching and source field mapping, or an unassigned variant.</param>
+    /// <param name="OptionalRelated4Variant">An optional related record used for rule matching and source field mapping, or an unassigned variant.</param>
+    /// <param name="TempFiltersQltyInspectionGenRule">A temporary record whose filters restrict which generation rules are considered; leave unfiltered to consider every automatic rule.</param>
+    /// <param name="QltyInspectionHeader">The created or reused inspection with a record filter applied, or a cleared record when nothing was resolved.</param>
+    /// <param name="IsNewlyCreated">True when the inspection was inserted by this call; false when an existing inspection was reused or nothing was resolved.</param>
+    /// <returns>True if an inspection was created or reused; otherwise, false.</returns>
+    procedure CreateInspectionFromRuleEngine(PrimaryRecordVariant: Variant; OptionalRelated2Variant: Variant; OptionalRelated3Variant: Variant; OptionalRelated4Variant: Variant; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var QltyInspectionHeader: Record "Qlty. Inspection Header"; var IsNewlyCreated: Boolean): Boolean
+    var
+        PreviousPreventShowingState: Boolean;
+        HasInspection: Boolean;
+    begin
+        Clear(QltyInspectionHeader);
+        IsNewlyCreated := false;
+
+        // The flag is assigned directly rather than through SetPreventDisplayingInspectionEvenIfConfigured so the
+        // previous value can be restored, leaving the instance unchanged for the caller after this call.
+        PreviousPreventShowingState := PreventShowingGeneratedInspectionEvenIfConfigured;
+        PreventShowingGeneratedInspectionEvenIfConfigured := true;
+        HasInspection := CreateInspectionWithMultiVariants(PrimaryRecordVariant, OptionalRelated2Variant, OptionalRelated3Variant, OptionalRelated4Variant, false, TempFiltersQltyInspectionGenRule);
+        PreventShowingGeneratedInspectionEvenIfConfigured := PreviousPreventShowingState;
+
+        if not HasInspection then
+            exit(false);
+
+        if not GetCreatedInspection(QltyInspectionHeader) then begin
+            Clear(QltyInspectionHeader);
+            exit(false);
+        end;
+
+        IsNewlyCreated := IsLastInspectionNewlyCreated();
+        exit(true);
+    end;
+
+    /// <summary>
+    /// Creates or reuses inspections for the supplied records and each line of a temporary tracking specification
+    /// buffer, through the generation rule engine with the same automatic semantics as CreateInspectionFromRuleEngine.
+    /// One creation call is issued per tracking line, with the tracking line supplied as the fourth record, which is
+    /// the same shape the app's own receiving triggers use for tracked sources. The buffer is iterated
+    /// within its current filters, so the caller can restrict the lines to process, and is left positioned on the last
+    /// processed line. When the buffer holds no lines, a single creation call is issued without tracking information.
+    /// The caller supplies the tracking lines, so any source can be served, including sources for which the app has no
+    /// tracking collector of its own.
+    ///
+    /// Several tracking lines can resolve to the same inspection depending on the "Inspection Creation Option" and
+    /// "Inspection Search Criteria" in Quality Management Setup, so the resolved inspections are returned as
+    /// deduplicated lists of inspection numbers rather than assumed to be one per tracking line. The inspection
+    /// resolved for a number is its latest re-inspection, which is the record found by filtering on "No." and
+    /// calling FindLast on the "No.", "Re-inspection No." key.
+    /// </summary>
+    /// <param name="PrimaryRecordVariant">The record to create the inspections for (Record, RecordRef, or RecordId).</param>
+    /// <param name="OptionalRelated2Variant">An optional related record used for rule matching and source field mapping, or an unassigned variant.</param>
+    /// <param name="OptionalRelated3Variant">An optional related record used for rule matching and source field mapping, or an unassigned variant.</param>
+    /// <param name="TempTrackingSpecification">The temporary tracking specification lines to create inspections for, iterated within their current filters.</param>
+    /// <param name="TempFiltersQltyInspectionGenRule">A temporary record whose filters restrict which generation rules are considered; leave unfiltered to consider every automatic rule.</param>
+    /// <param name="NewlyCreatedQltyInspectionIds">The numbers of the inspections inserted by this call, without duplicates.</param>
+    /// <param name="AllResolvedQltyInspectionIds">The numbers of every inspection created or reused by this call, without duplicates.</param>
+    /// <returns>True if at least one inspection was created or reused; otherwise, false.</returns>
+    procedure CreateInspectionsFromRuleEngine(PrimaryRecordVariant: Variant; OptionalRelated2Variant: Variant; OptionalRelated3Variant: Variant; var TempTrackingSpecification: Record "Tracking Specification" temporary; var TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary; var NewlyCreatedQltyInspectionIds: List of [Code[20]]; var AllResolvedQltyInspectionIds: List of [Code[20]]): Boolean
+    var
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        DummyVariant: Variant;
+        IsNewlyCreated: Boolean;
+    begin
+        Clear(NewlyCreatedQltyInspectionIds);
+        Clear(AllResolvedQltyInspectionIds);
+
+        if TempTrackingSpecification.FindSet() then
+            repeat
+                if CreateInspectionFromRuleEngine(PrimaryRecordVariant, OptionalRelated2Variant, OptionalRelated3Variant, TempTrackingSpecification, TempFiltersQltyInspectionGenRule, QltyInspectionHeader, IsNewlyCreated) then
+                    TrackResolvedInspectionNo(QltyInspectionHeader."No.", IsNewlyCreated, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+            until TempTrackingSpecification.Next() = 0
+        else
+            if CreateInspectionFromRuleEngine(PrimaryRecordVariant, OptionalRelated2Variant, OptionalRelated3Variant, DummyVariant, TempFiltersQltyInspectionGenRule, QltyInspectionHeader, IsNewlyCreated) then
+                TrackResolvedInspectionNo(QltyInspectionHeader."No.", IsNewlyCreated, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+
+        exit(AllResolvedQltyInspectionIds.Count() > 0);
+    end;
+
+    /// <summary>
     /// Creates an inspection for a record reference using matching generation-rule configuration.
     /// Use this to create a quality inspection for any given record.
     /// The generation rule configuration will be used to find the most appropriate
@@ -1188,12 +1294,24 @@ codeunit 20404 "Qlty. Inspection - Create"
         if not QltyInspectionCreate.GetCreatedInspection(LastResolvedQltyInspectionHeader) then
             exit;
 
-        if not AllResolvedQltyInspectionIds.Contains(LastResolvedQltyInspectionHeader."No.") then
-            AllResolvedQltyInspectionIds.Add(LastResolvedQltyInspectionHeader."No.");
+        TrackResolvedInspectionNo(LastResolvedQltyInspectionHeader."No.", QltyInspectionCreate.IsLastInspectionNewlyCreated(), NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+    end;
 
-        if QltyInspectionCreate.IsLastInspectionNewlyCreated() then
-            if not NewlyCreatedQltyInspectionIds.Contains(LastResolvedQltyInspectionHeader."No.") then
-                NewlyCreatedQltyInspectionIds.Add(LastResolvedQltyInspectionHeader."No.");
+    /// <summary>
+    /// Adds an inspection number to the deduplicated all-resolved list, and to the newly-created list when it was inserted rather than reused.
+    /// </summary>
+    /// <param name="InspectionNo">The inspection number to record.</param>
+    /// <param name="IsNewlyCreated">True when the inspection was inserted rather than reused.</param>
+    /// <param name="NewlyCreatedQltyInspectionIds">The list of newly inserted inspection numbers.</param>
+    /// <param name="AllResolvedQltyInspectionIds">The list of all resolved inspection numbers.</param>
+    local procedure TrackResolvedInspectionNo(InspectionNo: Code[20]; IsNewlyCreated: Boolean; var NewlyCreatedQltyInspectionIds: List of [Code[20]]; var AllResolvedQltyInspectionIds: List of [Code[20]])
+    begin
+        if not AllResolvedQltyInspectionIds.Contains(InspectionNo) then
+            AllResolvedQltyInspectionIds.Add(InspectionNo);
+
+        if IsNewlyCreated then
+            if not NewlyCreatedQltyInspectionIds.Contains(InspectionNo) then
+                NewlyCreatedQltyInspectionIds.Add(InspectionNo);
     end;
 
     /// <summary>

--- a/src/Apps/W1/Quality Management/test/src/QltyTestsCreateInspect.Codeunit.al
+++ b/src/Apps/W1/Quality Management/test/src/QltyTestsCreateInspect.Codeunit.al
@@ -2653,6 +2653,593 @@ codeunit 139959 "Qlty. Tests - Create Inspect."
         LibraryAssert.IsTrue(AllResolvedQltyInspectionIds.Contains(FirstCreatedQltyInspectionHeader."No."), 'The all-resolved list must include the reused inspection.');
     end;
 
+    [Test]
+    procedure CreateInspectionFromRuleEngine_MatchingRule_CreatesNewInspection()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        UnusedVariant: Variant;
+        HasInspection: Boolean;
+        IsNewlyCreated: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] The public rule engine facade creates a new inspection for a record that matches an automatic generation rule and returns it
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, an automatic generation rule on Purchase Line, and a purchase order line for an untracked item
+        LibraryInventory.CreateItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionFromRuleEngine is called for the purchase line without rule filters
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, CreatedQltyInspectionHeader, IsNewlyCreated);
+
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] One inspection is created from the purchase line with the rule's template and it is reported as newly created
+        LibraryAssert.IsTrue(HasInspection, 'The facade should report that an inspection was created.');
+        LibraryAssert.IsTrue(IsNewlyCreated, 'A newly inserted inspection must be reported as newly created.');
+        LibraryAssert.AreEqual(BeforeCount + 1, QltyInspectionHeader.Count(), 'Exactly one inspection should have been created.');
+        LibraryAssert.AreEqual(QltyInspectionTemplateHdr.Code, CreatedQltyInspectionHeader."Template Code", 'The inspection should use the template of the matching generation rule.');
+        LibraryAssert.AreEqual(PurchaseHeader."No.", CreatedQltyInspectionHeader."Source Document No.", 'The inspection should reference the purchase order.');
+        LibraryAssert.AreEqual(Item."No.", CreatedQltyInspectionHeader."Source Item No.", 'The inspection should reference the purchased item.');
+        LibraryAssert.AreEqual(Database::"Purchase Line", CreatedQltyInspectionHeader."Source Record Table No.", 'The inspection should be sourced from the purchase line.');
+    end;
+
+    [Test]
+    procedure CreateInspectionFromRuleEngine_ReuseConfigured_ReturnsExistingInspection()
+    var
+        QltyManagementSetup: Record "Qlty. Management Setup";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        FirstQltyInspectionHeader: Record "Qlty. Inspection Header";
+        SecondQltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        UnusedVariant: Variant;
+        PreviousQltyInspectCreationOption: Enum "Qlty. Inspect. Creation Option";
+        HasInspection: Boolean;
+        IsNewlyCreated: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] With "Use existing open inspection if available" configured, the facade returns the existing inspection and reports it as not newly created
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, an automatic generation rule on Purchase Line, and a purchase order line for an untracked item
+        LibraryInventory.CreateItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+
+        // [GIVEN] An open inspection already created for the purchase line through the facade
+        QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, FirstQltyInspectionHeader, IsNewlyCreated);
+
+        // [GIVEN] The Inspection Creation Option is set to "Use existing open inspection if available"
+        QltyManagementSetup.Get();
+        PreviousQltyInspectCreationOption := QltyManagementSetup."Inspection Creation Option";
+        QltyManagementSetup."Inspection Creation Option" := QltyManagementSetup."Inspection Creation Option"::"Use existing open inspection if available";
+        QltyManagementSetup.Modify();
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionFromRuleEngine is called again for the same purchase line
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, SecondQltyInspectionHeader, IsNewlyCreated);
+
+        QltyManagementSetup."Inspection Creation Option" := PreviousQltyInspectCreationOption;
+        QltyManagementSetup.Modify();
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] The existing inspection is returned, nothing new is inserted, and the call is reported as a reuse
+        LibraryAssert.IsTrue(HasInspection, 'The facade should report that an inspection was resolved.');
+        LibraryAssert.IsFalse(IsNewlyCreated, 'A reused inspection must not be reported as newly created.');
+        LibraryAssert.AreEqual(FirstQltyInspectionHeader."No.", SecondQltyInspectionHeader."No.", 'The existing inspection should have been returned.');
+        LibraryAssert.AreEqual(BeforeCount, QltyInspectionHeader.Count(), 'No new inspection should have been inserted when reusing.');
+    end;
+
+    [Test]
+    procedure CreateInspectionFromRuleEngine_NoMatchingRule_ReturnsFalseWithoutError()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        UnusedVariant: Variant;
+        HasInspection: Boolean;
+        IsNewlyCreated: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] When no generation rule matches, the facade returns false without raising an error and without opening any page
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A purchase order line for an untracked item, and no enabled generation rule for it
+        LibraryInventory.CreateItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+        QltyInspectionGenRule.Delete();
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionFromRuleEngine is called for the purchase line
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, CreatedQltyInspectionHeader, IsNewlyCreated);
+
+        // [THEN] The facade returns false, no inspection is returned, and nothing was inserted
+        LibraryAssert.IsFalse(HasInspection, 'The facade should report that no inspection was resolved.');
+        LibraryAssert.IsFalse(IsNewlyCreated, 'Nothing should be reported as newly created when no rule matches.');
+        LibraryAssert.IsTrue(CreatedQltyInspectionHeader."No." = '', 'No inspection should be returned when no rule matches.');
+        LibraryAssert.AreEqual(BeforeCount, QltyInspectionHeader.Count(), 'No inspection should have been inserted when no rule matches.');
+    end;
+
+    [Test]
+    procedure CreateInspectionFromRuleEngine_ManualOnlyRule_NotSelected()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        UnusedVariant: Variant;
+        HasInspection: Boolean;
+        IsNewlyCreated: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] A generation rule with Activation Trigger "Manual only" is not selected by the facade, which uses automatic semantics
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, a generation rule on Purchase Line restricted to manual creation, and a purchase order line for an untracked item
+        LibraryInventory.CreateItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+        QltyInspectionGenRule."Activation Trigger" := QltyInspectionGenRule."Activation Trigger"::"Manual only";
+        QltyInspectionGenRule.Modify();
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionFromRuleEngine is called for the purchase line
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, CreatedQltyInspectionHeader, IsNewlyCreated);
+
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] The manual-only rule is ignored and no inspection is created
+        LibraryAssert.IsFalse(HasInspection, 'A manual-only generation rule must not be selected with automatic semantics.');
+        LibraryAssert.AreEqual(BeforeCount, QltyInspectionHeader.Count(), 'No inspection should have been inserted from a manual-only rule.');
+    end;
+
+    [Test]
+    procedure CreateInspectionFromRuleEngine_RelatedRecordPromotedAndMapped()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        CreatedQltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        TempTrackingSpecification: Record "Tracking Specification" temporary;
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        UnusedVariant: Variant;
+        HasInspection: Boolean;
+        IsNewlyCreated: Boolean;
+    begin
+        // [SCENARIO] When the first record has no matching rule, the facade promotes the related record to primary and still maps the source fields of every supplied record
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, an automatic generation rule on Purchase Line, and a purchase order line for a lot-tracked item with one tracking line
+        QltyInspectionUtility.CreateLotTrackedItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+        CollectPurchaseLineTracking(PurchaseLine, TempTrackingSpecification);
+        TempTrackingSpecification.FindFirst();
+
+        // [WHEN] CreateInspectionFromRuleEngine is called with the tracking line first and the purchase line as the related record
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(TempTrackingSpecification, PurchaseLine, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, CreatedQltyInspectionHeader, IsNewlyCreated);
+
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] The inspection is created from the purchase line, and the lot from the tracking line is mapped onto it
+        LibraryAssert.IsTrue(HasInspection, 'The facade should resolve an inspection through the related purchase line.');
+        LibraryAssert.IsTrue(IsNewlyCreated, 'The inspection should be reported as newly created.');
+        LibraryAssert.AreEqual(Database::"Purchase Line", CreatedQltyInspectionHeader."Source Record Table No.", 'The related purchase line should have been promoted to the inspection source.');
+        LibraryAssert.AreEqual(PurchaseHeader."No.", CreatedQltyInspectionHeader."Source Document No.", 'The inspection should reference the purchase order.');
+        LibraryAssert.AreEqual(ReservationEntry."Lot No.", CreatedQltyInspectionHeader."Source Lot No.", 'The lot of the supplied tracking line should be mapped onto the inspection.');
+    end;
+
+    [Test]
+    procedure CreateInspectionFromRuleEngine_RuleFiltersRestrictMatchingRules()
+    var
+        QltyManagementSetup: Record "Qlty. Management Setup";
+        OnCreateQltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        OnPostQltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        OnCreateQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        OnPostQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        FilteredQltyInspectionHeader: Record "Qlty. Inspection Header";
+        UnfilteredQltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        Location: Record Location;
+        Vendor: Record Vendor;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
+        UnusedVariant: Variant;
+        PreviousQltyInspectCreationOption: Enum "Qlty. Inspect. Creation Option";
+        HasInspection: Boolean;
+        IsNewlyCreated: Boolean;
+    begin
+        // [SCENARIO] Filters on the supplied generation rule record restrict which rules the facade considers, so a caller can target the rules configured for its trigger moment
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] Two automatic generation rules on Purchase Line: the first in sort order targets warehouse receipt posting, the second targets warehouse receipt creation
+        QltyInspectionUtility.CreateTemplate(OnCreateQltyInspectionTemplateHdr, 1);
+        QltyInspectionUtility.CreatePrioritizedRule(OnCreateQltyInspectionTemplateHdr, Database::"Purchase Line", OnCreateQltyInspectionGenRule);
+        OnCreateQltyInspectionGenRule."Warehouse Receipt Trigger" := OnCreateQltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptCreate;
+        OnCreateQltyInspectionGenRule.Modify();
+
+        QltyInspectionUtility.CreateTemplate(OnPostQltyInspectionTemplateHdr, 1);
+        QltyInspectionUtility.CreatePrioritizedRule(OnPostQltyInspectionTemplateHdr, Database::"Purchase Line", OnPostQltyInspectionGenRule);
+        OnPostQltyInspectionGenRule."Warehouse Receipt Trigger" := OnPostQltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptPost;
+        OnPostQltyInspectionGenRule.Modify();
+
+        OnCreateQltyInspectionGenRule.Find();
+        OnCreateQltyInspectionGenRule."Activation Trigger" := OnCreateQltyInspectionGenRule."Activation Trigger"::"Manual or Automatic";
+        OnCreateQltyInspectionGenRule.Modify();
+        LibraryAssert.IsTrue(OnPostQltyInspectionGenRule."Sort Order" < OnCreateQltyInspectionGenRule."Sort Order", 'Testing the test: the receipt-post rule must sort before the receipt-create rule.');
+
+        // [GIVEN] A purchase order line for an untracked item, and setup that always creates a new inspection
+        LibraryInventory.CreateItem(Item);
+        LibraryWarehouse.CreateLocationWMS(Location, false, false, false, false, false);
+        LibraryPurchase.CreateVendor(Vendor);
+        QltyPurOrderGenerator.CreatePurchaseOrder(10, Location, Item, Vendor, '', PurchaseHeader, PurchaseLine, ReservationEntry);
+
+        QltyManagementSetup.Get();
+        PreviousQltyInspectCreationOption := QltyManagementSetup."Inspection Creation Option";
+        QltyManagementSetup."Inspection Creation Option" := QltyManagementSetup."Inspection Creation Option"::"Always create new inspection";
+        QltyManagementSetup.Modify();
+
+        // [WHEN] CreateInspectionFromRuleEngine is called with the rule record filtered on Warehouse Receipt Trigger = OnWarehouseReceiptCreate
+#pragma warning disable AA0210
+        TempFiltersQltyInspectionGenRule.SetRange("Warehouse Receipt Trigger", TempFiltersQltyInspectionGenRule."Warehouse Receipt Trigger"::OnWarehouseReceiptCreate);
+#pragma warning restore AA0210
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, FilteredQltyInspectionHeader, IsNewlyCreated);
+
+        // [THEN] The receipt-create rule is selected although the receipt-post rule sorts first
+        LibraryAssert.IsTrue(HasInspection, 'The facade should resolve an inspection from the filtered rule.');
+        LibraryAssert.AreEqual(OnCreateQltyInspectionTemplateHdr.Code, FilteredQltyInspectionHeader."Template Code", 'The rule filter should select the receipt-create rule over the receipt-post rule that sorts first.');
+
+        // [WHEN] CreateInspectionFromRuleEngine is called again without rule filters
+        TempFiltersQltyInspectionGenRule.Reset();
+        HasInspection := QltyInspectionCreate.CreateInspectionFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, UnusedVariant, TempFiltersQltyInspectionGenRule, UnfilteredQltyInspectionHeader, IsNewlyCreated);
+
+        QltyManagementSetup."Inspection Creation Option" := PreviousQltyInspectCreationOption;
+        QltyManagementSetup.Modify();
+        OnCreateQltyInspectionGenRule.Delete();
+        OnPostQltyInspectionGenRule.Delete();
+
+        // [THEN] The first rule in sort order is selected, which proves the earlier selection came from the filter
+        LibraryAssert.IsTrue(HasInspection, 'The facade should resolve an inspection without rule filters.');
+        LibraryAssert.AreEqual(OnPostQltyInspectionTemplateHdr.Code, UnfilteredQltyInspectionHeader."Template Code", 'Without rule filters the first rule in sort order should be selected.');
+    end;
+
+    [Test]
+    procedure CreateInspectionsFromRuleEngine_TrackingBuffer_CreatesOnePerTrackingLine()
+    var
+        QltyManagementSetup: Record "Qlty. Management Setup";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        TempTrackingSpecification: Record "Tracking Specification" temporary;
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        UnusedVariant: Variant;
+        PreviousQltyInspectCreationOption: Enum "Qlty. Inspect. Creation Option";
+        NewlyCreatedQltyInspectionIds: List of [Code[20]];
+        AllResolvedQltyInspectionIds: List of [Code[20]];
+        HasInspection: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] The tracked facade issues one creation call per tracking line and returns every created inspection
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, an automatic generation rule on Purchase Line, and a purchase order line for a serial-tracked item with two serial numbers
+        QltyInspectionUtility.CreateSerialTrackedItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 2);
+        CollectPurchaseLineTracking(PurchaseLine, TempTrackingSpecification);
+        LibraryAssert.AreEqual(2, TempTrackingSpecification.Count(), 'Testing the test: the purchase line should carry two tracking lines.');
+
+        // [GIVEN] Setup that always creates a new inspection
+        QltyManagementSetup.Get();
+        PreviousQltyInspectCreationOption := QltyManagementSetup."Inspection Creation Option";
+        QltyManagementSetup."Inspection Creation Option" := QltyManagementSetup."Inspection Creation Option"::"Always create new inspection";
+        QltyManagementSetup.Modify();
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionsFromRuleEngine is called with the purchase line and the tracking buffer
+        HasInspection := QltyInspectionCreate.CreateInspectionsFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, TempTrackingSpecification, TempFiltersQltyInspectionGenRule, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+
+        QltyManagementSetup."Inspection Creation Option" := PreviousQltyInspectCreationOption;
+        QltyManagementSetup.Modify();
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] Two inspections are created, one per serial number, and both are returned as newly created
+        LibraryAssert.IsTrue(HasInspection, 'The facade should report that inspections were created.');
+        LibraryAssert.AreEqual(2, NewlyCreatedQltyInspectionIds.Count(), 'One inspection should have been created per tracking line.');
+        LibraryAssert.AreEqual(2, AllResolvedQltyInspectionIds.Count(), 'Every created inspection should be reported as resolved.');
+        LibraryAssert.AreEqual(BeforeCount + 2, QltyInspectionHeader.Count(), 'Exactly two inspections should have been inserted.');
+        TempTrackingSpecification.FindSet();
+        repeat
+            QltyInspectionHeader.Reset();
+            QltyInspectionHeader.SetRange("Source Item No.", Item."No.");
+            QltyInspectionHeader.SetRange("Source Serial No.", TempTrackingSpecification."Serial No.");
+            LibraryAssert.AreEqual(1, QltyInspectionHeader.Count(), 'Each tracking line should have produced an inspection carrying its serial number.');
+            QltyInspectionHeader.FindFirst();
+            LibraryAssert.IsTrue(NewlyCreatedQltyInspectionIds.Contains(QltyInspectionHeader."No."), 'The inspection for each tracking line should be returned as newly created.');
+        until TempTrackingSpecification.Next() = 0;
+    end;
+
+    [Test]
+    procedure CreateInspectionsFromRuleEngine_EmptyTrackingBuffer_CreatesSingleInspection()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        TempTrackingSpecification: Record "Tracking Specification" temporary;
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        UnusedVariant: Variant;
+        NewlyCreatedQltyInspectionIds: List of [Code[20]];
+        AllResolvedQltyInspectionIds: List of [Code[20]];
+        HasInspection: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] With an empty tracking buffer, the tracked facade falls back to a single creation call without tracking information
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, an automatic generation rule on Purchase Line, and a purchase order line for an untracked item
+        LibraryInventory.CreateItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionsFromRuleEngine is called with an empty tracking buffer
+        HasInspection := QltyInspectionCreate.CreateInspectionsFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, TempTrackingSpecification, TempFiltersQltyInspectionGenRule, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] One inspection is created for the purchase line and returned as newly created
+        LibraryAssert.IsTrue(HasInspection, 'The facade should report that an inspection was created.');
+        LibraryAssert.AreEqual(1, NewlyCreatedQltyInspectionIds.Count(), 'One inspection should have been created without tracking.');
+        LibraryAssert.AreEqual(1, AllResolvedQltyInspectionIds.Count(), 'The created inspection should be reported as resolved.');
+        LibraryAssert.AreEqual(BeforeCount + 1, QltyInspectionHeader.Count(), 'Exactly one inspection should have been inserted.');
+        QltyInspectionHeader.SetRange("No.", NewlyCreatedQltyInspectionIds.Get(1));
+        QltyInspectionHeader.FindFirst();
+        LibraryAssert.AreEqual(PurchaseHeader."No.", QltyInspectionHeader."Source Document No.", 'The inspection should reference the purchase order.');
+    end;
+
+    [Test]
+    procedure CreateInspectionsFromRuleEngine_ReusedInspection_ReportedAsResolvedNotCreated()
+    var
+        QltyManagementSetup: Record "Qlty. Management Setup";
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservationEntry: Record "Reservation Entry";
+        TempTrackingSpecification: Record "Tracking Specification" temporary;
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        UnusedVariant: Variant;
+        PreviousQltyInspectCreationOption: Enum "Qlty. Inspect. Creation Option";
+        FirstNewlyCreatedQltyInspectionIds: List of [Code[20]];
+        FirstAllResolvedQltyInspectionIds: List of [Code[20]];
+        NewlyCreatedQltyInspectionIds: List of [Code[20]];
+        AllResolvedQltyInspectionIds: List of [Code[20]];
+        HasInspection: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] A reused inspection is reported by the tracked facade in the all-resolved list but not in the newly-created list
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template, an automatic generation rule on Purchase Line, and a purchase order line for an untracked item
+        LibraryInventory.CreateItem(Item);
+        SetupRuleEngineFacadePurchaseOrder(QltyInspectionTemplateHdr, QltyInspectionGenRule, Item, PurchaseHeader, PurchaseLine, ReservationEntry, 10);
+
+        // [GIVEN] An open inspection already created for the purchase line through the facade
+        QltyInspectionCreate.CreateInspectionsFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, TempTrackingSpecification, TempFiltersQltyInspectionGenRule, FirstNewlyCreatedQltyInspectionIds, FirstAllResolvedQltyInspectionIds);
+        LibraryAssert.AreEqual(1, FirstNewlyCreatedQltyInspectionIds.Count(), 'Testing the test: the first call should have created one inspection.');
+
+        // [GIVEN] The Inspection Creation Option is set to "Use existing open inspection if available"
+        QltyManagementSetup.Get();
+        PreviousQltyInspectCreationOption := QltyManagementSetup."Inspection Creation Option";
+        QltyManagementSetup."Inspection Creation Option" := QltyManagementSetup."Inspection Creation Option"::"Use existing open inspection if available";
+        QltyManagementSetup.Modify();
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionsFromRuleEngine is called again for the same purchase line
+        HasInspection := QltyInspectionCreate.CreateInspectionsFromRuleEngine(PurchaseLine, UnusedVariant, UnusedVariant, TempTrackingSpecification, TempFiltersQltyInspectionGenRule, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+
+        QltyManagementSetup."Inspection Creation Option" := PreviousQltyInspectCreationOption;
+        QltyManagementSetup.Modify();
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] The existing inspection is reported as resolved, nothing is reported as newly created, and nothing was inserted
+        LibraryAssert.IsTrue(HasInspection, 'The facade should report that an inspection was resolved.');
+        LibraryAssert.AreEqual(0, NewlyCreatedQltyInspectionIds.Count(), 'A reused inspection must not be reported as newly created.');
+        LibraryAssert.AreEqual(1, AllResolvedQltyInspectionIds.Count(), 'The reused inspection should be reported as resolved.');
+        LibraryAssert.AreEqual(FirstNewlyCreatedQltyInspectionIds.Get(1), AllResolvedQltyInspectionIds.Get(1), 'The inspection created by the first call should have been reused.');
+        LibraryAssert.AreEqual(BeforeCount, QltyInspectionHeader.Count(), 'No new inspection should have been inserted when reusing.');
+    end;
+
+    [Test]
+    procedure CreateInspectionsFromRuleEngine_SourceWithoutCollector_UsesSuppliedTracking()
+    var
+        QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr.";
+        QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
+        TempFiltersQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule" temporary;
+        QltyInspectionHeader: Record "Qlty. Inspection Header";
+        Item: Record Item;
+        ItemJournalBatch: Record "Item Journal Batch";
+        ItemJournalLine: Record "Item Journal Line";
+        ReservationEntry: Record "Reservation Entry";
+        TempTrackingSpecification: Record "Tracking Specification" temporary;
+        QltyInspectionCreate: Codeunit "Qlty. Inspection - Create";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+        LibraryUtility: Codeunit "Library - Utility";
+        UnusedVariant: Variant;
+        NewlyCreatedQltyInspectionIds: List of [Code[20]];
+        AllResolvedQltyInspectionIds: List of [Code[20]];
+        LotNo: Code[50];
+        HasInspection: Boolean;
+        BeforeCount: Integer;
+    begin
+        // [SCENARIO] The tracked facade serves a source the app has no tracking collector for, because the caller supplies the tracking lines
+
+        Initialize();
+        QltyInspectionUtility.EnsureSetupExists();
+
+        // [GIVEN] A template and an automatic generation rule on Item Journal Line, a table the app's own tracking collector does not handle
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 3);
+        QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Item Journal Line", QltyInspectionGenRule);
+
+        // [GIVEN] A positive adjustment journal line for a lot-tracked item with one lot assigned, and a tracking buffer built from that lot
+        QltyInspectionUtility.CreateLotTrackedItem(Item);
+        QltyInspectionUtility.CreateItemJournalTemplateAndBatch(Enum::"Item Journal Template Type"::Item, ItemJournalBatch);
+        LibraryInventory.CreateItemJournalLine(ItemJournalLine, ItemJournalBatch."Journal Template Name", ItemJournalBatch.Name, ItemJournalLine."Entry Type"::"Positive Adjmt.", Item."No.", 5);
+        LotNo := LibraryUtility.GenerateGUID();
+        LibraryItemTracking.CreateItemJournalLineItemTracking(ReservationEntry, ItemJournalLine, '', LotNo, 5);
+        ItemJournalLine.SetReservEntrySourceFilters(ReservationEntry, false);
+        CollectReservationEntryTracking(ReservationEntry, TempTrackingSpecification);
+        LibraryAssert.AreEqual(1, TempTrackingSpecification.Count(), 'Testing the test: the journal line should carry one tracking line.');
+
+        QltyInspectionHeader.Reset();
+        BeforeCount := QltyInspectionHeader.Count();
+
+        // [WHEN] CreateInspectionsFromRuleEngine is called with the journal line and the caller-built tracking buffer
+        HasInspection := QltyInspectionCreate.CreateInspectionsFromRuleEngine(ItemJournalLine, UnusedVariant, UnusedVariant, TempTrackingSpecification, TempFiltersQltyInspectionGenRule, NewlyCreatedQltyInspectionIds, AllResolvedQltyInspectionIds);
+
+        QltyInspectionGenRule.Delete();
+
+        // [THEN] One inspection is created from the journal line and carries the item and lot from the supplied tracking line
+        LibraryAssert.IsTrue(HasInspection, 'The facade should create an inspection for a source without an internal tracking collector.');
+        LibraryAssert.AreEqual(1, NewlyCreatedQltyInspectionIds.Count(), 'One inspection should have been created from the supplied tracking line.');
+        LibraryAssert.AreEqual(BeforeCount + 1, QltyInspectionHeader.Count(), 'Exactly one inspection should have been inserted.');
+        QltyInspectionHeader.SetRange("No.", NewlyCreatedQltyInspectionIds.Get(1));
+        QltyInspectionHeader.FindFirst();
+        LibraryAssert.AreEqual(Database::"Item Journal Line", QltyInspectionHeader."Source Record Table No.", 'The inspection should be sourced from the item journal line.');
+        LibraryAssert.AreEqual(Item."No.", QltyInspectionHeader."Source Item No.", 'The item from the supplied tracking line should be mapped onto the inspection.');
+        LibraryAssert.AreEqual(LotNo, QltyInspectionHeader."Source Lot No.", 'The lot from the supplied tracking line should be mapped onto the inspection.');
+    end;
+
+    local procedure SetupRuleEngineFacadePurchaseOrder(var QltyInspectionTemplateHdr: Record "Qlty. Inspection Template Hdr."; var QltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule"; var Item: Record Item; var PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line"; var ReservationEntry: Record "Reservation Entry"; Quantity: Decimal)
+    var
+        Location: Record Location;
+        Vendor: Record Vendor;
+        LibraryWarehouse: Codeunit "Library - Warehouse";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        QltyPurOrderGenerator: Codeunit "Qlty. Pur. Order Generator";
+    begin
+        QltyInspectionUtility.EnsureSetupExists();
+        QltyInspectionUtility.CreateTemplate(QltyInspectionTemplateHdr, 3);
+        QltyInspectionUtility.CreatePrioritizedRule(QltyInspectionTemplateHdr, Database::"Purchase Line", QltyInspectionGenRule);
+
+        LibraryWarehouse.CreateLocationWMS(Location, false, false, false, false, false);
+        LibraryPurchase.CreateVendor(Vendor);
+        QltyPurOrderGenerator.CreatePurchaseOrder(Quantity, Location, Item, Vendor, '', PurchaseHeader, PurchaseLine, ReservationEntry);
+    end;
+
+    local procedure CollectPurchaseLineTracking(PurchaseLine: Record "Purchase Line"; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    var
+        ReservationEntry: Record "Reservation Entry";
+    begin
+        PurchaseLine.SetReservationFilters(ReservationEntry);
+        CollectReservationEntryTracking(ReservationEntry, TempTrackingSpecification);
+    end;
+
+    local procedure CollectReservationEntryTracking(var ReservationEntry: Record "Reservation Entry"; var TempTrackingSpecification: Record "Tracking Specification" temporary)
+    var
+        EntryNo: Integer;
+    begin
+        if ReservationEntry.FindSet() then
+            repeat
+                EntryNo += 1;
+                TempTrackingSpecification.Init();
+                TempTrackingSpecification."Entry No." := EntryNo;
+                TempTrackingSpecification.SetSourceFromReservEntry(ReservationEntry);
+                TempTrackingSpecification."Item No." := ReservationEntry."Item No.";
+                TempTrackingSpecification."Variant Code" := ReservationEntry."Variant Code";
+                TempTrackingSpecification.CopyTrackingFromReservEntry(ReservationEntry);
+                TempTrackingSpecification.Insert();
+            until ReservationEntry.Next() = 0;
+    end;
+
     local procedure CreateInspectionWithTracking(var PurOrdPurchaseLine: Record "Purchase Line"; var TempSpecTrackingSpecification: Record "Tracking Specification" temporary; var OutQltyInspectionHeader: Record "Qlty. Inspection Header")
     var
         PurchaseLineRecordRef: RecordRef;


### PR DESCRIPTION
## What & why

Quality Management has no supported way for an extension to create inspections through the generation rule engine with automatic semantics: every creation procedure on codeunit 20404 "Qlty. Inspection - Create" is `internal`, and the two accessible entry points (API page `Qlty. Create Inspection API` and report `Qlty. Create Inspection`) hard-code `IsManualCreation = true`, which applies the manual-only rule filter, can open the inspection card and raises an error when no rule matches. An extension that needs a trigger moment the app does not ship (for example warehouse receipt creation for transfer-sourced lines, #9977) currently has to re-implement rule matching, source traversal, field mapping, duplicate detection and template expansion outside the app.

This PR adds the narrow public facade recommended in the issue discussion, on the same codeunit, and keeps every implementation helper internal:

- `CreateInspectionFromRuleEngine(PrimaryRecordVariant, OptionalRelated2Variant, OptionalRelated3Variant, OptionalRelated4Variant, var TempFiltersQltyInspectionGenRule, var QltyInspectionHeader, var IsNewlyCreated): Boolean`
  Creates or reuses one inspection through `CreateInspectionWithMultiVariants` with `IsManualCreation = false`, suppresses the inspection-created notification for the duration of the call (restoring the instance flag afterwards), and returns the resolved header plus whether it was newly inserted. No page is opened and no error is raised when no rule matches. Up to four records are accepted because the app's own automatic paths pass up to four (receiving: receipt line, source line, receipt header, tracking line; manufacturing: ledger entry, routing line, journal line, prod. order line).
- `CreateInspectionsFromRuleEngine(PrimaryRecordVariant, OptionalRelated2Variant, OptionalRelated3Variant, var TempTrackingSpecification, var TempFiltersQltyInspectionGenRule, var NewlyCreatedQltyInspectionIds, var AllResolvedQltyInspectionIds): Boolean`
  Tracked-source overload: one creation call per tracking line within the buffer's current filters, with the tracking line in the fourth slot, and a single untracked call when the buffer is empty. This is the shape `AttemptCreateInspectionWithReceiptLine` in "Qlty. Receiving Integration" uses. Because the caller supplies the tracking lines, it serves sources the app's own collector (`CollectSourceItemTracking`, limited to purchase, transfer and sales lines) cannot. Several tracking lines can resolve to the same inspection depending on setup, so the result is returned as deduplicated newly-created and all-resolved lists, the same idiom as `CreateMultipleInspectionsWithoutDisplaying`; the existing `TrackResolvedInspection` now shares the dedup helper.

Two points where this deliberately differs from the sketches in the issue thread, both explained in the doc comments:

1. **The generation rule filter record is part of the contract.** Every automatic path in the app filters rules on its own trigger field before calling the engine (`HasWarehouseReceiptCreateGenRule` and siblings), and the engine applies those filters to the rule search, including through traversal. Without the parameter, a caller adding a "warehouse receipt created" moment would also fire rules configured for "warehouse receipt posted", since the trigger enums default to Never and the search otherwise matches by sort order alone. Passing an unfiltered temporary record considers every automatic rule, which is what the sketches did, so nothing is lost.
2. **The result lists are newly-created plus all-resolved rather than created plus reused**, because with the latter an inspection created by the first tracking line and reused by the second would land in both lists. The codeunit already uses the newly-created plus all-resolved shape internally, and the parameter names follow its `...Ids` naming.

## Linked work

Fixes #9978

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Ten tests added to codeunit 139959 "Qlty. Tests - Create Inspect.", covering the six regression scenarios listed in the issue discussion plus the tracked overload and the rule filter: a matching rule creates and returns a new inspection; configured reuse returns the existing inspection with `IsNewlyCreated = false`; no matching rule returns false without an error; a manual-only rule is not selected; a related record is promoted to primary and its tracking line is mapped (tracking specification first, purchase line second, lot asserted on the inspection); rule filters select the second rule in sort order while the unfiltered call selects the first; a two-serial tracking buffer produces two inspections returned as newly created; an empty buffer falls back to one untracked creation; a reused inspection appears in the all-resolved list but not in the newly-created list; and, the case the buffer overload exists for, a source the internal collector does not handle (an item journal line) gets its item and lot from a caller-built buffer.
- The tests call the two public procedures directly from the test app rather than through the test library, so they also prove the procedures are reachable from outside the `internalsVisibleTo` boundary.
- I could not build or run the tests locally (no container in this environment), so I rely on the PR build for compilation, analyzers and test execution. Each test's arrangement was traced by hand through the test library (`CreatePrioritizedRule` disables all other rules and sorts the new one first; `Qlty. Pur. Order Generator` creates one reservation entry per serial; `EnsureSetupExists` commits, so it runs before any item is created) and through the engine.
- Notification suppression is not covered by a test: `NotifyInspectionCreated` exits on `not GuiAllowed()`, and the existing automatic-creation tests carry no notification handler, so a headless run cannot observe it. The facade uses the same flag the batch helper's `ConfigureForBatch` sets for the app's own automatic paths.
- No permission-lowered test was added; the facade runs under the same codeunit `Permissions` and the same automatic semantics as the existing subscribers on this codeunit, which are not permission-tested either. Happy to add one if you want it.

## Risk & compatibility

- Purely additive: two new public procedures and one local helper on codeunit 20404; no existing signature, event, enum or table changes. No new object, no permission set change, no translation impact. The new signatures become part of the supported surface from the next release on.
- Permissions: the facade runs with automatic semantics, so it does not call `VerifyCanCreateManualInspection`, exactly like the app's own event subscribers on the same codeunit. The codeunit's `Permissions` property covers only the Quality Management tables, so reading the caller's source record still runs under the caller's own permissions. The engine opens a temporary `RecordRef` on the table of the record the caller passed in; since the caller must already hold that record (or a `RecordId` it can read), no access is gained through the public entry point.
- Extensibility seam: `OnBeforeCreateInspection` with `IsHandled` already fires inside the path, so no new event is added around the facade; a handled creation returns false.
- The facade sets and restores `PreventShowingGeneratedInspectionEvenIfConfigured` on its own instance only; callers that share a codeunit instance with other code see no state change after the call.
- `Message(MultiRecordInspectionSourceFieldErr)` inside the engine (raised when several records are supplied and none maps a source field) and the workflow events raised on inspection creation are unchanged and apply to the facade like to every automatic path; the doc comment therefore promises only what the facade controls: no inspection page, no inspection-created notification, no error on no-match.
- Follow-up: #9977 (receipt-creation trigger for transfer and sales return lines) is the first consumer of this shape inside the app and stays a separate change.

