### PR TITLE
[28.4] Preserve legacy PEPPOL export events

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -121,24 +121,22 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
     var
-        SalesInvoicePEPPOL30: XMLport "Sales Invoice - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
+        SalesInvoicePEPPOLBIS30: XMLport "Sales Invoice - PEPPOL BIS 3.0";
     begin
-        SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
-        SalesInvoicePEPPOL30.SetGeneratePDF(GeneratePDF);
-        SalesInvoicePEPPOL30.SetDestination(OutStr);
-        SalesInvoicePEPPOL30.Export();
+        SalesInvoicePEPPOLBIS30.Initialize(VariantRec);
+        SalesInvoicePEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+        SalesInvoicePEPPOLBIS30.SetDestination(OutStr);
+        SalesInvoicePEPPOLBIS30.Export();
     end;
 
     local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
     var
-        SalesCrMemoPEPPOL30: XMLport "Sales Cr.Memo - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
+        SalesCrMemoPEPPOLBIS30: XMLport "Sales Cr.Memo - PEPPOL BIS 3.0";
     begin
-        SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
-        SalesCrMemoPEPPOL30.SetGeneratePDF(GeneratePDF);
-        SalesCrMemoPEPPOL30.SetDestination(OutStr);
-        SalesCrMemoPEPPOL30.Export();
+        SalesCrMemoPEPPOLBIS30.Initialize(VariantRec);
+        SalesCrMemoPEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+        SalesCrMemoPEPPOLBIS30.SetDestination(OutStr);
+        SalesCrMemoPEPPOLBIS30.Export();
     end;
 
     local procedure GenerateFinancialResultsXMLFile(VariantRec: Variant; var OutStr: OutStream)


### PR DESCRIPTION
## Summary
Restore the legacy PEPPOL BIS 3.0 invoice and credit memo XMLports in the E-Document PEPPOL export path.

The standalone `Sales Invoice - PEPPOL30` and `Sales Cr.Memo - PEPPOL30` XMLports bypass codeunit 1605 `PEPPOL Management` and the legacy XMLport events. Existing extensions subscribed to those events therefore no longer run during E-Document export.

This change routes invoice and credit memo generation through the legacy XMLports again, preserving the existing customization contract while producing the built-in PEPPOL 3.0 Sales format used by this release.

## Validation
- AL editor diagnostics: no errors
- `git diff --check`: passed
- Verified invoice and credit memo legacy export paths
- Diff is limited to codeunit 6165 `EDoc PEPPOL BIS 3.0`
