### PR TITLE
Ruleset hardening: promote four compatibility rules to Error

### DIFF
--- a/src/Apps/CZ/IntrastatCZ/app/permissions/D365BasicISVIntrastatCZ.PermissionsetExt.al
+++ b/src/Apps/CZ/IntrastatCZ/app/permissions/D365BasicISVIntrastatCZ.PermissionsetExt.al
@@ -1,5 +1,7 @@
 #pragma warning disable AA0247
 permissionsetextension 31303 "D365 BASIC ISV - Intrastat CZ" extends "D365 BASIC ISV"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Intrastat CZ - Edit";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/CZ/IntrastatCZ/app/permissions/D365BasicIntrastatCZ.PermissionsetExt.al
+++ b/src/Apps/CZ/IntrastatCZ/app/permissions/D365BasicIntrastatCZ.PermissionsetExt.al
@@ -1,5 +1,7 @@
 #pragma warning disable AA0247
 permissionsetextension 31302 "D365 BASIC - Intrastat CZ" extends "D365 BASIC"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Intrastat CZ - Edit";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/CZ/IntrastatCZ/app/permissions/D365ReadIntrastatCZ.PermissionsetExt.al
+++ b/src/Apps/CZ/IntrastatCZ/app/permissions/D365ReadIntrastatCZ.PermissionsetExt.al
@@ -1,5 +1,7 @@
 #pragma warning disable AA0247
 permissionsetextension 31304 "D365 READ - Intrastat CZ" extends "D365 READ"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Intrastat CZ - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/CZ/IntrastatCZ/app/permissions/D365TeamMemberIntrCZ.PermissionsetExt.al
+++ b/src/Apps/CZ/IntrastatCZ/app/permissions/D365TeamMemberIntrCZ.PermissionsetExt.al
@@ -1,5 +1,7 @@
 #pragma warning disable AA0247
 permissionsetextension 31305 "D365 TEAM MEMBER - Intr. CZ" extends "D365 TEAM MEMBER"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Intrastat CZ - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/CZ/IntrastatCZ/app/permissions/IntelligentCloudIntrCZ.PermissionsetExt.al
+++ b/src/Apps/CZ/IntrastatCZ/app/permissions/IntelligentCloudIntrCZ.PermissionsetExt.al
@@ -1,5 +1,7 @@
 #pragma warning disable AA0247
 permissionsetextension 31306 "INTELLIGENT CLOUD - Intr. CZ" extends "INTELLIGENT CLOUD"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Intrastat CZ - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/CZ/IntrastatCZ/app/permissions/LocalIntrastatCZ.PermissionsetExt.al
+++ b/src/Apps/CZ/IntrastatCZ/app/permissions/LocalIntrastatCZ.PermissionsetExt.al
@@ -1,5 +1,7 @@
 #pragma warning disable AA0247
 permissionsetextension 31301 "LOCAL - Intrastat CZ" extends LOCAL
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Intrastat CZ - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesCrMemoQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesCrMemoQRCode.page.al
@@ -30,7 +30,7 @@ page 18143 "Sales Cr Memo QR Code"
                     Page.Run(Page::"Sales Cr Memo Dialog", SalesCrMemoHeader);
                 end;
             }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field("QR Code"; Rec."QR Code")
 #pragma warning restore AW0009
             {

--- a/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesCrMemoQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesCrMemoQRCode.page.al
@@ -30,7 +30,9 @@ page 18143 "Sales Cr Memo QR Code"
                     Page.Run(Page::"Sales Cr Memo Dialog", SalesCrMemoHeader);
                 end;
             }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field("QR Code"; Rec."QR Code")
+#pragma warning restore AW0009
             {
                 ApplicationArea = Basic, Suite;
                 ToolTip = 'Specifies the QR Code assigned by e-invoice portal for sales document.';

--- a/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesInvoiceQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesInvoiceQRCode.page.al
@@ -30,7 +30,7 @@ page 18142 "Sales Invoice QR Code"
                     Page.Run(Page::"Sales Invoice Dialog", SalesInvoiceHeader);
                 end;
             }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field("QR Code"; Rec."QR Code")
 #pragma warning restore AW0009
             {

--- a/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesInvoiceQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTSales/src/Page/SalesInvoiceQRCode.page.al
@@ -30,7 +30,9 @@ page 18142 "Sales Invoice QR Code"
                     Page.Run(Page::"Sales Invoice Dialog", SalesInvoiceHeader);
                 end;
             }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field("QR Code"; Rec."QR Code")
+#pragma warning restore AW0009
             {
                 ApplicationArea = Basic, Suite;
                 ToolTip = 'Specifies the QR Code assigned by e-invoice portal for sales document.';

--- a/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceCrMemoQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceCrMemoQRCode.page.al
@@ -30,7 +30,7 @@ page 18165 "Service Cr Memo QR Code"
                     Page.Run(Page::"Service Cr Memo Dialog", ServiceCrMemoHeader);
                 end;
             }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field("QR Code"; Rec."QR Code")
 #pragma warning restore AW0009
             {

--- a/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceCrMemoQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceCrMemoQRCode.page.al
@@ -30,7 +30,9 @@ page 18165 "Service Cr Memo QR Code"
                     Page.Run(Page::"Service Cr Memo Dialog", ServiceCrMemoHeader);
                 end;
             }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field("QR Code"; Rec."QR Code")
+#pragma warning restore AW0009
             {
                 ApplicationArea = Basic, Suite;
                 ToolTip = 'Specifies the QR Code assigned by e-invoice portal for sales document.';

--- a/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceInvoiceQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceInvoiceQRCode.page.al
@@ -30,7 +30,9 @@ page 18162 "Service Invoice QR Code"
                     Page.Run(Page::"Service Invoice Dialog", ServiceInvoiceHeader);
                 end;
             }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field("QR Code"; Rec."QR Code")
+#pragma warning restore AW0009
             {
                 ApplicationArea = Basic, Suite;
                 ToolTip = 'Specifies the QR Code assigned by e-invoice portal for sales document.';

--- a/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceInvoiceQRCode.page.al
+++ b/src/Apps/IN/INGST/app/GSTService/src/Page/ServiceInvoiceQRCode.page.al
@@ -30,7 +30,7 @@ page 18162 "Service Invoice QR Code"
                     Page.Run(Page::"Service Invoice Dialog", ServiceInvoiceHeader);
                 end;
             }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field("QR Code"; Rec."QR Code")
 #pragma warning restore AW0009
             {

--- a/src/Apps/IN/INGST/app/GSTStockTransfer/src/page/TransferShipmentQRCode.Page.al
+++ b/src/Apps/IN/INGST/app/GSTStockTransfer/src/page/TransferShipmentQRCode.Page.al
@@ -30,7 +30,7 @@ page 18013 "Transfer Shipment QR Code"
                     Page.Run(Page::"Transfer Shipment Dialog", TransferShipmentHeader);
                 end;
             }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field("QR Code"; Rec."QR Code")
 #pragma warning restore AW0009
             {

--- a/src/Apps/IN/INGST/app/GSTStockTransfer/src/page/TransferShipmentQRCode.Page.al
+++ b/src/Apps/IN/INGST/app/GSTStockTransfer/src/page/TransferShipmentQRCode.Page.al
@@ -30,7 +30,9 @@ page 18013 "Transfer Shipment QR Code"
                     Page.Run(Page::"Transfer Shipment Dialog", TransferShipmentHeader);
                 end;
             }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field("QR Code"; Rec."QR Code")
+#pragma warning restore AW0009
             {
                 ApplicationArea = Basic, Suite;
                 ToolTip = 'Specifies the QR Code assigned by e-invoice portal for sales document.';

--- a/src/Apps/IN/INGST/app/GSTSubcontracting/src/Table/SubCompRcptLine.Table.al
+++ b/src/Apps/IN/INGST/app/GSTSubcontracting/src/Table/SubCompRcptLine.Table.al
@@ -174,7 +174,9 @@ table 18475 "Sub. Comp. Rcpt. Line"
             DataClassification = EndUserIdentifiableInformation;
         }
 #pragma warning disable AS0013 // The ID should have been within the range [1..49999]
+#pragma warning disable AS0099 // Accepted: Renumbering this existing published ID would be a breaking change.
         field(99000754; "Prod. Order Line No."; Integer)
+#pragma warning restore AS0099
         {
             Caption = 'Prod. Order Line No.';
             Description = '1';

--- a/src/Apps/IN/INGST/app/Permissions/d365readindiagst.permissionsetext.al
+++ b/src/Apps/IN/INGST/app/Permissions/d365readindiagst.permissionsetext.al
@@ -8,5 +8,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 18355 "D365 READ - India GST" extends "D365 READ"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "D365 Read Access - India GST";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/IN/INTaxBase/app/src/enumextension/VoucherEnum.EnumExt.al
+++ b/src/Apps/IN/INTaxBase/app/src/enumextension/VoucherEnum.EnumExt.al
@@ -7,6 +7,7 @@ namespace Microsoft.Finance.GeneralLedger.Journal;
 enumextension 18548 "Voucher Enum" extends "Gen. Journal Template Type"
 {
 #pragma warning disable AS0013,PTE0023 // The IDs should have been in the range [18543..18597]
+#pragma warning disable AS0099 // Accepted: Renumbering these existing published IDs would be a breaking change.
     value(18000; "Cash Receipt Voucher")
     {
         Caption = 'Cash Receipt Voucher';
@@ -31,5 +32,6 @@ enumextension 18548 "Voucher Enum" extends "Gen. Journal Template Type"
     {
         Caption = 'Journal Voucher';
     }
+#pragma warning restore AS0099
 #pragma warning restore AS0013,PTE0023 // The IDs should have been in the range [18543..18597]
 }

--- a/src/Apps/W1/APIV1/app/src/permissions/d365automationapiv1.permissionsetext.al
+++ b/src/Apps/W1/APIV1/app/src/permissions/d365automationapiv1.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 5503 "D365 AUTOMATION - APIV1" extends "D365 AUTOMATION"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "D365 Automation APIV1";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/APIV2/app/src/permissions/d365automationapiv2.permissionsetext.al
+++ b/src/Apps/W1/APIV2/app/src/permissions/d365automationapiv2.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 20766 "D365 AUTOMATION - APIV2" extends "D365 AUTOMATION"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "D365 Automation APIV2";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/HybridBC14/app/src/Migration/BufferTables/Setup/BC14InventoryPostingSetup.Table.al
+++ b/src/Apps/W1/HybridBC14/app/src/Migration/BufferTables/Setup/BC14InventoryPostingSetup.Table.al
@@ -21,7 +21,7 @@ table 46898 "BC14 Inventory Posting Setup"
         field(6; "Inventory Account"; Code[20]) { Caption = 'Inventory Account'; }
         field(20; Description; Text[100]) { Caption = 'Description'; }
         field(5800; "Inventory Account (Interim)"; Code[20]) { Caption = 'Inventory Account (Interim)'; }
-#pragma warning disable AS0099 // Accepted: Renumbering these existing published IDs would be a breaking change.
+#pragma warning disable AS0099 // Accepted: Migration buffer field IDs mirror the legacy BC14 source schema; renumbering would break source-data mapping.
         field(99000750; "WIP Account"; Code[20]) { Caption = 'WIP Account'; }
         field(99000753; "Material Variance Account"; Code[20]) { Caption = 'Material Variance Account'; }
         field(99000754; "Capacity Variance Account"; Code[20]) { Caption = 'Capacity Variance Account'; }

--- a/src/Apps/W1/HybridBC14/app/src/Migration/BufferTables/Setup/BC14InventoryPostingSetup.Table.al
+++ b/src/Apps/W1/HybridBC14/app/src/Migration/BufferTables/Setup/BC14InventoryPostingSetup.Table.al
@@ -21,6 +21,7 @@ table 46898 "BC14 Inventory Posting Setup"
         field(6; "Inventory Account"; Code[20]) { Caption = 'Inventory Account'; }
         field(20; Description; Text[100]) { Caption = 'Description'; }
         field(5800; "Inventory Account (Interim)"; Code[20]) { Caption = 'Inventory Account (Interim)'; }
+#pragma warning disable AS0099 // Accepted: Renumbering these existing published IDs would be a breaking change.
         field(99000750; "WIP Account"; Code[20]) { Caption = 'WIP Account'; }
         field(99000753; "Material Variance Account"; Code[20]) { Caption = 'Material Variance Account'; }
         field(99000754; "Capacity Variance Account"; Code[20]) { Caption = 'Capacity Variance Account'; }
@@ -28,6 +29,7 @@ table 46898 "BC14 Inventory Posting Setup"
         field(99000756; "Cap. Overhead Variance Account"; Code[20]) { Caption = 'Cap. Overhead Variance Account'; }
         field(99000757; "Subcontracted Variance Account"; Code[20]) { Caption = 'Subcontracted Variance Account'; }
         field(99000758; "Mat. Non-Inv. Variance Acc."; Code[20]) { Caption = 'Mat. Non-Inv. Variance Acc.'; }
+#pragma warning restore AS0099
     }
 
     keys

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365basicisvmasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365basicisvmasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7234 "D365 BASIC ISV - Master Data Mgt." extends "D365 BASIC ISV"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365basicmasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365basicmasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7233 "D365 BASIC - Master Data Mgt." extends "D365 BASIC"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365busfullaccessmasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365busfullaccessmasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7235 "D365 BUS FULL ACCESS - Master Data Mgt." extends "D365 BUS FULL ACCESS"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365buspremiummasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365buspremiummasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7236 "D365 BUS PREMIUM - Master Data Mgt." extends "D365 BUS PREMIUM"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365fullaccessmasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365fullaccessmasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7237 "D365 FULL ACCESS - Master Data Mgt." extends "D365 FULL ACCESS"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365readmasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365readmasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7238 "D365 READ - Master Data Mgt." extends "D365 READ"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/d365teammembermasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/d365teammembermasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7240 "D365 TEAM MEMBER - Master Data Mgt." extends "D365 TEAM MEMBER"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/MasterDataManagement/app/permissions/intelligentcloudmasterdatamgt.permissionsetext.al
+++ b/src/Apps/W1/MasterDataManagement/app/permissions/intelligentcloudmasterdatamgt.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 7239 "INTELLIGENT CLOUD - Master Data Mgt." extends "INTELLIGENT CLOUD"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Master Data Mgt. - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardSetup.Page.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardSetup.Page.al
@@ -85,7 +85,9 @@ page 1070 "MS - PayPal Standard Setup"
                         end;
                     }
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Logo; MSPayPalStandardTemplate.Logo)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Logo';

--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardSetup.Page.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardSetup.Page.al
@@ -85,7 +85,7 @@ page 1070 "MS - PayPal Standard Setup"
                         end;
                     }
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Logo; MSPayPalStandardTemplate.Logo)
 #pragma warning restore AW0009
                 {

--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardTemplate.Page.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardTemplate.Page.al
@@ -24,7 +24,9 @@ page 1071 "MS - PayPal Standard Template"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the default description for the PayPal payment service.';
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Logo; Rec.Logo)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the default logo for the PayPal payment service.';

--- a/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardTemplate.Page.al
+++ b/src/Apps/W1/PayPalPaymentsStandard/app/src/pages/MSPayPalStandardTemplate.Page.al
@@ -24,7 +24,7 @@ page 1071 "MS - PayPal Standard Template"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the default description for the PayPal payment service.';
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Logo; Rec.Logo)
 #pragma warning restore AW0009
                 {

--- a/src/Apps/W1/ReviewGLEntries/app/permissions/d365busfullaccessreviewglentries.permissionsetext.al
+++ b/src/Apps/W1/ReviewGLEntries/app/permissions/d365busfullaccessreviewglentries.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 22217 "D365 BUS FULL ACCESS - Review G/L Entries" extends "D365 BUS FULL ACCESS"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Review G/L Entries - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/ReviewGLEntries/app/permissions/d365buspremiumreviewglentries.permissionsetext.al
+++ b/src/Apps/W1/ReviewGLEntries/app/permissions/d365buspremiumreviewglentries.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 22216 "D365 BUS PREMIUM - Review G/L Entries" extends "D365 BUS PREMIUM"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Review G/L Entries - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/ReviewGLEntries/app/permissions/d365fullaccessreviewglentries.permissionsetext.al
+++ b/src/Apps/W1/ReviewGLEntries/app/permissions/d365fullaccessreviewglentries.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 22215 "D365 FULL ACCESS - Review G/L Entries" extends "D365 FULL ACCESS"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Review G/L Entries - View";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/ReviewGLEntries/app/permissions/d365readreviewglentries.permissionsetext.al
+++ b/src/Apps/W1/ReviewGLEntries/app/permissions/d365readreviewglentries.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 22214 "D365 READ - Review G/L Entries" extends "D365 READ"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Review G/L Entries - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/ReviewGLEntries/app/permissions/d365teammemberreviewglentries.permissionsetext.al
+++ b/src/Apps/W1/ReviewGLEntries/app/permissions/d365teammemberreviewglentries.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 22213 "D365 TEAM MEMBER - Review G/L Entries" extends "D365 TEAM MEMBER"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Review G/L Entries - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Apps/W1/ReviewGLEntries/app/permissions/intelligentcloudreviewglentries.permissionsetext.al
+++ b/src/Apps/W1/ReviewGLEntries/app/permissions/intelligentcloudreviewglentries.permissionsetext.al
@@ -4,5 +4,7 @@ using System.Security.AccessControl;
 
 permissionsetextension 22212 "INTELLIGENT CLOUD - Review G/L Entries" extends "INTELLIGENT CLOUD"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Review G/L Entries - Read";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -133,7 +133,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -133,7 +133,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/APAC/BaseApp/Local/FinancialMgt/GeneralLedger/Journal/PostDatedCheckLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Local/FinancialMgt/GeneralLedger/Journal/PostDatedCheckLine.Table.al
@@ -506,7 +506,9 @@ table 28090 "Post Dated Check Line"
                 Rec.ShowDimensions();
             end;
         }
+#pragma warning disable AS0099 // Accepted: Renumbering this existing published ID would be a breaking change.
         field(1500000; "Template Name"; Code[20])
+#pragma warning restore AS0099
         {
             Caption = 'Template Name';
         }

--- a/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -160,7 +160,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company registration number for submitting VAT-VIES tax reports electronically.';
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -160,7 +160,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company registration number for submitting VAT-VIES tax reports electronically.';
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/BE/BaseApp/Bank/DirectDebit/DirectDebitCollection.Table.al
+++ b/src/Layers/BE/BaseApp/Bank/DirectDebit/DirectDebitCollection.Table.al
@@ -111,7 +111,9 @@ table 1207 "Direct Debit Collection"
             Caption = 'Partner Type';
             Editable = false;
         }
+#pragma warning disable AS0099 // Accepted: Renumbering this existing published ID would be a breaking change.
         field(20000022; "Domiciliation Batch Name"; Code[20])
+#pragma warning restore AS0099
         {
             Caption = 'Domiciliation Batch Name';
         }

--- a/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -132,7 +132,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -132,7 +132,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -155,7 +155,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company''s number in the Swiss Business and Enterprise Register.';
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -155,7 +155,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company''s number in the Swiss Business and Enterprise Register.';
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAEZAGPictures.Page.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAEZAGPictures.Page.al
@@ -14,7 +14,7 @@ page 3010543 "DTA EZAG Pictures"
     {
         area(content)
         {
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob fields to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The fields remain Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field("EZAG Bar Code"; Rec."EZAG Bar Code")
             {
                 ApplicationArea = Basic, Suite;

--- a/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAEZAGPictures.Page.al
+++ b/src/Layers/CH/BaseApp/Local/Bank/Payment/DTAEZAGPictures.Page.al
@@ -14,6 +14,7 @@ page 3010543 "DTA EZAG Pictures"
     {
         area(content)
         {
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob fields to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field("EZAG Bar Code"; Rec."EZAG Bar Code")
             {
                 ApplicationArea = Basic, Suite;
@@ -24,6 +25,7 @@ page 3010543 "DTA EZAG Pictures"
                 ApplicationArea = Basic, Suite;
                 ToolTip = 'Specifies the Elektronischer Zahlungsauftrag (EZAG) post logo that is associated with the bank code for DTA processing.';
             }
+#pragma warning restore AW0009
         }
     }
 

--- a/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -145,7 +145,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company registration number for submitting VAT-VIES tax reports electronically.';
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -145,7 +145,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company registration number for submitting VAT-VIES tax reports electronically.';
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -145,7 +145,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company registration number for submitting VAT-VIES tax reports electronically.';
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -145,7 +145,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the company registration number for submitting VAT-VIES tax reports electronically.';
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -138,7 +138,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -138,7 +138,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -142,7 +142,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -142,7 +142,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -127,7 +127,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -127,7 +127,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -189,7 +189,9 @@ page 1 "Company Information"
                     Importance = Additional;
                 }
 #endif
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -189,7 +189,7 @@ page 1 "Company Information"
                     Importance = Additional;
                 }
 #endif
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/GB/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
+++ b/src/Layers/GB/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
@@ -145,7 +145,9 @@ page 1803 "Assisted Company Setup Wizard"
                         ShowMandatory = true;
                         Visible = false;
                     }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                     field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Company Logo';

--- a/src/Layers/GB/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
+++ b/src/Layers/GB/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
@@ -145,7 +145,7 @@ page 1803 "Assisted Company Setup Wizard"
                         ShowMandatory = true;
                         Visible = false;
                     }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                     field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                     {

--- a/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -127,7 +127,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -127,7 +127,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -149,7 +149,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -149,7 +149,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -136,7 +136,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -136,7 +136,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/NA/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
+++ b/src/Layers/NA/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
@@ -135,7 +135,7 @@ page 1803 "Assisted Company Setup Wizard"
                         ShowMandatory = true;
                         Visible = false;
                     }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                     field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                     {

--- a/src/Layers/NA/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
+++ b/src/Layers/NA/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
@@ -135,7 +135,9 @@ page 1803 "Assisted Company Setup Wizard"
                         ShowMandatory = true;
                         Visible = false;
                     }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                     field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Company Logo';

--- a/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -137,7 +137,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -137,7 +137,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -143,7 +143,7 @@ page 1 "Company Information"
                     ObsoleteTag = '29.0';
                 }
 #endif
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -143,7 +143,9 @@ page 1 "Company Information"
                     ObsoleteTag = '29.0';
                 }
 #endif
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -133,7 +133,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -133,7 +133,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -152,7 +152,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -152,7 +152,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -132,7 +132,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -132,7 +132,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -133,7 +133,7 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -133,7 +133,9 @@ page 1 "Company Information"
                     ApplicationArea = Basic, Suite;
                     Importance = Additional;
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
 

--- a/src/Layers/W1/BaseApp/Inventory/MarketingText/MarketingTextScenario.EnumExt.al
+++ b/src/Layers/W1/BaseApp/Inventory/MarketingText/MarketingTextScenario.EnumExt.al
@@ -9,7 +9,9 @@ using System.Text;
 enumextension 5825 "Marketing Text Scenario" extends "Entity Text Scenario"
 {
 #pragma warning disable PTE0023
+#pragma warning disable AS0099 // Accepted: Renumbering this existing published ID would be a breaking change.
     value(0; "Marketing Text")
+#pragma warning restore AS0099
     {
         Caption = 'Marketing Text';
     }

--- a/src/Layers/W1/BaseApp/Invoicing/O365DeviceSetup.Page.al
+++ b/src/Layers/W1/BaseApp/Invoicing/O365DeviceSetup.Page.al
@@ -29,7 +29,9 @@ page 1308 "O365 Device Setup"
                         Editable = false;
                         ExtendedDatatype = URL;
                     }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                     field(QR; Rec."QR Code")
+#pragma warning restore AW0009
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'or QR Code';

--- a/src/Layers/W1/BaseApp/Invoicing/O365DeviceSetup.Page.al
+++ b/src/Layers/W1/BaseApp/Invoicing/O365DeviceSetup.Page.al
@@ -29,7 +29,7 @@ page 1308 "O365 Device Setup"
                         Editable = false;
                         ExtendedDatatype = URL;
                     }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                     field(QR; Rec."QR Code")
 #pragma warning restore AW0009
                     {

--- a/src/Layers/W1/BaseApp/Permissions/retenpoladminbaseapp.permissionsetext.al
+++ b/src/Layers/W1/BaseApp/Permissions/retenpoladminbaseapp.permissionsetext.al
@@ -4,5 +4,7 @@ using System.DataAdministration;
 
 permissionsetextension 649 "Reten. Pol. Admin - BaseApp" extends "Retention Pol. Admin"
 {
+#pragma warning disable AA0052, PTE0018 // Accepted: The existing cross-application inclusion must remain to preserve the current permission composition.
     IncludedPermissionSets = "Reten. Pol. Setup - BaseApp";
+#pragma warning restore AA0052, PTE0018
 }

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigWizard.Page.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigWizard.Page.al
@@ -66,7 +66,9 @@ page 8629 "Config. Wizard"
                         ToolTip = 'Specifies the type of industry that the company that you are configuring is.';
                     }
                 }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                 field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                 {
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies the picture that has been set up for the company, for example, a company logo.';

--- a/src/Layers/W1/BaseApp/System/RapidStart/ConfigWizard.Page.al
+++ b/src/Layers/W1/BaseApp/System/RapidStart/ConfigWizard.Page.al
@@ -66,7 +66,7 @@ page 8629 "Config. Wizard"
                         ToolTip = 'Specifies the type of industry that the company that you are configuring is.';
                     }
                 }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                 field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                 {

--- a/src/Layers/W1/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
+++ b/src/Layers/W1/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
@@ -123,7 +123,7 @@ page 1803 "Assisted Company Setup Wizard"
                         ShowMandatory = true;
                         Visible = false;
                     }
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
                     field(Picture; Rec.Picture)
 #pragma warning restore AW0009
                     {

--- a/src/Layers/W1/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
+++ b/src/Layers/W1/BaseApp/Utilities/AssistedCompanySetupWizard.Page.al
@@ -123,7 +123,9 @@ page 1803 "Assisted Company Setup Wizard"
                         ShowMandatory = true;
                         Visible = false;
                     }
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
                     field(Picture; Rec.Picture)
+#pragma warning restore AW0009
                     {
                         ApplicationArea = Basic, Suite;
                         Caption = 'Company Logo';

--- a/src/Layers/W1/BaseApp/eServices/EDocument/O365IncomingDocAttPict.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/O365IncomingDocAttPict.Page.al
@@ -17,7 +17,9 @@ page 2123 "O365 Incoming Doc. Att. Pict."
     {
         area(content)
         {
+#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
             field(AttachmentContent; Rec.Content)
+#pragma warning restore AW0009
             {
                 ApplicationArea = Basic, Suite;
                 ShowCaption = false;

--- a/src/Layers/W1/BaseApp/eServices/EDocument/O365IncomingDocAttPict.Page.al
+++ b/src/Layers/W1/BaseApp/eServices/EDocument/O365IncomingDocAttPict.Page.al
@@ -17,7 +17,7 @@ page 2123 "O365 Incoming Doc. Att. Pict."
     {
         area(content)
         {
-#pragma warning disable AW0009 // Accepted: Migrating the underlying Blob field to Media or MediaSet requires a data-schema migration outside this low-risk ruleset change.
+#pragma warning disable AW0009 // Accepted: The field remains Blob/Bitmap; migrating existing data to Media or MediaSet requires a breaking schema and data upgrade. Tracked by AB#640773.
             field(AttachmentContent; Rec.Content)
 #pragma warning restore AW0009
             {

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -92,11 +92,6 @@
       "justification": "Legacy extensionsPermissionSet.xml files in INTCS, INTDS and INTaxEngine must be converted to AL PermissionSet objects. Tracked by AB#640773."
     },
     {
-      "id": "AS0099",
-      "action": "Warning",
-      "justification": "The ID '0' for the EnumValue 'Marketing Text' is not valid. It should be within the range '[1..2147483647]', which is allocated to the application, and outside the range '[50000..99999]', which is allocated to per-tenant customizations."
-    },
-    {
       "id": "AS0103",
       "action": "Warning",
       "justification": "Table is missing a matching permission set."
@@ -110,11 +105,6 @@
       "id": "AA0022",
       "action": "Warning",
       "justification": "Substitute the IF THEN ELSE structure with a CASE."
-    },
-    {
-      "id": "AA0052",
-      "action": "Warning",
-      "justification": "The permission set should not be included through a permission set extension because it includes permissions for objects defined in another application."
     },
     {
       "id": "AA0073",
@@ -295,11 +285,6 @@
       "justification": "Action should have a value for the Image property."
     },
     {
-      "id": "AW0009",
-      "action": "Warning",
-      "justification": "Using a Blob with subtype Bitmap on a page field is deprecated. "
-    },
-    {
       "id": "AW0011",
       "action": "Warning",
       "justification": "Group 'Processing' only contains promoted actions that are not set to PromotedOnly='true'."
@@ -318,10 +303,6 @@
       "id": "PTE0008",
       "action": "Warning",
       "justification": "Action must have a value for the ApplicationArea property so that they are visible to users. From runtime 11.0, you can specify on the application object level the ApplicationArea to use as default for all its controls and actions."
-    },
-    {
-      "id": "PTE0018",
-      "action": "Warning"
     },
     {
       "id": "AL0603",


### PR DESCRIPTION
## Summary

Promote four rules from `Warning` to `Error` by removing their overrides from `src/rulesets/base.ruleset.json` and accepting existing compatibility-sensitive violations with tightly scoped pragmas:

- `AA0052` and `PTE0018`: 24 shared scopes around the same cross-application permission-set inclusions. The existing permission composition is preserved rather than redesigned.
- `AS0099`: 6 scopes covering 17 enum value and field IDs. Published IDs are retained to avoid breaking compatibility; the BC14 migration-buffer fields retain legacy source IDs to preserve source-data mapping.
- `AW0009`: 33 scopes covering 34 page fields backed by Blob/Bitmap fields. Converting them to Media/MediaSet requires a breaking schema and data upgrade, tracked by [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773).

This is intentionally a four-rule batch because `AA0052` and `PTE0018` share every one of their 24 sites. Promoting them intentionally makes future cross-application permission-set inclusions fail at `Error`: contributors must avoid the pattern or add a narrowly justified local pragma where preserving permission composition is necessary. This is a deliberate security and ownership posture, not an accidental contributor regression.

All pragma sites came from actual analyzer/build diagnostic data, not a source-pattern scan. Raw diagnostic records were reconciled to physical declarations, and required layer propagation was verified with `Invoke-MiSnapApp`. The final delta contains 63 AL files plus the base ruleset. `AL0424` remains `Warning` and is otherwise untouched.

The Clean + Default CI matrix is the hard merge gate and is still running; this PR should not merge until that matrix succeeds.

[AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773)


