### PR TITLE
[Bug 641000] Add the CLEAN29 preprocessor for the document report experience

### DIFF
--- a/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/APAC/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -420,7 +420,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -742,7 +744,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -756,9 +760,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -776,7 +784,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/AT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -532,7 +532,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -854,7 +856,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -868,9 +872,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -888,7 +896,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/BE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -413,7 +413,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -735,7 +737,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -749,9 +753,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -769,7 +777,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/CH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -527,7 +527,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -849,7 +851,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -863,9 +867,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -883,7 +891,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DACH/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -517,7 +517,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -839,7 +841,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -853,9 +857,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -873,7 +881,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/DE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -507,7 +507,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -829,7 +831,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -843,9 +847,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -863,7 +871,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/ES/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -437,7 +437,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -784,7 +786,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -798,9 +802,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -818,7 +826,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FI/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -404,7 +404,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -726,7 +728,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -740,9 +744,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -760,7 +768,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/FR/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -433,7 +433,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -755,7 +757,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -769,9 +773,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -789,7 +797,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/GB/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -562,7 +562,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -887,7 +889,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -901,9 +905,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -930,7 +938,9 @@ page 1 "Company Information"
 #endif        
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IS/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -395,7 +395,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -717,7 +719,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -731,9 +735,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -751,7 +759,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/IT/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -526,7 +526,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -866,7 +868,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -880,9 +884,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -900,7 +908,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NA/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -469,7 +469,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -802,7 +804,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -816,9 +820,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -836,7 +844,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NL/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -399,7 +399,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -721,7 +723,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -735,9 +739,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -755,7 +763,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NO/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -405,7 +405,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -727,7 +729,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -741,9 +745,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -761,7 +769,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/NZ/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -422,7 +422,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -744,7 +746,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -758,9 +762,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -778,7 +786,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/RU/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -603,7 +603,9 @@ page 1 "Company Information"
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Default Theme';
+#if not CLEAN29
                     Visible = DocumentReportExperienceEnabled;
+#endif
                     ToolTip = 'Specifies the default theme applied to this company''s Word report layouts when no more specific configuration applies. Use the assist-edit to pick a theme; clear the value to remove it.';
 
                     trigger OnAssistEdit()
@@ -622,7 +624,9 @@ page 1 "Company Information"
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Default Header/Footer';
+#if not CLEAN29
                     Visible = DocumentReportExperienceEnabled;
+#endif
                     ToolTip = 'Specifies the default header/footer applied to this company''s Word report layouts when no more specific configuration applies. Use the assist-edit to pick a part; clear the value to remove it.';
 
                     trigger OnAssistEdit()
@@ -947,7 +951,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -961,9 +967,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -981,7 +991,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/SE/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -394,7 +394,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -716,7 +718,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -730,9 +734,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -750,7 +758,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/W1/BaseApp/FeatureKeyManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/FeatureKeyManagement.Codeunit.al
@@ -16,7 +16,9 @@ codeunit 265 "Feature Key Management"
         FeatureTelemetry: Codeunit System.Telemetry."Feature Telemetry";
         AutomaticAccountCodesTxt: Label 'AutomaticAccountCodes', Locked = true;
         SIEAuditFileExportTxt: Label 'SIEAuditFileExport', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceTxt: Label 'DocumentReportExperience', Locked = true;
+#endif
         ConcurrentInventoryPostingLbl: Label 'ConcurrentInventoryPosting', Locked = true;
         ConcurrentInventoryPosting: Boolean;
         ConcurrentInventoryPostingRead: Boolean;
@@ -38,10 +40,12 @@ codeunit 265 "Feature Key Management"
         exit(FeatureManagementFacade.IsEnabled(GetSIEAuditFileExportFeatureKeyId()));
     end;
 
+#if not CLEAN29
     procedure IsDocumentReportExperienceEnabled(): Boolean
     begin
         exit(FeatureManagementFacade.IsEnabled(DocumentReportExperienceTxt));
     end;
+#endif
 
 #if not CLEAN27
     [Obsolete('This function is deprecated. Concurrent warehouse posting is always on.', '27.0')]

--- a/src/Layers/W1/BaseApp/FeatureKeyManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/FeatureKeyManagement.Codeunit.al
@@ -41,6 +41,7 @@ codeunit 265 "Feature Key Management"
     end;
 
 #if not CLEAN29
+    [Obsolete('The Document Report Experience feature key is being retired. The composite layout feature is always on.', '29.0')]
     procedure IsDocumentReportExperienceEnabled(): Boolean
     begin
         exit(FeatureManagementFacade.IsEnabled(DocumentReportExperienceTxt));

--- a/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Company/CompanyInformation.Page.al
@@ -395,7 +395,9 @@ page 1 "Company Information"
             group(Reporting)
             {
                 Caption = 'Reporting';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 field(DefaultThemePart; ThemePartDisplay)
                 {
@@ -717,7 +719,9 @@ page 1 "Company Information"
     var
         ApplicationAreaMgmtFacade: Codeunit "Application Area Mgmt. Facade";
         MonitorSensitiveField: Codeunit "Monitor Sensitive Field";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         Rec.Reset();
         if not Rec.Get() then begin
@@ -731,9 +735,13 @@ page 1 "Company Information"
 
         BankAcctPostingGroup := CompanyInformationMgt.GetCompanyBankAccountPostingGroup();
 
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled then
             LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#else
+        LookupHelper.GetCompanyDefaultDisplays(HeaderPartDisplay, ThemePartDisplay);
+#endif
     end;
 
     var
@@ -751,7 +759,9 @@ page 1 "Company Information"
         IsShipToCountyVisible: Boolean;
         CompanyBadgeRefreshPageTxt: Label 'The Company Badge settings have changed. Refresh the browser (Ctrl+F5) to update the badge.';
         CompanyBadgeChangedLbl: Label 'The Company badge settings have changed by UserSecurityId %1.', Locked = true;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/HeaderFooterThemeAssignment.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/HeaderFooterThemeAssignment.Page.al
@@ -98,10 +98,14 @@ page 9667 "Header/Footer Theme Assignment"
     trigger OnOpenPage()
     var
         TenantReportLayoutCfg: Record "Tenant Report Layout Cfg";
+#if not CLEAN29
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
+#if not CLEAN29
         if not FeatureKeyManagement.IsDocumentReportExperienceEnabled() then
             Error(FeatureNotEnabledErr);
+#endif
 
         if (LayoutName <> '') and (not LookupHelper.IsBodyLayout(ReportID, LayoutName)) then
             Error(NotBodyLayoutErr, LookupHelper.DecodeLayoutName(LayoutName));
@@ -240,7 +244,9 @@ page 9667 "Header/Footer Theme Assignment"
         CompanyOverrideExists: Boolean;
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
+#if not CLEAN29
         FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
+#endif
         NotBodyLayoutErr: Label 'A theme and header/footer can only be set on a body layout, and "%1" is not one. They are merged onto a body layout when the report renders, so there is nothing to merge them onto here.', Comment = '%1 = layout name';
         CompanyOverrideLbl: Label '%1 sets its own theme and header/footer for this layout: %2 and %3. That is more specific than the setting below, so it keeps applying in %1 whatever you choose here.', Comment = '%1 = company name; %2 = header/footer part name; %3 = theme part name';
         OverrideHeaderLbl: Label 'header/footer %1', Comment = '%1 = header/footer part name';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutNewDialog.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutNewDialog.page.al
@@ -139,14 +139,18 @@ page 9662 "Report Layout New Dialog"
     }
 
     trigger OnOpenPage()
+#if not CLEAN29
     var
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         CreateEmptyLayout := false;
         ExcelMultipleDataSheets := "Excel Sheet Configuration"::Default;
         LayoutName := '';
         AvailableInAllCompanies := true;
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
+#endif
         if ImpliedSubtypeSet then
             FormatOptions := FormatOptions::Word
         else begin
@@ -181,7 +185,9 @@ page 9662 "Report Layout New Dialog"
         PartSubtypeVisible: Boolean;
         BodySubtypeVisible: Boolean;
         ImpliedSubtypeSet: Boolean;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         ExcelMultipleDataSheets: enum "Excel Sheet Configuration";
         emptyGuid: Guid;
 
@@ -260,8 +266,16 @@ page 9662 "Report Layout New Dialog"
 
     local procedure UpdateSubtypeVisibility()
     begin
+#if not CLEAN29
         PartSubtypeVisible := DocumentReportExperienceEnabled and ImpliedSubtypeSet;
+#else
+        PartSubtypeVisible := ImpliedSubtypeSet;
+#endif
+#if not CLEAN29
         BodySubtypeVisible := DocumentReportExperienceEnabled and (not ImpliedSubtypeSet);
+#else
+        BodySubtypeVisible := (not ImpliedSubtypeSet);
+#endif
 
         if ImpliedSubtypeSet then
             exit;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutSelection.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutSelection.Page.al
@@ -196,7 +196,9 @@ page 9652 "Report Layout Selection"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Show layout parts';
                 Image = ViewDocumentLine;
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
                 ToolTip = 'Show the header/footer and theme parts that will actually apply to the selected report in the current company, including where each part is resolved from.';
 
                 trigger OnAction()
@@ -281,11 +283,15 @@ page 9652 "Report Layout Selection"
     end;
 
     trigger OnOpenPage()
+#if not CLEAN29
     var
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         SelectedCompany := CompanyName;
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
+#endif
     end;
 
     var
@@ -298,7 +304,9 @@ page 9652 "Report Layout Selection"
         DefaultLbl: Label '(Default)';
         CustomLayoutDescription: Text;
         IsInitialized: Boolean;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         CouldNotFindCustomReportLayoutErr: Label 'There is no custom report layout with %1 in the description.', Comment = '%1 Description of custom report layout';
         CouldNotFindBuiltInReportLayoutErr: Label 'There is no built-in report layout with %1 in the description.', Comment = '%1 Description of custom report layout';
         ShowLayoutPartsMsg: Label 'Header/Footer Part: %1\Theme Part: %2', Comment = '%1 = resolved header/footer part, %2 = resolved theme part';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -127,7 +127,9 @@ page 9660 "Report Layouts"
                 {
                     ApplicationArea = Basic, Suite;
                     Editable = false;
+#if not CLEAN29
                     Visible = DocumentReportExperienceEnabled;
+#endif
                     Caption = 'Subtype';
                     ToolTip = 'Specifies the role of the layout in the Composite Layout Merge: full body (Default), header/footer part, or theme part.';
                 }
@@ -190,7 +192,11 @@ page 9660 "Report Layouts"
                 SubPageLink = "Report ID" = field("Report ID"),
                               Name = field(Name),
                               "Application ID" = field("Application ID");
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled and BodyLayoutSelected;
+#else
+                Visible = BodyLayoutSelected;
+#endif
             }
             systempart(Control11; Notes)
             {
@@ -412,7 +418,9 @@ page 9660 "Report Layouts"
             {
                 Caption = 'Composite layout';
                 Image = Document;
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
                 // The assignment page and lookup helper declare RIMD on Tenant Report Layout Cfg (indirect
                 // permission) so the tenant-wide write can happen there. Each action below is gated with
                 // AccessByPermission so only a user who actually holds Modify on that configuration can reach it;
@@ -636,7 +644,9 @@ page 9660 "Report Layouts"
             group(CompositeLayout)
             {
                 Caption = 'Composite layout';
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
 
                 actionref(AssignReportDefaults_Promoted; AssignReportDefaults)
                 {
@@ -692,14 +702,20 @@ page 9660 "Report Layouts"
     }
 
     trigger OnOpenPage()
+#if not CLEAN29
     var
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
         ReportLayoutsImpl.SetSelectedCompany(CompanyName());
         if CurrPage.LookupMode and (not IncludeUnapproved) then
             Rec.SetRange("Layout Status", Enum::"Report Layout Status"::Approved);
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
         if DocumentReportExperienceEnabled and (not CurrPage.LookupMode) and (ImpliedSubtype = Enum::"Report Layout Subtype"::Default) then begin
+#else
+        if (not CurrPage.LookupMode) and (ImpliedSubtype = Enum::"Report Layout Subtype"::Default) then begin
+#endif
             Rec.FilterGroup(2);
             Rec.SetFilter("Layout Subtype", '<>%1&<>%2', Rec."Layout Subtype"::HeaderFooter, Rec."Layout Subtype"::Theme);
             Rec.FilterGroup(0);
@@ -791,7 +807,9 @@ page 9660 "Report Layouts"
         ShareOptionsVisible: Boolean;
         ShareOptionsEnabled: Boolean;
         CanModifyStatus: Boolean;
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         WordLayoutSelected: Boolean;
         BodyLayoutSelected: Boolean;
         IncludeUnapproved: Boolean;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
@@ -248,11 +248,15 @@ page 9666 "Report Theme and Header/Footer"
     }
 
     trigger OnOpenPage()
+#if not CLEAN29
     var
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
+#if not CLEAN29
         if not FeatureKeyManagement.IsDocumentReportExperienceEnabled() then
             Error(FeatureNotEnabledErr);
+#endif
 
         NewThemeVisible := (not LookupSubtypeSet) or (LookupSubtype = LookupSubtype::Theme);
         NewHeaderFooterVisible := (not LookupSubtypeSet) or (LookupSubtype = LookupSubtype::HeaderFooter);
@@ -492,7 +496,9 @@ page 9666 "Report Theme and Header/Footer"
         LookupSubtypeSet: Boolean;
         NewThemeVisible: Boolean;
         NewHeaderFooterVisible: Boolean;
+#if not CLEAN29
         FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
+#endif
         CannotDeleteOobErr: Label 'Out-of-box themes and header/footer parts cannot be deleted.';
         CannotReplaceOobErr: Label 'Out-of-box themes and header/footer parts cannot be replaced.';
         CannotEditOobErr: Label 'Out-of-box themes and header/footer parts cannot be edited.';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutCfg.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutCfg.Page.al
@@ -227,11 +227,15 @@ page 9663 "Tenant Report Layout Cfg"
     }
 
     trigger OnOpenPage()
+#if not CLEAN29
     var
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
+#if not CLEAN29
         if not FeatureKeyManagement.IsDocumentReportExperienceEnabled() then
             Error(FeatureNotEnabledErr);
+#endif
     end;
 
     trigger OnAfterGetCurrRecord()
@@ -408,7 +412,9 @@ page 9663 "Tenant Report Layout Cfg"
         LayoutNameDisplay: Text;
         LayoutScopeSet: Boolean;
         ReportNameDisplay: Text;
+#if not CLEAN29
         FeatureNotEnabledErr: Label 'The Composite Layout feature is gated by the Document Report Experience preview. Enable it in Feature Management before opening this page.';
+#endif
         GlobalWildcardCannotHaveLayoutNameErr: Label 'When Report ID is 0, the row applies to every report, so Layout Name must be empty.';
         ScopeExistsErr: Label 'A row for %1 already exists. Change that row instead of pointing this one at the same scope.', Comment = '%1 = scope description, for example All layouts of Sales Invoice';
         PickReportFirstErr: Label 'Choose a report first. A layout belongs to one report, so there is nothing to pick from until Report ID is set.';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutSelection.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/TenantReportLayoutSelection.Page.al
@@ -58,14 +58,18 @@ page 9664 "Tenant Report Layout Selection"
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Header/Footer Part';
+#if not CLEAN29
                     Visible = DocumentReportExperienceEnabled;
+#endif
                     ToolTip = 'Specifies the header/footer layout part composed on top of the body layout when this report is rendered. Configured via the Tenant Report Layout Configuration page.';
                 }
                 field(ThemePartDisplay; ThemePartDisplay)
                 {
                     ApplicationArea = Basic, Suite;
                     Caption = 'Theme Part';
+#if not CLEAN29
                     Visible = DocumentReportExperienceEnabled;
+#endif
                     ToolTip = 'Specifies the theme layout part whose styles override the merged result when this report is rendered. Configured via the Tenant Report Layout Configuration page.';
                 }
             }
@@ -81,7 +85,9 @@ page 9664 "Tenant Report Layout Selection"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Test composite render';
                 Image = TestReport;
+#if not CLEAN29
                 Visible = DocumentReportExperienceEnabled;
+#endif
                 ToolTip = 'Runs the selected report so the Composite Layout Merge can be verified end-to-end against the configured Header/Footer and Theme parts.';
 
                 trigger OnAction()
@@ -110,15 +116,21 @@ page 9664 "Tenant Report Layout Selection"
     end;
 
     trigger OnOpenPage()
+#if not CLEAN29
     var
         FeatureKeyManagement: Codeunit "Feature Key Management";
+#endif
     begin
+#if not CLEAN29
         DocumentReportExperienceEnabled := FeatureKeyManagement.IsDocumentReportExperienceEnabled();
+#endif
     end;
 
     var
         LookupHelper: Codeunit "Composite Layout Lookup Helper";
+#if not CLEAN29
         DocumentReportExperienceEnabled: Boolean;
+#endif
         HeaderPartDisplay: Text;
         ThemePartDisplay: Text;
         SelectReportFirstErr: Label 'Select a row with a Report ID before running a test render.';


### PR DESCRIPTION
## What & why

The `DocumentReportExperience` feature key gates the composite layout feature — the layout subtype,
the header/footer and theme parts, and the pages that configure them. The feature is GA in 29, so
every piece of that gating is now wrapped in `#if not CLEAN29`: **29 keeps the feature key exactly as
it behaves today**, and 30 compiles without the flag, leaving the feature unconditional.

This is the first of the two steps the MCP feature flag went through. `EnableMcpAccess` was wrapped
the same way at GA and then deleted wholesale once CLEAN28 came due (`3ffea8e5e1`, 3 files, 39
deletions). Nothing is removed here — that is the follow-up change when 29 is cleaned up.

`Feature Key Management` keeps `IsDocumentReportExperienceEnabled` reading the feature key, with the
procedure and its `DocumentReportExperienceTxt` label both inside the guard. The procedure carries
`[Obsolete('...', '29.0')]` inside the guard: per the deprecation guidelines the symbol version matches the
major of the ObsoleteTag, so this is obsoleted in 29, still present in 30 and 31, and removable at the
earliest in 32.

The other guarded symbols carry no attribute deliberately. `DocumentReportExperienceTxt` is a global of
this codeunit, which is `Access = Internal`; all 23 `DocumentReportExperienceEnabled` declarations are in
plain `var` sections rather than `protected var`; and the three `FeatureNotEnabledErr` labels are page
private. None is reachable by a consumer, so an obsolete-pending attribute would warn nobody. No page
element is being deprecated either - the Reporting group, the Subtype field and the composite layout
actions all survive into 32 and merely stop being conditionally visible.

At the call sites:

- **19 country Company Information pages** — the Reporting group's `Visible` property, the
  `FeatureKeyManagement` declaration, the resolve-on-open block, and the
  `DocumentReportExperienceEnabled` variable.
- **7 W1 Reporting pages** — the Subtype field, the composite layout groups and actions, the
  header/footer and theme part fields, the two `OnOpenPage` gates that raise `FeatureNotEnabledErr`,
  and the three labels behind them.

`#else` branches appear only where a term has to survive into 30: the company default displays call,
`ReportLayouts`' `Visible = ... and BodyLayoutSelected` plus its `OnOpenPage` condition, and
`ReportLayoutNewDialog`'s two subtype visibility assignments.

Where `FeatureKeyManagement` was a trigger's only local, the `var` keyword is inside the guard too,
so 30 does not end up with an empty `var` section.

**27 files, 266 insertions, 0 deletions.**

An earlier attempt at this work (#11066) deleted the gating instead of guarding it — that made the
feature unconditional in 29 as well and left nothing for CLEAN29 to remove. It was closed and its
branch deleted; this replaces it.

## Linked work

[AB#641000](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641000) — tracked in ADO (Dynamics SMB); internal cleanup with no public issue.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- **Static verification only, and I want to be plain about that.** Every `#if` is balanced by an
  `#endif` across all 27 files, and no reference to `DocumentReportExperienceEnabled`,
  `IsDocumentReportExperienceEnabled` or `FeatureNotEnabledErr` remains outside a guard — checked by
  walking each file and tracking guard depth line by line. Insertions only, no deletions, and no BOM
  or end-of-file newline drift.
- **Not compiled.** Base Application does not currently build in my local enlistment on master:
  `b3a8ac793e` promoted AL0659 and AL0685 to Error, and NAV master's own source still violates them
  12 times (9 flowfield length violations in `FSProjectTask.Table.al` / `FSResourcePayType.Table.al`,
  3 over-long enum identifiers in `RetenPolDocArchiveFltrng.EnumExt.al` — the latter already carrying
  a `#pragma warning disable AL0659` that stops working once the rule is an error). That is unrelated
  to this change but it does mean CI is the first real compile of this diff, so please treat the
  build check accordingly.
- **No tests added or needed.** 29 behaviour is unchanged — the gating is byte-for-byte what it was,
  just inside a guard. In 30 the flag is gone and the feature is always on, which is what the tests
  already exercise: every relevant test in codeunit 134619 calls `EnableDocumentReportExperience()`
  in its setup, so they were already running with the feature enabled.

## Risk & compatibility

29 is unaffected by design — same feature key, same behaviour, same code paths. The only behavioural
change lands in 30, where the feature becomes unconditional, which is the intent of the GA.

Two things a reviewer may want to weigh in on:

- `TenantReportLayoutCfg` and `TenantReportLayoutSelection` end up with an empty `OnOpenPage`
  (`begin end;`) under CLEAN29, since their triggers existed only to enforce the gate. That is legal
  AL, but wrapping each trigger whole would remove it entirely in 30. Happy to change if preferred.
- The `DocumentReportExperience` feature key is registered by the platform, not by BCApps, so once
  CLEAN29 is cleaned up the key will need dropping platform-side or it will linger in Feature
  Management with nothing reading it.



