### PR TITLE
SOA: Clear previous search filter

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
@@ -226,6 +226,7 @@ codeunit 4591 "SOA Item Search"
             exit;
         CrossColumnSearchFilter := SearchFilter;
         Clear(ResolvedItemVariants);
+        Rec.SetRange(SystemId);
         if SearchFilter = '=''<>*''' then //If the search filter is empty, clear the previous search state without running a new search
             exit;
 


### PR DESCRIPTION
Fixes [AB#649165](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649165)

**Summary**
Clears the stale SystemId filter before processing a new item search. This prevents previous search results from restricting subsequent searches and ensures empty searches correctly reset the search state.

