### PR TITLE
[Bug 641000] Add the CLEAN29 preprocessor for the document report experience

### DIFF
--- a/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -420,7 +420,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -742,7 +741,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -756,9 +754,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -776,7 +772,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -532,7 +532,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -854,7 +853,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -868,9 +866,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -888,7 +884,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -413,7 +413,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -735,7 +734,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -749,9 +747,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -769,7 +765,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -527,7 +527,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -849,7 +848,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -863,9 +861,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -883,7 +879,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -517,7 +517,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -839,7 +838,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -853,9 +851,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -873,7 +869,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -507,7 +507,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -829,7 +828,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -843,9 +841,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -863,7 +859,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -437,7 +437,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -784,7 +783,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -798,9 +796,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -818,7 +814,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -404,7 +404,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -726,7 +725,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -740,9 +738,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -760,7 +756,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -433,7 +433,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -755,7 +754,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -769,9 +767,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -789,7 +785,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -562,7 +562,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -887,7 +886,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -901,9 +899,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -930,7 +926,6 @@ page 1 "Company Information"
 #endif        
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -395,7 +395,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -717,7 +716,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -731,9 +729,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -751,7 +747,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -526,7 +526,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -866,7 +865,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -880,9 +878,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -900,7 +896,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -469,7 +469,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -802,7 +801,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -816,9 +814,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -836,7 +832,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -399,7 +399,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -721,7 +720,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -735,9 +733,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -755,7 +751,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -405,7 +405,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -727,7 +726,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -741,9 +739,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -761,7 +757,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -422,7 +422,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -744,7 +743,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -758,9 +756,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -778,7 +774,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -603,7 +603,6 @@ page 1 "Company Information"
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Default Theme';
-                    Visible = DocumentReportExperienceEnabled;
                     ToolTip = 'Specifies the default theme applied to this company''s Word report layouts when no more specific configuration applies. Use the assist-edit to pick a theme; clear the value to remove it.';
 
                     trigger OnAssistEdit()
@@ -622,7 +621,6 @@ page 1 "Company Information"
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Default Header/Footer';
-                    Visible = DocumentReportExperienceEnabled;
                     ToolTip = 'Specifies the default header/footer applied to this company''s Word report layouts when no more specific configuration applies. Use the assist-edit to pick a part; clear the value to remove it.';
 
                     trigger OnAssistEdit()
@@ -947,7 +945,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -961,9 +958,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -981,7 +976,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -394,7 +394,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -716,7 +715,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -730,9 +728,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -750,7 +746,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/W1/BaseApp/FeatureKeyManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/FeatureKeyManagement.Codeunit.al
@@ -16,7 +16,6 @@ codeunit 265 "Feature Key Management"
         FeatureTelemetry: Codeunit System.Telemetry."Feature Telemetry";
         AutomaticAccountCodesTxt: Label 'AutomaticAccountCodes', Locked = true;
         SIEAuditFileExportTxt: Label 'SIEAuditFileExport', Locked = true;
-        DocumentReportExperienceTxt: Label 'DocumentReportExperience', Locked = true;
         ConcurrentInventoryPostingLbl: Label 'ConcurrentInventoryPosting', Locked = true;
         ConcurrentInventoryPosting: Boolean;
         ConcurrentInventoryPostingRead: Boolean;
@@ -38,10 +37,13 @@ codeunit 265 "Feature Key Management"
         exit(FeatureManagementFacade.IsEnabled(GetSIEAuditFileExportFeatureKeyId()));
     end;
 
+#if not CLEAN29
+    [Obsolete('This function is deprecated. The document report experience is always on.', '29.0')]
     procedure IsDocumentReportExperienceEnabled(): Boolean
     begin
-        exit(FeatureManagementFacade.IsEnabled(DocumentReportExperienceTxt));
+        exit(true);
     end;
+#endif
 
 #if not CLEAN27
     [Obsolete('This function is deprecated. Concurrent warehouse posting is always on.', '27.0')]

--- a/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -395,7 +395,6 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
-                Visible = DocumentReportExperienceEnabled;
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -717,7 +716,6 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -731,9 +729,7 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled then
-            LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
     end;
 
     var
@@ -751,7 +747,6 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/HeaderFooterThemeAssignment.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/HeaderFooterThemeAssignment.Page.al
@@ -98,11 +98,7 @@ page 9667 "Header/Footer Theme Assignment"
     trigger OnOpenPage()
     var
         TenantReportLayoutCfg: Record "Tenant Report Layout Cfg";
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
-        if not FeatureKeyManagement.IsDocumentReportExperienceEnabled() then
-            Error(FeatureNotEnabledErr);
-
         if (LayoutName <> '') and (not LookupHelper.IsBodyLayout(ReportID, LayoutName)) then
             Error(NotBodyLayoutErr, LookupHelper.DecodeLayoutName(LayoutName));
 
@@ -240,7 +236,6 @@ page 9667 "Header/Footer Theme Assignment"
         CompanyOverrideExists: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
-        FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
         NotBodyLayoutErr: Label 'A theme and header/footer can only be set on a body layout, and "%1" is not one. They are merged onto a body layout when the report renders, so there is nothing to merge them onto here.', Comment = '%1 = layout name';
         CompanyOverrideLbl: Label '%1 sets its own theme and header/footer for this layout: %2 and %3. That is more specific than the setting below, so it keeps applying in %1 whatever you choose here.', Comment = '%1 = company name; %2 = header/footer part name; %3 = theme part name';
         OverrideHeaderLbl: Label 'header/footer %1', Comment = '%1 = header/footer part name';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutNewDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutNewDialog.page.al
@@ -139,14 +139,11 @@ page 9662 "Report Layout New Dialog"
     }
 
     trigger OnOpenPage()
-    var
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         CreateEmptyLayout := false;
         ExcelMultipleDataSheets := "Excel Sheet Configuration"::Default;
         LayoutName := '';
         AvailableInAllCompanies := true;
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if ImpliedSubtypeSet then
             FormatOptions := FormatOptions::Word
         else begin
@@ -181,7 +178,6 @@ page 9662 "Report Layout New Dialog"
         PartSubtypeVisible: Boolean;
         BodySubtypeVisible: Boolean;
         ImpliedSubtypeSet: Boolean;
-        DocumentReportExperienceEnabled: Boolean;
         ExcelMultipleDataSheets: enum "Excel Sheet Configuration";
         emptyGuid: Guid;
 
@@ -260,8 +256,8 @@ page 9662 "Report Layout New Dialog"
 
     local procedure UpdateSubtypeVisibility()
     begin
-        PartSubtypeVisible := DocumentReportExperienceEnabled and ImpliedSubtypeSet;
-        BodySubtypeVisible := DocumentReportExperienceEnabled and (not ImpliedSubtypeSet);
+        PartSubtypeVisible := ImpliedSubtypeSet;
+        BodySubtypeVisible := not ImpliedSubtypeSet;
 
         if ImpliedSubtypeSet then
             exit;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutSelection.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutSelection.Page.al
@@ -197,7 +197,6 @@ page 9652 "Report Layout Selection"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Show layout parts';
                 Image = ViewDocumentLine;
-                Visible = DocumentReportExperienceEnabled;
                 ToolTip = 'Show the header/footer and theme parts that will actually apply to the selected report in the current company, including where each part is resolved from.';
 
                 trigger OnAction()
@@ -282,11 +281,8 @@ page 9652 "Report Layout Selection"
     end;
 
     trigger OnOpenPage()
-    var
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         SelectedCompany := CompanyName;
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
     end;
 
     var
@@ -299,7 +295,6 @@ page 9652 "Report Layout Selection"
         DefaultLbl: Label '(Default)';
         CustomLayoutDescription: Text;
         IsInitialized: Boolean;
-        DocumentReportExperienceEnabled: Boolean;
         CouldNotFindCustomReportLayoutErr: Label 'There is no custom report layout with %1 in the description.', Comment = '%1 Description of custom report layout';
         CouldNotFindBuiltInReportLayoutErr: Label 'There is no built-in report layout with %1 in the description.', Comment = '%1 Description of custom report layout';
         ShowLayoutPartsMsg: Label 'Header/Footer Part: %1\Theme Part: %2', Comment = '%1 = resolved header/footer part, %2 = resolved theme part';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -127,7 +127,6 @@ page 9660 "Report Layouts"
                 {
                     ApplicationArea = Basic, Suite;
                     Editable = false;
-                    Visible = DocumentReportExperienceEnabled;
                     Caption = 'Subtype';
                     ToolTip = 'Specifies the role of the layout in the Composite Layout Merge: full body (Default), header/footer part, or theme part.';
                 }
@@ -190,7 +189,7 @@ page 9660 "Report Layouts"
                 SubPageLink = "Report ID" = field("Report ID"),
                               Name = field(Name),
                               "Application ID" = field("Application ID");
-                Visible = DocumentReportExperienceEnabled and BodyLayoutSelected;
+                Visible = BodyLayoutSelected;
             }
             systempart(Control11; Notes)
             {
@@ -412,7 +411,6 @@ page 9660 "Report Layouts"
             {
                 Caption = 'Composite layout';
                 Image = Document;
-                Visible = DocumentReportExperienceEnabled;
                 // The assignment page and lookup helper declare RIMD on Tenant Report Layout Cfg (indirect
                 // permission) so the tenant-wide write can happen there. Each action below is gated with
                 // AccessByPermission so only a user who actually holds Modify on that configuration can reach it;
@@ -636,7 +634,6 @@ page 9660 "Report Layouts"
             group(CompositeLayout)
             {
                 Caption = 'Composite layout';
-                Visible = DocumentReportExperienceEnabled;
 
                 actionref(AssignReportDefaults_Promoted; AssignReportDefaults)
                 {
@@ -692,14 +689,11 @@ page 9660 "Report Layouts"
     }
 
     trigger OnOpenPage()
-    var
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
         ReportLayoutsImpl.SetSelectedCompany(CompanyName());
         if CurrPage.LookupMode and (not IncludeUnapproved) then
             Rec.SetRange("Layout Status", Enum::"Report Layout Status"::Approved);
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-        if DocumentReportExperienceEnabled and (not CurrPage.LookupMode) and (ImpliedSubtype = Enum::"Report Layout Subtype"::Default) then begin
+        if (not CurrPage.LookupMode) and (ImpliedSubtype = Enum::"Report Layout Subtype"::Default) then begin
             Rec.FilterGroup(2);
             Rec.SetFilter("Layout Subtype", '<>%1&<>%2', Rec."Layout Subtype"::HeaderFooter, Rec."Layout Subtype"::Theme);
             Rec.FilterGroup(0);
@@ -791,7 +785,6 @@ page 9660 "Report Layouts"
         ShareOptionsVisible: Boolean;
         ShareOptionsEnabled: Boolean;
         CanModifyStatus: Boolean;
-        DocumentReportExperienceEnabled: Boolean;
         WordLayoutSelected: Boolean;
         BodyLayoutSelected: Boolean;
         IncludeUnapproved: Boolean;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
@@ -248,12 +248,7 @@ page 9666 "Report Theme and Header/Footer"
     }
 
     trigger OnOpenPage()
-    var
-        FeatureKeyManagement: Codeunit "Feature Key Management";
     begin
-        if not FeatureKeyManagement.IsDocumentReportExperienceEnabled() then
-            Error(FeatureNotEnabledErr);
-
         NewThemeVisible := (not LookupSubtypeSet) or (LookupSubtype = LookupSubtype::Theme);
         NewHeaderFooterVisible := (not LookupSubtypeSet) or (LookupSubtype = LookupSubtype::HeaderFooter);
 
@@ -492,7 +487,6 @@ page 9666 "Report Theme and Header/Footer"
         LookupSubtypeSet: Boolean;
         NewThemeVisible: Boolean;
         NewHeaderFooterVisible: Boolean;
-        FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
         CannotDeleteOobErr: Label 'Out-of-box themes and header/footer parts cannot be deleted.';
         CannotReplaceOobErr: Label 'Out-of-box themes and header/footer parts cannot be replaced.';
         CannotEditOobErr: Label 'Out-of-box themes and header/footer parts cannot be edited.';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutCfg.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutCfg.Page.al
@@ -226,14 +226,6 @@ page 9663 "Tenant Report Layout Cfg"
         }
     }
 
-    trigger OnOpenPage()
-    var
-        FeatureKeyManagement: Codeunit "Feature Key Management";
-    begin
-        if not FeatureKeyManagement.IsDocumentReportExperienceEnabled() then
-            Error(FeatureNotEnabledErr);
-    end;
-
     trigger OnAfterGetCurrRecord()
     begin
         LayoutScopeSet := Rec."Layout Name" <> '';
@@ -408,7 +400,6 @@ page 9663 "Tenant Report Layout Cfg"
         LayoutNameDisplay: Text;
         LayoutScopeSet: Boolean;
         ReportNameDisplay: Text;
-        FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
         GlobalWildcardCannotHaveLayoutNameErr: Label 'When Report ID is 0, the row applies to every report, so Layout Name must be empty.';
         ScopeExistsErr: Label 'A row for %1 already exists. Change that row instead of pointing this one at the same scope.', Comment = '%1 = scope description, for example All layouts of Sales Invoice';
         PickReportFirstErr: Label 'Choose a report first. A layout belongs to one report, so there is nothing to pick from until Report ID is set.';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutSelection.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutSelection.Page.al
@@ -58,14 +58,12 @@ page 9664 "Tenant Report Layout Selection"
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Header/Footer Part';
-                    Visible = DocumentReportExperienceEnabled;
                     ToolTip = 'Specifies the header/footer layout part composed on top of the body layout when this report is rendered. Configured via the Tenant Report Layout Configuration page.';
                 }
                 field(ThemePartDisplay; ThemePartDisplay)
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Theme Part';
-                    Visible = DocumentReportExperienceEnabled;
                     ToolTip = 'Specifies the theme layout part whose styles override the merged result when this report is rendered. Configured via the Tenant Report Layout Configuration page.';
                 }
             }
@@ -81,7 +79,6 @@ page 9664 "Tenant Report Layout Selection"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Test composite render';
                 Image = TestReport;
-                Visible = DocumentReportExperienceEnabled;
                 ToolTip = 'Runs the selected report so the Composite Layout Merge can be verified end-to-end against the configured Header/Footer and Theme parts.';
 
                 trigger OnAction()
@@ -109,16 +106,8 @@ page 9664 "Tenant Report Layout Selection"
         ThemePartDisplay := LookupHelper.DecodeLayoutName(Rec."Theme Part Name");
     end;
 
-    trigger OnOpenPage()
-    var
-        FeatureKeyManagement: Codeunit "Feature Key Management";
-    begin
-        DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
-    end;
-
     var
         LookupHelper: Codeunit "Composite Layout Lookup Helper";
-        DocumentReportExperienceEnabled: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
         SelectReportFirstErr: Label 'Select a row with a Report ID before running a test render.';


### PR DESCRIPTION
## What & why

The `DocumentReportExperience` feature key gated the composite layout feature — the layout subtype,
the header/footer and theme parts, and the pages that configure them. The feature is GA in 29, so
the gating comes out of every call site and the accessor survives only behind the preprocessor.

`IsDocumentReportExperienceEnabled` now lives behind `#if not CLEAN29`, is marked `Obsolete` with tag
`29.0` and returns `true`, mirroring what CLEAN27 did to `IsConcurrentWarehousingPostingEnabled` in
this same codeunit. Codeunit 265 is `Access = Internal`, so the stub has no callers left inside or
outside the repo — it is kept for parity with that precedent and as the version marker, and it
disappears in 30 along with the flag. Its `DocumentReportExperienceTxt` label is no longer read and
is removed.

At the call sites the flag is gone entirely, which makes the feature unconditional in both 29 and 30:

- **19 country Company Information pages** — the Reporting group is always visible and the company
  default displays are always fetched. Reading `Tenant Report Layout Cfg` on every page open is safe
  because `Composite Layout Lookup Helper` declares indirect RIMD permission on that table.
- **7 W1 Reporting pages** — the Subtype field, the composite layout groups and actions, and the
  header/footer and theme part fields are always visible.
- `Tenant Report Layout Cfg` and `Tenant Report Layout Selection` had `OnOpenPage` triggers that did
  nothing but enforce the gate, so those triggers are gone, along with the three
  `FeatureNotEnabledErr` labels.

## Linked work

[AB#641000](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641000) — tracked in ADO (Dynamics SMB); internal cleanup with no public issue.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built Base Application locally for **W1** and **DE** with `CLEAN15..CLEAN29` defined, so the guarded
  accessor is preprocessed away and every call-site removal has to be self-consistent. Both clean:
  `analyzerErrors=0`, and **zero issues in the 27 changed files**. The 12 remaining warnings
  (AL0685 x9, AL0659 x3) are pre-existing and in unrelated files.
- Ran the repo's own `Test-PreprocessorSymbols` over all 27 changed files with the bounds
  `TestPreprocessorSymbols.ps1` computes (CLEAN 25-29, CLEANSCHEMA 23-32): **0 invalid findings**.
- Verified no residual references: after the change, `IsDocumentReportExperienceEnabled` appears only
  in the guarded stub, and `FeatureNotEnabledErr` nowhere in product code.
- **Not compiled: the other 17 country layers.** They received the identical 4-line pattern and passed
  the symbol check, but only W1 and DE were built. CI covers the rest.
- **Not run: codeunit 134619.** No test was added or needed — this change contains no logic, and every
  relevant test in 134619 already calls `EnableDocumentReportExperience()` in its setup, so those
  tests were already exercising the feature-enabled path. Removing the gate cannot change what they
  observe; at most it makes their own setup redundant.

## Risk & compatibility

The feature becomes unconditional in 29 and 30. That is the intent of the GA, and it is the behaviour
the tests already ran under.

No external compatibility concern: codeunit 265 is `Access = Internal`, so no extension could call the
accessor.

One follow-up outside this repo: the `DocumentReportExperience` feature key is registered by the
platform, not by BCApps, so it will still be listed in Feature Management with nothing reading it
until the platform drops the registration.



