### PR TITLE
[28.x] Backport PEPPOL onboarding and E-Document fixes

### DIFF
--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
@@ -26,34 +26,40 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         ServiceInvoiceHeader: Record "Service Invoice Header";
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
-        PEPPOLValidation: Codeunit "PEPPOL30 Sales Validation";
-        PEPPOLServiceValidation: Codeunit "PEPPOL30 Service Validation";
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+        SalesValidation: Interface "PEPPOL30 Validation";
+        ServiceValidation: Interface "PEPPOL30 Validation";
     begin
+        PeppolSetup.GetSetup();
+        SalesValidation := PeppolSetup."PEPPOL 3.0 Sales Format";
+        ServiceValidation := PeppolSetup."PEPPOL 3.0 Service Format";
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesHeader);
-                    PEPPOLValidation.Run(SalesHeader);
+                    SalesValidation.ValidateDocument(SalesHeader);
+                    SalesValidation.ValidateDocumentLines(SalesHeader);
                 end;
             Database::"Sales Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesInvoiceHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesInvoiceHeader);
+                    SalesValidation.ValidatePostedDocument(SalesInvoiceHeader);
                 end;
             Database::"Sales Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesCrMemoHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesCrMemoHeader);
+                    SalesValidation.ValidatePostedDocument(SalesCrMemoHeader);
                 end;
             Database::"Service Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceInvoiceHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
                 end;
             Database::"Service Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceCrMemoHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
                 end;
         end;
     end;

--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -25,35 +25,39 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
         ReminderHeader: Record "Reminder Header";
         FinChargeMemoHeader: Record "Finance Charge Memo Header";
-        PEPPOLValidation: Codeunit "PEPPOL30 Sales Validation";
-        PEPPOLServiceValidation: Codeunit "PEPPOL30 Service Validation";
         EDocPEPPOLValidation: Codeunit "E-Doc. PEPPOL Validation";
+        SalesValidation: Interface "PEPPOL30 Validation";
+        ServiceValidation: Interface "PEPPOL30 Validation";
     begin
+        SalesValidation := GetSalesFormat();
+        ServiceValidation := GetServiceFormat();
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesHeader);
-                    PEPPOLValidation.Run(SalesHeader);
+                    SalesValidation.ValidateDocument(SalesHeader);
+                    SalesValidation.ValidateDocumentLines(SalesHeader);
                 end;
             Database::"Sales Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesInvoiceHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesInvoiceHeader);
+                    SalesValidation.ValidatePostedDocument(SalesInvoiceHeader);
                 end;
             Database::"Sales Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesCrMemoHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesCrMemoHeader);
+                    SalesValidation.ValidatePostedDocument(SalesCrMemoHeader);
                 end;
             Database::"Service Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceInvoiceHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
                 end;
             Database::"Service Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceCrMemoHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
                 end;
             Database::"Reminder Header":
                 begin
@@ -68,7 +72,8 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
             Database::"Service Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceHeader);
-                    PEPPOLServiceValidation.Run(ServiceHeader);
+                    ServiceValidation.ValidateDocument(ServiceHeader);
+                    ServiceValidation.ValidateDocumentLines(ServiceHeader);
                 end;
         end;
     end;
@@ -80,10 +85,14 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
     begin
         TempBlob.CreateOutStream(DocOutStream);
         case EDocument."Document Type" of
-            EDocument."Document Type"::"Sales Invoice", EDocument."Document Type"::"Service Invoice":
-                GenerateInvoiceXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
-            EDocument."Document Type"::"Sales Credit Memo", EDocument."Document Type"::"Service Credit Memo":
-                GenerateCrMemoXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
+            EDocument."Document Type"::"Sales Invoice":
+                GenerateInvoiceXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export", GetSalesFormat());
+            EDocument."Document Type"::"Service Invoice":
+                GenerateInvoiceXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export", GetServiceFormat());
+            EDocument."Document Type"::"Sales Credit Memo":
+                GenerateCrMemoXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export", GetSalesFormat());
+            EDocument."Document Type"::"Service Credit Memo":
+                GenerateCrMemoXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export", GetServiceFormat());
             EDocument."Document Type"::"Issued Reminder", EDocument."Document Type"::"Issued Finance Charge Memo":
                 GenerateFinancialResultsXMLFile(SourceDocumentHeader, DocOutStream);
             EDocument."Document Type"::"Sales Shipment":
@@ -119,26 +128,40 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         CreatedDocumentLines.GetTable(TempPurchaseLine);
     end;
 
-    local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
+    local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean; PEPPOLFormat: Enum "PEPPOL 3.0 Format")
     var
         SalesInvoicePEPPOL30: XMLport "Sales Invoice - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
     begin
-        SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
+        SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat);
         SalesInvoicePEPPOL30.SetGeneratePDF(GeneratePDF);
         SalesInvoicePEPPOL30.SetDestination(OutStr);
         SalesInvoicePEPPOL30.Export();
     end;
 
-    local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
+    local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean; PEPPOLFormat: Enum "PEPPOL 3.0 Format")
     var
         SalesCrMemoPEPPOL30: XMLport "Sales Cr.Memo - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
     begin
-        SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
+        SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat);
         SalesCrMemoPEPPOL30.SetGeneratePDF(GeneratePDF);
         SalesCrMemoPEPPOL30.SetDestination(OutStr);
         SalesCrMemoPEPPOL30.Export();
+    end;
+
+    local procedure GetSalesFormat(): Enum "PEPPOL 3.0 Format"
+    var
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+    begin
+        PeppolSetup.GetSetup();
+        exit(PeppolSetup."PEPPOL 3.0 Sales Format");
+    end;
+
+    local procedure GetServiceFormat(): Enum "PEPPOL 3.0 Format"
+    var
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+    begin
+        PeppolSetup.GetSetup();
+        exit(PeppolSetup."PEPPOL 3.0 Service Format");
     end;
 
     local procedure GenerateFinancialResultsXMLFile(VariantRec: Variant; var OutStr: OutStream)

--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -130,8 +130,17 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean; PEPPOLFormat: Enum "PEPPOL 3.0 Format")
     var
+        SalesInvoicePEPPOLBIS30: XMLport "Sales Invoice - PEPPOL BIS 3.0";
         SalesInvoicePEPPOL30: XMLport "Sales Invoice - PEPPOL30";
     begin
+        if PEPPOLFormat in [PEPPOLFormat::"PEPPOL 3.0 - Sales", PEPPOLFormat::"PEPPOL 3.0 - Service"] then begin
+            SalesInvoicePEPPOLBIS30.Initialize(VariantRec);
+            SalesInvoicePEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+            SalesInvoicePEPPOLBIS30.SetDestination(OutStr);
+            SalesInvoicePEPPOLBIS30.Export();
+            exit;
+        end;
+
         SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat);
         SalesInvoicePEPPOL30.SetGeneratePDF(GeneratePDF);
         SalesInvoicePEPPOL30.SetDestination(OutStr);
@@ -140,8 +149,17 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean; PEPPOLFormat: Enum "PEPPOL 3.0 Format")
     var
+        SalesCrMemoPEPPOLBIS30: XMLport "Sales Cr.Memo - PEPPOL BIS 3.0";
         SalesCrMemoPEPPOL30: XMLport "Sales Cr.Memo - PEPPOL30";
     begin
+        if PEPPOLFormat in [PEPPOLFormat::"PEPPOL 3.0 - Sales", PEPPOLFormat::"PEPPOL 3.0 - Service"] then begin
+            SalesCrMemoPEPPOLBIS30.Initialize(VariantRec);
+            SalesCrMemoPEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+            SalesCrMemoPEPPOLBIS30.SetDestination(OutStr);
+            SalesCrMemoPEPPOLBIS30.Export();
+            exit;
+        end;
+
         SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat);
         SalesCrMemoPEPPOL30.SetGeneratePDF(GeneratePDF);
         SalesCrMemoPEPPOL30.SetDestination(OutStr);

--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -130,17 +130,8 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean; PEPPOLFormat: Enum "PEPPOL 3.0 Format")
     var
-        SalesInvoicePEPPOLBIS30: XMLport "Sales Invoice - PEPPOL BIS 3.0";
         SalesInvoicePEPPOL30: XMLport "Sales Invoice - PEPPOL30";
     begin
-        if PEPPOLFormat in [PEPPOLFormat::"PEPPOL 3.0 - Sales", PEPPOLFormat::"PEPPOL 3.0 - Service"] then begin
-            SalesInvoicePEPPOLBIS30.Initialize(VariantRec);
-            SalesInvoicePEPPOLBIS30.SetGeneratePDF(GeneratePDF);
-            SalesInvoicePEPPOLBIS30.SetDestination(OutStr);
-            SalesInvoicePEPPOLBIS30.Export();
-            exit;
-        end;
-
         SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat);
         SalesInvoicePEPPOL30.SetGeneratePDF(GeneratePDF);
         SalesInvoicePEPPOL30.SetDestination(OutStr);
@@ -149,17 +140,8 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean; PEPPOLFormat: Enum "PEPPOL 3.0 Format")
     var
-        SalesCrMemoPEPPOLBIS30: XMLport "Sales Cr.Memo - PEPPOL BIS 3.0";
         SalesCrMemoPEPPOL30: XMLport "Sales Cr.Memo - PEPPOL30";
     begin
-        if PEPPOLFormat in [PEPPOLFormat::"PEPPOL 3.0 - Sales", PEPPOLFormat::"PEPPOL 3.0 - Service"] then begin
-            SalesCrMemoPEPPOLBIS30.Initialize(VariantRec);
-            SalesCrMemoPEPPOLBIS30.SetGeneratePDF(GeneratePDF);
-            SalesCrMemoPEPPOLBIS30.SetDestination(OutStr);
-            SalesCrMemoPEPPOLBIS30.Export();
-            exit;
-        end;
-
         SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat);
         SalesCrMemoPEPPOL30.SetGeneratePDF(GeneratePDF);
         SalesCrMemoPEPPOL30.SetDestination(OutStr);

--- a/src/Apps/W1/EDocument/Demo Data/3.Transactions/CreateEDocumentTransactions.Codeunit.al
+++ b/src/Apps/W1/EDocument/Demo Data/3.Transactions/CreateEDocumentTransactions.Codeunit.al
@@ -15,7 +15,7 @@ using Microsoft.Purchases.Posting;
 using Microsoft.Purchases.Vendor;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
-using Microsoft.Sales.Peppol;
+using Microsoft.Peppol;
 using Microsoft.Sales.Setup;
 using System.IO;
 using System.Utilities;
@@ -142,7 +142,7 @@ codeunit 5376 "Create E-Document Transactions"
         SalesSetup: Record "Sales & Receivables Setup";
         ContosoCustomer: Codeunit "Create Common Customer/Vendor";
         CreateEDocTransactions: Codeunit "Create E-Document Transactions";
-        ExportSalesInv: Codeunit "Exp. Sales Inv. PEPPOL BIS3.0";
+        ExportSalesInv: Codeunit "Exp. Sales Inv. PEPPOL30";
         TempBlob: Codeunit "Temp Blob";
         TempBlobList: Codeunit "Temp Blob List";
         OutStr: OutStream;
@@ -170,7 +170,7 @@ codeunit 5376 "Create E-Document Transactions"
         CorrectSalesInvHeader(SalesInvHeader);
 
         TempBlob.CreateOutStream(OutStr);
-        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr);
+        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr, "PEPPOL 3.0 Format"::"PEPPOL 3.0 - Sales");
         TempBlobList.Add(TempBlob);
         SalesInvHeader.Delete(true);
         SalesHeader.Delete();
@@ -200,7 +200,7 @@ codeunit 5376 "Create E-Document Transactions"
 
         Clear(TempBlob);
         TempBlob.CreateOutStream(OutStr);
-        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr);
+        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr, "PEPPOL 3.0 Format"::"PEPPOL 3.0 - Sales");
         TempBlobList.Add(TempBlob);
         SalesInvHeader.Delete(true);
         SalesHeader.Delete();
@@ -220,7 +220,7 @@ codeunit 5376 "Create E-Document Transactions"
 
         Clear(TempBlob);
         TempBlob.CreateOutStream(OutStr);
-        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr);
+        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr, "PEPPOL 3.0 Format"::"PEPPOL 3.0 - Sales");
         TempBlobList.Add(TempBlob);
         SalesInvHeader.Delete(true);
         SalesHeader.Delete();
@@ -245,7 +245,7 @@ codeunit 5376 "Create E-Document Transactions"
 
         Clear(TempBlob);
         TempBlob.CreateOutStream(OutStr);
-        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr);
+        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr, "PEPPOL 3.0 Format"::"PEPPOL 3.0 - Sales");
         TempBlobList.Add(TempBlob);
         SalesInvHeader.Delete(true);
         SalesHeader.Delete();
@@ -268,7 +268,7 @@ codeunit 5376 "Create E-Document Transactions"
 
         Clear(TempBlob);
         TempBlob.CreateOutStream(OutStr);
-        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr);
+        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr, "PEPPOL 3.0 Format"::"PEPPOL 3.0 - Sales");
         TempBlobList.Add(TempBlob);
         SalesInvHeader.Delete(true);
         SalesHeader.Delete();
@@ -288,7 +288,7 @@ codeunit 5376 "Create E-Document Transactions"
 
         Clear(TempBlob);
         TempBlob.CreateOutStream(OutStr);
-        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr);
+        ExportSalesInv.GenerateXMLFile(SalesInvHeader, OutStr, "PEPPOL 3.0 Format"::"PEPPOL 3.0 - Sales");
         TempBlobList.Add(TempBlob);
         SalesInvHeader.Delete(true);
         SalesHeader.Delete();

--- a/src/Apps/W1/EDocument/Demo Data/app.json
+++ b/src/Apps/W1/EDocument/Demo Data/app.json
@@ -22,7 +22,13 @@
       "id": "5a0b41e9-7a42-4123-d521-2265186cfb31",
       "name": "Contoso Coffee Demo Dataset",
       "publisher": "Microsoft",
-      "version": "28.6.0.0"
+      "version": "29.0.0.0"
+    },
+    {
+      "id": "e1966889-b5fb-4fda-a84c-ea71b590e1a9",
+      "name": "PEPPOL",
+      "publisher": "Microsoft",
+      "version": "29.0.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/Apps/W1/EDocument/Demo Data/app.json
+++ b/src/Apps/W1/EDocument/Demo Data/app.json
@@ -28,7 +28,7 @@
       "id": "e1966889-b5fb-4fda-a84c-ea71b590e1a9",
       "name": "PEPPOL",
       "publisher": "Microsoft",
-      "version": "29.0.0.0"
+      "version": "28.6.0.0"
     }
   ],
   "internalsVisibleTo": [

--- a/src/Apps/W1/EDocument/Demo Data/app.json
+++ b/src/Apps/W1/EDocument/Demo Data/app.json
@@ -22,7 +22,7 @@
       "id": "5a0b41e9-7a42-4123-d521-2265186cfb31",
       "name": "Contoso Coffee Demo Dataset",
       "publisher": "Microsoft",
-      "version": "29.0.0.0"
+      "version": "28.6.0.0"
     },
     {
       "id": "e1966889-b5fb-4fda-a84c-ea71b590e1a9",

--- a/src/Apps/W1/EDocument/Test/src/LibraryEDocument.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/LibraryEDocument.Codeunit.al
@@ -92,6 +92,7 @@ codeunit 139629 "Library - E-Document"
         Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
         Customer."VAT Registration No." := LibraryERM.GenerateVATRegistrationNo(CountryRegion.Code);
         Customer.Validate(GLN, '1234567890128');
+        Customer.Validate("E-Mail", 'edoc-test@contoso.com');
         Customer."Document Sending Profile" := DocumentSendingProfile.Code;
         Customer.Modify(true);
 

--- a/src/Apps/W1/EDocument/Test/src/LibraryEDocument.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/LibraryEDocument.Codeunit.al
@@ -69,6 +69,8 @@ codeunit 139629 "Library - E-Document"
         CountryRegion: Record "Country/Region";
         DocumentSendingProfile: Record "Document Sending Profile";
         SalesSetup: Record "Sales & Receivables Setup";
+        Contact: Record Contact;
+        ContactBusinessRelation: Record "Contact Business Relation";
         WorkflowSetup: Codeunit "Workflow Setup";
         WorkflowCode: Code[20];
     begin
@@ -95,6 +97,18 @@ codeunit 139629 "Library - E-Document"
         Customer.Validate("E-Mail", 'edoc-test@contoso.com');
         Customer."Document Sending Profile" := DocumentSendingProfile.Code;
         Customer.Modify(true);
+
+        // Set the same e-mail on the customer's contact. Validating the sell-to customer on a sales
+        // document copies the customer e-mail to "Sell-to E-Mail"; if the linked contact has no
+        // e-mail (e.g. via the OIOUBL "Sell-to Customer No." validation on NAV_DK) base app raises
+        // the "contact has no e-mail address" confirm, which fails these tests as Unhandled UI.
+        ContactBusinessRelation.SetRange("Link to Table", ContactBusinessRelation."Link to Table"::Customer);
+        ContactBusinessRelation.SetRange("No.", Customer."No.");
+        if ContactBusinessRelation.FindFirst() then
+            if Contact.Get(ContactBusinessRelation."Contact No.") then begin
+                Contact."E-Mail" := 'edoc-test@contoso.com';
+                Contact.Modify();
+            end;
 
         // Create Item
         if StandardItem."No." = '' then begin

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocFormatTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocFormatTests.Codeunit.al
@@ -13,6 +13,7 @@ using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
 using Microsoft.Foundation.Reporting;
+using Microsoft.Peppol;
 using Microsoft.Inventory.Item;
 using Microsoft.Purchases.History;
 using Microsoft.Purchases.Payables;
@@ -51,12 +52,19 @@ codeunit 139519 "E-Doc. Format Tests"
         DocumentSendingProfile: Record "Document Sending Profile";
         ServiceHeader: Record "Service Header";
         ServiceMngmtSetup: Record "Service Mgt. Setup";
+        Peppol30Setup: Record "PEPPOL 3.0 Setup";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
         ExpectedErr: Text;
         WorkflowCode: Code[20];
     begin
         // [SCENARIO 608765] E-Documents: Check 'Your reference' not available in service documents in Belgian localisation
         Initialize(Enum::"Service Integration"::Mock);
+
+        // Force the W1 PEPPOL 3.0 service validation impl so that country-specific overrides (e.g. DE,
+        // which omits the Your Reference check) do not change the asserted W1 behavior.
+        Peppol30Setup.GetSetup();
+        Peppol30Setup."PEPPOL 3.0 Service Format" := Peppol30Setup."PEPPOL 3.0 Service Format"::"PEPPOL 3.0 - Service";
+        Peppol30Setup.Modify();
 
         // [WHEN] Team member create invoice and update company information.
         UpdateCompanyInformation();

--- a/src/Apps/W1/PEPPOL/App/src/Setup/PEPPOL30Setup.Table.al
+++ b/src/Apps/W1/PEPPOL/App/src/Setup/PEPPOL30Setup.Table.al
@@ -28,11 +28,13 @@ table 37202 "PEPPOL 3.0 Setup"
         {
             Caption = 'PEPPOL 3.0 Sales Format';
             ToolTip = 'Specifies the PEPPOL 3.0 format to be used for electronic documents of type sales.';
+            DataClassification = SystemMetadata;
         }
         field(3; "PEPPOL 3.0 Service Format"; Enum "PEPPOL 3.0 Format")
         {
             Caption = 'PEPPOL 3.0 Service Format';
             ToolTip = 'Specifies the PEPPOL 3.0 format to be used for electronic documents of type service.';
+            DataClassification = SystemMetadata;
         }
     }
 


### PR DESCRIPTION
Backports all applicable changes from #8498 to `releases/28.x`.

The E-Document bridge previously called the W1 `PEPPOL30 Sales Validation` implementation directly, bypassing localized validators such as Belgium's validator that accepts Enterprise No. This backport restores setup-driven validation and also includes the associated PEPPOL onboarding demo, test, and metadata fixes from the original PR.

Included in this PR:
- Resolve sales and service validation and XML generation through `PEPPOL 3.0 Setup`.
- Migrate E-Document demo data to the standalone `PEPPOL30` exporter and add its direct dependency.
- Set customer and contact email in the shared E-Document test setup.
- Pin the W1 PEPPOL service format in the format-specific test.
- Add field-level `DataClassification` to PEPPOL setup fields 2 and 3.

Four other files from #8498 already contain the required changes on this release branch: the PEPPOL data-exchange subscribers, financial-results XMLport, E-Document test dependency, and purchase-header whitespace cleanup.

Validation:
- Audited all 11 files in the net diff of #8498 against this branch.
- Verified every functional addition and removal, including localized setup routing and six demo XML-generation calls.
- `git diff --check origin/releases/28.x..HEAD` passed.

Related: #8498

Fixes
[AB#649036](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649036)


