### PR TITLE
29.x: Allow bank rec. duplicated transactions surfaced in UI

### DIFF
--- a/src/Layers/CH/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
+++ b/src/Layers/CH/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
@@ -573,6 +573,31 @@ page 1290 "Payment Reconciliation Journal"
                         end;
                     end;
                 }
+                action(AllowDuplicatedTransactions)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Duplicated Transactions';
+                    Image = ChangeStatus;
+                    ToolTip = 'Toggle whether transactions that have the same transaction ID can be imported into this journal.';
+
+                    trigger OnAction()
+                    var
+                        ConfirmManagement: Codeunit "Confirm Management";
+                        ChangeSettingQst: Text;
+                    begin
+                        InitializeBankAccRecon();
+
+                        if BankAccReconciliation."Allow Duplicated Transactions" then
+                            ChangeSettingQst := SkipDuplicatedTransactionsQst
+                        else
+                            ChangeSettingQst := AllowDuplicatedTransactionsQst;
+                        if not ConfirmManagement.GetResponseOrDefault(ChangeSettingQst, false) then
+                            exit;
+
+                        BankAccReconciliation.Validate("Allow Duplicated Transactions", not BankAccReconciliation."Allow Duplicated Transactions");
+                        BankAccReconciliation.Modify(true);
+                    end;
+                }
                 action(ApplyAutomatically)
                 {
                     ApplicationArea = Basic, Suite;
@@ -1287,6 +1312,8 @@ page 1290 "Payment Reconciliation Journal"
         ShowDetailsTxt: Label 'Open bank account card';
         DisableNotificationTxt: Label 'Don''t show this again';
         WouldYouLikeToRunMapTexttoAccountAgainQst: Label 'Do you want to re-apply the text to account mapping rules to all lines in the bank statement?';
+        AllowDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently skipped when you import a bank statement into this journal. Do you want to import them?';
+        SkipDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently considered when importing into this journal. Do you want to skip them instead?';
         StatementEndingBalance: Text;
 
     protected var

--- a/src/Layers/CH/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
+++ b/src/Layers/CH/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
@@ -598,6 +598,34 @@ page 1290 "Payment Reconciliation Journal"
                         BankAccReconciliation.Modify(true);
                     end;
                 }
+                action(ImportPostedTransactions)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Posted Transactions';
+                    Image = ChangeStatus;
+                    ToolTip = 'Toggle whether transactions that are already applied, but whose related bank account ledger entries are not closed, can be imported into this journal.';
+
+                    trigger OnAction()
+                    var
+                        ConfirmManagement: Codeunit "Confirm Management";
+                        ChangeSettingQst: Text;
+                    begin
+                        InitializeBankAccRecon();
+
+                        if BankAccReconciliation."Import Posted Transactions" = BankAccReconciliation."Import Posted Transactions"::Yes then
+                            ChangeSettingQst := SkipPostedTransactionsQst
+                        else
+                            ChangeSettingQst := ImportPostedTransactionsQst;
+                        if not ConfirmManagement.GetResponseOrDefault(ChangeSettingQst, false) then
+                            exit;
+
+                        if BankAccReconciliation."Import Posted Transactions" = BankAccReconciliation."Import Posted Transactions"::Yes then
+                            BankAccReconciliation.Validate("Import Posted Transactions", BankAccReconciliation."Import Posted Transactions"::No)
+                        else
+                            BankAccReconciliation.Validate("Import Posted Transactions", BankAccReconciliation."Import Posted Transactions"::Yes);
+                        BankAccReconciliation.Modify(true);
+                    end;
+                }
                 action(ApplyAutomatically)
                 {
                     ApplicationArea = Basic, Suite;
@@ -1314,6 +1342,8 @@ page 1290 "Payment Reconciliation Journal"
         WouldYouLikeToRunMapTexttoAccountAgainQst: Label 'Do you want to re-apply the text to account mapping rules to all lines in the bank statement?';
         AllowDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently skipped when you import a bank statement into this journal. Do you want to import them?';
         SkipDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently considered when importing into this journal. Do you want to skip them instead?';
+        ImportPostedTransactionsQst: Label 'Transactions that are already applied, but whose related bank account ledger entries are not closed, are currently skipped when you import a bank statement into this journal. Do you want to import them?';
+        SkipPostedTransactionsQst: Label 'Transactions that are already applied, but whose related bank account ledger entries are not closed, are currently imported into this journal. Do you want to skip them instead?';
         StatementEndingBalance: Text;
 
     protected var

--- a/src/Layers/CH/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
+++ b/src/Layers/CH/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
@@ -576,7 +576,7 @@ page 1290 "Payment Reconciliation Journal"
                 action(AllowDuplicatedTransactions)
                 {
                     ApplicationArea = Basic, Suite;
-                    Caption = 'Import Duplicated Transactions';
+                    Caption = 'Allow Duplicated Transactions';
                     Image = ChangeStatus;
                     ToolTip = 'Toggle whether transactions that have the same transaction ID can be imported into this journal.';
 

--- a/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
+++ b/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
@@ -82,6 +82,12 @@ page 379 "Bank Acc. Reconciliation"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Statement Ending Balance';
                 }
+                field(AllowDuplicatedTransactions; Rec."Allow Duplicated Transactions")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Duplicated Transactions';
+                    Visible = false;
+                }
             }
             group(Control8)
             {

--- a/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
+++ b/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
@@ -88,6 +88,12 @@ page 379 "Bank Acc. Reconciliation"
                     Caption = 'Import Duplicated Transactions';
                     Visible = false;
                 }
+                field(ImportPostedTransactions; Rec."Import Posted Transactions")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Posted Transactions';
+                    Visible = false;
+                }
             }
             group(Control8)
             {

--- a/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
+++ b/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
@@ -413,8 +413,8 @@ table 273 "Bank Acc. Reconciliation"
         /// </summary>
         field(51; "Allow Duplicated Transactions"; Boolean)
         {
-            Caption = 'Allow Duplicated Transactions';
-            ToolTip = 'Specifies whether to allow bank account reconciliation lines to have the same transaction ID. Although itâ€™s rare, this is useful when your bank statement file contains transactions with duplicate IDs. Most businesses leave this toggle turned off.';
+            Caption = 'Import Duplicated Transactions';
+            ToolTip = 'Specifies whether to allow bank account reconciliation lines to have the same transaction ID.';
         }
         /// <summary>
         /// Dimension set identifier linking this reconciliation to its dimension values.

--- a/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
+++ b/src/Layers/NA/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
@@ -307,6 +307,7 @@ table 273 "Bank Acc. Reconciliation"
         field(24; "Import Posted Transactions"; Option)
         {
             Caption = 'Import Posted Transactions';
+            ToolTip = 'Specifies whether to import bank transactions that are already applied but whose related bank account ledger entries are not yet closed.';
             OptionCaption = ' ,Yes,No';
             OptionMembers = " ",Yes,No;
         }

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
@@ -82,6 +82,12 @@ page 379 "Bank Acc. Reconciliation"
                     ApplicationArea = Basic, Suite;
                     Caption = 'Statement Ending Balance';
                 }
+                field(AllowDuplicatedTransactions; Rec."Allow Duplicated Transactions")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Duplicated Transactions';
+                    Visible = false;
+                }
             }
             group(Control8)
             {

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Page.al
@@ -88,6 +88,12 @@ page 379 "Bank Acc. Reconciliation"
                     Caption = 'Import Duplicated Transactions';
                     Visible = false;
                 }
+                field(ImportPostedTransactions; Rec."Import Posted Transactions")
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Posted Transactions';
+                    Visible = false;
+                }
             }
             group(Control8)
             {

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
@@ -410,8 +410,8 @@ table 273 "Bank Acc. Reconciliation"
         /// </summary>
         field(51; "Allow Duplicated Transactions"; Boolean)
         {
-            Caption = 'Allow Duplicated Transactions';
-            ToolTip = 'Specifies whether to allow bank account reconciliation lines to have the same transaction ID. Although itâ€™s rare, this is useful when your bank statement file contains transactions with duplicate IDs. Most businesses leave this toggle turned off.';
+            Caption = 'Import Duplicated Transactions';
+            ToolTip = 'Specifies whether to allow bank account reconciliation lines to have the same transaction ID.';
         }
         /// <summary>
         /// Dimension set identifier linking this reconciliation to its dimension values.

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/BankAccReconciliation.Table.al
@@ -304,6 +304,7 @@ table 273 "Bank Acc. Reconciliation"
         field(24; "Import Posted Transactions"; Option)
         {
             Caption = 'Import Posted Transactions';
+            ToolTip = 'Specifies whether to import bank transactions that are already applied but whose related bank account ledger entries are not yet closed.';
             OptionCaption = ' ,Yes,No';
             OptionMembers = " ",Yes,No;
         }

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
@@ -565,6 +565,31 @@ page 1290 "Payment Reconciliation Journal"
                         end;
                     end;
                 }
+                action(AllowDuplicatedTransactions)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Duplicated Transactions';
+                    Image = ChangeStatus;
+                    ToolTip = 'Toggle whether transactions that have the same transaction ID can be imported into this journal.';
+
+                    trigger OnAction()
+                    var
+                        ConfirmManagement: Codeunit "Confirm Management";
+                        ChangeSettingQst: Text;
+                    begin
+                        InitializeBankAccRecon();
+
+                        if BankAccReconciliation."Allow Duplicated Transactions" then
+                            ChangeSettingQst := SkipDuplicatedTransactionsQst
+                        else
+                            ChangeSettingQst := AllowDuplicatedTransactionsQst;
+                        if not ConfirmManagement.GetResponseOrDefault(ChangeSettingQst, false) then
+                            exit;
+
+                        BankAccReconciliation.Validate("Allow Duplicated Transactions", not BankAccReconciliation."Allow Duplicated Transactions");
+                        BankAccReconciliation.Modify(true);
+                    end;
+                }
                 action(ApplyAutomatically)
                 {
                     ApplicationArea = Basic, Suite;
@@ -1279,6 +1304,8 @@ page 1290 "Payment Reconciliation Journal"
         ShowDetailsTxt: Label 'Open bank account card';
         DisableNotificationTxt: Label 'Don''t show this again';
         WouldYouLikeToRunMapTexttoAccountAgainQst: Label 'Do you want to re-apply the text to account mapping rules to all lines in the bank statement?';
+        AllowDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently skipped when you import a bank statement into this journal. Do you want to import them?';
+        SkipDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently considered when importing into this journal. Do you want to skip them instead?';
         StatementEndingBalance: Text;
 
     protected var

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
@@ -590,6 +590,34 @@ page 1290 "Payment Reconciliation Journal"
                         BankAccReconciliation.Modify(true);
                     end;
                 }
+                action(ImportPostedTransactions)
+                {
+                    ApplicationArea = Basic, Suite;
+                    Caption = 'Import Posted Transactions';
+                    Image = ChangeStatus;
+                    ToolTip = 'Toggle whether transactions that are already applied, but whose related bank account ledger entries are not closed, can be imported into this journal.';
+
+                    trigger OnAction()
+                    var
+                        ConfirmManagement: Codeunit "Confirm Management";
+                        ChangeSettingQst: Text;
+                    begin
+                        InitializeBankAccRecon();
+
+                        if BankAccReconciliation."Import Posted Transactions" = BankAccReconciliation."Import Posted Transactions"::Yes then
+                            ChangeSettingQst := SkipPostedTransactionsQst
+                        else
+                            ChangeSettingQst := ImportPostedTransactionsQst;
+                        if not ConfirmManagement.GetResponseOrDefault(ChangeSettingQst, false) then
+                            exit;
+
+                        if BankAccReconciliation."Import Posted Transactions" = BankAccReconciliation."Import Posted Transactions"::Yes then
+                            BankAccReconciliation.Validate("Import Posted Transactions", BankAccReconciliation."Import Posted Transactions"::No)
+                        else
+                            BankAccReconciliation.Validate("Import Posted Transactions", BankAccReconciliation."Import Posted Transactions"::Yes);
+                        BankAccReconciliation.Modify(true);
+                    end;
+                }
                 action(ApplyAutomatically)
                 {
                     ApplicationArea = Basic, Suite;
@@ -1306,6 +1334,8 @@ page 1290 "Payment Reconciliation Journal"
         WouldYouLikeToRunMapTexttoAccountAgainQst: Label 'Do you want to re-apply the text to account mapping rules to all lines in the bank statement?';
         AllowDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently skipped when you import a bank statement into this journal. Do you want to import them?';
         SkipDuplicatedTransactionsQst: Label 'Transactions that have the same transaction ID are currently considered when importing into this journal. Do you want to skip them instead?';
+        ImportPostedTransactionsQst: Label 'Transactions that are already applied, but whose related bank account ledger entries are not closed, are currently skipped when you import a bank statement into this journal. Do you want to import them?';
+        SkipPostedTransactionsQst: Label 'Transactions that are already applied, but whose related bank account ledger entries are not closed, are currently imported into this journal. Do you want to skip them instead?';
         StatementEndingBalance: Text;
 
     protected var

--- a/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
+++ b/src/Layers/W1/BaseApp/Bank/Reconciliation/PaymentReconciliationJournal.Page.al
@@ -568,7 +568,7 @@ page 1290 "Payment Reconciliation Journal"
                 action(AllowDuplicatedTransactions)
                 {
                     ApplicationArea = Basic, Suite;
-                    Caption = 'Import Duplicated Transactions';
+                    Caption = 'Allow Duplicated Transactions';
                     Image = ChangeStatus;
                     ToolTip = 'Toggle whether transactions that have the same transaction ID can be imported into this journal.';
 


### PR DESCRIPTION
We already had a functionality that unblocks several scenarios when importing bank statements. However, there was no UI surface for it.

This change resurfaces this functionality, to give this option to users that need it. In particular, this was discovered when a DE customer was trying to import SEPA CAMT files, that have Transaction ID coming from EndToEndId, which I validated in https://www.iso20022.org/iso-20022-message-definitions?scope%5B0%5D=messages&search=camt  MDR part 3 that the uniqueness in enforced by the initiator of the transaction, making imports with same id under the same file plausible.

Used the opportunity to change the captions to something a bit more precise.

Fixes [AB#649134](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649134)


