### PR TITLE
Hardening subscription billing + drop shipment scenarios

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SalesDocuments.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Billing/Codeunits/SalesDocuments.Codeunit.al
@@ -388,6 +388,26 @@ codeunit 8063 "Sales Documents"
             end;
     end;
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Purch.-Post", OnUpdateAssocOrderOnBeforeSalesOrderLineModify, '', false, false)]
+    local procedure CloseSalesOrderLineOnDropShipmentAssocOrderUpdate(var SalesOrderLine: Record "Sales Line")
+    begin
+        if not SalesLineShouldSkipInvoicing(SalesOrderLine) then
+            exit;
+
+        SetSubscriptionItemLineAsInvoiced(SalesOrderLine);
+    end;
+
+    local procedure SetSubscriptionItemLineAsInvoiced(var SalesLine: Record "Sales Line")
+    begin
+        SalesLine."Quantity Invoiced" := SalesLine."Quantity Shipped";
+        SalesLine."Qty. Invoiced (Base)" := SalesLine."Qty. Shipped (Base)";
+        SalesLine."Qty. Shipped Not Invoiced" := 0;
+        SalesLine."Qty. Shipped Not Invd. (Base)" := 0;
+        SalesLine."Shipped Not Invoiced" := 0;
+        SalesLine."Shipped Not Invoiced (LCY)" := 0;
+        SalesLine."Shipped Not Inv. (LCY) No VAT" := 0;
+    end;
+
 #if not CLEAN28
     [Obsolete('Use OnAfterPostItemJnlLine event subscriber to create Subscription Headers during item journal posting', '29.0')]
     procedure CreateServiceObjectFromSales(var SalesHeader: Record "Sales Header"; var SalesLine: Record "Sales Line"; var SalesShptLine: Record "Sales Shipment Line")
@@ -430,13 +450,7 @@ codeunit 8063 "Sales Documents"
         if not ShouldModifySalesLine then
             exit;
 
-        TempSalesLine."Quantity Invoiced" := TempSalesLine."Quantity Shipped";
-        TempSalesLine."Qty. Invoiced (Base)" := TempSalesLine."Qty. Shipped (Base)";
-        TempSalesLine."Qty. Shipped Not Invoiced" := 0;
-        TempSalesLine."Qty. Shipped Not Invd. (Base)" := 0;
-        TempSalesLine."Shipped Not Invoiced" := 0;
-        TempSalesLine."Shipped Not Invoiced (LCY)" := 0;
-        TempSalesLine."Shipped Not Inv. (LCY) No VAT" := 0;
+        SetSubscriptionItemLineAsInvoiced(TempSalesLine);
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Sales-Post", OnInsertShipmentLineOnAfterInitQuantityFields, '', false, false)]
@@ -534,7 +548,7 @@ codeunit 8063 "Sales Documents"
             exit;
 
         if SerialNo = '' then
-            CreateServiceObject(ServiceObject, SalesHeader, SalesLine, SalesLine."Qty. to Ship", SerialNo, ItemLedgerEntryNo)
+            CreateServiceObject(ServiceObject, SalesHeader, SalesLine, QtyPerSerialNo = 0 ? SalesLine."Qty. to Ship" : QtyPerSerialNo, SerialNo, ItemLedgerEntryNo)
         else
             CreateServiceObject(ServiceObject, SalesHeader, SalesLine, QtyPerSerialNo, SerialNo, ItemLedgerEntryNo);
 

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -231,6 +231,73 @@ codeunit 139915 "Sales Service Commitment Test"
     end;
 
     [Test]
+    procedure CheckCreateServiceObjectOnDropShipment()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        RequisitionLine: Record "Requisition Line";
+        Vendor: Record Vendor;
+        ExpectedQuantity: Decimal;
+    begin
+        // [SCENARIO] The Subscription created for a drop shipped non-serialized Subscription Item carries the posted quantity, not zero.
+        Initialize();
+
+        // [GIVEN] A released drop shipment sales order for a non-serialized Subscription Item
+        CreateAndReleaseSalesDocumentForDropShipment();
+        ExpectedQuantity := SalesLine.Quantity;
+
+        LibraryPurchase.CreateVendor(Vendor);
+        Item."Vendor No." := Vendor."No.";
+        Item.Modify(false);
+
+        // [WHEN] The linked purchase order is created from the sales order and received
+        RunGetSalesOrders(RequisitionLine, SalesHeader);
+        ReqWkshCarryOutActionMessage(RequisitionLine);
+        PurchaseHeader.SetRange("Buy-from Vendor No.", Vendor."No.");
+        PurchaseHeader.FindLast();
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] A single Subscription is created with the posted quantity (Qty. to Ship on the sales line is 0 for a drop shipment)
+        ServiceObject.Reset();
+        ServiceObject.FilterOnItemNo(Item."No.");
+        Assert.RecordCount(ServiceObject, 1);
+        ServiceObject.FindFirst();
+        ServiceObject.TestField(Quantity, ExpectedQuantity);
+    end;
+
+    [Test]
+    procedure CheckSalesOrderLineClosedAfterDropShipment()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        FetchSalesLine: Record "Sales Line";
+        RequisitionLine: Record "Requisition Line";
+        Vendor: Record Vendor;
+    begin
+        // [SCENARIO] After a drop shipment receipt the Subscription Item sales line is treated as fully invoiced, so the sales order can be completed.
+        Initialize();
+
+        // [GIVEN] A released drop shipment sales order for a non-serialized Subscription Item
+        CreateAndReleaseSalesDocumentForDropShipment();
+
+        LibraryPurchase.CreateVendor(Vendor);
+        Item."Vendor No." := Vendor."No.";
+        Item.Modify(false);
+
+        // [WHEN] The linked purchase order is created from the sales order and received
+        RunGetSalesOrders(RequisitionLine, SalesHeader);
+        ReqWkshCarryOutActionMessage(RequisitionLine);
+        PurchaseHeader.SetRange("Buy-from Vendor No.", Vendor."No.");
+        PurchaseHeader.FindLast();
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+
+        // [THEN] The sales line is fully shipped and marked as fully invoiced, with nothing left shipped not invoiced.
+        // This is what lets the order be completed: Qty. Shipped Not Invoiced = 0 makes Sales Line CheckNotInvoicedQty pass on delete.
+        FetchSalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        FetchSalesLine.TestField("Quantity Shipped", SalesLine.Quantity);
+        FetchSalesLine.TestField("Quantity Invoiced", FetchSalesLine."Quantity Shipped");
+        FetchSalesLine.TestField("Qty. Shipped Not Invoiced", 0);
+    end;
+
+    [Test]
     procedure CheckDeleteSalesServiceCommitmentWhenTypeOrNoChangedForSalesLine()
     var
         Item2: Record Item;
@@ -2188,6 +2255,19 @@ codeunit 139915 "Sales Service Commitment Test"
         for i := 1 to NoOfServiceObjects do
             LibraryItemTracking.CreatePurchOrderItemTracking(ReservationEntry, PurchaseLine, SerialNo[i], '', 1);
         LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
+    end;
+
+    local procedure CreateAndReleaseSalesDocumentForDropShipment()
+    var
+        Purchasing: Record Purchasing;
+    begin
+        LibraryPurchase.CreateDropShipmentPurchasingCode(Purchasing);
+        ContractTestLibrary.CreateItemWithServiceCommitmentOption(Item, Enum::"Item Service Commitment Type"::"Service Commitment Item");
+        ContractTestLibrary.AssignItemToServiceCommitmentPackage(Item, ServiceCommitmentPackage.Code, true);
+        CreateSalesDocumentAndLineWithRandomQuantity("Sales Document Type"::Order);
+        SalesLine.Validate("Purchasing Code", Purchasing.Code);
+        SalesLine.Modify(true);
+        LibrarySales.ReleaseSalesDocument(SalesHeader);
     end;
 
     local procedure CreateAndReleaseSalesDocumentWithSerialNoForDropShipment()

--- a/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Service Commitments/SalesServiceCommitmentTest.Codeunit.al
@@ -245,9 +245,7 @@ codeunit 139915 "Sales Service Commitment Test"
         CreateAndReleaseSalesDocumentForDropShipment();
         ExpectedQuantity := SalesLine.Quantity;
 
-        LibraryPurchase.CreateVendor(Vendor);
-        Item."Vendor No." := Vendor."No.";
-        Item.Modify(false);
+        CreateVendorForDropShipmentItem(Vendor);
 
         // [WHEN] The linked purchase order is created from the sales order and received
         RunGetSalesOrders(RequisitionLine, SalesHeader);
@@ -278,9 +276,7 @@ codeunit 139915 "Sales Service Commitment Test"
         // [GIVEN] A released drop shipment sales order for a non-serialized Subscription Item
         CreateAndReleaseSalesDocumentForDropShipment();
 
-        LibraryPurchase.CreateVendor(Vendor);
-        Item."Vendor No." := Vendor."No.";
-        Item.Modify(false);
+        CreateVendorForDropShipmentItem(Vendor);
 
         // [WHEN] The linked purchase order is created from the sales order and received
         RunGetSalesOrders(RequisitionLine, SalesHeader);
@@ -2260,11 +2256,26 @@ codeunit 139915 "Sales Service Commitment Test"
     local procedure CreateAndReleaseSalesDocumentForDropShipment()
     var
         Purchasing: Record Purchasing;
+        VATPostingSetup: Record "VAT Posting Setup";
+        Quantity: Decimal;
     begin
         LibraryPurchase.CreateDropShipmentPurchasingCode(Purchasing);
         ContractTestLibrary.CreateItemWithServiceCommitmentOption(Item, Enum::"Item Service Commitment Type"::"Service Commitment Item");
         ContractTestLibrary.AssignItemToServiceCommitmentPackage(Item, ServiceCommitmentPackage.Code, true);
-        CreateSalesDocumentAndLineWithRandomQuantity("Sales Document Type"::Order);
+
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", LibraryRandom.RandIntInRange(10, 25));
+        Item.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        Item.Modify(true);
+
+        LibrarySales.CreateCustomer(Customer);
+        Customer.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        Customer.Modify(true);
+
+        LibrarySales.CreateSalesHeader(SalesHeader, "Sales Document Type"::Order, Customer."No.");
+        Quantity := LibraryRandom.RandInt(10);
+        NoOfServiceObjects := Quantity;
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, Enum::"Sales Line Type"::Item, Item."No.", Quantity);
+
         SalesLine.Validate("Purchasing Code", Purchasing.Code);
         SalesLine.Modify(true);
         LibrarySales.ReleaseSalesDocument(SalesHeader);
@@ -2370,6 +2381,16 @@ codeunit 139915 "Sales Service Commitment Test"
         Item."Subscription Option" := Enum::"Item Service Commitment Type"::"Sales with Service Commitment";
         Item.Modify(false);
         ContractTestLibrary.AssignItemToServiceCommitmentPackage(Item, ServiceCommitmentPackage.Code, true);
+    end;
+
+    local procedure CreateVendorForDropShipmentItem(var Vendor: Record Vendor)
+    begin
+        LibraryPurchase.CreateVendor(Vendor);
+        Vendor.Validate("VAT Bus. Posting Group", Customer."VAT Bus. Posting Group");
+        Vendor.Modify(true);
+
+        Item."Vendor No." := Vendor."No.";
+        Item.Modify(false);
     end;
 
     local procedure FilterSalesServiceCommForLineDisc(ExpectedCalculationBaseAmount: Decimal)


### PR DESCRIPTION
Two scenarios stemming form a customer case:

- We use the "Qty. to ship" to create the subscriptions at release of the sales order, this doesn't play well when "Sales & Receivables Setup" has "Default Quantity to Ship" set to "Blank".
- In non-drop shipment scenarios for subscription billing we usually "fake invoice" the originating sales order, this was not the case when the release of the sales order was triggered by receiving the purchase order on a drop shipment.

Fixes:
- Use the QtyPerSerialNo we already had and only fallback to "Qty to ship" when zero.
- Subscribe also to when the sales order was being closed by a drop shipment purchase order, and set the same values as on the other path

Obviously, verified locally the scenarios and added tests.

Fixes [AB#649032](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649032) 
Fixed [AB#649031](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649031)



