### PR TITLE
Honour a deliberate 0% discount on Amount Type = Discount price list lines

### DIFF
--- a/src/Layers/W1/BaseApp/Pricing/Calculation/PriceCalculationV16.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Pricing/Calculation/PriceCalculationV16.Codeunit.al
@@ -244,17 +244,25 @@ codeunit 7002 "Price Calculation - V16" implements "Price Calculation"
     local procedure PickBestLine(AmountType: Enum "Price Amount Type"; PriceListLine: Record "Price List Line"; var BestPriceListLine: Record "Price List Line"; var FoundBestLine: Boolean)
     var
         IsHandled: Boolean;
+        DiscountIsDeclared: Boolean;
     begin
         IsHandled := false;
         OnBeforePickBestLine(AmountType, PriceListLine, BestPriceListLine, FoundBestLine, IsHandled);
         if IsHandled then
             exit;
 
+        // On an "Any" line a zero discount cannot be told apart from an unset field, so only a Discount line declares it.
+        DiscountIsDeclared :=
+            (PriceListLine."Amount Type" = PriceListLine."Amount Type"::Discount) or
+            (PriceListLine."Line Discount %" > 0);
+
         if IsImprovedLine(PriceListLine, BestPriceListLine) or not IsDegradedLine(PriceListLine, BestPriceListLine) then begin
             if IsImprovedLine(PriceListLine, BestPriceListLine) and not IsDegradedLine(PriceListLine, BestPriceListLine) then
-                if (AmountType <> AmountType::Discount) or (PriceListLine."Line Discount %" > 0) then
+                if (AmountType <> AmountType::Discount) or DiscountIsDeclared then
                     Clear(BestPriceListLine);
-            if IsBetterLine(PriceListLine, AmountType, BestPriceListLine) then begin
+            if IsBetterLine(PriceListLine, AmountType, BestPriceListLine) or
+               ((AmountType = AmountType::Discount) and DiscountIsDeclared and not BestPriceListLine.IsRealLine())
+            then begin
                 BestPriceListLine := PriceListLine;
                 FoundBestLine := true;
             end;

--- a/src/Layers/W1/Tests/ERM/TestPriceCalculationV16.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/TestPriceCalculationV16.Codeunit.al
@@ -6245,6 +6245,231 @@ codeunit 134159 "Test Price Calculation - V16"
     end;
 
     [Test]
+    procedure PurchVariantZeroPctDiscountLineWinsOverGenericDiscount()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OldHandler: Enum "Price Calculation Handler";
+        GenericDiscountPct: Decimal;
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] A variant-specific Discount line with 0% overrides the generic discount, generic line created first
+        Initialize();
+
+        // [GIVEN] Default price calculation is 'V16'
+        OldHandler := LibraryPriceCalculation.SetupDefaultHandler("Price Calculation Handler"::"Business Central (Version 16.0)");
+
+        // [GIVEN] Vendor 'V', Item 'I' with Variant 'VAR'
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+        GenericDiscountPct := LibraryRandom.RandIntInRange(10, 40);
+
+        // [GIVEN] Purchase price list for 'V' with a generic discount line (no variant), added first
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Purchase, "Price Source Type"::Vendor, Vendor."No.");
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", '', '', GenericDiscountPct);
+
+        // [GIVEN] and a variant-specific discount line of 0%
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", ItemVariant.Code, '', 0);
+
+        // [GIVEN] Purchase order for 'V' with Item 'I' and no variant
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+
+        // [THEN] Without variant, the generic discount applies
+        Assert.AreEqual(GenericDiscountPct, PurchaseLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, PurchaseLine.FieldCaption("Line Discount %"), GenericDiscountPct, PurchaseLine.TableCaption()));
+
+        // [WHEN] Validate Variant Code 'VAR' on the purchase line
+        PurchaseLine.Validate("Variant Code", ItemVariant.Code);
+
+        // [THEN] The variant-specific 0% wins over the generic discount
+        Assert.AreEqual(0, PurchaseLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, PurchaseLine.FieldCaption("Line Discount %"), 0, PurchaseLine.TableCaption()));
+
+        // Cleanup
+        LibraryPriceCalculation.SetupDefaultHandler(OldHandler);
+    end;
+
+    [Test]
+    procedure PurchVariantZeroPctDiscountLineWinsWhenAddedBeforeGenericDiscount()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OldHandler: Enum "Price Calculation Handler";
+        GenericDiscountPct: Decimal;
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] Line selection is independent of the order the price list lines are stored in
+        Initialize();
+
+        // [GIVEN] Default price calculation is 'V16'
+        OldHandler := LibraryPriceCalculation.SetupDefaultHandler("Price Calculation Handler"::"Business Central (Version 16.0)");
+
+        // [GIVEN] Vendor 'V', Item 'I' with Variant 'VAR'
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+        GenericDiscountPct := LibraryRandom.RandIntInRange(10, 40);
+
+        // [GIVEN] Purchase price list for 'V' with the variant-specific 0% discount line added FIRST
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Purchase, "Price Source Type"::Vendor, Vendor."No.");
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", ItemVariant.Code, '', 0);
+
+        // [GIVEN] and the generic discount line (no variant) added second
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", '', '', GenericDiscountPct);
+
+        // [GIVEN] Purchase order for 'V' with Item 'I' and no variant
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+
+        // [THEN] Without variant, the generic discount applies
+        Assert.AreEqual(GenericDiscountPct, PurchaseLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, PurchaseLine.FieldCaption("Line Discount %"), GenericDiscountPct, PurchaseLine.TableCaption()));
+
+        // [WHEN] Validate Variant Code 'VAR' on the purchase line
+        PurchaseLine.Validate("Variant Code", ItemVariant.Code);
+
+        // [THEN] The variant-specific 0% still wins
+        Assert.AreEqual(0, PurchaseLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, PurchaseLine.FieldCaption("Line Discount %"), 0, PurchaseLine.TableCaption()));
+
+        // Cleanup
+        LibraryPriceCalculation.SetupDefaultHandler(OldHandler);
+    end;
+
+    [Test]
+    procedure SalesVariantZeroPctDiscountLineWinsOverGenericDiscount()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        OldHandler: Enum "Price Calculation Handler";
+        GenericDiscountPct: Decimal;
+    begin
+        // [FEATURE] [SalesPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] A variant-specific Discount line with 0% overrides the generic discount on sales as well
+        Initialize();
+
+        // [GIVEN] Default price calculation is 'V16'
+        OldHandler := LibraryPriceCalculation.SetupDefaultHandler("Price Calculation Handler"::"Business Central (Version 16.0)");
+
+        // [GIVEN] Customer 'C', Item 'I' with Variant 'VAR'
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+        GenericDiscountPct := LibraryRandom.RandIntInRange(10, 40);
+
+        // [GIVEN] Sales price list for 'C' with a generic discount line and a variant-specific 0% line
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Sale, "Price Source Type"::Customer, Customer."No.");
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", '', '', GenericDiscountPct);
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", ItemVariant.Code, '', 0);
+
+        // [GIVEN] Sales quote for 'C' with Item 'I' and no variant
+        LibrarySales.CreateSalesHeader(SalesHeader, "Sales Document Type"::Quote, Customer."No.");
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, "Sales Line Type"::Item, Item."No.", 1);
+
+        // [THEN] Without variant, the generic discount applies
+        Assert.AreEqual(GenericDiscountPct, SalesLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, SalesLine.FieldCaption("Line Discount %"), GenericDiscountPct, SalesLine.TableCaption()));
+
+        // [WHEN] Validate Variant Code 'VAR' on the sales line
+        SalesLine.Validate("Variant Code", ItemVariant.Code);
+
+        // [THEN] The variant-specific 0% wins over the generic discount
+        Assert.AreEqual(0, SalesLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, SalesLine.FieldCaption("Line Discount %"), 0, SalesLine.TableCaption()));
+
+        // Cleanup
+        LibraryPriceCalculation.SetupDefaultHandler(OldHandler);
+    end;
+
+    [Test]
+    procedure PurchCurrencyZeroPctDiscountLineWinsOverGenericDiscount()
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        PriceListHeader: Record "Price List Header";
+        PriceListLine: Record "Price List Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        OldHandler: Enum "Price Calculation Handler";
+        CurrencyCode: Code[10];
+        CurrencyFactor: Decimal;
+        GenericDiscountPct: Decimal;
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Currency] [Discount]
+        // [SCENARIO 649151] A currency-specific Discount line with 0% overrides the generic discount
+        Initialize();
+
+        // [GIVEN] Default price calculation is 'V16'
+        OldHandler := LibraryPriceCalculation.SetupDefaultHandler("Price Calculation Handler"::"Business Central (Version 16.0)");
+
+        // [GIVEN] Vendor 'V', Item 'I' and Currency 'CUR'
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        CurrencyFactor := LibraryRandom.RandDecInRange(2, 5, 2);
+        CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), CurrencyFactor, CurrencyFactor);
+        GenericDiscountPct := LibraryRandom.RandIntInRange(10, 40);
+
+        // [GIVEN] Purchase price list for 'V' with a generic discount line and a currency-specific 0% line
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Purchase, "Price Source Type"::Vendor, Vendor."No.");
+        PriceListHeader."Allow Updating Defaults" := true;
+        PriceListHeader.Modify();
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", '', '', GenericDiscountPct);
+        CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, Item."No.", '', CurrencyCode, 0);
+
+        // [GIVEN] Purchase order for 'V' in local currency
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+
+        // [THEN] The generic discount applies
+        Assert.AreEqual(GenericDiscountPct, PurchaseLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, PurchaseLine.FieldCaption("Line Discount %"), GenericDiscountPct, PurchaseLine.TableCaption()));
+
+        // [WHEN] A purchase order for 'V' in currency 'CUR' is created
+        Clear(PurchaseHeader);
+        Clear(PurchaseLine);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        PurchaseHeader.Validate("Currency Code", CurrencyCode);
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+
+        // [THEN] The currency-specific 0% wins over the generic discount
+        Assert.AreEqual(0, PurchaseLine."Line Discount %",
+            StrSubstNo(ValueMustBeEqualErr, PurchaseLine.FieldCaption("Line Discount %"), 0, PurchaseLine.TableCaption()));
+
+        // Cleanup
+        LibraryPriceCalculation.SetupDefaultHandler(OldHandler);
+    end;
+
+    local procedure CreateActiveItemDiscountLine(var PriceListLine: Record "Price List Line"; PriceListHeader: Record "Price List Header"; ItemNo: Code[20]; VariantCode: Code[10]; CurrencyCode: Code[10]; DiscountPct: Decimal)
+    begin
+        Clear(PriceListLine);
+        LibraryPriceCalculation.CreatePriceListLine(
+            PriceListLine, PriceListHeader, "Price Amount Type"::Discount, "Price Asset Type"::Item, ItemNo);
+        PriceListLine.Validate("Variant Code", VariantCode);
+        PriceListLine.Validate("Currency Code", CurrencyCode);
+        PriceListLine.Validate("Line Discount %", DiscountPct);
+        PriceListLine.Status := "Price Status"::Active;
+        PriceListLine.Modify(true);
+    end;
+
+    [Test]
     procedure SalesLineResourceUnitCostWhenWorkTypeBeforeQuantity()
     var
         Customer: Record Customer;


### PR DESCRIPTION
## What & why

A variant- or currency-specific price list line with `Line Discount % = 0` could never win over a less specific line, so there was no way to configure "no discount for this variant".

In `PickBestLine`, the specificity reset was gated on `(AmountType <> AmountType::Discount) or (PriceListLine."Line Discount %" > 0)`. During discount calculation `AmountType` is always `::Discount` (passed as a literal from `CalcBestAmount` via `ApplyDiscount`), so the effective gate was just `"Line Discount %" > 0` — a 0% line could never displace the generic one.

The gate now asks whether the line *declares* a discount rather than whether the value is positive: an explicit `Amount Type = Discount` line means the 0 was deliberate, while on an `Amount Type = Any` line a 0 is indistinguishable from an unset field and is still ignored. That keeps #582311 working (an `Any` line carrying a price with an untouched 0% discount must not wipe out a real discount).

A second change lets a declaring line take over a cleared best line, so selection is order-independent. Without it the fix only worked when the generic line happened to be iterated first.

**Blast radius is provably narrow.** `DiscountIsDeclared` differs from the old `> 0` test only when `Amount Type = Discount` *and* the discount is `0`, and the new take-over clause can only fire when `IsBetterLine` is false and the best line isn't real — which for discounts also means `0`. For `AmountType = Price` the first clause of the gate is always true and the new clause always false, so the price path is unchanged.

Old pricing (V15) already behaves correctly here — `PurchPriceCalcMgt.CalcBestLineDisc` gives a specific line an unconditional win — so this also closes a V15 → V16 parity gap.

## Linked work

<!-- No GitHub issue exists for this yet; it came in through a customer support incident. -->

Fixes #

[AB#649151](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649151)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built **Base Application** locally with `alc` against a v30 dev instance: **0 errors**, 635 warnings — all pre-existing `AL0432`/`AL0684`, none referencing `PriceCalculationV16`.
- Built **Tests-ERM** with the new tests: **0 errors**, 1 pre-existing warning in an unrelated file.
- Published the rebuilt Base Application to a local BC instance (`30.0.54275.1`), 257/257 apps installed cleanly.
- **Manual verification in the client is still outstanding — this is why the PR is a draft.** The scenario to walk through: purchase price list with a blank-variant `Discount` line at 30% and a variant-specific `Discount` line at 0%; a purchase line with that variant should show 0%, and switching the variant line to `Price & Discount` should return it to 30%.
- **The new automated tests have not been executed yet**, only compiled.

Four tests added to `TestPriceCalculationV16.Codeunit.al`:

| Test | Covers |
|---|---|
| `PurchVariantZeroPctDiscountLineWinsOverGenericDiscount` | Purchase, generic line stored first |
| `PurchVariantZeroPctDiscountLineWinsWhenAddedBeforeGenericDiscount` | Purchase, variant line stored first — guards the order-dependence bug |
| `SalesVariantZeroPctDiscountLineWinsOverGenericDiscount` | Sales side |
| `PurchCurrencyZeroPctDiscountLineWinsOverGenericDiscount` | `Currency Code` specificity, which shares the code path |

The three existing tests that pin the current behaviour were traced by hand against both iteration orders and remain satisfied, because all three use `"Price Amount Type"::Any` for their spurious 0% line:
`DiscountPreservedWhenSpuriousZeroPctVariantLineExists`, `VariantSpecificDiscountOverridesHigherGenericDiscount`, `VariantDiscountSelectedWhenSpuriousZeroPctAndRealVariantDiscountExist`.

## Risk & compatibility

- **Behaviour change on upgrade.** A tenant that already has an `Amount Type = Discount` line sitting at 0% will see it start taking effect; today such lines are inert. This is not measurable from telemetry. Mitigating factor: the V15 → V16 data conversion in `CopyFromToPriceListLine` writes migrated discount records as `Amount Type = Discount` with the variant preserved, so most affected lines are migrated configurations this change *restores* rather than breaks.
- **Does not auto-fix the reporting customer.** Their lines are `Amount Type = Price & Discount`; they must change the variant line to `Discount`. Support needs to communicate this.
- The same gap exists for `Currency Code` and is fixed by the same code path.
- No schema, API or permission changes. Price calculation path untouched.
- Written with agent assistance; the diff has been reviewed line by line and built locally, but not yet exercised in the client.


