### PR TITLE
[28.x] Restore E-Document lifecycle message infrastructure

### DIFF
--- a/src/Apps/W1/EDocument/App/Permissions/EDocCoreObjects.PermissionSet.al
+++ b/src/Apps/W1/EDocument/App/Permissions/EDocCoreObjects.PermissionSet.al
@@ -51,6 +51,8 @@ permissionset 6100 "E-Doc. Core - Objects"
         table "ED Purchase Line Field Setup" = X,
         table "E-Doc Sample Purch. Inv File" = X,
         table "E-Document Message" = X,
+        table "E-Doc. Payment Occurrence" = X,
+        table "E-Doc. External Reference" = X,
 #if not CLEAN28
 #pragma warning disable AL0432
         table "EDoc Historical Matching Setup" = X,
@@ -96,7 +98,11 @@ permissionset 6100 "E-Doc. Core - Objects"
         codeunit "E-Doc. PO AOAI Function" = X,
         codeunit "E-Doc. PO Copilot Matching" = X,
         codeunit "E-Doc. Attachment Processor" = X,
+        codeunit "E-Doc. Message Context" = X,
         codeunit "E-Doc. Message Mgt." = X,
+        codeunit "E-Doc. Msg. Transport Default" = X,
+        codeunit "E-Doc. Payment Occ. Dispatcher" = X,
+        codeunit "E-Doc. Payment Occ. Runner" = X,
         codeunit "Service Participant" = X,
         page "E-Doc. Changes Part" = X,
         page "E-Doc. Changes Preview" = X,

--- a/src/Apps/W1/EDocument/App/Permissions/EDocCoreUser.PermissionSet.al
+++ b/src/Apps/W1/EDocument/App/Permissions/EDocCoreUser.PermissionSet.al
@@ -23,6 +23,13 @@ permissionset 6105 "E-Doc. Core - User"
     IncludedPermissionSets = "E-Doc. Core - Read";
 
     Permissions =
+        codeunit "E-Document Message API" = X,
+        codeunit "E-Doc. Message Response Job" = X,
+        codeunit "E-Doc. Message Send Job" = X,
+        codeunit "E-Doc. Message Send Runner" = X,
+        codeunit "E-Doc. Payment Occ. Dispatcher" = X,
+        codeunit "E-Doc. Payment Occ. Runner" = X,
+        codeunit "E-Doc. Payment Occurrence Mgt." = X,
         tabledata "E-Document" = iMD,
     #region Service
         tabledata "E-Document Service" = im,
@@ -40,6 +47,8 @@ permissionset 6105 "E-Doc. Core - User"
         tabledata "E-Doc. Data Storage" = imd,
         tabledata "E-Document Integration Log" = imd,
         tabledata "E-Document Message" = imd,
+        tabledata "E-Doc. Payment Occurrence" = rimd,
+        tabledata "E-Doc. External Reference" = rimd,
     #endregion Logging
         tabledata "E-Doc. Imported Line" = IMD,
         tabledata "E-Doc. Order Match" = IMD,

--- a/src/Apps/W1/EDocument/App/app.json
+++ b/src/Apps/W1/EDocument/App/app.json
@@ -66,12 +66,20 @@
       "to": 6234
     },
     {
+      "from": 6244,
+      "to": 6249
+    },
+    {
       "from": 6401,
       "to": 6410
     },
     {
       "from": 6427,
       "to": 6436
+    },
+    {
+      "from": 6530,
+      "to": 6539
     }
   ],
   "resourceExposurePolicy": {

--- a/src/Apps/W1/EDocument/App/src/Document/EDocument.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Document/EDocument.Table.al
@@ -429,6 +429,7 @@ table 6121 "E-Document"
         EDocumentIntegrationLog: Record "E-Document Integration Log";
         EDocumentLog: Record "E-Document Log";
         EDocImportedLine: Record "E-Doc. Imported Line";
+        EDocExternalReference: Record "E-Doc. External Reference";
         EDocumentMessage: Record "E-Document Message";
         EDocumentServiceStatus: Record "E-Document Service Status";
 #if not CLEAN27
@@ -467,6 +468,10 @@ table 6121 "E-Document"
         EDocumentMessage.SetRange("E-Document Entry No.", Rec."Entry No");
         if not EDocumentMessage.IsEmpty() then
             EDocumentMessage.DeleteAll(true);
+
+        EDocExternalReference.SetRange("E-Document Entry No.", Rec."Entry No");
+        if not EDocExternalReference.IsEmpty() then
+            EDocExternalReference.DeleteAll(true);
 
 #if not CLEAN27
         // Version 1 processing cleanup

--- a/src/Apps/W1/EDocument/App/src/Integration/Interfaces/IMessageResponseHandler.Interface.al
+++ b/src/Apps/W1/EDocument/App/src/Integration/Interfaces/IMessageResponseHandler.Interface.al
@@ -1,0 +1,29 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Integration.Interfaces;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
+
+/// <summary>
+/// Polls the asynchronous response for an outgoing child E-Document message.
+/// </summary>
+interface IMessageResponseHandler
+{
+    /// <summary>
+    /// Polls the external service for the response to a previously sent child message.
+    /// </summary>
+    /// <param name="EDocument">The parent E-Document.</param>
+    /// <param name="EDocumentService">The service used to send the message.</param>
+    /// <param name="MessageContext">The original message context and transport diagnostics.</param>
+    /// <returns>True when the response is complete; otherwise false.</returns>
+    /// <remarks>
+    /// A completed response must set the context status to Sent. A response that is not ready must set it to Pending Response.
+    /// Implementations must use MessageContext.GetMessageEntryNo() to correlate the external request.
+    /// The E-Document Core app does not provide connector endpoint, authentication, or response parsing behavior.
+    /// A connector or integration adapter must implement those transport-specific responsibilities.
+    /// </remarks>
+    procedure GetResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; MessageContext: Codeunit "E-Doc. Message Context"): Boolean;
+}

--- a/src/Apps/W1/EDocument/App/src/Integration/Interfaces/IMessageSender.Interface.al
+++ b/src/Apps/W1/EDocument/App/src/Integration/Interfaces/IMessageSender.Interface.al
@@ -1,0 +1,27 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Integration.Interfaces;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
+
+/// <summary>
+/// Sends a child message associated with an E-Document through a service integration.
+/// </summary>
+interface IMessageSender
+{
+    /// <summary>
+    /// Sends the payload in the message context.
+    /// </summary>
+    /// <param name="EDocument">The parent E-Document.</param>
+    /// <param name="EDocumentService">The service used to send the message.</param>
+    /// <param name="MessageContext">The message payload, transport state, and result. The implementation must set the result to Sent or Pending Response after successful transmission.</param>
+    /// <remarks>
+    /// The implementation is responsible for obtaining any privacy consent required by the external service before transmitting data.
+    /// Implementations must use MessageContext.GetMessageEntryNo() as an idempotency key because a message can be retried after an ambiguous transport failure.
+    /// Set the context status to Pending Response when the external service accepted the message but requires asynchronous response polling.
+    /// </remarks>
+    procedure SendMessage(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; MessageContext: Codeunit "E-Doc. Message Context");
+}

--- a/src/Apps/W1/EDocument/App/src/Integration/ServiceIntegration.Enum.al
+++ b/src/Apps/W1/EDocument/App/src/Integration/ServiceIntegration.Enum.al
@@ -6,12 +6,20 @@ namespace Microsoft.eServices.EDocument.Integration;
 
 using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration.Interfaces;
+using Microsoft.eServices.EDocument.Processing.Message;
 
-enum 6151 "Service Integration" implements IDocumentSender, IDocumentReceiver, IConsentManager
+enum 6151 "Service Integration" implements IDocumentSender, IDocumentReceiver, IConsentManager, IMessageSender, IMessageResponseHandler
 {
     Extensible = true;
     Access = Public;
-    DefaultImplementation = IConsentManager = "Consent Manager Default Impl.";
+    DefaultImplementation = IConsentManager = "Consent Manager Default Impl.",
+                            IMessageSender = "E-Doc. Msg. Transport Default",
+                            IMessageResponseHandler = "E-Doc. Msg. Transport Default";
+    UnknownValueImplementation = IDocumentSender = "E-Document No Integration",
+                                 IDocumentReceiver = "E-Document No Integration",
+                                 IConsentManager = "E-Document No Integration",
+                                 IMessageSender = "E-Doc. Msg. Transport Default",
+                                 IMessageResponseHandler = "E-Doc. Msg. Transport Default";
 
     value(0; "No Integration")
     {

--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentBackgroundJobs.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentBackgroundJobs.Codeunit.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.eServices.EDocument;
 
+using Microsoft.eServices.EDocument.Processing.Message;
 using System.Telemetry;
 using System.Threading;
 
@@ -19,6 +20,54 @@ codeunit 6133 "E-Document Background Jobs"
     begin
         EDocument."Job Queue Entry ID" := ScheduleEDocumentJob(Codeunit::"E-Document Created Flow", EDocument.RecordId(), 0);
         EDocument.Modify();
+    end;
+
+    procedure ScheduleMessageSend(EDocumentMessage: Record "E-Document Message")
+    begin
+        ScheduleEDocumentJob(Codeunit::"E-Doc. Message Send Job", EDocumentMessage.RecordId(), 0);
+    end;
+
+    procedure SchedulePaymentOccurrence(EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence")
+    begin
+        ScheduleEDocumentJob(Codeunit::"E-Doc. Payment Occurrence Mgt.", EDocPaymentOccurrence.RecordId(), 0);
+    end;
+
+    procedure TrySchedulePaymentOccurrence(EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence"): Boolean
+    begin
+        exit(TryScheduleEDocumentJob(Codeunit::"E-Doc. Payment Occurrence Mgt.", EDocPaymentOccurrence.RecordId(), 0));
+    end;
+
+    internal procedure EnsurePaymentOccurrenceDispatcher()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+        BlankRecordId: RecordId;
+    begin
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"E-Doc. Payment Occ. Dispatcher");
+        JobQueueEntry.SetFilter(Status, '<>%1', JobQueueEntry.Status::Finished);
+        if not JobQueueEntry.IsEmpty() then
+            exit;
+
+        JobQueueEntry.ScheduleRecurrentJobQueueEntryWithFrequency(
+            JobQueueEntry."Object Type to Run"::Codeunit, Codeunit::"E-Doc. Payment Occ. Dispatcher", BlankRecordId, 5);
+        JobQueueEntry."Job Queue Category Code" := JobQueueCategoryTok;
+        JobQueueEntry."No. of Attempts to Run" := 0;
+        JobQueueEntry.Modify();
+    end;
+
+    procedure TryScheduleMessageSend(EDocumentMessage: Record "E-Document Message"): Boolean
+    begin
+        exit(TryScheduleEDocumentJob(Codeunit::"E-Doc. Message Send Job", EDocumentMessage.RecordId(), 0));
+    end;
+
+    procedure ScheduleMessageResponse(EDocumentMessage: Record "E-Document Message")
+    begin
+        ScheduleEDocumentJob(Codeunit::"E-Doc. Message Response Job", EDocumentMessage.RecordId(), 300000);
+    end;
+
+    procedure TryScheduleMessageResponse(EDocumentMessage: Record "E-Document Message"): Boolean
+    begin
+        exit(TryScheduleEDocumentJob(Codeunit::"E-Doc. Message Response Job", EDocumentMessage.RecordId(), 300000));
     end;
 
     procedure ScheduleGetResponseJob()
@@ -155,9 +204,26 @@ codeunit 6133 "E-Document Background Jobs"
     local procedure ScheduleEDocumentJob(CodeunitId: Integer; JobRecordId: RecordId; EarliestStartDateTime: Integer): Guid
     var
         JobQueueEntry: Record "Job Queue Entry";
+    begin
+        PrepareEDocumentJob(JobQueueEntry, CodeunitId, JobRecordId, EarliestStartDateTime);
+        Codeunit.Run(Codeunit::"Job Queue - Enqueue", JobQueueEntry);
+        exit(JobQueueEntry.ID);
+    end;
+
+    local procedure TryScheduleEDocumentJob(CodeunitId: Integer; JobRecordId: RecordId; EarliestStartDateTime: Integer): Boolean
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        PrepareEDocumentJob(JobQueueEntry, CodeunitId, JobRecordId, EarliestStartDateTime);
+        exit(Codeunit.Run(Codeunit::"Job Queue - Enqueue", JobQueueEntry));
+    end;
+
+    local procedure PrepareEDocumentJob(var JobQueueEntry: Record "Job Queue Entry"; CodeunitId: Integer; JobRecordId: RecordId; EarliestStartDateTime: Integer)
+    var
         Telemetry: Codeunit Telemetry;
         TelemetryDimensions: Dictionary of [Text, Text];
     begin
+        OnBeforeScheduleEDocumentJob(CodeunitId, JobRecordId);
         JobQueueEntry.Init();
         JobQueueEntry."Object Type to Run" := JobQueueEntry."Object Type to Run"::Codeunit;
         JobQueueEntry."Object ID to Run" := CodeunitId;
@@ -172,9 +238,12 @@ codeunit 6133 "E-Document Background Jobs"
         TelemetryDimensions.Add('Record Id', Format(JobRecordId));
         TelemetryDimensions.Add('User Session ID', Format(JobQueueEntry."User Session ID"));
         TelemetryDimensions.Add('Earliest Start Date/Time', Format(JobQueueEntry."Earliest Start Date/Time"));
-        Telemetry.LogMessage('0000LC6', EDocumentJobTelemetryLbl, Verbosity::Normal, DataClassification::OrganizationIdentifiableInformation, TelemetryScope::All, TelemetryDimensions);
-        Codeunit.Run(Codeunit::"Job Queue - Enqueue", JobQueueEntry);
-        exit(JobQueueEntry.ID);
+        Telemetry.LogMessage('0000LC6', EDocumentJobTelemetryLbl, Verbosity::Normal, DataClassification::OrganizationIdentifiableInformation, TelemetryScope::ExtensionPublisher, TelemetryDimensions);
+    end;
+
+    [InternalEvent(false, false)]
+    local procedure OnBeforeScheduleEDocumentJob(CodeunitId: Integer; JobRecordId: RecordId)
+    begin
     end;
 
     var

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocExternalReference.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocExternalReference.Table.al
@@ -1,0 +1,64 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using Microsoft.eServices.EDocument;
+
+table 6434 "E-Doc. External Reference"
+{
+    Access = Internal;
+    Caption = 'E-Document External Reference';
+    DataClassification = CustomerContent;
+    InherentEntitlements = RIMDX;
+    InherentPermissions = RIMDX;
+    ReplicateData = false;
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            AutoIncrement = true;
+            Caption = 'Entry No.';
+            DataClassification = SystemMetadata;
+        }
+        field(2; Service; Code[20])
+        {
+            Caption = 'Service';
+            DataClassification = SystemMetadata;
+            TableRelation = "E-Document Service";
+        }
+        field(3; "External Document ID"; Text[250])
+        {
+            Caption = 'External Document ID';
+            DataClassification = CustomerContent;
+        }
+        field(4; "E-Document Entry No."; Integer)
+        {
+            Caption = 'E-Document Entry No.';
+            DataClassification = SystemMetadata;
+            TableRelation = "E-Document"."Entry No";
+        }
+        field(5; "Created At"; DateTime)
+        {
+            Caption = 'Created At';
+            DataClassification = SystemMetadata;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+        key(ExternalDocument; Service, "External Document ID")
+        {
+            Unique = true;
+        }
+        key(EDocument; "E-Document Entry No.")
+        {
+        }
+    }
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageContext.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageContext.Codeunit.al
@@ -1,0 +1,86 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using Microsoft.eServices.EDocument.Integration;
+using Microsoft.eServices.EDocument.Integration.Action;
+using System.Utilities;
+
+codeunit 6533 "E-Doc. Message Context"
+{
+    Access = Public;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    internal procedure Initialize(EDocMessage: Record "E-Document Message"; TempBlob: Codeunit "Temp Blob")
+    begin
+        MessageEntryNo := EDocMessage."Entry No.";
+        MessageType := EDocMessage."Message Type";
+        ResponseType := EDocMessage."Response Type";
+        Payload := TempBlob;
+    end;
+
+    /// <summary>
+    /// Gets the entry number of the child E-Document message being sent.
+    /// </summary>
+    /// <returns>The E-Document message entry number.</returns>
+    procedure GetMessageEntryNo(): Integer
+    begin
+        exit(MessageEntryNo);
+    end;
+
+    /// <summary>
+    /// Gets the semantic type of the child E-Document message.
+    /// </summary>
+    /// <returns>The E-Document message type.</returns>
+    procedure GetMessageType(): Enum "E-Document Message Type"
+    begin
+        exit(MessageType);
+    end;
+
+    /// <summary>
+    /// Gets the response type represented by the child message.
+    /// </summary>
+    /// <returns>The E-Document response type.</returns>
+    procedure GetResponseType(): Enum "E-Doc. Response Type"
+    begin
+        exit(ResponseType);
+    end;
+
+    /// <summary>
+    /// Gets the message payload.
+    /// </summary>
+    /// <returns>A temporary blob containing the message payload.</returns>
+    procedure GetTempBlob(): Codeunit "Temp Blob"
+    begin
+        exit(Payload);
+    end;
+
+    /// <summary>
+    /// Gets the HTTP state used to record the connector request and response.
+    /// </summary>
+    /// <returns>The HTTP message state.</returns>
+    procedure Http(): Codeunit "Http Message State"
+    begin
+        exit(HttpMessageState);
+    end;
+
+    /// <summary>
+    /// Gets the transport result. A connector must set the status to Sent or Pending Response after successful transmission.
+    /// </summary>
+    /// <returns>The integration action status.</returns>
+    procedure Status(): Codeunit "Integration Action Status"
+    begin
+        exit(IntegrationActionStatus);
+    end;
+
+    var
+        HttpMessageState: Codeunit "Http Message State";
+        IntegrationActionStatus: Codeunit "Integration Action Status";
+        Payload: Codeunit "Temp Blob";
+        MessageType: Enum "E-Document Message Type";
+        ResponseType: Enum "E-Doc. Response Type";
+        MessageEntryNo: Integer;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageMgt.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageMgt.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.eServices.EDocument.Processing.Message;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Integration.Interfaces;
 using System.Utilities;
 
 /// <summary>
@@ -79,6 +80,325 @@ codeunit 6433 "E-Doc. Message Mgt."
         TempBlob := EDocDataStorage.GetTempBlob();
     end;
 
+    procedure GetMessageEDocument(MessageEntryNo: Integer; var EDocument: Record "E-Document")
+    var
+        EDocMessage: Record "E-Document Message";
+    begin
+        EDocMessage.SetLoadFields("E-Document Entry No.");
+        EDocMessage.Get(MessageEntryNo);
+        EDocument.Get(EDocMessage."E-Document Entry No.");
+    end;
+
+    procedure GetMessageDirection(MessageEntryNo: Integer): Enum "E-Document Direction"
+    var
+        EDocMessage: Record "E-Document Message";
+    begin
+        EDocMessage.SetLoadFields(Direction);
+        EDocMessage.Get(MessageEntryNo);
+        exit(EDocMessage.Direction);
+    end;
+
+    procedure GetMessageStatus(MessageEntryNo: Integer): Enum "E-Doc. Message Status"
+    var
+        EDocMessage: Record "E-Document Message";
+    begin
+        EDocMessage.SetLoadFields(Status);
+        EDocMessage.Get(MessageEntryNo);
+        exit(EDocMessage.Status);
+    end;
+
+    procedure GetMessageResponseType(MessageEntryNo: Integer): Enum "E-Doc. Response Type"
+    var
+        EDocMessage: Record "E-Document Message";
+    begin
+        EDocMessage.SetLoadFields("Response Type");
+        EDocMessage.Get(MessageEntryNo);
+        exit(EDocMessage."Response Type");
+    end;
+
+    procedure SendMessage(MessageEntryNo: Integer)
+    var
+        EDocument: Record "E-Document";
+        EDocumentService: Record "E-Document Service";
+        EDocMessage: Record "E-Document Message";
+        EDocMessageContext: Codeunit "E-Doc. Message Context";
+        EDocumentLog: Codeunit "E-Document Log";
+        TempBlob: Codeunit "Temp Blob";
+        MessageSender: Interface IMessageSender;
+        ConnectorErrorInfo: ErrorInfo;
+        ConnectorErrorText: Text;
+        MessageSendingErrorInfo: ErrorInfo;
+    begin
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.TestField(Direction, EDocMessage.Direction::Outgoing);
+        if not (EDocMessage.Status in [EDocMessage.Status::Created, EDocMessage.Status::Queued, EDocMessage.Status::Error]) then
+            EDocMessage.FieldError(Status);
+        EDocMessage.TestField(Service);
+
+        EDocument.Get(EDocMessage."E-Document Entry No.");
+        EDocumentService.Get(EDocMessage.Service);
+        GetMessageBlob(MessageEntryNo, TempBlob);
+        if not TempBlob.HasValue() then
+            Error(MessagePayloadErr, MessageEntryNo);
+
+        EDocMessageContext.Initialize(EDocMessage, TempBlob);
+        MessageSender := EDocumentService."Service Integration V2";
+        if not TrySendMessage(MessageSender, EDocument, EDocumentService, EDocMessageContext) then begin
+            ConnectorErrorText := GetLastErrorText();
+            if ConnectorErrorText = '' then
+                ConnectorErrorText := StrSubstNo(MessageSendingErr, MessageEntryNo);
+            ConnectorErrorInfo := ErrorInfo.Create(ConnectorErrorText);
+            EDocumentLog.InsertIntegrationLog(
+                EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+            Commit();
+            ConnectorErrorInfo.DetailedMessage := StrSubstNo(MessageSendingErr, MessageEntryNo);
+            ConnectorErrorInfo.DataClassification := DataClassification::SystemMetadata;
+            Error(ConnectorErrorInfo);
+        end;
+        if not (EDocMessageContext.Status().GetStatus() in ["E-Document Service Status"::Sent, "E-Document Service Status"::"Pending Response"]) then begin
+            EDocumentLog.InsertIntegrationLog(
+                EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+            Commit();
+            MessageSendingErrorInfo.ErrorType := ErrorType::Internal;
+            MessageSendingErrorInfo.Message := StrSubstNo(MessageSendingErr, MessageEntryNo);
+            MessageSendingErrorInfo.DetailedMessage := StrSubstNo(MessageSendingDetailedErr, EDocMessageContext.Status().GetStatus());
+            MessageSendingErrorInfo.DataClassification := DataClassification::SystemMetadata;
+            Error(MessageSendingErrorInfo);
+        end;
+
+        EDocumentLog.InsertIntegrationLog(
+            EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+        if EDocMessageContext.Status().GetStatus() = "E-Document Service Status"::"Pending Response" then
+            EDocMessage.Status := EDocMessage.Status::"Pending Response"
+        else
+            EDocMessage.Status := EDocMessage.Status::Sent;
+        EDocMessage."Last Attempt At" := CurrentDateTime();
+        Clear(EDocMessage."Last Error");
+        EDocMessage.Modify();
+        if EDocMessage.Status = EDocMessage.Status::"Pending Response" then begin
+            Commit();
+            if not TryScheduleMessageResponse(EDocMessage) then
+                SetMessageSchedulingError(EDocMessage, EDocMessage.Status::"Response Error");
+        end;
+    end;
+
+    procedure PollMessageResponse(MessageEntryNo: Integer)
+    var
+        EDocument: Record "E-Document";
+        EDocumentService: Record "E-Document Service";
+        EDocMessage: Record "E-Document Message";
+        EDocMessageContext: Codeunit "E-Doc. Message Context";
+        EDocumentLog: Codeunit "E-Document Log";
+        TempBlob: Codeunit "Temp Blob";
+        MessageResponseHandler: Interface IMessageResponseHandler;
+        ConnectorErrorInfo: ErrorInfo;
+        ConnectorErrorText: Text;
+        ResponseReceived: Boolean;
+    begin
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.TestField(Direction, EDocMessage.Direction::Outgoing);
+        EDocMessage.TestField(Status, EDocMessage.Status::"Pending Response");
+        EDocMessage.TestField(Service);
+        EDocument.Get(EDocMessage."E-Document Entry No.");
+        EDocumentService.Get(EDocMessage.Service);
+        GetMessageBlob(MessageEntryNo, TempBlob);
+        EDocMessageContext.Initialize(EDocMessage, TempBlob);
+        MessageResponseHandler := EDocumentService."Service Integration V2";
+        if not TryGetResponse(MessageResponseHandler, EDocument, EDocumentService, EDocMessageContext, ResponseReceived) then begin
+            ConnectorErrorText := GetLastErrorText();
+            if ConnectorErrorText = '' then
+                ConnectorErrorText := StrSubstNo(MessageResponseErr, MessageEntryNo);
+            ConnectorErrorInfo := ErrorInfo.Create(ConnectorErrorText);
+            EDocumentLog.InsertIntegrationLog(
+                EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+            Commit();
+            ConnectorErrorInfo.DetailedMessage := StrSubstNo(MessageResponseErr, MessageEntryNo);
+            ConnectorErrorInfo.DataClassification := DataClassification::SystemMetadata;
+            Error(ConnectorErrorInfo);
+        end;
+
+        if ResponseReceived then begin
+            if EDocMessageContext.Status().GetStatus() <> "E-Document Service Status"::Sent then begin
+                EDocumentLog.InsertIntegrationLog(
+                    EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+                Commit();
+                Error(MessageResponseStatusErr, MessageEntryNo, EDocMessageContext.Status().GetStatus());
+            end;
+            EDocMessage.Status := EDocMessage.Status::Sent;
+        end else begin
+            if EDocMessageContext.Status().GetStatus() <> "E-Document Service Status"::"Pending Response" then begin
+                EDocumentLog.InsertIntegrationLog(
+                    EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+                Commit();
+                Error(MessageResponseStatusErr, MessageEntryNo, EDocMessageContext.Status().GetStatus());
+            end;
+            EDocMessage.Status := EDocMessage.Status::"Pending Response";
+        end;
+
+        EDocumentLog.InsertIntegrationLog(
+            EDocument, EDocumentService, EDocMessageContext.Http().GetHttpRequestMessage(), EDocMessageContext.Http().GetHttpResponseMessage());
+        EDocMessage."Last Attempt At" := CurrentDateTime();
+        Clear(EDocMessage."Last Error");
+        EDocMessage.Modify();
+        if not ResponseReceived then begin
+            Commit();
+            if not TryScheduleMessageResponse(EDocMessage) then
+                SetMessageSchedulingError(EDocMessage, EDocMessage.Status::"Response Error");
+        end;
+    end;
+
+    [TryFunction]
+    local procedure TrySendMessage(MessageSender: Interface IMessageSender; var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; EDocMessageContext: Codeunit "E-Doc. Message Context")
+    begin
+        MessageSender.SendMessage(EDocument, EDocumentService, EDocMessageContext);
+    end;
+
+    [TryFunction]
+    local procedure TryGetResponse(MessageResponseHandler: Interface IMessageResponseHandler; var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; EDocMessageContext: Codeunit "E-Doc. Message Context"; var ResponseReceived: Boolean)
+    begin
+        ResponseReceived := MessageResponseHandler.GetResponse(EDocument, EDocumentService, EDocMessageContext);
+    end;
+
+    procedure QueueMessage(MessageEntryNo: Integer)
+    var
+        EDocMessage: Record "E-Document Message";
+    begin
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.TestField(Direction, EDocMessage.Direction::Outgoing);
+        EDocMessage.TestField(Status, EDocMessage.Status::Created);
+        EDocMessage.TestField(Service);
+
+        EDocMessage.Status := EDocMessage.Status::Queued;
+        EDocMessage.Modify();
+        Commit();
+        if TryScheduleMessageSend(EDocMessage) then
+            exit;
+
+        SetMessageSchedulingError(EDocMessage, EDocMessage.Status::Error);
+    end;
+
+    local procedure TryScheduleMessageSend(EDocMessage: Record "E-Document Message"): Boolean
+    var
+        EDocumentBackgroundJobs: Codeunit "E-Document Background Jobs";
+    begin
+        exit(EDocumentBackgroundJobs.TryScheduleMessageSend(EDocMessage));
+    end;
+
+    local procedure TryScheduleMessageResponse(EDocMessage: Record "E-Document Message"): Boolean
+    var
+        EDocumentBackgroundJobs: Codeunit "E-Document Background Jobs";
+    begin
+        exit(EDocumentBackgroundJobs.TryScheduleMessageResponse(EDocMessage));
+    end;
+
+    local procedure SetMessageSchedulingError(var EDocMessage: Record "E-Document Message"; ErrorStatus: Enum "E-Doc. Message Status")
+    var
+        SchedulingError: Text;
+    begin
+        SchedulingError := GetLastErrorText();
+        EDocMessage.Get(EDocMessage."Entry No.");
+        EDocMessage.Status := ErrorStatus;
+        EDocMessage."Last Attempt At" := CurrentDateTime();
+        EDocMessage."Retry Count" += 1;
+        EDocMessage."Last Error" := CopyStr(SchedulingError, 1, MaxStrLen(EDocMessage."Last Error"));
+        EDocMessage.Modify();
+        ClearLastError();
+    end;
+
+    procedure RetryMessage(MessageEntryNo: Integer)
+    var
+        EDocMessage: Record "E-Document Message";
+    begin
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.TestField(Direction, EDocMessage.Direction::Outgoing);
+        if EDocMessage.Status <> EDocMessage.Status::"Response Error" then
+            EDocMessage.TestField(Status, EDocMessage.Status::Error);
+        EDocMessage.TestField(Service);
+
+        if EDocMessage.Status = EDocMessage.Status::"Response Error" then
+            EDocMessage.Status := EDocMessage.Status::"Pending Response"
+        else
+            EDocMessage.Status := EDocMessage.Status::Queued;
+        EDocMessage.Modify();
+        Commit();
+        if EDocMessage.Status = EDocMessage.Status::"Pending Response" then begin
+            if not TryScheduleMessageResponse(EDocMessage) then
+                SetMessageSchedulingError(EDocMessage, EDocMessage.Status::"Response Error");
+        end else
+            if not TryScheduleMessageSend(EDocMessage) then
+                SetMessageSchedulingError(EDocMessage, EDocMessage.Status::Error);
+    end;
+
+    procedure RegisterExternalDocumentReference(EDocument: Record "E-Document"; ServiceCode: Code[20]; ExternalDocumentID: Text[250])
+    var
+        EDocExternalReference: Record "E-Doc. External Reference";
+        EDocumentService: Record "E-Document Service";
+    begin
+        if ExternalDocumentID = '' then
+            Error(ExternalDocumentIDRequiredErr);
+
+        EDocument.Get(EDocument."Entry No");
+        EDocument.TestField(Service, ServiceCode);
+        EDocumentService.Get(ServiceCode);
+
+        EDocExternalReference.SetCurrentKey(Service, "External Document ID");
+        EDocExternalReference.SetRange(Service, ServiceCode);
+        EDocExternalReference.SetRange("External Document ID", ExternalDocumentID);
+        if EDocExternalReference.FindFirst() then begin
+            if EDocExternalReference."E-Document Entry No." = EDocument."Entry No" then
+                exit;
+            Error(ExternalDocumentIDConflictErr, ExternalDocumentID, ServiceCode);
+        end;
+
+        EDocExternalReference.Init();
+        EDocExternalReference.Service := ServiceCode;
+        EDocExternalReference."External Document ID" := ExternalDocumentID;
+        EDocExternalReference."E-Document Entry No." := EDocument."Entry No";
+        EDocExternalReference."Created At" := CurrentDateTime();
+        EDocExternalReference.Insert();
+    end;
+
+    procedure CreateIncomingMessage(ServiceCode: Code[20]; ExternalDocumentID: Text[250]; ExternalMessageID: Text[250]; MessageType: Enum "E-Document Message Type"; ResponseType: Enum "E-Doc. Response Type"; ReceivedAt: DateTime; var TempBlob: Codeunit "Temp Blob"): Integer
+    var
+        EDocument: Record "E-Document";
+        EDocExternalReference: Record "E-Doc. External Reference";
+        EDocMessage: Record "E-Document Message";
+        MessageEntryNo: Integer;
+    begin
+        if ExternalDocumentID = '' then
+            Error(ExternalDocumentIDRequiredErr);
+        if ExternalMessageID = '' then
+            Error(ExternalMessageIDRequiredErr);
+        if not TempBlob.HasValue() then
+            Error(IncomingMessagePayloadRequiredErr);
+
+        EDocMessage.LockTable();
+        EDocMessage.SetCurrentKey(Service, "External Message ID");
+        EDocMessage.SetRange(Service, ServiceCode);
+        EDocMessage.SetRange("External Message ID", ExternalMessageID);
+        if EDocMessage.FindFirst() then
+            exit(EDocMessage."Entry No.");
+
+        EDocExternalReference.SetCurrentKey(Service, "External Document ID");
+        EDocExternalReference.SetRange(Service, ServiceCode);
+        EDocExternalReference.SetRange("External Document ID", ExternalDocumentID);
+        if not EDocExternalReference.FindFirst() then
+            Error(ExternalDocumentNotFoundErr, ExternalDocumentID, ServiceCode);
+
+        EDocument.Get(EDocExternalReference."E-Document Entry No.");
+        MessageEntryNo := CreateMessage(EDocument, MessageType, "E-Document Direction"::Incoming, ResponseType, TempBlob);
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.Status := EDocMessage.Status::Received;
+        EDocMessage."External Message ID" := ExternalMessageID;
+        EDocMessage."External Document ID" := ExternalDocumentID;
+        if ReceivedAt = 0DT then
+            EDocMessage."Received At" := CurrentDateTime()
+        else
+            EDocMessage."Received At" := ReceivedAt;
+        EDocMessage.Modify();
+        exit(MessageEntryNo);
+    end;
+
     local procedure InsertDataStorage(TempBlob: Codeunit "Temp Blob"): Integer
     var
         EDocDataStorage: Record "E-Doc. Data Storage";
@@ -96,4 +416,16 @@ codeunit 6433 "E-Doc. Message Mgt."
         EDocRecRef.Modify();
         exit(EDocDataStorage."Entry No.");
     end;
+
+    var
+        MessagePayloadErr: Label 'E-Document message %1 does not contain a payload.', Comment = '%1 = E-Document message entry number';
+        MessageSendingErr: Label 'E-Document message %1 could not be sent.', Comment = '%1 = E-Document message entry number';
+        MessageResponseErr: Label 'A response for E-Document message %1 could not be retrieved.', Comment = '%1 = E-Document message entry number';
+        MessageSendingDetailedErr: Label 'The E-Document message integration returned status %1.', Comment = '%1 = integration status';
+        MessageResponseStatusErr: Label 'The connector returned invalid response status %2 for E-Document message %1.', Comment = '%1 = message entry number, %2 = connector status';
+        ExternalDocumentIDRequiredErr: Label 'An external document ID is required.';
+        ExternalMessageIDRequiredErr: Label 'An external message ID is required.';
+        IncomingMessagePayloadRequiredErr: Label 'An incoming E-Document message payload is required.';
+        ExternalDocumentIDConflictErr: Label 'External document ID %1 is already associated with another E-Document for service %2.', Comment = '%1 = external document ID, %2 = service code';
+        ExternalDocumentNotFoundErr: Label 'External document ID %1 is not registered for E-Document service %2.', Comment = '%1 = external document ID, %2 = service code';
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageRespRunner.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageRespRunner.Codeunit.al
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+codeunit 6538 "E-Doc. Message Resp. Runner"
+{
+    Access = Internal;
+    TableNo = "E-Document Message";
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnRun()
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.PollMessageResponse(Rec."Entry No.");
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageResponseJob.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageResponseJob.Codeunit.al
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using System.Telemetry;
+using System.Threading;
+
+codeunit 6539 "E-Doc. Message Response Job"
+{
+    Access = Internal;
+    TableNo = "Job Queue Entry";
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnRun()
+    var
+        EDocumentMessage: Record "E-Document Message";
+        Telemetry: Codeunit Telemetry;
+        TelemetryDimensions: Dictionary of [Text, Text];
+        LastErrorInfo: ErrorInfo;
+        LastErrorText: Text;
+    begin
+        EDocumentMessage.Get(Rec."Record ID to Process");
+        if Codeunit.Run(Codeunit::"E-Doc. Message Resp. Runner", EDocumentMessage) then
+            exit;
+
+        LastErrorText := GetLastErrorText();
+        LastErrorInfo := ErrorInfo.Create(LastErrorText);
+        EDocumentMessage.Get(EDocumentMessage."Entry No.");
+        EDocumentMessage.Status := EDocumentMessage.Status::"Response Error";
+        EDocumentMessage."Last Attempt At" := CurrentDateTime();
+        EDocumentMessage."Retry Count" += 1;
+        EDocumentMessage."Last Error" := CopyStr(LastErrorText, 1, MaxStrLen(EDocumentMessage."Last Error"));
+        EDocumentMessage.Modify();
+        TelemetryDimensions.Add('Message Entry No.', Format(EDocumentMessage."Entry No."));
+        TelemetryDimensions.Add('Message Type', Format(EDocumentMessage."Message Type"));
+        TelemetryDimensions.Add('Service', EDocumentMessage.Service);
+        TelemetryDimensions.Add('Retry Count', Format(EDocumentMessage."Retry Count"));
+        TelemetryDimensions.Add('Job Queue Entry ID', Format(Rec.ID));
+        Telemetry.LogMessage('0000LC8', MessageResponseFailureTelemetryLbl, Verbosity::Error, DataClassification::OrganizationIdentifiableInformation, TelemetryScope::All, TelemetryDimensions);
+        Commit();
+        Error(LastErrorInfo);
+    end;
+
+    var
+        MessageResponseFailureTelemetryLbl: Label 'E-Document child message response polling failed', Locked = true;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageSendJob.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageSendJob.Codeunit.al
@@ -1,0 +1,49 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using System.Telemetry;
+using System.Threading;
+
+codeunit 6535 "E-Doc. Message Send Job"
+{
+    Access = Internal;
+    TableNo = "Job Queue Entry";
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnRun()
+    var
+        EDocumentMessage: Record "E-Document Message";
+        Telemetry: Codeunit Telemetry;
+        TelemetryDimensions: Dictionary of [Text, Text];
+        LastErrorInfo: ErrorInfo;
+        LastErrorText: Text;
+    begin
+        EDocumentMessage.Get(Rec."Record ID to Process");
+        if Codeunit.Run(Codeunit::"E-Doc. Message Send Runner", EDocumentMessage) then
+            exit;
+
+        LastErrorText := GetLastErrorText();
+        LastErrorInfo := ErrorInfo.Create(LastErrorText);
+        EDocumentMessage.Get(EDocumentMessage."Entry No.");
+        EDocumentMessage.Status := EDocumentMessage.Status::Error;
+        EDocumentMessage."Last Attempt At" := CurrentDateTime();
+        EDocumentMessage."Retry Count" += 1;
+        EDocumentMessage."Last Error" := CopyStr(LastErrorText, 1, MaxStrLen(EDocumentMessage."Last Error"));
+        EDocumentMessage.Modify();
+        TelemetryDimensions.Add('Message Entry No.', Format(EDocumentMessage."Entry No."));
+        TelemetryDimensions.Add('Message Type', Format(EDocumentMessage."Message Type"));
+        TelemetryDimensions.Add('Service', EDocumentMessage.Service);
+        TelemetryDimensions.Add('Retry Count', Format(EDocumentMessage."Retry Count"));
+        TelemetryDimensions.Add('Job Queue Entry ID', Format(Rec.ID));
+        Telemetry.LogMessage('0000LC7', MessageSendFailureTelemetryLbl, Verbosity::Error, DataClassification::OrganizationIdentifiableInformation, TelemetryScope::All, TelemetryDimensions);
+        Commit();
+        Error(LastErrorInfo);
+    end;
+
+    var
+        MessageSendFailureTelemetryLbl: Label 'E-Document child message send failed', Locked = true;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageSendRunner.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMessageSendRunner.Codeunit.al
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+codeunit 6537 "E-Doc. Message Send Runner"
+{
+    Access = Internal;
+    TableNo = "E-Document Message";
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnRun()
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.SendMessage(Rec."Entry No.");
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMsgTransportDefault.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocMsgTransportDefault.Codeunit.al
@@ -1,0 +1,44 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Integration.Interfaces;
+
+codeunit 6534 "E-Doc. Msg. Transport Default" implements IMessageSender, IMessageResponseHandler
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    procedure SendMessage(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; MessageContext: Codeunit "E-Doc. Message Context")
+    var
+        MessageTransportErrorInfo: ErrorInfo;
+    begin
+        MessageTransportErrorInfo.Message := StrSubstNo(MessageTransportNotSupportedErr, EDocumentService.Code);
+        MessageTransportErrorInfo.DataClassification := DataClassification::SystemMetadata;
+        MessageTransportErrorInfo.RecordId := EDocumentService.RecordId;
+        MessageTransportErrorInfo.PageNo := Page::"E-Document Service";
+        MessageTransportErrorInfo.AddNavigationAction(ShowEDocumentServiceLbl);
+        Error(MessageTransportErrorInfo);
+    end;
+
+    procedure GetResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; MessageContext: Codeunit "E-Doc. Message Context"): Boolean
+    var
+        MessageTransportErrorInfo: ErrorInfo;
+    begin
+        MessageTransportErrorInfo.Message := StrSubstNo(MessageResponseNotSupportedErr, EDocumentService.Code);
+        MessageTransportErrorInfo.DataClassification := DataClassification::SystemMetadata;
+        MessageTransportErrorInfo.RecordId := EDocumentService.RecordId;
+        MessageTransportErrorInfo.PageNo := Page::"E-Document Service";
+        MessageTransportErrorInfo.AddNavigationAction(ShowEDocumentServiceLbl);
+        Error(MessageTransportErrorInfo);
+    end;
+
+    var
+        MessageTransportNotSupportedErr: Label 'E-Document service %1 does not support sending E-Document messages.', Comment = '%1 = E-Document service code';
+        MessageResponseNotSupportedErr: Label 'E-Document service %1 does not support polling E-Document message responses.', Comment = '%1 = E-Document service code';
+        ShowEDocumentServiceLbl: Label 'Open E-Document Service';
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccDispatcher.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccDispatcher.Codeunit.al
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+codeunit 6248 "E-Doc. Payment Occ. Dispatcher"
+{
+    Access = Internal;
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    Permissions = tabledata "E-Doc. Payment Occurrence" = rm;
+
+    trigger OnRun()
+    var
+        EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence";
+        EDocPaymentOccurrenceMgt: Codeunit "E-Doc. Payment Occurrence Mgt.";
+        EntryNo: Integer;
+    begin
+        EDocPaymentOccurrence.SetFilter(Status, '%1|%2|%3', EDocPaymentOccurrence.Status::Pending, EDocPaymentOccurrence.Status::Error, EDocPaymentOccurrence.Status::Processing);
+        EDocPaymentOccurrence.SetFilter("Next Attempt At", '%1|<=%2', 0DT, CurrentDateTime());
+        while EDocPaymentOccurrence.FindFirst() do begin
+            EntryNo := EDocPaymentOccurrence."Entry No.";
+            Commit();
+            if EDocPaymentOccurrence.Get(EntryNo) then
+                EDocPaymentOccurrenceMgt.ProcessPaymentOccurrence(EDocPaymentOccurrence);
+            EDocPaymentOccurrence.SetFilter(Status, '%1|%2|%3', EDocPaymentOccurrence.Status::Pending, EDocPaymentOccurrence.Status::Error, EDocPaymentOccurrence.Status::Processing);
+            EDocPaymentOccurrence.SetFilter("Next Attempt At", '%1|<=%2', 0DT, CurrentDateTime());
+        end;
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccRunner.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccRunner.Codeunit.al
@@ -1,0 +1,20 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+codeunit 6249 "E-Doc. Payment Occ. Runner"
+{
+    Access = Internal;
+    TableNo = "E-Doc. Payment Occurrence";
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    trigger OnRun()
+    var
+        EDocPaymentOccurrenceMgt: Codeunit "E-Doc. Payment Occurrence Mgt.";
+    begin
+        EDocPaymentOccurrenceMgt.NotifyPaymentOccurrence(Rec);
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccStatus.Enum.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccStatus.Enum.al
@@ -5,38 +5,27 @@
 namespace Microsoft.eServices.EDocument.Processing.Message;
 
 /// <summary>
-/// Operational status of an E-Document message record.
+/// Operational status of an E-Document payment occurrence.
 /// </summary>
-enum 6429 "E-Doc. Message Status"
+enum 6539 "E-Doc. Payment Occ. Status"
 {
-    Extensible = true;
+    Access = Public;
+    Extensible = false;
 
-    value(0; Created)
+    value(0; Pending)
     {
-        Caption = 'Created';
+        Caption = 'Pending';
     }
-    value(1; Sent)
+    value(1; Processed)
     {
-        Caption = 'Sent';
+        Caption = 'Processed';
     }
-    value(2; Queued)
-    {
-        Caption = 'Queued';
-    }
-    value(3; Error)
+    value(2; Error)
     {
         Caption = 'Error';
     }
-    value(4; Received)
+    value(3; Processing)
     {
-        Caption = 'Received';
-    }
-    value(5; "Pending Response")
-    {
-        Caption = 'Pending response';
-    }
-    value(6; "Response Error")
-    {
-        Caption = 'Response error';
+        Caption = 'Processing';
     }
 }

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccurrence.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccurrence.Table.al
@@ -1,0 +1,122 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using Microsoft.eServices.EDocument;
+
+/// <summary>
+/// Stores an immutable payment application or reversal associated with an outgoing E-Document.
+/// </summary>
+table 6433 "E-Doc. Payment Occurrence"
+{
+    Access = Public;
+    Caption = 'E-Document Payment Occurrence';
+    DataClassification = CustomerContent;
+    InherentEntitlements = RIMDX;
+    InherentPermissions = RIMDX;
+    ReplicateData = false;
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            AutoIncrement = true;
+            Caption = 'Entry No.';
+            DataClassification = SystemMetadata;
+        }
+        field(2; "E-Document Entry No."; Integer)
+        {
+            Caption = 'E-Document Entry No.';
+            DataClassification = SystemMetadata;
+            TableRelation = "E-Document"."Entry No";
+        }
+        field(3; Type; Enum "E-Doc. Payment Occurrence Type")
+        {
+            Caption = 'Type';
+            DataClassification = SystemMetadata;
+        }
+        field(4; "Source Occurrence ID"; Guid)
+        {
+            Caption = 'Source Occurrence ID';
+            DataClassification = SystemMetadata;
+        }
+        field(5; "Original Occurrence Entry No."; Integer)
+        {
+            Caption = 'Original Occurrence Entry No.';
+            DataClassification = SystemMetadata;
+            TableRelation = "E-Doc. Payment Occurrence"."Entry No.";
+        }
+        field(6; Amount; Decimal)
+        {
+            AutoFormatExpression = Rec."Currency Code";
+            AutoFormatType = 1;
+            Caption = 'Amount';
+            DataClassification = CustomerContent;
+        }
+        field(7; "Currency Code"; Code[10])
+        {
+            Caption = 'Currency Code';
+            DataClassification = CustomerContent;
+        }
+        field(8; "Event Date"; Date)
+        {
+            Caption = 'Event Date';
+            DataClassification = CustomerContent;
+        }
+        field(9; "Detailed Ledger Entry No."; Integer)
+        {
+            Caption = 'Detailed Ledger Entry No.';
+            DataClassification = SystemMetadata;
+        }
+        field(10; "Created At"; DateTime)
+        {
+            Caption = 'Created At';
+            DataClassification = SystemMetadata;
+        }
+        field(11; Status; Enum "E-Doc. Payment Occ. Status")
+        {
+            Caption = 'Status';
+            DataClassification = SystemMetadata;
+        }
+        field(12; "Last Attempt At"; DateTime)
+        {
+            Caption = 'Last Attempt At';
+            DataClassification = SystemMetadata;
+        }
+        field(13; "Retry Count"; Integer)
+        {
+            Caption = 'Retry Count';
+            DataClassification = SystemMetadata;
+        }
+        field(14; "Last Error"; Text[2048])
+        {
+            Caption = 'Last Error';
+            DataClassification = CustomerContent;
+        }
+        field(15; "Next Attempt At"; DateTime)
+        {
+            Caption = 'Next Attempt At';
+            DataClassification = SystemMetadata;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+        key(Occurrence; "E-Document Entry No.", "Source Occurrence ID", Type)
+        {
+            Unique = true;
+        }
+        key(Source; "Source Occurrence ID", Type)
+        {
+        }
+        key(Processing; Status, "Next Attempt At")
+        {
+        }
+    }
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccurrenceMgt.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccurrenceMgt.Codeunit.al
@@ -1,0 +1,212 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.Finance.GeneralLedger.Journal;
+using Microsoft.Finance.GeneralLedger.Posting;
+using Microsoft.Finance.ReceivablesPayables;
+using Microsoft.Sales.Customer;
+using Microsoft.Sales.History;
+using Microsoft.Sales.Receivables;
+using System.Threading;
+
+/// <summary>
+/// Captures payment applications and reversals for outgoing E-Documents and publishes them to localization apps.
+/// </summary>
+codeunit 6536 "E-Doc. Payment Occurrence Mgt."
+{
+    Access = Public;
+    TableNo = "Job Queue Entry";
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    Permissions =
+        tabledata "Cust. Ledger Entry" = r,
+        tabledata "Detailed Cust. Ledg. Entry" = r,
+        tabledata "E-Document" = r,
+        tabledata "E-Doc. Payment Occurrence" = rim,
+        tabledata "Sales Invoice Header" = r;
+
+    trigger OnRun()
+    var
+        EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence";
+    begin
+        EDocPaymentOccurrence.Get(Rec."Record ID to Process");
+        ProcessPaymentOccurrence(EDocPaymentOccurrence);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Gen. Jnl.-Post Line", 'OnAfterInsertDtldCustLedgEntry', '', false, false)]
+    local procedure OnAfterInsertDtldCustLedgEntry(var DtldCustLedgEntry: Record "Detailed Cust. Ledg. Entry"; GenJournalLine: Record "Gen. Journal Line"; DtldCVLedgEntryBuffer: Record "Detailed CV Ledg. Entry Buffer"; Offset: Integer)
+    begin
+        ProcessApplication(DtldCustLedgEntry);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Gen. Jnl.-Post Line", 'OnAfterInsertDtldCustLedgEntryUnapply', '', false, false)]
+    local procedure OnAfterInsertDtldCustLedgEntryUnapply(var CustomerPostingGroup: Record "Customer Posting Group"; var OldDetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry"; var GenJnlLine: Record "Gen. Journal Line"; var NewDetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry")
+    begin
+        ProcessUnapplication(OldDetailedCustLedgEntry, NewDetailedCustLedgEntry);
+    end;
+
+    /// <summary>
+    /// Captures an invoice payment application for every matching outgoing E-Document.
+    /// </summary>
+    /// <param name="DetailedCustLedgEntry">The detailed customer ledger application entry.</param>
+    procedure ProcessApplication(DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry")
+    var
+        EDocument: Record "E-Document";
+        InvoiceCustLedgerEntry: Record "Cust. Ledger Entry";
+        PaymentCustLedgerEntry: Record "Cust. Ledger Entry";
+    begin
+        if not IsInvoiceApplication(DetailedCustLedgEntry) then
+            exit;
+        if not InvoiceCustLedgerEntry.Get(DetailedCustLedgEntry."Cust. Ledger Entry No.") then
+            exit;
+        if not PaymentCustLedgerEntry.Get(DetailedCustLedgEntry."Applied Cust. Ledger Entry No.") then
+            exit;
+        if PaymentCustLedgerEntry."Document Type" <> PaymentCustLedgerEntry."Document Type"::Payment then
+            exit;
+        if not FindInvoiceEDocuments(EDocument, InvoiceCustLedgerEntry) then
+            exit;
+
+        repeat
+            CreateOccurrence(
+                EDocument."Entry No", "E-Doc. Payment Occurrence Type"::Applied, DetailedCustLedgEntry.SystemId,
+                -DetailedCustLedgEntry.Amount, DetailedCustLedgEntry."Currency Code", DetailedCustLedgEntry."Posting Date",
+                DetailedCustLedgEntry."Entry No.", 0);
+        until EDocument.Next() = 0;
+    end;
+
+    /// <summary>
+    /// Captures the reversal of each payment occurrence created from the original application entry.
+    /// </summary>
+    /// <param name="OldDetailedCustLedgEntry">The original detailed customer ledger application entry.</param>
+    /// <param name="NewDetailedCustLedgEntry">The detailed customer ledger reversal entry.</param>
+    procedure ProcessUnapplication(OldDetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry"; NewDetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry")
+    var
+        AppliedOccurrence: Record "E-Doc. Payment Occurrence";
+    begin
+        if not IsInvoiceApplication(OldDetailedCustLedgEntry) then
+            exit;
+
+        AppliedOccurrence.SetRange("Source Occurrence ID", OldDetailedCustLedgEntry.SystemId);
+        AppliedOccurrence.SetRange(Type, AppliedOccurrence.Type::Applied);
+        AppliedOccurrence.SetLoadFields("E-Document Entry No.", Amount, "Currency Code", "Entry No.");
+        if not AppliedOccurrence.FindSet() then
+            exit;
+
+        repeat
+            CreateOccurrence(
+                AppliedOccurrence."E-Document Entry No.", "E-Doc. Payment Occurrence Type"::Reversed, NewDetailedCustLedgEntry.SystemId,
+                -AppliedOccurrence.Amount, AppliedOccurrence."Currency Code", NewDetailedCustLedgEntry."Posting Date",
+                NewDetailedCustLedgEntry."Entry No.", AppliedOccurrence."Entry No.");
+        until AppliedOccurrence.Next() = 0;
+    end;
+
+    local procedure CreateOccurrence(EDocumentEntryNo: Integer; OccurrenceType: Enum "E-Doc. Payment Occurrence Type"; SourceOccurrenceID: Guid; Amount: Decimal; CurrencyCode: Code[10]; EventDate: Date; DetailedLedgerEntryNo: Integer; OriginalOccurrenceEntryNo: Integer)
+    var
+        EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence";
+    begin
+        EDocPaymentOccurrence.LockTable();
+        EDocPaymentOccurrence.SetRange("E-Document Entry No.", EDocumentEntryNo);
+        EDocPaymentOccurrence.SetRange("Source Occurrence ID", SourceOccurrenceID);
+        EDocPaymentOccurrence.SetRange(Type, OccurrenceType);
+        if not EDocPaymentOccurrence.IsEmpty() then
+            exit;
+
+        EDocPaymentOccurrence.Init();
+        EDocPaymentOccurrence."E-Document Entry No." := EDocumentEntryNo;
+        EDocPaymentOccurrence.Type := OccurrenceType;
+        EDocPaymentOccurrence."Source Occurrence ID" := SourceOccurrenceID;
+        EDocPaymentOccurrence."Original Occurrence Entry No." := OriginalOccurrenceEntryNo;
+        EDocPaymentOccurrence.Amount := Amount;
+        EDocPaymentOccurrence."Currency Code" := CurrencyCode;
+        EDocPaymentOccurrence."Event Date" := EventDate;
+        EDocPaymentOccurrence."Detailed Ledger Entry No." := DetailedLedgerEntryNo;
+        EDocPaymentOccurrence."Created At" := CurrentDateTime();
+        EDocPaymentOccurrence.Status := EDocPaymentOccurrence.Status::Pending;
+        EDocPaymentOccurrence.Insert();
+    end;
+
+    internal procedure ProcessPaymentOccurrence(var EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence")
+    var
+        LastErrorText: Text;
+    begin
+        EDocPaymentOccurrence.LockTable();
+        EDocPaymentOccurrence.Get(EDocPaymentOccurrence."Entry No.");
+        if (EDocPaymentOccurrence.Status = EDocPaymentOccurrence.Status::Processed) or
+           ((EDocPaymentOccurrence.Status = EDocPaymentOccurrence.Status::Processing) and
+            (EDocPaymentOccurrence."Next Attempt At" > CurrentDateTime()))
+        then
+            exit;
+
+        EDocPaymentOccurrence.Status := EDocPaymentOccurrence.Status::Processing;
+        EDocPaymentOccurrence."Last Attempt At" := CurrentDateTime();
+        EDocPaymentOccurrence."Next Attempt At" := CurrentDateTime() + RetryDelay();
+        EDocPaymentOccurrence.Modify();
+        Commit();
+        if Codeunit.Run(Codeunit::"E-Doc. Payment Occ. Runner", EDocPaymentOccurrence) then begin
+            EDocPaymentOccurrence.Get(EDocPaymentOccurrence."Entry No.");
+            EDocPaymentOccurrence.Status := EDocPaymentOccurrence.Status::Processed;
+            EDocPaymentOccurrence."Last Attempt At" := CurrentDateTime();
+            EDocPaymentOccurrence."Next Attempt At" := 0DT;
+            Clear(EDocPaymentOccurrence."Last Error");
+            EDocPaymentOccurrence.Modify();
+            exit;
+        end;
+
+        LastErrorText := GetLastErrorText();
+        EDocPaymentOccurrence.Get(EDocPaymentOccurrence."Entry No.");
+        EDocPaymentOccurrence.Status := EDocPaymentOccurrence.Status::Error;
+        EDocPaymentOccurrence."Last Attempt At" := CurrentDateTime();
+        EDocPaymentOccurrence."Retry Count" += 1;
+        EDocPaymentOccurrence."Next Attempt At" := CurrentDateTime() + RetryDelay();
+        EDocPaymentOccurrence."Last Error" := CopyStr(LastErrorText, 1, MaxStrLen(EDocPaymentOccurrence."Last Error"));
+        EDocPaymentOccurrence.Modify();
+        ClearLastError();
+    end;
+
+    internal procedure NotifyPaymentOccurrence(var EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence")
+    begin
+        OnAfterCreatePaymentOccurrence(EDocPaymentOccurrence);
+    end;
+
+    local procedure FindInvoiceEDocuments(var EDocument: Record "E-Document"; InvoiceCustLedgerEntry: Record "Cust. Ledger Entry"): Boolean
+    var
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+    begin
+        if InvoiceCustLedgerEntry."Document Type" <> InvoiceCustLedgerEntry."Document Type"::Invoice then
+            exit(false);
+        if not SalesInvoiceHeader.Get(InvoiceCustLedgerEntry."Document No.") then
+            exit(false);
+
+        EDocument.SetRange("Document Record ID", SalesInvoiceHeader.RecordId);
+        EDocument.SetRange(Direction, EDocument.Direction::Outgoing);
+        EDocument.SetRange("Document Type", EDocument."Document Type"::"Sales Invoice");
+        exit(EDocument.FindSet());
+    end;
+
+    local procedure IsInvoiceApplication(DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry"): Boolean
+    begin
+        exit(
+            (DetailedCustLedgEntry."Entry Type" = DetailedCustLedgEntry."Entry Type"::Application) and
+            (DetailedCustLedgEntry."Initial Document Type" = DetailedCustLedgEntry."Initial Document Type"::Invoice) and
+            (DetailedCustLedgEntry.Amount < 0));
+    end;
+
+    /// <summary>
+    /// Notifies localization and format apps after a payment occurrence has been persisted.
+    /// </summary>
+    /// <param name="EDocPaymentOccurrence">The persisted payment occurrence.</param>
+    [IntegrationEvent(false, false)]
+    procedure OnAfterCreatePaymentOccurrence(var EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence")
+    begin
+    end;
+
+    local procedure RetryDelay(): Duration
+    begin
+        exit(300000);
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccurrenceType.Enum.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocPaymentOccurrenceType.Enum.al
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+/// <summary>
+/// Identifies whether an E-Document payment occurrence applies or reverses an amount.
+/// </summary>
+enum 6115 "E-Doc. Payment Occurrence Type"
+{
+    Access = Public;
+    Extensible = false;
+
+    value(0; Applied)
+    {
+        Caption = 'Applied';
+    }
+    value(1; Reversed)
+    {
+        Caption = 'Reversed';
+    }
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessage.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessage.Table.al
@@ -69,6 +69,36 @@ table 6432 "E-Document Message"
             TableRelation = "E-Document Service";
             DataClassification = SystemMetadata;
         }
+        field(10; "Last Attempt At"; DateTime)
+        {
+            Caption = 'Last Attempt At';
+            DataClassification = SystemMetadata;
+        }
+        field(11; "Retry Count"; Integer)
+        {
+            Caption = 'Retry Count';
+            DataClassification = SystemMetadata;
+        }
+        field(12; "Last Error"; Text[2048])
+        {
+            Caption = 'Last Error';
+            DataClassification = CustomerContent;
+        }
+        field(13; "External Message ID"; Text[250])
+        {
+            Caption = 'External Message ID';
+            DataClassification = CustomerContent;
+        }
+        field(14; "External Document ID"; Text[250])
+        {
+            Caption = 'External Document ID';
+            DataClassification = CustomerContent;
+        }
+        field(15; "Received At"; DateTime)
+        {
+            Caption = 'Received At';
+            DataClassification = SystemMetadata;
+        }
     }
 
     keys
@@ -78,6 +108,9 @@ table 6432 "E-Document Message"
             Clustered = true;
         }
         key(EDocument; "E-Document Entry No.")
+        {
+        }
+        key(ExternalMessage; Service, "External Message ID")
         {
         }
     }

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessageAPI.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessageAPI.Codeunit.al
@@ -1,0 +1,152 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Processing.Message;
+
+using Microsoft.eServices.EDocument;
+using System.Utilities;
+
+codeunit 6532 "E-Document Message API"
+{
+    Access = Public;
+    InherentEntitlements = X;
+
+    /// <summary>
+    /// Creates an outgoing child message for an E-Document and stores its payload.
+    /// </summary>
+    /// <param name="EDocument">The parent E-Document.</param>
+    /// <param name="MessageType">The semantic message type.</param>
+    /// <param name="ResponseType">The response represented by the message.</param>
+    /// <param name="TempBlob">The message payload.</param>
+    /// <returns>The entry number of the created E-Document message.</returns>
+    procedure CreateMessage(EDocument: Record "E-Document"; MessageType: Enum "E-Document Message Type"; ResponseType: Enum "E-Doc. Response Type"; var TempBlob: Codeunit "Temp Blob"): Integer
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        exit(EDocMessageMgt.CreateMessage(EDocument, MessageType, EDocument.Direction::Outgoing, ResponseType, TempBlob));
+    end;
+
+    /// <summary>
+    /// Gets the parent E-Document of an E-Document message.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the E-Document message.</param>
+    /// <param name="EDocument">The parent E-Document.</param>
+    procedure GetMessageEDocument(MessageEntryNo: Integer; var EDocument: Record "E-Document")
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.GetMessageEDocument(MessageEntryNo, EDocument);
+    end;
+
+    /// <summary>
+    /// Gets the direction of an E-Document message.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the E-Document message.</param>
+    /// <returns>The message direction.</returns>
+    procedure GetMessageDirection(MessageEntryNo: Integer): Enum "E-Document Direction"
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        exit(EDocMessageMgt.GetMessageDirection(MessageEntryNo));
+    end;
+
+    /// <summary>
+    /// Gets the processing status of an E-Document message.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the E-Document message.</param>
+    /// <returns>The message processing status.</returns>
+    procedure GetMessageStatus(MessageEntryNo: Integer): Enum "E-Doc. Message Status"
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        exit(EDocMessageMgt.GetMessageStatus(MessageEntryNo));
+    end;
+
+    /// <summary>
+    /// Gets the response type represented by an E-Document message.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the E-Document message.</param>
+    /// <returns>The message response type.</returns>
+    procedure GetMessageResponseType(MessageEntryNo: Integer): Enum "E-Doc. Response Type"
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        exit(EDocMessageMgt.GetMessageResponseType(MessageEntryNo));
+    end;
+
+    /// <summary>
+    /// Sends a previously created outgoing E-Document message through its E-Document service.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the E-Document message to send.</param>
+    procedure SendMessage(MessageEntryNo: Integer)
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.SendMessage(MessageEntryNo);
+    end;
+
+    /// <summary>
+    /// Queues a previously created outgoing E-Document message for background transmission.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the E-Document message to queue.</param>
+    procedure QueueMessage(MessageEntryNo: Integer)
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.QueueMessage(MessageEntryNo);
+    end;
+
+    /// <summary>
+    /// Requeues a failed outgoing E-Document message for background transmission using its stored payload.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of the failed E-Document message to retry.</param>
+    procedure RetryMessage(MessageEntryNo: Integer)
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.RetryMessage(MessageEntryNo);
+    end;
+
+    /// <summary>
+    /// Polls the service for the asynchronous response to an outgoing child message.
+    /// </summary>
+    /// <param name="MessageEntryNo">The entry number of a message in Pending Response status.</param>
+    procedure PollMessageResponse(MessageEntryNo: Integer)
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.PollMessageResponse(MessageEntryNo);
+    end;
+
+    /// <summary>
+    /// Associates an external service document identifier with an E-Document for later message correlation.
+    /// </summary>
+    /// <param name="EDocument">The E-Document known by the external service.</param>
+    /// <param name="ServiceCode">The E-Document service that issued the identifier.</param>
+    /// <param name="ExternalDocumentID">The service-specific document identifier.</param>
+    procedure RegisterExternalDocumentReference(EDocument: Record "E-Document"; ServiceCode: Code[20]; ExternalDocumentID: Text[250])
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        EDocMessageMgt.RegisterExternalDocumentReference(EDocument, ServiceCode, ExternalDocumentID);
+    end;
+
+    /// <summary>
+    /// Stores an incoming child message and correlates it to an E-Document by service-specific identifiers.
+    /// </summary>
+    /// <param name="ServiceCode">The service from which the message was received.</param>
+    /// <param name="ExternalDocumentID">The external identifier of the parent document.</param>
+    /// <param name="ExternalMessageID">The external identifier used to deduplicate the message.</param>
+    /// <param name="MessageType">The semantic message type.</param>
+    /// <param name="ResponseType">The response represented by the message.</param>
+    /// <param name="ReceivedAt">The source timestamp, or zero to use the current date and time.</param>
+    /// <param name="TempBlob">The original message payload.</param>
+    /// <returns>The entry number of the new or previously stored E-Document message.</returns>
+    procedure CreateIncomingMessage(ServiceCode: Code[20]; ExternalDocumentID: Text[250]; ExternalMessageID: Text[250]; MessageType: Enum "E-Document Message Type"; ResponseType: Enum "E-Doc. Response Type"; ReceivedAt: DateTime; var TempBlob: Codeunit "Temp Blob"): Integer
+    var
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+    begin
+        exit(EDocMessageMgt.CreateIncomingMessage(ServiceCode, ExternalDocumentID, ExternalMessageID, MessageType, ResponseType, ReceivedAt, TempBlob));
+    end;
+}

--- a/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessagesFactBox.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Message/EDocumentMessagesFactBox.Page.al
@@ -53,6 +53,31 @@ page 6434 "E-Document Messages FactBox"
                     ApplicationArea = Basic, Suite;
                     ToolTip = 'Specifies when the message was created.';
                 }
+                field("Last Attempt At"; Rec."Last Attempt At")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies when the service last attempted to send the message.';
+                }
+                field("Retry Count"; Rec."Retry Count")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies how many background send attempts have failed.';
+                }
+                field("Last Error"; Rec."Last Error")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies the error returned by the most recent failed send attempt.';
+                }
+                field("External Message ID"; Rec."External Message ID")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies the identifier assigned to the message by the external service.';
+                }
+                field("Received At"; Rec."Received At")
+                {
+                    ApplicationArea = Basic, Suite;
+                    ToolTip = 'Specifies when the external service created or delivered the incoming message.';
+                }
             }
         }
     }
@@ -61,6 +86,23 @@ page 6434 "E-Document Messages FactBox"
     {
         area(processing)
         {
+            action(Retry)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Retry';
+                ToolTip = 'Retry the failed message transmission or response polling operation using its existing payload.';
+                Image = Refresh;
+                Scope = Repeater;
+                Enabled = RetryEnabled;
+
+                trigger OnAction()
+                var
+                    EDocumentMessageAPI: Codeunit "E-Document Message API";
+                begin
+                    EDocumentMessageAPI.RetryMessage(Rec."Entry No.");
+                    CurrPage.Update(false);
+                end;
+            }
             action(ViewXML)
             {
                 ApplicationArea = Basic, Suite;
@@ -87,7 +129,13 @@ page 6434 "E-Document Messages FactBox"
         }
     }
 
+    trigger OnAfterGetCurrRecord()
+    begin
+        RetryEnabled := (Rec.Direction = Rec.Direction::Outgoing) and (Rec.Status in [Rec.Status::Error, Rec.Status::"Response Error"]);
+    end;
+
     var
+        RetryEnabled: Boolean;
         FileNameTok: Label 'E-Document_%1_Response_%2.xml', Comment = '%1 = E-Document number, %2 = human-readable response type', Locked = true;
 
     local procedure BuildFileName(): Text

--- a/src/Apps/W1/EDocument/App/src/Setup/EDocumentUpgrade.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Setup/EDocumentUpgrade.Codeunit.al
@@ -74,5 +74,4 @@ codeunit 6168 "E-Document Upgrade"
     begin
         exit('MS-EDoc-ProcessDraftEnum-20260407');
     end;
-
 }

--- a/src/Apps/W1/EDocument/Test/src/Mock/EDocImplState.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Mock/EDocImplState.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.eServices.EDocument.Test;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Processing.Message;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.Document;
@@ -21,6 +22,7 @@ codeunit 139630 "E-Doc. Impl. State"
         PurchDocTestBuffer: Codeunit "E-Doc. Test Buffer";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
         EnableOnCheck, DisableOnCreateOutput, DisableOnCreateBatch, IsAsync2, EnableHttpData, ThrowIntegrationRuntimeError, ThrowIntegrationLoggedError : Boolean;
+        ThrowPaymentOccurrenceProcessingError: Boolean;
         ThrowRuntimeError, ThrowLoggedError, ThrowBasicInfoError, ThrowCompleteInfoError, OnGetResponseSuccess, OnGetApprovalSuccess, ActionHasUpdate : Boolean;
         LocalHttpResponse: HttpResponseMessage;
         ActionStatus: Enum "E-Document Service Status";
@@ -29,6 +31,13 @@ codeunit 139630 "E-Doc. Impl. State"
     local procedure OnAfterCreateEDocument(var EDocument: Record "E-Document")
     begin
         LibraryVariableStorage.Enqueue(EDocument);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"E-Doc. Payment Occurrence Mgt.", 'OnAfterCreatePaymentOccurrence', '', false, false)]
+    local procedure OnAfterCreatePaymentOccurrence(var EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence")
+    begin
+        if ThrowPaymentOccurrenceProcessingError then
+            Error('TEST PAYMENT OCCURRENCE PROCESSING');
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"E-Doc. Export", 'OnBeforeCreateEDocument', '', false, false)]
@@ -177,12 +186,6 @@ codeunit 139630 "E-Doc. Impl. State"
         IsAsync := IsAsync2;
         HttpResponse := LocalHttpResponse;
 
-        if ThrowIntegrationRuntimeError then
-            Error('TEST');
-
-        if ThrowIntegrationLoggedError then
-            EDocErrorHelper.LogSimpleErrorMessage(EDocument, 'TEST');
-
         if EnableHttpData then begin
             HttpRequest.SetRequestUri('http://cronus.test');
             HttpRequest.Method := 'POST';
@@ -191,6 +194,12 @@ codeunit 139630 "E-Doc. Impl. State"
             HttpResponse.Content.WriteFrom('Test response');
             HttpResponse.Headers.Add('Accept', '*');
         end;
+
+        if ThrowIntegrationRuntimeError then
+            Error('TEST');
+
+        if ThrowIntegrationLoggedError then
+            EDocErrorHelper.LogSimpleErrorMessage(EDocument, 'TEST');
 
     end;
 
@@ -226,12 +235,6 @@ codeunit 139630 "E-Doc. Impl. State"
         Success := OnGetResponseSuccess;
         HttpResponse := LocalHttpResponse;
 
-        if ThrowIntegrationRuntimeError then
-            Error('TEST');
-
-        if ThrowIntegrationLoggedError then
-            EDocErrorHelper.LogSimpleErrorMessage(EDocument, 'TEST');
-
         if EnableHttpData then begin
             HttpRequest.SetRequestUri('http://cronus.test');
             HttpRequest.Method := 'POST';
@@ -240,6 +243,12 @@ codeunit 139630 "E-Doc. Impl. State"
             HttpResponse.Content.WriteFrom('Test response');
             HttpResponse.Headers.Add('Accept', '*');
         end;
+
+        if ThrowIntegrationRuntimeError then
+            Error('TEST');
+
+        if ThrowIntegrationLoggedError then
+            EDocErrorHelper.LogSimpleErrorMessage(EDocument, 'TEST');
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"E-Doc. Integration Mock V2", OnReceiveDocuments, '', false, false)]
@@ -476,6 +485,11 @@ codeunit 139630 "E-Doc. Impl. State"
     internal procedure SetThrowIntegrationRuntimeError()
     begin
         ThrowIntegrationRuntimeError := true;
+    end;
+
+    internal procedure SetThrowPaymentOccurrenceProcessingError()
+    begin
+        ThrowPaymentOccurrenceProcessingError := true;
     end;
 
     internal procedure SetHttpResponse(HttpResponse: HttpResponseMessage)

--- a/src/Apps/W1/EDocument/Test/src/Mock/EDocIntegrationMockV2.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Mock/EDocIntegrationMockV2.Codeunit.al
@@ -8,9 +8,10 @@ using Microsoft.eServices.EDocument;
 using Microsoft.eServices.EDocument.Integration.Interfaces;
 using Microsoft.eServices.EDocument.Integration.Receive;
 using Microsoft.eServices.EDocument.Integration.Send;
+using Microsoft.eServices.EDocument.Processing.Message;
 using System.Utilities;
 
-codeunit 139658 "E-Doc. Integration Mock V2" implements IDocumentSender, IDocumentReceiver, IDocumentResponseHandler, ISentDocumentActions, IConsentManager
+codeunit 139658 "E-Doc. Integration Mock V2" implements IDocumentSender, IDocumentReceiver, IDocumentResponseHandler, ISentDocumentActions, IConsentManager, IMessageSender, IMessageResponseHandler
 {
 
     Access = Internal;
@@ -35,6 +36,31 @@ codeunit 139658 "E-Doc. Integration Mock V2" implements IDocumentSender, IDocume
     begin
         OnGetResponse(EDocument, SendContext.Http().GetHttpRequestMessage(), SendContext.Http().GetHttpResponseMessage(), Success);
         exit(Success);
+    end;
+
+    procedure GetResponse(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; MessageContext: Codeunit "E-Doc. Message Context"): Boolean
+    var
+        ResponseReceived: Boolean;
+    begin
+        OnGetResponse(EDocument, MessageContext.Http().GetHttpRequestMessage(), MessageContext.Http().GetHttpResponseMessage(), ResponseReceived);
+        if ResponseReceived then
+            MessageContext.Status().SetStatus("E-Document Service Status"::Sent)
+        else
+            MessageContext.Status().SetStatus("E-Document Service Status"::"Pending Response");
+        exit(ResponseReceived);
+    end;
+
+    procedure SendMessage(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; MessageContext: Codeunit "E-Doc. Message Context")
+    var
+        TempBlob: Codeunit "Temp Blob";
+        IsAsync: Boolean;
+    begin
+        TempBlob := MessageContext.GetTempBlob();
+        OnSend(EDocument, EDocumentService, TempBlob, IsAsync, MessageContext.Http().GetHttpRequestMessage(), MessageContext.Http().GetHttpResponseMessage());
+        if IsAsync then
+            MessageContext.Status().SetStatus("E-Document Service Status"::"Pending Response")
+        else
+            MessageContext.Status().SetStatus("E-Document Service Status"::Sent);
     end;
 
     procedure ReceiveDocuments(var EDocumentService: Record "E-Document Service"; DocumentsMetadata: Codeunit "Temp Blob List"; ReceiveContext: Codeunit ReceiveContext)

--- a/src/Apps/W1/EDocument/Test/src/Mock/EDocIntegrationMockV2.EnumExt.al
+++ b/src/Apps/W1/EDocument/Test/src/Mock/EDocIntegrationMockV2.EnumExt.al
@@ -12,7 +12,7 @@ enumextension 139617 "E-Doc Integration Mock V2" extends "Service Integration"
 
     value(133501; "Mock")
     {
-        Implementation = IDocumentSender = "E-Doc. Integration Mock V2", IDocumentReceiver = "E-Doc. Integration Mock V2", IConsentManager = "E-Doc. Integration Mock V2";
+        Implementation = IDocumentSender = "E-Doc. Integration Mock V2", IDocumentReceiver = "E-Doc. Integration Mock V2", IConsentManager = "E-Doc. Integration Mock V2", IMessageSender = "E-Doc. Integration Mock V2", IMessageResponseHandler = "E-Doc. Integration Mock V2";
     }
     value(133502; "Mock Sync")
     {

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocMessageMgtTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocMessageMgtTests.Codeunit.al
@@ -1,0 +1,543 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.eServices.EDocument.Test;
+
+using Microsoft.eServices.EDocument;
+using Microsoft.eServices.EDocument.Integration;
+using Microsoft.eServices.EDocument.Processing.Message;
+using Microsoft.Sales.Customer;
+using Microsoft.Sales.History;
+using Microsoft.Sales.Receivables;
+using System.Threading;
+using System.Utilities;
+
+codeunit 139898 "E-Doc. Message Mgt. Tests"
+{
+    Subtype = Test;
+    TestType = IntegrationTest;
+    TestPermissions = Disabled;
+
+    var
+        EDocumentService: Record "E-Document Service";
+        Assert: Codeunit Assert;
+        EDocImplState: Codeunit "E-Doc. Impl. State";
+        LibraryEDoc: Codeunit "Library - E-Document";
+        LibraryLowerPermission: Codeunit "Library - Lower Permissions";
+        IsInitialized: Boolean;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure QueueMessageSchedulesBackgroundSend()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        JobQueueEntry: Record "Job Queue Entry";
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] Queueing an outgoing E-Document message schedules its background send job
+        Initialize(Customer);
+
+        // [GIVEN] A created outgoing E-Document message
+        CreateOutgoingEDocument(EDocument);
+        TempBlob.CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText('<Message />');
+        MessageEntryNo := EDocMessageMgt.CreateMessage(
+            EDocument, "E-Document Message Type"::Unknown, "E-Document Direction"::Outgoing,
+            "E-Doc. Response Type"::None, TempBlob);
+
+        // [WHEN] The message is queued
+        EDocMessageMgt.QueueMessage(MessageEntryNo);
+
+        // [THEN] The message is marked Queued and a send job is scheduled for it
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual("E-Doc. Message Status"::Queued, EDocMessage.Status, 'The message must be queued.');
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"E-Doc. Message Send Job");
+        JobQueueEntry.SetRange("Record ID to Process", EDocMessage.RecordId());
+        Assert.RecordCount(JobQueueEntry, 1);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure RetryMessageRequeuesExistingMessage()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        JobQueueEntry: Record "Job Queue Entry";
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+        EDocumentMessageAPI: Codeunit "E-Document Message API";
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+        DataStorageEntryNo: Integer;
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 647423] Retrying a failed outgoing message requeues the existing message without duplication
+        Initialize(Customer);
+
+        // [GIVEN] A failed outgoing E-Document message with a stored payload
+        CreateOutgoingEDocument(EDocument);
+        TempBlob.CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText('<Message />');
+        MessageEntryNo := EDocMessageMgt.CreateMessage(
+            EDocument, "E-Document Message Type"::Unknown, "E-Document Direction"::Outgoing,
+            "E-Doc. Response Type"::None, TempBlob);
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.Status := EDocMessage.Status::Error;
+        EDocMessage."Last Error" := 'Temporary transport failure';
+        EDocMessage.Modify();
+        DataStorageEntryNo := EDocMessage."Data Storage Entry No.";
+
+        // [WHEN] The failed message is retried
+        EDocumentMessageAPI.RetryMessage(MessageEntryNo);
+
+        // [THEN] The same message and payload are queued with one background send job
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual("E-Doc. Message Status"::Queued, EDocMessage.Status, 'The existing message must be requeued.');
+        Assert.AreEqual(DataStorageEntryNo, EDocMessage."Data Storage Entry No.", 'Retry must reuse the stored message payload.');
+        Assert.RecordCount(EDocMessage, 1);
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"E-Doc. Message Send Job");
+        JobQueueEntry.SetRange("Record ID to Process", EDocMessage.RecordId());
+        Assert.RecordCount(JobQueueEntry, 1);
+    end;
+
+    [Test]
+    procedure RetryMessageRejectsMessageWithoutError()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocumentMessageAPI: Codeunit "E-Document Message API";
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 647423] Retry rejects an outgoing message that is not in Error status
+        Initialize(Customer);
+
+        // [GIVEN] A newly created outgoing E-Document message
+        CreateOutgoingEDocument(EDocument);
+        TempBlob.CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText('<Message />');
+        MessageEntryNo := EDocMessageMgt.CreateMessage(
+            EDocument, "E-Document Message Type"::Unknown, "E-Document Direction"::Outgoing,
+            "E-Doc. Response Type"::None, TempBlob);
+
+        // [WHEN] The message is retried
+        asserterror EDocumentMessageAPI.RetryMessage(MessageEntryNo);
+
+        // [THEN] Retry is rejected because the message has not failed
+        Assert.ExpectedError('Status must be equal to ''Error''');
+    end;
+
+    [Test]
+    procedure RetryMessageRejectsIncomingMessage()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        EDocumentMessageAPI: Codeunit "E-Document Message API";
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 647423] Retry rejects a failed incoming message
+        Initialize(Customer);
+
+        // [GIVEN] A failed incoming E-Document message
+        CreateOutgoingEDocument(EDocument);
+        TempBlob.CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText('<Message />');
+        MessageEntryNo := EDocMessageMgt.CreateMessage(
+            EDocument, "E-Document Message Type"::Unknown, "E-Document Direction"::Incoming,
+            "E-Doc. Response Type"::None, TempBlob);
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.Status := EDocMessage.Status::Error;
+        EDocMessage.Modify();
+
+        // [WHEN] The incoming message is retried
+        asserterror EDocumentMessageAPI.RetryMessage(MessageEntryNo);
+
+        // [THEN] Retry is rejected because only outgoing messages can be sent
+        Assert.ExpectedError('Direction must be equal to ''Outgoing''');
+    end;
+
+    [Test]
+    procedure PollMessageResponseCompletesPendingMessage()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        EDocumentMessageAPI: Codeunit "E-Document Message API";
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] A completed asynchronous response marks the existing child message as Sent.
+        Initialize(Customer);
+
+        // [GIVEN] An outgoing child message waiting for a connector response
+        CreateOutgoingEDocument(EDocument);
+        MessageEntryNo := CreatePendingMessage(EDocument);
+        BindSubscription(EDocImplState);
+        EDocImplState.SetOnGetResponseSuccess();
+
+        // [WHEN] The connector reports that the response is complete
+        EDocumentMessageAPI.PollMessageResponse(MessageEntryNo);
+        UnbindSubscription(EDocImplState);
+
+        // [THEN] The existing child message is marked Sent
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual(EDocMessage.Status::Sent, EDocMessage.Status, 'The completed message must be Sent.');
+        Assert.AreNotEqual(0DT, EDocMessage."Last Attempt At", 'The polling attempt time must be stored.');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure PollMessageResponseReschedulesPendingMessage()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        JobQueueEntry: Record "Job Queue Entry";
+        EDocumentMessageAPI: Codeunit "E-Document Message API";
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] An incomplete asynchronous response remains pending and schedules another poll.
+        Initialize(Customer);
+
+        // [GIVEN] An outgoing child message waiting for a connector response
+        CreateOutgoingEDocument(EDocument);
+        MessageEntryNo := CreatePendingMessage(EDocument);
+        BindSubscription(EDocImplState);
+
+        // [WHEN] The connector reports that the response is still pending
+        EDocumentMessageAPI.PollMessageResponse(MessageEntryNo);
+        UnbindSubscription(EDocImplState);
+
+        // [THEN] The message remains pending and one response job is scheduled
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual(EDocMessage.Status::"Pending Response", EDocMessage.Status, 'The message must remain pending.');
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"E-Doc. Message Response Job");
+        JobQueueEntry.SetRange("Record ID to Process", EDocMessage.RecordId());
+        Assert.RecordCount(JobQueueEntry, 1);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure PollMessageResponseJobStoresConnectorError()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocumentIntegrationLog: Record "E-Document Integration Log";
+        EDocMessage: Record "E-Document Message";
+        JobQueueEntry: Record "Job Queue Entry";
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] A connector polling failure is persisted on the existing child message.
+        Initialize(Customer);
+
+        // [GIVEN] A pending child message and a connector that raises a runtime error
+        CreateOutgoingEDocument(EDocument);
+        MessageEntryNo := CreatePendingMessage(EDocument);
+        EDocMessage.Get(MessageEntryNo);
+        JobQueueEntry."Record ID to Process" := EDocMessage.RecordId();
+        BindSubscription(EDocImplState);
+        EDocImplState.SetEnableHttpData();
+        EDocImplState.SetThrowIntegrationRuntimeError();
+        Commit();
+
+        // [WHEN] The response polling background job runs
+        Assert.IsFalse(Codeunit.Run(Codeunit::"E-Doc. Message Response Job", JobQueueEntry), 'The polling job must report the connector failure.');
+        UnbindSubscription(EDocImplState);
+
+        // [THEN] The existing message contains response-error diagnostics
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual(EDocMessage.Status::"Response Error", EDocMessage.Status, 'The message must have a response error.');
+        Assert.AreEqual(1, EDocMessage."Retry Count", 'The failed polling attempt must increment the retry count.');
+        Assert.IsTrue(EDocMessage."Last Error".Contains('TEST'), 'The connector error must be stored.');
+        EDocumentIntegrationLog.SetRange("E-Doc. Entry No", EDocument."Entry No");
+        Assert.RecordCount(EDocumentIntegrationLog, 1);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure SendMessageJobStoresConnectorErrorAndIntegrationLog()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocumentIntegrationLog: Record "E-Document Integration Log";
+        EDocMessage: Record "E-Document Message";
+        JobQueueEntry: Record "Job Queue Entry";
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO 647423] A failed child-message send retains diagnostics and the HTTP exchange
+        Initialize(Customer);
+
+        // [GIVEN] Queued message "M" and a connector that records HTTP data before failing
+        CreateOutgoingEDocument(EDocument);
+        TempBlob.CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText('<Message />');
+        MessageEntryNo := EDocMessageMgt.CreateMessage(
+            EDocument, "E-Document Message Type"::Unknown, "E-Document Direction"::Outgoing,
+            "E-Doc. Response Type"::None, TempBlob);
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.Status := EDocMessage.Status::Queued;
+        EDocMessage.Modify();
+        JobQueueEntry."Record ID to Process" := EDocMessage.RecordId();
+        BindSubscription(EDocImplState);
+        EDocImplState.SetEnableHttpData();
+        EDocImplState.SetThrowIntegrationRuntimeError();
+        Commit();
+
+        // [WHEN] The message send background job runs
+        Assert.IsFalse(Codeunit.Run(Codeunit::"E-Doc. Message Send Job", JobQueueEntry), 'The send job must report the connector failure.');
+        UnbindSubscription(EDocImplState);
+
+        // [THEN] Message "M" contains diagnostics and its HTTP exchange is retained
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual(EDocMessage.Status::Error, EDocMessage.Status, 'The message must have a send error.');
+        Assert.AreEqual(1, EDocMessage."Retry Count", 'The failed send attempt must increment the retry count.');
+        Assert.IsTrue(EDocMessage."Last Error".Contains('TEST'), 'The connector error must be stored.');
+        EDocumentIntegrationLog.SetRange("E-Doc. Entry No", EDocument."Entry No");
+        Assert.RecordCount(EDocumentIntegrationLog, 1);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
+    procedure RetryMessageReschedulesFailedResponsePoll()
+    var
+        Customer: Record Customer;
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        JobQueueEntry: Record "Job Queue Entry";
+        EDocumentMessageAPI: Codeunit "E-Document Message API";
+        MessageEntryNo: Integer;
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] Retrying a response error schedules polling instead of resending the child message.
+        Initialize(Customer);
+
+        // [GIVEN] An outgoing child message whose response polling failed
+        CreateOutgoingEDocument(EDocument);
+        MessageEntryNo := CreatePendingMessage(EDocument);
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.Status := EDocMessage.Status::"Response Error";
+        EDocMessage.Modify();
+
+        // [WHEN] The failed message is retried
+        EDocumentMessageAPI.RetryMessage(MessageEntryNo);
+
+        // [THEN] The message is pending and only a response polling job is scheduled
+        EDocMessage.Get(MessageEntryNo);
+        Assert.AreEqual(EDocMessage.Status::"Pending Response", EDocMessage.Status, 'Retry must restore Pending Response status.');
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"E-Doc. Message Response Job");
+        JobQueueEntry.SetRange("Record ID to Process", EDocMessage.RecordId());
+        Assert.RecordCount(JobQueueEntry, 1);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"E-Doc. Message Send Job");
+        Assert.RecordCount(JobQueueEntry, 0);
+    end;
+
+    [Test]
+    procedure PaymentOccurrenceDispatcherProcessesPendingCapture()
+    var
+        Customer: Record Customer;
+        DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry";
+        EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence";
+        EDocument: Record "E-Document";
+        EDocPaymentOccurrenceDispatcher: Codeunit "E-Doc. Payment Occ. Dispatcher";
+        EDocPaymentOccurrenceMgt: Codeunit "E-Doc. Payment Occurrence Mgt.";
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] The recurrent dispatcher processes a pending payment occurrence
+        Initialize(Customer);
+
+        // [GIVEN] An outgoing invoice E-Document and a payment application
+        CreatePaymentOccurrenceScenario(EDocument, DetailedCustLedgEntry);
+
+        // [WHEN] The payment application is captured
+        EDocPaymentOccurrenceMgt.ProcessApplication(DetailedCustLedgEntry);
+
+        // [THEN] The occurrence remains pending for the dispatcher without retry metadata
+        EDocPaymentOccurrence.SetRange("E-Document Entry No.", EDocument."Entry No");
+        EDocPaymentOccurrence.FindFirst();
+        Assert.AreEqual(EDocPaymentOccurrence.Status::Pending, EDocPaymentOccurrence.Status, 'A captured occurrence must remain pending for the dispatcher.');
+        Assert.AreEqual(0, EDocPaymentOccurrence."Retry Count", 'A pending occurrence must not have a retry count.');
+        Assert.AreEqual('', EDocPaymentOccurrence."Last Error", 'A pending occurrence must not contain an error.');
+
+        // [WHEN] The recurrent dispatcher runs
+        EDocPaymentOccurrenceDispatcher.Run();
+
+        // [THEN] The occurrence is processed
+        EDocPaymentOccurrence.Get(EDocPaymentOccurrence."Entry No.");
+        Assert.AreEqual(EDocPaymentOccurrence.Status::Processed, EDocPaymentOccurrence.Status, 'The dispatcher must process a pending occurrence.');
+    end;
+
+    [Test]
+    procedure PaymentOccurrenceDispatcherRetriesFailedProcessing()
+    var
+        Customer: Record Customer;
+        DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry";
+        EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence";
+        EDocument: Record "E-Document";
+        EDocPaymentOccurrenceDispatcher: Codeunit "E-Doc. Payment Occ. Dispatcher";
+        EDocPaymentOccurrenceMgt: Codeunit "E-Doc. Payment Occurrence Mgt.";
+    begin
+        // [FEATURE] [AI test]
+        // [SCENARIO] A failed payment occurrence is retained and processed by the dispatcher retry
+        Initialize(Customer);
+
+        // [GIVEN] A persisted payment occurrence whose localization processing fails
+        CreatePaymentOccurrenceScenario(EDocument, DetailedCustLedgEntry);
+        EDocPaymentOccurrenceMgt.ProcessApplication(DetailedCustLedgEntry);
+        EDocPaymentOccurrence.SetRange("E-Document Entry No.", EDocument."Entry No");
+        EDocPaymentOccurrence.FindFirst();
+        EDocImplState.SetThrowPaymentOccurrenceProcessingError();
+        BindSubscription(EDocImplState);
+        EDocPaymentOccurrenceMgt.ProcessPaymentOccurrence(EDocPaymentOccurrence);
+        UnbindSubscription(EDocImplState);
+        EDocPaymentOccurrence.Get(EDocPaymentOccurrence."Entry No.");
+        Assert.AreEqual(EDocPaymentOccurrence.Status::Error, EDocPaymentOccurrence.Status, 'Failed processing must leave the occurrence in Error.');
+        Assert.AreEqual(1, EDocPaymentOccurrence."Retry Count", 'Failed processing must increment the retry count.');
+        EDocPaymentOccurrence."Next Attempt At" := 0DT;
+        EDocPaymentOccurrence.Modify();
+
+        // [WHEN] The recurrent dispatcher retries the occurrence
+        EDocPaymentOccurrenceDispatcher.Run();
+
+        // [THEN] The occurrence is marked processed and its error is cleared
+        EDocPaymentOccurrence.Get(EDocPaymentOccurrence."Entry No.");
+        Assert.AreEqual(EDocPaymentOccurrence.Status::Processed, EDocPaymentOccurrence.Status, 'A successful retry must mark the occurrence Processed.');
+        Assert.AreEqual('', EDocPaymentOccurrence."Last Error", 'A successful retry must clear the previous error.');
+    end;
+
+    local procedure Initialize(var Customer: Record Customer)
+    var
+        EDocument: Record "E-Document";
+        EDocMessage: Record "E-Document Message";
+        EDocPaymentOccurrence: Record "E-Doc. Payment Occurrence";
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        if UnbindSubscription(EDocImplState) then;
+        Clear(EDocImplState);
+        LibraryLowerPermission.SetOutsideO365Scope();
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetFilter("Object ID to Run", '%1|%2', Codeunit::"E-Doc. Message Send Job", Codeunit::"E-Doc. Message Response Job");
+        JobQueueEntry.DeleteAll();
+        EDocMessage.DeleteAll();
+        EDocPaymentOccurrence.DeleteAll();
+        EDocument.DeleteAll();
+
+        if not IsInitialized then begin
+            LibraryEDoc.SetupStandardVAT();
+            IsInitialized := true;
+        end;
+
+        EDocumentService.DeleteAll();
+        LibraryEDoc.SetupStandardSalesScenario(
+            Customer, EDocumentService, Enum::"E-Document Format"::Mock, Enum::"Service Integration"::Mock);
+    end;
+
+    local procedure CreatePaymentOccurrenceScenario(var EDocument: Record "E-Document"; var DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry")
+    var
+        InvoiceCustLedgerEntry: Record "Cust. Ledger Entry";
+        PaymentCustLedgerEntry: Record "Cust. Ledger Entry";
+        SalesInvoiceHeader: Record "Sales Invoice Header";
+    begin
+        SalesInvoiceHeader.Init();
+        SalesInvoiceHeader."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(SalesInvoiceHeader."No."));
+        SalesInvoiceHeader.Insert();
+        EDocument.Init();
+        EDocument."Document No." := SalesInvoiceHeader."No.";
+        EDocument."Document Record ID" := SalesInvoiceHeader.RecordId;
+        EDocument.Direction := EDocument.Direction::Outgoing;
+        EDocument."Document Type" := EDocument."Document Type"::"Sales Invoice";
+        EDocument.Insert();
+        InvoiceCustLedgerEntry.Init();
+        InvoiceCustLedgerEntry."Entry No." := GetUnusedCustLedgerEntryNo();
+        InvoiceCustLedgerEntry."Document Type" := InvoiceCustLedgerEntry."Document Type"::Invoice;
+        InvoiceCustLedgerEntry."Document No." := SalesInvoiceHeader."No.";
+        InvoiceCustLedgerEntry.Insert();
+        PaymentCustLedgerEntry.Init();
+        PaymentCustLedgerEntry."Entry No." := GetUnusedCustLedgerEntryNo();
+        PaymentCustLedgerEntry."Document Type" := PaymentCustLedgerEntry."Document Type"::Payment;
+        PaymentCustLedgerEntry.Insert();
+        DetailedCustLedgEntry.Init();
+        DetailedCustLedgEntry."Entry No." := GetUnusedDetailedCustLedgerEntryNo();
+        DetailedCustLedgEntry."Cust. Ledger Entry No." := InvoiceCustLedgerEntry."Entry No.";
+        DetailedCustLedgEntry."Applied Cust. Ledger Entry No." := PaymentCustLedgerEntry."Entry No.";
+        DetailedCustLedgEntry."Entry Type" := DetailedCustLedgEntry."Entry Type"::Application;
+        DetailedCustLedgEntry."Initial Document Type" := DetailedCustLedgEntry."Initial Document Type"::Invoice;
+        DetailedCustLedgEntry.Amount := -100;
+        DetailedCustLedgEntry.SystemId := CreateGuid();
+        DetailedCustLedgEntry.Insert();
+    end;
+
+    local procedure GetUnusedCustLedgerEntryNo(): Integer
+    var
+        CustLedgerEntry: Record "Cust. Ledger Entry";
+        EntryNo: Integer;
+    begin
+        EntryNo := -1;
+        while CustLedgerEntry.Get(EntryNo) do
+            EntryNo -= 1;
+        exit(EntryNo);
+    end;
+
+    local procedure GetUnusedDetailedCustLedgerEntryNo(): Integer
+    var
+        DetailedCustLedgEntry: Record "Detailed Cust. Ledg. Entry";
+        EntryNo: Integer;
+    begin
+        EntryNo := -1;
+        while DetailedCustLedgEntry.Get(EntryNo) do
+            EntryNo -= 1;
+        exit(EntryNo);
+    end;
+
+    local procedure CreateOutgoingEDocument(var EDocument: Record "E-Document")
+    begin
+        EDocument.Init();
+        EDocument.Direction := EDocument.Direction::Outgoing;
+        EDocument.Service := EDocumentService.Code;
+        EDocument.Insert();
+    end;
+
+    local procedure CreatePendingMessage(EDocument: Record "E-Document"): Integer
+    var
+        EDocMessage: Record "E-Document Message";
+        EDocMessageMgt: Codeunit "E-Doc. Message Mgt.";
+        TempBlob: Codeunit "Temp Blob";
+        OutStream: OutStream;
+        MessageEntryNo: Integer;
+    begin
+        TempBlob.CreateOutStream(OutStream, TextEncoding::UTF8);
+        OutStream.WriteText('<Message />');
+        MessageEntryNo := EDocMessageMgt.CreateMessage(
+            EDocument, "E-Document Message Type"::Unknown, "E-Document Direction"::Outgoing,
+            "E-Doc. Response Type"::None, TempBlob);
+        EDocMessage.Get(MessageEntryNo);
+        EDocMessage.Status := EDocMessage.Status::"Pending Response";
+        EDocMessage.Modify();
+        exit(MessageEntryNo);
+    end;
+}

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocMessageResponseTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocMessageResponseTests.Codeunit.al
@@ -11,7 +11,7 @@ using Microsoft.Peppol.Response;
 using Microsoft.Sales.Customer;
 using System.Utilities;
 
-codeunit 139898 "E-Doc. Message Response Tests"
+codeunit 139864 "E-Doc. Message Response Tests"
 {
     Subtype = Test;
     TestType = IntegrationTest;


### PR DESCRIPTION
## Why

PR #10946 was reverted after the FR app was identified as NAV-inline for releases/28.x. The reusable W1 E-Document lifecycle infrastructure still belongs in BCApps and is required by the French implementation.

## Summary

- **Restored** the public message transport, payload, processing, queueing, response polling, and retry infrastructure in E-Document Core.
- **Restored** payment-occurrence tracking, external references, permissions, background jobs, and focused W1 tests.
- **Excluded** all French E-Reporting app changes so they can be delivered separately in NAV.

Related to [AB#648771](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648771)

