### PR TITLE
Validate image content before sending to Computer Vision

### DIFF
--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
@@ -17,9 +17,13 @@ codeunit 2020 "Image Analysis Management"
         LimitType: Option Year,Month,Day,Hour;
         LimitValue: Integer;
         ImagePath: Text;
+        PendingValidationError: Text;
         SetMediaErr: Label 'There was a problem uploading the image file. Please try again.';
         NoApiKeyUriErr: Label 'To analyze images, you must provide an API key and an API URI for Computer Vision.';
         NoImageErr: Label 'You haven''t uploaded an image to analyze.';
+        MediaTooLargeErr: Label 'The media file is too large. Only images up to 4 MB are supported.';
+        MediaTooSmallErr: Label 'The media file is too small. It must be at least 50x50 pixels.';
+        MediaWrongFormatErr: Label 'The media file is not supported. Only images of the following types are supported: JPEG, PNG, GIF, BMP.';
         LastError: Text;
         IsLastErrorUsageLimitError: Boolean;
         UseOAuth2: Boolean;
@@ -41,6 +45,13 @@ codeunit 2020 "Image Analysis Management"
         UsingOAuth2TelemetryMsg: Label 'Using OAuth2 token authentication for Computer Vision.', Locked = true;
         UsingApiKeyTelemetryMsg: Label 'Using API key authentication for Computer Vision (OAuth2 not configured or failed).', Locked = true;
         UsingCustomConfigTelemetryMsg: Label 'Using customer-configured API key and URI for Computer Vision.', Locked = true;
+        ImageValidationFailedTelemetryMsg: Label 'Image content validation failed before sending to Computer Vision. Reason: %1.', Locked = true;
+        MissingFileTelemetryTxt: Label 'MissingFile', Locked = true;
+        TooLargeTelemetryTxt: Label 'TooLarge', Locked = true;
+        TooSmallTelemetryTxt: Label 'TooSmall', Locked = true;
+        NotAnImageTelemetryTxt: Label 'NotAnImage', Locked = true;
+        UnsupportedFormatTelemetryTxt: Label 'UnsupportedFormat', Locked = true;
+        UnsupportedMediaMetadataTelemetryTxt: Label 'UnsupportedMediaMetadata', Locked = true;
 
     [NonDebuggable]
     procedure Initialize()
@@ -98,9 +109,24 @@ codeunit 2020 "Image Analysis Management"
         FileManagement: Codeunit "File Management";
     begin
         if TenantMedia.Get(MediaId) then begin
-            ImageAnalysisProvider.IsMediaSupported(MediaId);
-            ImagePath := FileManagement.ServerTempFileName('');
+            PendingValidationError := '';
+
+            if not ImageAnalysisProvider.IsMediaSupported(MediaId) then begin
+                LogImageValidationFailure(UnsupportedMediaMetadataTelemetryTxt);
+                PendingValidationError := ImageAnalysisProvider.GetLastError();
+                if PendingValidationError = '' then
+                    PendingValidationError := MediaWrongFormatErr;
+                exit;
+            end;
+
             TenantMedia.CalcFields(Content);
+            if TenantMedia.Content.Length() > MaxImageSizeInBytes() then begin
+                LogImageValidationFailure(TooLargeTelemetryTxt);
+                PendingValidationError := MediaTooLargeErr;
+                exit;
+            end;
+
+            ImagePath := FileManagement.ServerTempFileName('');
             TenantMedia.Content.Export(ImagePath);
         end else
             Error(SetMediaErr);
@@ -111,6 +137,7 @@ codeunit 2020 "Image Analysis Management"
         FileManagement: Codeunit "File Management";
     begin
         FileManagement.IsAllowedPath(Path, false);
+        PendingValidationError := '';
         ImagePath := Path;
     end;
 
@@ -118,6 +145,14 @@ codeunit 2020 "Image Analysis Management"
     var
         FileManagement: Codeunit "File Management";
     begin
+        PendingValidationError := '';
+
+        if TempBlob.Length() > MaxImageSizeInBytes() then begin
+            LogImageValidationFailure(TooLargeTelemetryTxt);
+            PendingValidationError := MediaTooLargeErr;
+            exit;
+        end;
+
         ImagePath := FileManagement.ServerTempFileName('');
         FileManagement.BLOBExportToServerFile(TempBlob, ImagePath);
     end;
@@ -197,6 +232,7 @@ codeunit 2020 "Image Analysis Management"
         ImageAnalysisSetup: Record "Image Analysis Setup";
         ResultJSONManagement: Codeunit "JSON Management";
         UsageLimitError: Text;
+        ImageValidationError: Text;
     begin
         Initialize();
         SetLastError('', false);
@@ -209,24 +245,118 @@ codeunit 2020 "Image Analysis Management"
         if (Key.IsEmpty()) or (Uri = '') then
             SetLastError(NoApiKeyUriErr, false)
         else
-            if ImagePath = '' then
-                SetLastError(NoImageErr, false)
+            if PendingValidationError <> '' then
+                SetLastError(PendingValidationError, false)
             else
-                if ImageAnalysisSetup.IsUsageLimitReached(UsageLimitError, LimitValue, LimitType) then
-                    SetLastError(UsageLimitError, true)
-                else
-                    if InvokeAnalysisWithAuth(ResultJSONManagement, Uri, Key, ImagePath, AnalysisTypes, GlobalLanguage()) then
-                        ImageAnalysisSetup.Increment()
+                if ImagePath = '' then
+                    SetLastError(NoImageErr, false)
+                else begin
+                    ImageValidationError := GetImageValidationError(ImagePath);
+                    if ImageValidationError <> '' then
+                        SetLastError(ImageValidationError, false)
                     else
-                        if ImageAnalysisProvider.GetLastError() <> '' then
-                            SetLastError(ImageAnalysisProvider.GetLastError(), false)
+                        if ImageAnalysisSetup.IsUsageLimitReached(UsageLimitError, LimitValue, LimitType) then
+                            SetLastError(UsageLimitError, true)
                         else
-                            SetLastError(GenericErrorErr, false);
+                            if InvokeAnalysisWithAuth(ResultJSONManagement, Uri, Key, ImagePath, AnalysisTypes, GlobalLanguage()) then
+                                ImageAnalysisSetup.Increment()
+                            else
+                                if ImageAnalysisProvider.GetLastError() <> '' then
+                                    SetLastError(ImageAnalysisProvider.GetLastError(), false)
+                                else
+                                    SetLastError(GenericErrorErr, false);
+                end;
 
         ImageAnalysisResult.SetResult(ResultJSONManagement, AnalysisTypes);
         OnAfterImageAnalysis(ImageAnalysisResult);
 
         exit(not HasError());
+    end;
+
+    /// <summary>
+    /// Validates that the file that is about to be sent to the Computer Vision API really is an image
+    /// of a supported format, and that it is within the size and dimension boundaries that the API accepts.
+    /// The validation is done on the decoded content, not on caller-supplied metadata, and it is done on the
+    /// exact bytes that are sent, so that no unvalidated content can leave Business Central.
+    /// </summary>
+    /// <param name="Path">The path of the file that is about to be sent.</param>
+    /// <returns>An empty text if the content is valid, otherwise the error message to show to the user.</returns>
+    local procedure GetImageValidationError(Path: Text) ValidationError: Text
+    var
+        TempBlob: Codeunit "Temp Blob";
+        FileManagement: Codeunit "File Management";
+        ImageFormat: Enum "Image Format";
+        ImageInStream: InStream;
+        ImageHeight: Integer;
+        ImageWidth: Integer;
+    begin
+        if not FileManagement.ServerFileExists(Path) then begin
+            LogImageValidationFailure(MissingFileTelemetryTxt);
+            exit(NoImageErr);
+        end;
+
+        FileManagement.BLOBImportFromServerFile(TempBlob, Path);
+
+        if TempBlob.Length() > MaxImageSizeInBytes() then begin
+            LogImageValidationFailure(TooLargeTelemetryTxt);
+            exit(MediaTooLargeErr);
+        end;
+
+        TempBlob.CreateInStream(ImageInStream);
+        if not TryGetImageProperties(ImageInStream, ImageFormat, ImageWidth, ImageHeight) then begin
+            LogImageValidationFailure(NotAnImageTelemetryTxt);
+            exit(MediaWrongFormatErr);
+        end;
+
+        if not IsSupportedImageFormat(ImageFormat) then begin
+            LogImageValidationFailure(UnsupportedFormatTelemetryTxt);
+            exit(MediaWrongFormatErr);
+        end;
+
+        if (ImageWidth < MinImageDimensionInPixels()) or (ImageHeight < MinImageDimensionInPixels()) then begin
+            LogImageValidationFailure(TooSmallTelemetryTxt);
+            exit(MediaTooSmallErr);
+        end;
+    end;
+
+    [TryFunction]
+    local procedure TryGetImageProperties(ImageInStream: InStream; var ImageFormat: Enum "Image Format"; var ImageWidth: Integer; var ImageHeight: Integer)
+    var
+        Image: Codeunit Image;
+    begin
+        Image.FromStream(ImageInStream);
+        ImageFormat := Image.GetFormat();
+        ImageWidth := Image.GetWidth();
+        ImageHeight := Image.GetHeight();
+    end;
+
+    local procedure IsSupportedImageFormat(ImageFormat: Enum "Image Format"): Boolean
+    begin
+        case ImageFormat of
+            Enum::"Image Format"::Jpeg,
+            Enum::"Image Format"::Png,
+            Enum::"Image Format"::Gif,
+            Enum::"Image Format"::Bmp:
+                exit(true);
+        end;
+
+        exit(false);
+    end;
+
+    local procedure MaxImageSizeInBytes(): Integer
+    begin
+        exit(4 * 1024 * 1024);
+    end;
+
+    local procedure MinImageDimensionInPixels(): Integer
+    begin
+        exit(50);
+    end;
+
+    local procedure LogImageValidationFailure(Reason: Text)
+    begin
+        Session.LogMessage('0000QJ8', StrSubstNo(ImageValidationFailedTelemetryMsg, Reason),
+            Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', ImageAnalysisTelemetryCategoryTxt);
     end;
 
     [Scope('OnPrem')]

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
@@ -247,7 +247,7 @@ codeunit 2020 "Image Analysis Management"
     /// </summary>
     /// <param name="Path">The path of the file that is about to be sent.</param>
     /// <returns>An empty text if the content is valid, otherwise the error message to show to the user.</returns>
-    local procedure GetImageValidationError(Path: Text) ValidationError: Text
+    local procedure GetImageValidationError(Path: Text): Text
     var
         TempBlob: Codeunit "Temp Blob";
         FileManagement: Codeunit "File Management";
@@ -271,6 +271,8 @@ codeunit 2020 "Image Analysis Management"
             LogImageValidationFailure(UnsupportedFormatTelemetryTxt);
             exit(MediaWrongFormatErr);
         end;
+
+        exit('');
     end;
 
     [TryFunction]

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
@@ -17,12 +17,9 @@ codeunit 2020 "Image Analysis Management"
         LimitType: Option Year,Month,Day,Hour;
         LimitValue: Integer;
         ImagePath: Text;
-        PendingValidationError: Text;
         SetMediaErr: Label 'There was a problem uploading the image file. Please try again.';
         NoApiKeyUriErr: Label 'To analyze images, you must provide an API key and an API URI for Computer Vision.';
         NoImageErr: Label 'You haven''t uploaded an image to analyze.';
-        MediaTooLargeErr: Label 'The media file is too large. Only images up to 4 MB are supported.';
-        MediaTooSmallErr: Label 'The media file is too small. It must be at least 50x50 pixels.';
         MediaWrongFormatErr: Label 'The media file is not supported. Only images of the following types are supported: JPEG, PNG, GIF, BMP.';
         LastError: Text;
         IsLastErrorUsageLimitError: Boolean;
@@ -47,11 +44,8 @@ codeunit 2020 "Image Analysis Management"
         UsingCustomConfigTelemetryMsg: Label 'Using customer-configured API key and URI for Computer Vision.', Locked = true;
         ImageValidationFailedTelemetryMsg: Label 'Image content validation failed before sending to Computer Vision. Reason: %1.', Locked = true;
         MissingFileTelemetryTxt: Label 'MissingFile', Locked = true;
-        TooLargeTelemetryTxt: Label 'TooLarge', Locked = true;
-        TooSmallTelemetryTxt: Label 'TooSmall', Locked = true;
         NotAnImageTelemetryTxt: Label 'NotAnImage', Locked = true;
         UnsupportedFormatTelemetryTxt: Label 'UnsupportedFormat', Locked = true;
-        UnsupportedMediaMetadataTelemetryTxt: Label 'UnsupportedMediaMetadata', Locked = true;
 
     [NonDebuggable]
     procedure Initialize()
@@ -109,24 +103,10 @@ codeunit 2020 "Image Analysis Management"
         FileManagement: Codeunit "File Management";
     begin
         if TenantMedia.Get(MediaId) then begin
-            PendingValidationError := '';
-
-            if not ImageAnalysisProvider.IsMediaSupported(MediaId) then begin
-                LogImageValidationFailure(UnsupportedMediaMetadataTelemetryTxt);
-                PendingValidationError := ImageAnalysisProvider.GetLastError();
-                if PendingValidationError = '' then
-                    PendingValidationError := MediaWrongFormatErr;
-                exit;
-            end;
-
-            TenantMedia.CalcFields(Content);
-            if TenantMedia.Content.Length() > MaxImageSizeInBytes() then begin
-                LogImageValidationFailure(TooLargeTelemetryTxt);
-                PendingValidationError := MediaTooLargeErr;
-                exit;
-            end;
-
+            // Keep metadata checks advisory; Analyze validates the actual image content.
+            ImageAnalysisProvider.IsMediaSupported(MediaId);
             ImagePath := FileManagement.ServerTempFileName('');
+            TenantMedia.CalcFields(Content);
             TenantMedia.Content.Export(ImagePath);
         end else
             Error(SetMediaErr);
@@ -137,7 +117,6 @@ codeunit 2020 "Image Analysis Management"
         FileManagement: Codeunit "File Management";
     begin
         FileManagement.IsAllowedPath(Path, false);
-        PendingValidationError := '';
         ImagePath := Path;
     end;
 
@@ -145,14 +124,6 @@ codeunit 2020 "Image Analysis Management"
     var
         FileManagement: Codeunit "File Management";
     begin
-        PendingValidationError := '';
-
-        if TempBlob.Length() > MaxImageSizeInBytes() then begin
-            LogImageValidationFailure(TooLargeTelemetryTxt);
-            PendingValidationError := MediaTooLargeErr;
-            exit;
-        end;
-
         ImagePath := FileManagement.ServerTempFileName('');
         FileManagement.BLOBExportToServerFile(TempBlob, ImagePath);
     end;
@@ -245,27 +216,24 @@ codeunit 2020 "Image Analysis Management"
         if (Key.IsEmpty()) or (Uri = '') then
             SetLastError(NoApiKeyUriErr, false)
         else
-            if PendingValidationError <> '' then
-                SetLastError(PendingValidationError, false)
-            else
-                if ImagePath = '' then
-                    SetLastError(NoImageErr, false)
-                else begin
-                    ImageValidationError := GetImageValidationError(ImagePath);
-                    if ImageValidationError <> '' then
-                        SetLastError(ImageValidationError, false)
+            if ImagePath = '' then
+                SetLastError(NoImageErr, false)
+            else begin
+                ImageValidationError := GetImageValidationError(ImagePath);
+                if ImageValidationError <> '' then
+                    SetLastError(ImageValidationError, false)
+                else
+                    if ImageAnalysisSetup.IsUsageLimitReached(UsageLimitError, LimitValue, LimitType) then
+                        SetLastError(UsageLimitError, true)
                     else
-                        if ImageAnalysisSetup.IsUsageLimitReached(UsageLimitError, LimitValue, LimitType) then
-                            SetLastError(UsageLimitError, true)
+                        if InvokeAnalysisWithAuth(ResultJSONManagement, Uri, Key, ImagePath, AnalysisTypes, GlobalLanguage()) then
+                            ImageAnalysisSetup.Increment()
                         else
-                            if InvokeAnalysisWithAuth(ResultJSONManagement, Uri, Key, ImagePath, AnalysisTypes, GlobalLanguage()) then
-                                ImageAnalysisSetup.Increment()
+                            if ImageAnalysisProvider.GetLastError() <> '' then
+                                SetLastError(ImageAnalysisProvider.GetLastError(), false)
                             else
-                                if ImageAnalysisProvider.GetLastError() <> '' then
-                                    SetLastError(ImageAnalysisProvider.GetLastError(), false)
-                                else
-                                    SetLastError(GenericErrorErr, false);
-                end;
+                                SetLastError(GenericErrorErr, false);
+            end;
 
         ImageAnalysisResult.SetResult(ResultJSONManagement, AnalysisTypes);
         OnAfterImageAnalysis(ImageAnalysisResult);
@@ -274,10 +242,8 @@ codeunit 2020 "Image Analysis Management"
     end;
 
     /// <summary>
-    /// Validates that the file that is about to be sent to the Computer Vision API really is an image
-    /// of a supported format, and that it is within the size and dimension boundaries that the API accepts.
-    /// The validation is done on the decoded content, not on caller-supplied metadata, and it is done on the
-    /// exact bytes that are sent, so that no unvalidated content can leave Business Central.
+    /// Validates the image format from the file content rather than caller-supplied metadata.
+    /// API-specific size and dimension restrictions are left to the configured service.
     /// </summary>
     /// <param name="Path">The path of the file that is about to be sent.</param>
     /// <returns>An empty text if the content is valid, otherwise the error message to show to the user.</returns>
@@ -287,8 +253,6 @@ codeunit 2020 "Image Analysis Management"
         FileManagement: Codeunit "File Management";
         ImageFormat: Enum "Image Format";
         ImageInStream: InStream;
-        ImageHeight: Integer;
-        ImageWidth: Integer;
     begin
         if not FileManagement.ServerFileExists(Path) then begin
             LogImageValidationFailure(MissingFileTelemetryTxt);
@@ -297,13 +261,8 @@ codeunit 2020 "Image Analysis Management"
 
         FileManagement.BLOBImportFromServerFile(TempBlob, Path);
 
-        if TempBlob.Length() > MaxImageSizeInBytes() then begin
-            LogImageValidationFailure(TooLargeTelemetryTxt);
-            exit(MediaTooLargeErr);
-        end;
-
         TempBlob.CreateInStream(ImageInStream);
-        if not TryGetImageProperties(ImageInStream, ImageFormat, ImageWidth, ImageHeight) then begin
+        if not TryGetImageFormat(ImageInStream, ImageFormat) then begin
             LogImageValidationFailure(NotAnImageTelemetryTxt);
             exit(MediaWrongFormatErr);
         end;
@@ -312,22 +271,15 @@ codeunit 2020 "Image Analysis Management"
             LogImageValidationFailure(UnsupportedFormatTelemetryTxt);
             exit(MediaWrongFormatErr);
         end;
-
-        if (ImageWidth < MinImageDimensionInPixels()) or (ImageHeight < MinImageDimensionInPixels()) then begin
-            LogImageValidationFailure(TooSmallTelemetryTxt);
-            exit(MediaTooSmallErr);
-        end;
     end;
 
     [TryFunction]
-    local procedure TryGetImageProperties(ImageInStream: InStream; var ImageFormat: Enum "Image Format"; var ImageWidth: Integer; var ImageHeight: Integer)
+    local procedure TryGetImageFormat(ImageInStream: InStream; var ImageFormat: Enum "Image Format")
     var
         Image: Codeunit Image;
     begin
         Image.FromStream(ImageInStream);
         ImageFormat := Image.GetFormat();
-        ImageWidth := Image.GetWidth();
-        ImageHeight := Image.GetHeight();
     end;
 
     local procedure IsSupportedImageFormat(ImageFormat: Enum "Image Format"): Boolean
@@ -341,16 +293,6 @@ codeunit 2020 "Image Analysis Management"
         end;
 
         exit(false);
-    end;
-
-    local procedure MaxImageSizeInBytes(): Integer
-    begin
-        exit(4 * 1024 * 1024);
-    end;
-
-    local procedure MinImageDimensionInPixels(): Integer
-    begin
-        exit(50);
     end;
 
     local procedure LogImageValidationFailure(Reason: Text)

--- a/src/Layers/W1/Tests/Integration-Internal/ImageAnalysisManagementTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration-Internal/ImageAnalysisManagementTest.Codeunit.al
@@ -25,6 +25,9 @@ codeunit 135206 "Image Analysis Management Test"
         MissingImageAnalysisSecretErr: Label 'There is a missing configuration value on our end. Try again later.';
         GenericErrorErr: Label 'There was an error in contacting the Computer Vision API. Please try again or contact an administrator.';
         ChangingLimitAfterInitErr: Label 'You cannot change the limit setting after initialization.';
+        MediaTooLargeErr: Label 'The media file is too large. Only images up to 4 MB are supported.';
+        MediaTooSmallErr: Label 'The media file is too small. It must be at least 50x50 pixels.';
+        MediaWrongFormatErr: Label 'The media file is not supported. Only images of the following types are supported: JPEG, PNG, GIF, BMP.';
         LimitType: Option Year,Month,Day,Hour;
 
     [Test]
@@ -319,6 +322,144 @@ codeunit 135206 "Image Analysis Management Test"
         Result := ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
         Assert.IsFalse(IsUsageLimitError, 'Did not expect a usage limit error.');
         Assert.AreEqual(UnauthorizedErr, ErrorValue, 'Expected the last error to be Unauthorized error.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeRejectsContentThatIsNotAnImage()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        ContentOutStream: OutStream;
+        Result: Boolean;
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+    begin
+        // [SCENARIO] Content that cannot be decoded as an image is never sent to the Computer Vision API
+
+        // [GIVEN] A blob that contains text instead of an image
+        TempBlob.CreateOutStream(ContentOutStream);
+        ContentOutStream.WriteText('This is not an image. It only claims to be one.');
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        InitializeMockKeyvault('fakekey', 'https://fakeuri', '1000', 'Hour');
+
+        ImageAnalysisManagement.Initialize();
+        ImageAnalysisManagement.SetBlob(TempBlob);
+        ImageAnalysisManagement.SetHttpMessageHandler(
+          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+
+        // [WHEN] Analyze is invoked
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+
+        // [THEN] The analysis fails with the unsupported format error
+        Assert.IsFalse(Result, 'Analysis should have failed for content that is not an image.');
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.AreEqual(MediaWrongFormatErr, ErrorValue, 'Expected the unsupported media format error.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeRejectsUnsupportedImageFormat()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        Result: Boolean;
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+    begin
+        // [SCENARIO] A valid image in a format that Computer Vision does not accept is never sent
+
+        // [GIVEN] A TIFF image
+        CreateImageBlob(TempBlob, 500, 600, Enum::"Image Format"::Tiff);
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        InitializeMockKeyvault('fakekey', 'https://fakeuri', '1000', 'Hour');
+
+        ImageAnalysisManagement.Initialize();
+        ImageAnalysisManagement.SetBlob(TempBlob);
+        ImageAnalysisManagement.SetHttpMessageHandler(
+          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+
+        // [WHEN] Analyze is invoked
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+
+        // [THEN] The analysis fails with the unsupported format error
+        Assert.IsFalse(Result, 'Analysis should have failed for an unsupported image format.');
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.AreEqual(MediaWrongFormatErr, ErrorValue, 'Expected the unsupported media format error.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeRejectsImageThatIsTooSmall()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        Result: Boolean;
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+    begin
+        // [SCENARIO] An image that is smaller than what Computer Vision accepts is never sent
+
+        // [GIVEN] A 10x10 pixel image
+        CreateImageBlob(TempBlob, 10, 10, Enum::"Image Format"::Jpeg);
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        InitializeMockKeyvault('fakekey', 'https://fakeuri', '1000', 'Hour');
+
+        ImageAnalysisManagement.Initialize();
+        ImageAnalysisManagement.SetBlob(TempBlob);
+        ImageAnalysisManagement.SetHttpMessageHandler(
+          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+
+        // [WHEN] Analyze is invoked
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+
+        // [THEN] The analysis fails with the too small error
+        Assert.IsFalse(Result, 'Analysis should have failed for an image that is too small.');
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.AreEqual(MediaTooSmallErr, ErrorValue, 'Expected the media too small error.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeRejectsImageThatIsTooLarge()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        Result: Boolean;
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+    begin
+        // [SCENARIO] Content that is larger than what Computer Vision accepts is never sent
+
+        // [GIVEN] An uncompressed image of more than 4 MB
+        CreateImageBlob(TempBlob, 1500, 1500, Enum::"Image Format"::Bmp);
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        InitializeMockKeyvault('fakekey', 'https://fakeuri', '1000', 'Hour');
+
+        ImageAnalysisManagement.Initialize();
+        ImageAnalysisManagement.SetBlob(TempBlob);
+        ImageAnalysisManagement.SetHttpMessageHandler(
+          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+
+        // [WHEN] Analyze is invoked
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+
+        // [THEN] The analysis fails with the too large error
+        Assert.IsFalse(Result, 'Analysis should have failed for an image that is too large.');
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.AreEqual(MediaTooLargeErr, ErrorValue, 'Expected the media too large error.');
     end;
 
     [Test]
@@ -662,6 +803,30 @@ codeunit 135206 "Image Analysis Management Test"
     local procedure GetImagePath(): Text
     begin
         exit(LibraryUtilityOnPrem.GetInetRoot() + '\App\Test\Files\ImageAnalysis\AllowedImage.jpg');
+    end;
+
+    [Normal]
+    local procedure CreateImageBlob(var TempBlob: Codeunit "Temp Blob"; Width: Integer; Height: Integer; ImageFormat: Enum "Image Format")
+    var
+        SourceTempBlob: Codeunit "Temp Blob";
+        FileManagement: Codeunit "File Management";
+        Image: Codeunit Image;
+        ImageInStream: InStream;
+        ImageOutStream: OutStream;
+    begin
+        // This import needs to happen before setting to saas
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+        FileManagement.BLOBImportFromServerFile(SourceTempBlob, GetImagePath());
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+
+        SourceTempBlob.CreateInStream(ImageInStream);
+        Image.FromStream(ImageInStream);
+        Image.Resize(Width, Height);
+        Image.SetFormat(ImageFormat);
+
+        Clear(TempBlob);
+        TempBlob.CreateOutStream(ImageOutStream);
+        Image.Save(ImageOutStream);
     end;
 
     [Normal]

--- a/src/Layers/W1/Tests/Integration-Internal/ImageAnalysisManagementTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration-Internal/ImageAnalysisManagementTest.Codeunit.al
@@ -2,6 +2,7 @@ codeunit 135206 "Image Analysis Management Test"
 {
     Permissions = TableData "Azure AI Usage" = rimd;
     Subtype = Test;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -25,10 +26,9 @@ codeunit 135206 "Image Analysis Management Test"
         MissingImageAnalysisSecretErr: Label 'There is a missing configuration value on our end. Try again later.';
         GenericErrorErr: Label 'There was an error in contacting the Computer Vision API. Please try again or contact an administrator.';
         ChangingLimitAfterInitErr: Label 'You cannot change the limit setting after initialization.';
-        MediaTooLargeErr: Label 'The media file is too large. Only images up to 4 MB are supported.';
-        MediaTooSmallErr: Label 'The media file is too small. It must be at least 50x50 pixels.';
         MediaWrongFormatErr: Label 'The media file is not supported. Only images of the following types are supported: JPEG, PNG, GIF, BMP.';
         LimitType: Option Year,Month,Day,Hour;
+        ImageAnalysisRequestCount: Integer;
 
     [Test]
     [Scope('OnPrem')]
@@ -348,14 +348,15 @@ codeunit 135206 "Image Analysis Management Test"
 
         ImageAnalysisManagement.Initialize();
         ImageAnalysisManagement.SetBlob(TempBlob);
-        ImageAnalysisManagement.SetHttpMessageHandler(
-          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+        HttpMessageHandler := HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath());
+        ImageAnalysisManagement.SetHttpMessageHandler(HttpMessageHandler);
 
         // [WHEN] Analyze is invoked
         Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
 
         // [THEN] The analysis fails with the unsupported format error
         Assert.IsFalse(Result, 'Analysis should have failed for content that is not an image.');
+        Assert.IsTrue(IsNull(HttpMessageHandler.RequestMessage), 'Invalid content must not be sent.');
         ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
         Assert.AreEqual(MediaWrongFormatErr, ErrorValue, 'Expected the unsupported media format error.');
     end;
@@ -382,14 +383,15 @@ codeunit 135206 "Image Analysis Management Test"
 
         ImageAnalysisManagement.Initialize();
         ImageAnalysisManagement.SetBlob(TempBlob);
-        ImageAnalysisManagement.SetHttpMessageHandler(
-          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+        HttpMessageHandler := HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath());
+        ImageAnalysisManagement.SetHttpMessageHandler(HttpMessageHandler);
 
         // [WHEN] Analyze is invoked
         Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
 
         // [THEN] The analysis fails with the unsupported format error
         Assert.IsFalse(Result, 'Analysis should have failed for an unsupported image format.');
+        Assert.IsTrue(IsNull(HttpMessageHandler.RequestMessage), 'Unsupported image formats must not be sent.');
         ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
         Assert.AreEqual(MediaWrongFormatErr, ErrorValue, 'Expected the unsupported media format error.');
     end;
@@ -397,69 +399,215 @@ codeunit 135206 "Image Analysis Management Test"
     [Test]
     [TestPermissions(TestPermissions::Disabled)]
     [Scope('OnPrem')]
-    procedure TestAnalyzeRejectsImageThatIsTooSmall()
+    procedure TestAnalyzeSmallImageForCustomVision()
     var
         TempBlob: Codeunit "Temp Blob";
         ImageAnalysisManagement: Codeunit "Image Analysis Management";
         ImageAnalysisResult: Codeunit "Image Analysis Result";
+        HttpRequestMessage: DotNet HttpRequestMessage;
+        HttpRequestHeaders: DotNet HttpRequestHeaders;
         Result: Boolean;
         ErrorValue: Text;
         IsUsageLimitError: Boolean;
     begin
-        // [SCENARIO] An image that is smaller than what Computer Vision accepts is never sent
+        // [SCENARIO] BC does not impose Computer Vision's minimum dimensions on Custom Vision
 
         // [GIVEN] A 10x10 pixel image
         CreateImageBlob(TempBlob, 10, 10, Enum::"Image Format"::Jpeg);
 
         EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
-        InitializeMockKeyvault('fakekey', 'https://fakeuri', '1000', 'Hour');
-
+        ImageAnalysisManagement.SetUriAndKey('https://fakeuri/customvision/', GetKey());
         ImageAnalysisManagement.Initialize();
         ImageAnalysisManagement.SetBlob(TempBlob);
-        ImageAnalysisManagement.SetHttpMessageHandler(
-          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+        HttpMessageHandler := HttpMessageHandler.MockHttpMessageHandler(GetCustomImageAnalysisTagsResponsePath());
+        ImageAnalysisManagement.SetHttpMessageHandler(HttpMessageHandler);
 
         // [WHEN] Analyze is invoked
         Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
 
-        // [THEN] The analysis fails with the too small error
-        Assert.IsFalse(Result, 'Analysis should have failed for an image that is too small.');
+        // [THEN] The image reaches the customer's Custom Vision endpoint with its existing authentication
         ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
-        Assert.AreEqual(MediaTooSmallErr, ErrorValue, 'Expected the media too small error.');
+        Assert.IsTrue(Result, 'A small image should reach Custom Vision. Error: ' + ErrorValue);
+        HttpRequestMessage := HttpMessageHandler.RequestMessage;
+        Assert.AreEqual('https://fakeuri/customvision/', HttpRequestMessage.RequestUri.AbsoluteUri, 'Unexpected endpoint.');
+        HttpRequestHeaders := HttpRequestMessage.Headers;
+        HttpRequestHeaders.GetValues('Prediction-Key');
     end;
 
     [Test]
     [TestPermissions(TestPermissions::Disabled)]
     [Scope('OnPrem')]
-    procedure TestAnalyzeRejectsImageThatIsTooLarge()
+    procedure TestAnalyzeLargeImageForCustomerResource()
     var
         TempBlob: Codeunit "Temp Blob";
         ImageAnalysisManagement: Codeunit "Image Analysis Management";
         ImageAnalysisResult: Codeunit "Image Analysis Result";
+        HttpRequestMessage: DotNet HttpRequestMessage;
+        HttpRequestHeaders: DotNet HttpRequestHeaders;
         Result: Boolean;
         ErrorValue: Text;
         IsUsageLimitError: Boolean;
     begin
-        // [SCENARIO] Content that is larger than what Computer Vision accepts is never sent
+        // [SCENARIO] The configured service, not a universal BC restriction, decides the allowed file size
 
         // [GIVEN] An uncompressed image of more than 4 MB
         CreateImageBlob(TempBlob, 1500, 1500, Enum::"Image Format"::Bmp);
+        Assert.IsTrue(TempBlob.Length() > 4 * 1024 * 1024, 'The image must exceed 4 MB.');
 
         EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
-        InitializeMockKeyvault('fakekey', 'https://fakeuri', '1000', 'Hour');
-
+        ImageAnalysisManagement.SetUriAndKey('https://fakeuri', GetKey());
         ImageAnalysisManagement.Initialize();
         ImageAnalysisManagement.SetBlob(TempBlob);
-        ImageAnalysisManagement.SetHttpMessageHandler(
-          HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath()));
+        HttpMessageHandler := HttpMessageHandler.MockHttpMessageHandler(GetImageAnalysisTagsResponsePath());
+        ImageAnalysisManagement.SetHttpMessageHandler(HttpMessageHandler);
 
         // [WHEN] Analyze is invoked
         Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
 
-        // [THEN] The analysis fails with the too large error
-        Assert.IsFalse(Result, 'Analysis should have failed for an image that is too large.');
+        // [THEN] BC forwards the image and uses the mocked service response
         ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
-        Assert.AreEqual(MediaTooLargeErr, ErrorValue, 'Expected the media too large error.');
+        Assert.IsTrue(Result, 'The configured service should decide the size limit. Error: ' + ErrorValue);
+        HttpRequestMessage := HttpMessageHandler.RequestMessage;
+        HttpRequestHeaders := HttpRequestMessage.Headers;
+        HttpRequestHeaders.GetValues('Ocp-Apim-Subscription-Key');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeRejectsNonImagePathForCustomVision()
+    var
+        TempBlob: Codeunit "Temp Blob";
+        FileManagement: Codeunit "File Management";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        ContentOutStream: OutStream;
+        ImagePath: Text;
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+        Result: Boolean;
+    begin
+        // [SCENARIO] SetImagePath cannot bypass content validation for a customer-configured Custom Vision endpoint
+        TempBlob.CreateOutStream(ContentOutStream);
+        ContentOutStream.WriteText('This is not an image.');
+        ImagePath := FileManagement.ServerTempFileName('jpg');
+        FileManagement.BLOBExportToServerFile(TempBlob, ImagePath);
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        ImageAnalysisManagement.SetUriAndKey('https://fakeuri/customvision/', GetKey());
+        ImageAnalysisManagement.Initialize();
+        ImageAnalysisManagement.SetImagePath(ImagePath);
+        HttpMessageHandler := HttpMessageHandler.MockHttpMessageHandler(GetCustomImageAnalysisTagsResponsePath());
+        ImageAnalysisManagement.SetHttpMessageHandler(HttpMessageHandler);
+
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+        FileManagement.DeleteServerFile(ImagePath);
+
+        Assert.IsFalse(Result, 'Custom Vision must not receive non-image content.');
+        Assert.IsTrue(IsNull(HttpMessageHandler.RequestMessage), 'Invalid content must not be sent.');
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.AreEqual(MediaWrongFormatErr, ErrorValue, 'Expected the unsupported media format error.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeV32AcceptsImageWithIncorrectMetadata()
+    var
+        Item: Record Item;
+        TenantMedia: Record "Tenant Media";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        ImageAnalysisManagementTest: Codeunit "Image Analysis Management Test";
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+        Result: Boolean;
+    begin
+        // [SCENARIO] V3.2 accepts supported image bytes even when the stored MIME type and dimensions are incorrect
+        LibraryInventory.CreateItem(Item);
+        Item.Picture.ImportFile(GetImagePath(), 'Description');
+        TenantMedia.Get(Item.Picture.Item(1));
+        TenantMedia."Mime Type" := 'application/octet-stream';
+        TenantMedia.Width := 0;
+        TenantMedia.Height := 0;
+        TenantMedia.Modify();
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        ImageAnalysisManagement.SetUriAndKey('https://fakeuri', GetKey());
+        ImageAnalysisManagement.Initialize(Enum::"Image Analysis Provider"::"v3.2");
+        ImageAnalysisManagement.SetMedia(TenantMedia.ID);
+        BindSubscription(ImageAnalysisManagementTest);
+
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+        UnbindSubscription(ImageAnalysisManagementTest);
+
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.IsTrue(Result, 'Valid image content must not be rejected based on metadata. Error: ' + ErrorValue);
+        Assert.AreEqual(1, ImageAnalysisManagementTest.GetImageAnalysisRequestCount(), 'The image should reach V3.2.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeV32RejectsNonImageWithImageMetadata()
+    var
+        Item: Record Item;
+        TenantMedia: Record "Tenant Media";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        ImageAnalysisManagementTest: Codeunit "Image Analysis Management Test";
+        ContentOutStream: OutStream;
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+        Result: Boolean;
+    begin
+        // [SCENARIO] V3.2 rejects non-image bytes even when the stored metadata describes a supported image
+        LibraryInventory.CreateItem(Item);
+        Item.Picture.ImportFile(GetImagePath(), 'Description');
+        TenantMedia.Get(Item.Picture.Item(1));
+        TenantMedia.CalcFields(Content);
+        Clear(TenantMedia.Content);
+        TenantMedia.Content.CreateOutStream(ContentOutStream);
+        ContentOutStream.WriteText('This is not an image.');
+        TenantMedia.Modify();
+
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(true);
+        ImageAnalysisManagement.SetUriAndKey('https://fakeuri', GetKey());
+        ImageAnalysisManagement.Initialize(Enum::"Image Analysis Provider"::"v3.2");
+        ImageAnalysisManagement.SetMedia(TenantMedia.ID);
+        BindSubscription(ImageAnalysisManagementTest);
+
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+        UnbindSubscription(ImageAnalysisManagementTest);
+
+        Assert.IsFalse(Result, 'Image metadata must not make non-image content valid.');
+        Assert.AreEqual(0, ImageAnalysisManagementTest.GetImageAnalysisRequestCount(), 'Invalid content must not be sent.');
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.AreEqual(MediaWrongFormatErr, ErrorValue, 'Expected the unsupported media format error.');
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzePngForCustomVision()
+    begin
+        AnalyzeSupportedFormatForCustomVision(Enum::"Image Format"::Png);
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeGifForCustomVision()
+    begin
+        AnalyzeSupportedFormatForCustomVision(Enum::"Image Format"::Gif);
+    end;
+
+    [Test]
+    [TestPermissions(TestPermissions::Disabled)]
+    [Scope('OnPrem')]
+    procedure TestAnalyzeBmpForCustomVision()
+    begin
+        AnalyzeSupportedFormatForCustomVision(Enum::"Image Format"::Bmp);
     end;
 
     [Test]
@@ -827,6 +975,46 @@ codeunit 135206 "Image Analysis Management Test"
         Clear(TempBlob);
         TempBlob.CreateOutStream(ImageOutStream);
         Image.Save(ImageOutStream);
+    end;
+
+    local procedure AnalyzeSupportedFormatForCustomVision(ImageFormat: Enum "Image Format")
+    var
+        TempBlob: Codeunit "Temp Blob";
+        ImageAnalysisManagement: Codeunit "Image Analysis Management";
+        ImageAnalysisResult: Codeunit "Image Analysis Result";
+        ErrorValue: Text;
+        IsUsageLimitError: Boolean;
+        Result: Boolean;
+    begin
+        // [SCENARIO] Custom Vision's supported formats remain accepted with customer-provided credentials
+        CreateImageBlob(TempBlob, 500, 600, ImageFormat);
+        ImageAnalysisManagement.SetUriAndKey('https://fakeuri/customvision/', GetKey());
+        ImageAnalysisManagement.Initialize();
+        ImageAnalysisManagement.SetBlob(TempBlob);
+        HttpMessageHandler := HttpMessageHandler.MockHttpMessageHandler(GetCustomImageAnalysisTagsResponsePath());
+        ImageAnalysisManagement.SetHttpMessageHandler(HttpMessageHandler);
+
+        Result := ImageAnalysisManagement.AnalyzeTags(ImageAnalysisResult);
+
+        ImageAnalysisManagement.GetLastError(ErrorValue, IsUsageLimitError);
+        Assert.IsTrue(Result, 'The image format should be accepted by BC. Error: ' + ErrorValue);
+        Assert.IsFalse(IsNull(HttpMessageHandler.RequestMessage), 'The image must reach the configured endpoint.');
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Image Analysis Management", OnBeforeSendImageAnalysisRequest, '', false, false)]
+    local procedure OnBeforeSendImageAnalysisRequestProvideResponse(HttpContent: HttpContent; RequestUrl: Text; var HttpStatusCode: Integer; var HttpResponseContentText: Text; var Handled: Boolean)
+    begin
+        Assert.IsFalse(Handled, 'The request should not already be handled.');
+        Assert.IsTrue(RequestUrl.StartsWith('https://fakeuri/vision/v3.2/analyze?'), 'Unexpected V3.2 endpoint.');
+        ImageAnalysisRequestCount += 1;
+        HttpStatusCode := 200;
+        HttpResponseContentText := '{"requestId":"93c49f4b-085c-4c83-b29c-e4eb9013a1b9","tags":[]}';
+        Handled := true;
+    end;
+
+    procedure GetImageAnalysisRequestCount(): Integer
+    begin
+        exit(ImageAnalysisRequestCount);
     end;
 
     [Normal]


### PR DESCRIPTION
## What & why

Validate image content before sending it to the configured Vision endpoint ([AB#648727](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648727)).

`SetMedia` currently invokes a non-blocking, metadata-based provider check; `SetBlob` and `SetImagePath` have no content check. The shared `Analyze` path now loads the file using the existing System Application `Image` codeunit and accepts decoded JPEG, PNG, GIF and BMP formats. This covers both V1.0 and V3.2 without relying on the filename or caller-supplied MIME type.

The allowlist matches the documented formats for [Computer Vision 3.2](https://learn.microsoft.com/en-us/azure/ai-services/computer-vision/overview-image-analysis#input-requirements) and [Azure Custom Vision](https://learn.microsoft.com/en-us/azure/ai-services/custom-vision-service/limits-and-quotas).

**Scope narrowed after compatibility review:** no universal 4 MB limit or 50x50 minimum, and no new hard rejection based on stored media metadata. Those checks from the initial draft are removed. API-specific size/dimension decisions remain with the configured service. The provider metadata check remains advisory, as before.

Customer-owned Azure resources and the existing Custom Vision path are supported scenarios. This change does not alter endpoint selection, customer keys, OAuth, `Prediction-Key`, subscription-key headers, or the uploaded image bytes. Validation failures return through the existing `Analyze` / `GetLastError` notification path, with rejection telemetry `0000QJ8`.

Harms/XPIA detection, image rewriting and endpoint restrictions are outside this change.

## Linked work

[AB#648727](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648727) - [AI Business Solutions] Validate file content and metadata before sending to AI Vision

An approved GitHub issue is not linked; this draft tracks the internal security slice.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Regression coverage added to codeunit 135206 (not yet run in BC):

- Non-image blobs and TIFFs are rejected without an HTTP request.
- Non-image files cannot bypass validation through `SetImagePath` with customer-configured Custom Vision.
- V3.2 accepts valid image content despite incorrect MIME/dimension metadata, and rejects non-image content despite valid image metadata. These tests use the existing request event, without replacing V3.2 with the V1.0 mock.
- Customer-configured Custom Vision accepts JPEG (including 10x10), PNG, GIF and BMP, preserving the Custom Vision endpoint and prediction-key header.
- A BMP larger than 4 MB reaches the mocked customer-configured service. This asserts that BC does not impose a universal size restriction; it does not claim that a live Computer Vision API accepts oversized images.

Both edited files passed the installed AL compiler's syntax parser. A temporary isolated `alc.exe` project using the available BC 27 symbols compiled the image-format APIs, fixture generation, media metadata/content updates and request-URI access with no errors or warnings. A Windows `System.Drawing` smoke probe confirmed the fixture formats/dimensions, an over-4-MB BMP and rejection of text content. These checks do not replace a full app build or BC test execution.

Attempted the existing integration-test project compilation with `alc.exe` and the available package cache. It is blocked by AL1022: required Application 30, System 29 and BC 30 test-library packages are unavailable (the local cache contains BC 27 System Application packages). The local Docker Windows engine is also unavailable, so the BC tests and manual scenario were not run.

## Risk & compatibility

- This is intentional input hardening, not a guarantee of zero behavioral change: non-images, unsupported formats and images the local decoder cannot load now fail before the HTTP request. Arbitrary compatible endpoints accepting other formats are not guaranteed compatibility.
- The reused `Image` codeunit has its own 50 MB decoding limit. Removing the draft's 4 MB rule does not make input size unlimited.
- There is no new metadata-only rejection and no new API-specific size/dimension policy shared across providers. Customer resource configuration and authentication remain unchanged.
- Validation reads/decodes the image locally, adding memory/CPU overhead. It does not strip metadata, re-encode the outgoing file, or provide harmful-content detection.
- Keep this PR as draft until the affected apps can be built and the regression scenarios run in a matching BC environment.



