### PR TITLE
[Bug][E-Document DE] XRechnung credit memo export omits PayeeFinancialAccount, failing BR-61 and BR-DE-23-a validation

### DIFF
--- a/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/XRechnung/ExportXRechnungDocument.Codeunit.al
@@ -223,7 +223,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertAccountingSupplierParty(SalesCrMemoHeader."Responsibility Center", SalesCrMemoHeader."Salesperson Code", RootXMLNode);
         InsertAccountingCustomerParty(RootXMLNode, SalesCrMemoHeader);
         InsertDelivery(RootXMLNode, SalesCrMemoHeader);
-        InsertPaymentMeans(RootXMLNode, '58', '', SalesCrMemoHeader."Company Bank Account Code");
+        InsertPaymentMeans(RootXMLNode, '58', 'PayeeFinancialAccount', SalesCrMemoHeader."Company Bank Account Code");
         InsertPaymentTerms(RootXMLNode, SalesCrMemoHeader."Payment Terms Code");
         InsertVATAmounts(SalesCrMemoLine, LineVATAmount, LineAmount, LineDiscAmount, SalesCrMemoHeader."Prices Including VAT", Currency);
         InsertInvDiscountAllowanceCharge(LineAmounts, SalesCrMemoLine, CurrencyCode, RootXMLNode, LineDiscAmount, LineAmount, Currency."Amount Rounding Precision");
@@ -340,7 +340,7 @@ codeunit 13916 "Export XRechnung Document"
         InsertAccountingSupplierParty(SalesCrMemoHeader."Responsibility Center", SalesCrMemoHeader."Salesperson Code", RootXMLNode);
         InsertAccountingCustomerParty(RootXMLNode, SalesCrMemoHeader);
         InsertDelivery(RootXMLNode, SalesCrMemoHeader);
-        InsertPaymentMeans(RootXMLNode, '58', '', SalesCrMemoHeader."Company Bank Account Code");
+        InsertPaymentMeans(RootXMLNode, '58', 'PayeeFinancialAccount', SalesCrMemoHeader."Company Bank Account Code");
         InsertPaymentTerms(RootXMLNode, SalesCrMemoHeader."Payment Terms Code");
         InsertVATAmounts(TempSalesCrMemoLine, LineVATAmount, LineAmount, LineDiscAmount, SalesCrMemoHeader."Prices Including VAT", Currency);
         InsertInvDiscountAllowanceCharge(LineAmounts, TempSalesCrMemoLine, CurrencyCode, RootXMLNode, LineDiscAmount, LineAmount, Currency."Amount Rounding Precision");

--- a/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al
@@ -1035,7 +1035,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
 
         // [THEN] XRechnung Electronic Document is created with bank informarion as payment means
-        VerifyPaymentMeans(TempXMLBuffer, '/ns0:CreditNote/cac:PaymentMeans');
+        VerifyPaymentMeans(TempXMLBuffer, '/ns0:CreditNote/cac:PaymentMeans', CompanyInformation.IBAN, CompanyInformation."SWIFT Code");
     end;
 
     [Test]
@@ -1064,8 +1064,8 @@ codeunit 13918 "XRechnung XML Document Tests"
         // [WHEN] Export XRechnung Electronic Document.
         ExportCreditMemo(SalesCrMemoHeader, TempXMLBuffer);
 
-        // [THEN] XRechnung Electronic Document has payment means code
-        VerifyPaymentMeans(TempXMLBuffer, '/ns0:CreditNote/cac:PaymentMeans');
+        // [THEN] XRechnung Electronic Document uses Bank Account IBAN and SWIFT Code
+        VerifyPaymentMeans(TempXMLBuffer, '/ns0:CreditNote/cac:PaymentMeans', BankAccountIBAN, BankAccountSWIFT);
     end;
 
     [Test]
@@ -1367,7 +1367,7 @@ codeunit 13918 "XRechnung XML Document Tests"
         ExportServiceCreditMemo(ServiceCrMemoHeader, TempXMLBuffer);
 
         // [THEN] XRechnung Electronic Document is created with bank information as payment means
-        VerifyPaymentMeans(TempXMLBuffer, '/ns0:CreditNote/cac:PaymentMeans');
+        VerifyPaymentMeans(TempXMLBuffer, '/ns0:CreditNote/cac:PaymentMeans', CompanyInformation.IBAN, CompanyInformation."SWIFT Code");
     end;
 
     [Test]


### PR DESCRIPTION
## What & why

XRechnung e-documents exported from posted sales and service credit memos declare a SEPA credit transfer (`cbc:PaymentMeansCode` 58) but carry no seller bank account, so every exported `CreditNote` fails EN 16931 rule BR-61 and XRechnung CIUS rule BR-DE-23-a at the recipient's validator, and German public-sector customers reject the document. Invoices exported from the same setup validate fine.

In codeunit 13916 `Export XRechnung Document`, the two credit memo `CreateXML` paths (sales and service) call `InsertPaymentMeans` with an empty element name where the invoice paths pass `'PayeeFinancialAccount'`, so `InsertPayeeFinancialAccount` is skipped entirely.

This change passes `'PayeeFinancialAccount'` at both credit memo call sites, aligning them with the invoice paths. The existing `InsertPayeeFinancialAccount` / `GetBankAccountPaymentDetails` logic then writes the IBAN and, when available, the BIC into `cac:PayeeFinancialAccount`:

```al
InsertPaymentMeans(RootXMLNode, '58', 'PayeeFinancialAccount', SalesCrMemoHeader."Company Bank Account Code");
```

## Linked work

Fixes #11057

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

- Built `E-Document for Germany` and `E-Document for Germany Tests` with `alc.exe` against BC 29 symbols, with CodeCop, UICop and AppSourceCop and the repository `base.ruleset.json`: 0 errors for both, and no new analyzer warnings (the remaining warnings are pre-existing ones in files this change does not touch).
- Test codeunit 13918 `XRechnung XML Document Tests` (`src/Apps/DE/EDocumentDE/test/src/XRechnungXMLDocumentTests.Codeunit.al`): the three existing credit memo payment-means tests now assert IBAN and BIC in `cac:PayeeFinancialAccount` through the existing `VerifyPaymentMeans` overload, the same assertion the invoice tests already make:
  - `ExportPostedSalesCrMemoInXRechnungFormatVerifyPaymentMeans` (Company Information IBAN / SWIFT)
  - `ExportPostedSalesCrMemoInXRechnungFormatVerifyBankAccountPaymentMeans` (company bank account IBAN / SWIFT)
  - `ExportPostedServiceCrMemoInXRechnungFormatVerifyPaymentMeans` (Company Information IBAN / SWIFT)
- TDD red before the fix: all three tests failed with `Node not found: /ns0:CreditNote/cac:PaymentMeans/cac:PayeeFinancialAccount/cbc:ID`. Green after the two call-site changes.
- Mutation loop, each mutant built, published to the container and re-run:

  | Mutant | Expected to be killed by | Result |
  |---|---|---|
  | Revert only the sales credit memo call site to `''` | Both sales credit memo payment-means tests | Killed |
  | Revert only the service credit memo call site to `''` | `ExportPostedServiceCrMemoInXRechnungFormatVerifyPaymentMeans` | Killed |
  | Drop the `cac:FinancialInstitutionBranch` (BIC) node | All three credit memo payment-means tests | Killed |

- Full run of codeunit 13918 against the `bc29de` container (BC 29): 84 passed, covering the invoice and credit memo payment-means tests for sales and service documents. The only two failures in that run are the pre-existing, order-dependent attachment tests `ExportPostedServiceInvoiceInXRechnungFormatVerifyDocumentAttachments` and `ExportPostedSalesInvoiceInXRechnungFormatVerifyUnsupportedAttachmentIsSkipped`, which pass when run in isolation and do not touch payment means.
- ZUGFeRD and PEPPOL BIS output is not affected: the change is confined to the XRechnung export codeunit and touches no shared PEPPOL code.

## Risk & compatibility

- Behavioural change for newly exported XRechnung credit memos: `cac:PaymentMeans` now contains `cac:PayeeFinancialAccount` with the IBAN (and `cac:FinancialInstitutionBranch` with the BIC when the bank account has a SWIFT code), exactly as invoices already do. E-documents that were exported before this change are not touched.
- A credit memo without a configured IBAN now goes through the same helper and the same code path as an invoice without one; nothing new is introduced for that case.
- The invoice paths, ZUGFeRD and PEPPOL BIS are unchanged. No new labels, translations, permissions, telemetry or upgrade impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


