### PR TITLE
[29.x] Re-enable the composite layout resolution tests on a real body layout

### DIFF
--- a/src/DisabledTests/Tests-Report/Tests-Report.DisabledTest.json
+++ b/src/DisabledTests/Tests-Report/Tests-Report.DisabledTest.json
@@ -1635,36 +1635,5 @@
     "codeunitId": 135549,
     "codeunitName": "Report Inbox API E2E",
     "method": "TestPostReportInboxCompaniesNotAllowed"
-  },
-  {
-    "codeunitId": 134619,
-    "codeunitName": "Composite Layout Tests",
-    "method": "LayoutLevelAssignmentResolvesAsThisLayout",
-    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
-  }
-  ,
-  {
-    "codeunitId": 134619,
-    "codeunitName": "Composite Layout Tests",
-    "method": "HeaderAndThemeResolveIndependently",
-    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
-  },
-  {
-    "codeunitId": 134619,
-    "codeunitName": "Composite Layout Tests",
-    "method": "MoreSpecificLevelWinsOverGlobal",
-    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
-  },
-  {
-    "codeunitId": 134619,
-    "codeunitName": "Composite Layout Tests",
-    "method": "PageShowsDecodedPartNamesNotComposite",
-    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
-  },
-  {
-    "codeunitId": 134619,
-    "codeunitName": "Composite Layout Tests",
-    "method": "ShowInfoReportsPartDetailsAndUsage",
-    "bug": "Must be aligned with updated platform behavior for layout level assignment resolution; disabled globally."
   }
 ]

--- a/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
@@ -100,13 +100,17 @@ codeunit 134619 "Composite Layout Tests"
     procedure LayoutLevelAssignmentResolvesAsThisLayout()
     var
         HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource : Text;
+        BodyKey: Text;
     begin
         // [SCENARIO] Parts assigned at the report+layout level resolve with source 'This layout'.
         Initialize();
-        InsertCfg(TestReportID, 'Body', '', CreatePart('MyHF', Enum::"Report Layout Subtype"::HeaderFooter), CreatePart('MyTheme', Enum::"Report Layout Subtype"::Theme));
+
+        // [GIVEN] Both parts assigned to one body layout of a report, keyed by the composite reference to that layout.
+        BodyKey := CreateLayoutOnReport(BodyReportID, 'ResolveBody', Enum::"Report Layout Subtype"::Body);
+        InsertCfg(BodyReportID, BodyKey, '', CreatePart('MyHF', Enum::"Report Layout Subtype"::HeaderFooter), CreatePart('MyTheme', Enum::"Report Layout Subtype"::Theme));
 
         // [WHEN] Resolving the parts for that layout.
-        LookupHelper.GetResolvedPartDisplays(TestReportID, 'Body', HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
+        LookupHelper.GetResolvedPartDisplays(BodyReportID, BodyKey, HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
 
         // [THEN] The decoded part names and the 'This layout' source are returned.
         Assert.AreEqual('MyHF', HeaderDisplay, 'Header part name.');
@@ -180,15 +184,18 @@ codeunit 134619 "Composite Layout Tests"
     procedure HeaderAndThemeResolveIndependently()
     var
         HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource : Text;
+        BodyKey: Text;
     begin
         // [SCENARIO] The header and theme are resolved independently, so each can come from a different level.
         Initialize();
-        // Header only at the layout level; theme only at the global level.
-        InsertCfg(TestReportID, 'Body', '', CreatePart('LayoutHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
+
+        // [GIVEN] The header assigned only to one body layout of a report; the theme assigned only globally.
+        BodyKey := CreateLayoutOnReport(BodyReportID, 'IndependentBody', Enum::"Report Layout Subtype"::Body);
+        InsertCfg(BodyReportID, BodyKey, '', CreatePart('LayoutHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
         InsertCfg(0, '', '', '', CreatePart('GlobalTheme', Enum::"Report Layout Subtype"::Theme));
 
         // [WHEN] Resolving the parts.
-        LookupHelper.GetResolvedPartDisplays(TestReportID, 'Body', HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
+        LookupHelper.GetResolvedPartDisplays(BodyReportID, BodyKey, HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
 
         // [THEN] The header resolves from the layout level and the theme from the global level.
         Assert.AreEqual('LayoutHF', HeaderDisplay, 'Header part name.');
@@ -202,14 +209,18 @@ codeunit 134619 "Composite Layout Tests"
     procedure MoreSpecificLevelWinsOverGlobal()
     var
         HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource : Text;
+        BodyKey: Text;
     begin
         // [SCENARIO] When a part is configured at both the layout level and globally, the layout level wins.
         Initialize();
+
+        // [GIVEN] One header/footer part assigned globally and another to one body layout of a report.
+        BodyKey := CreateLayoutOnReport(BodyReportID, 'SpecificBody', Enum::"Report Layout Subtype"::Body);
         InsertCfg(0, '', '', CreatePart('GlobalHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
-        InsertCfg(TestReportID, 'Body', '', CreatePart('LayoutHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
+        InsertCfg(BodyReportID, BodyKey, '', CreatePart('LayoutHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
 
         // [WHEN] Resolving the parts.
-        LookupHelper.GetResolvedPartDisplays(TestReportID, 'Body', HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
+        LookupHelper.GetResolvedPartDisplays(BodyReportID, BodyKey, HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
 
         // [THEN] The more specific (layout) configuration is used.
         Assert.AreEqual('LayoutHF', HeaderDisplay, 'The layout-level part should win over the global default.');
@@ -222,19 +233,21 @@ codeunit 134619 "Composite Layout Tests"
     var
         TenantReportLayoutCfgPage: TestPage "Tenant Report Layout Cfg";
         HeaderComposite: Text;
+        BodyKey: Text;
     begin
         // [SCENARIO 645022] The Tenant Report Layout Configuration page displays the plain header/footer and theme part
         // names, not the raw <guid>::<name> composite reference stored in the Header/Theme Part Name columns.
         Initialize();
         EnableDocumentReportExperience();
 
-        // [GIVEN] A configuration row whose parts are stored as composite references (<guid>::<name>).
+        // [GIVEN] A layout-scoped configuration row whose parts are stored as composite references (<guid>::<name>).
+        BodyKey := CreateLayoutOnReport(BodyReportID, 'PageBody', Enum::"Report Layout Subtype"::Body);
         HeaderComposite := CreatePart('PageHF', Enum::"Report Layout Subtype"::HeaderFooter);
-        InsertCfg(TestReportID, 'Body', '', HeaderComposite, CreatePart('PageTheme', Enum::"Report Layout Subtype"::Theme));
+        InsertCfg(BodyReportID, BodyKey, '', HeaderComposite, CreatePart('PageTheme', Enum::"Report Layout Subtype"::Theme));
 
         // [WHEN] Opening the page on that row.
         TenantReportLayoutCfgPage.OpenView();
-        TenantReportLayoutCfgPage.Filter.SetFilter("Report ID", Format(TestReportID));
+        TenantReportLayoutCfgPage.Filter.SetFilter("Report ID", Format(BodyReportID));
         Assert.IsTrue(TenantReportLayoutCfgPage.First(), 'The configured row should be shown on the page.');
 
         // [THEN] The columns show the decoded part names, not the stored composite value.
@@ -284,14 +297,16 @@ codeunit 134619 "Composite Layout Tests"
         ReportThemePage: TestPage "Report Theme and Header/Footer";
         Composite: Text;
         ActualMessage: Text;
+        BodyKey: Text;
     begin
         // [SCENARIO 645022] Show info reports the part details and how many report configurations use it.
         Initialize();
         EnableDocumentReportExperience();
 
-        // [GIVEN] A tenant theme part assigned in exactly one report configuration.
+        // [GIVEN] A tenant theme part assigned in exactly one report configuration, scoped to one body layout.
         Composite := CreatePart('ThemeInfo', Enum::"Report Layout Subtype"::Theme);
-        InsertCfg(TestReportID, 'Body', '', '', Composite);
+        BodyKey := CreateLayoutOnReport(BodyReportID, 'InfoBody', Enum::"Report Layout Subtype"::Body);
+        InsertCfg(BodyReportID, BodyKey, '', '', Composite);
 
         // [WHEN] Invoking Show info on that part.
         ReportThemePage.OpenView();
@@ -1034,9 +1049,11 @@ codeunit 134619 "Composite Layout Tests"
 
         // These tests run in a non-isolated (Legacy) bucket against a shared company, so rows are not rolled back
         // between test methods. Clear every configuration row this suite can create before each test. Without this,
-        // the layout-level row left by LayoutLevelAssignmentResolvesAsThisLayout (report 50000, layout 'Body') leaks
-        // into the report/company/global-default tests and wins resolution ahead of the row they set up, and the
-        // report-0 wildcard rows leak out as global/company defaults that affect other tests sharing the company.
+        // the report-level rows the assignment tests leave on the body-layout report resolve as 'Report default' for
+        // the layout-scoped resolution tests on that same report - ApplyToAllLayoutsWidensTheRowAndKeepsItsParts
+        // widens its row to cover every layout, and ApplyToAllLayoutsIsRefusedWhenTheWiderRowAlreadyExists keeps the
+        // wider row it set up - and the report-0 wildcard rows leak out as global/company defaults that affect other
+        // tests sharing the company.
         TenantReportLayoutCfg.SetRange("Report ID", TestReportID);
         TenantReportLayoutCfg.DeleteAll(true);
         TenantReportLayoutCfg.SetRange("Report ID", BodyReportID);


### PR DESCRIPTION
## What & why

Backport of Bug 647094 to `releases/29.x`. Cherry-pick of BCApps main commit `9757a740d8` (PR #10983).

Five test methods in codeunit 134619 `Composite Layout Tests` are disabled on this branch. They
asserted a call shape the product never makes: each inserted a `Tenant Report Layout Cfg` row keyed
by the plain layout name `'Body'` on the fake report 50000, then resolved with that same plain name.
Every product caller resolves with `CompositeLayoutKey(Rec)` — the `<appid>::<name>` composite
reference — so once the configuration rows were keyed that way the tests broke and stopped covering
the real resolution path.

Each of the five now creates an actual body layout on `Report::TestReportLayoutsReport` and keys its
configuration row by that layout's composite reference, which is what `ReportLayoutFactBox` and the
`Layout Theme and Header/Footer` page pass in. The assertions and the precedence levels they cover
are unchanged. Their entries are removed from `Tests-Report.DisabledTest.json`.

## Linked work

[AB#649146](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649146) — backport work item, tracked in ADO (Dynamics SMB). Parent: [AB#647094](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647094), merged to main as #10983.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Codeunit 134619 ran in full on the main-targeted change: **32 total, 32 passed, 0 failed, 0 skipped**,
  169.2s, with all five formerly-disabled methods running and passing.
- This branch's diff is byte-identical to the merged main commit: `git diff origin/releases/29.x bug/649146`
  hashes the same as `git diff 9757a740d8~1 9757a740d8`. Both files on `releases/29.x` were byte-identical to
  main's pre-merge state, so the cherry-pick applied without conflict.
- Not built against this release branch locally — the local enlistment is pointed at master, and
  repointing it at 29.x would not add signal given the diff is provably the same change that already
  passed. CI on this branch is the gate for the release-branch build.

## Risk & compatibility

Test-only change — no product code, no schema, no permissions, no telemetry. Re-enables five tests
that are currently skipped on this branch.

The matching NAV-side removal of `App/DisabledTests/CompositeLayoutTests.DisabledTest.json` plus the
BCApps submodule pointer bump goes with the 29.x ingestion, tracked on [AB#649146](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649146).




