### PR TITLE
[29.x] Discrepancy in inventory picks when the quantity exceeds the available inventory.

### DIFF
--- a/src/Layers/W1/BaseApp/Warehouse/Activity/CreateInventoryPickMovement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Warehouse/Activity/CreateInventoryPickMovement.Codeunit.al
@@ -934,7 +934,9 @@ codeunit 7322 "Create Inventory Pick/Movement"
         if HasExpiredItems then
             QtyRemToPickBase := RemQtyToPickBase
         else
-            QtyRemToPickBase := OriginalRemQtyToPickBase - QtyAvailToPickBase + RemQtyToPickBase;
+            // Cap availability at the originally requested quantity so surplus stock reserved for other demand
+            // does not cancel out the blank-bin shortage line when "Always Create Pick Line" is enabled.
+            QtyRemToPickBase := OriginalRemQtyToPickBase - Minimum(QtyAvailToPickBase, OriginalRemQtyToPickBase) + RemQtyToPickBase;
         if CurrLocation."Always Create Pick Line" and (QtyRemToPickBase > 0) then begin
             MakeWarehouseActivityHeader();
             MakeWarehouseActivityLine(NewWarehouseActivityLine, '', QtyRemToPickBase, QtyRemToPickBase);

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
@@ -18,6 +18,7 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Warehouse.Activity;
+using Microsoft.Warehouse.InternalDocument;
 using Microsoft.Warehouse.Request;
 using Microsoft.Warehouse.Setup;
 using Microsoft.Warehouse.Structure;
@@ -53,6 +54,8 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         NothingToHandleMsg: Label 'Nothing to handle. The production components are completely picked or not eligible for picking.';
         CannotPostConsumptionMsg: Label 'You cannot post consumption for order no. %1 because a quantity of %2 remains to be picked.', Comment = '%1 - Production Order No., %2 - Quantity';
         PickActivitiesCreatedMsg: Label 'Number of Invt. Pick activities created';
+        BinPickQtyIsWrongErr: Label 'Bin pick quantity is wrong.';
+        ShortageLineQtyIsWrongErr: Label 'Shortage line quantity is wrong.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1602,6 +1605,97 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         ItemLedgerEntry.FindFirst();
 
         Assert.RecordIsNotEmpty(ItemLedgerEntry);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    [HandlerFunctions('SimpleMessageHandler')]
+    procedure AlwaysCreatePickLineCreatesShortageWhenBinStockInsufficient()
+    var
+        Bin: Record Bin;
+        FromBin: Record Bin;
+        ToBin: Record Bin;
+        CompItem: Record Item;
+        InternalMovementHeader: Record "Internal Movement Header";
+        InternalMovementLine: Record "Internal Movement Line";
+        Location: Record Location;
+        ParentItem: Record Item;
+        ProductionBOMHeader: Record "Production BOM Header";
+        ProductionOrder: Record "Production Order";
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+        CreateInvtPickMovement: Codeunit "Create Inventory Pick/Movement";
+        BinStockQty: Decimal;
+        ComponentQty: Decimal;
+        ExcessQty: Decimal;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO] Blank-bin shortage line is created for the unfulfilled quantity when the available inventory exceeds the
+        // component demand but the quantity that can actually be picked from the bin is short.
+        Initialize();
+        ComponentQty := LibraryRandom.RandIntInRange(5, 20);
+        BinStockQty := LibraryRandom.RandInt(ComponentQty - 1);
+        ExcessQty := 2 * ComponentQty;
+
+        // [GIVEN] Create a Location with Bin Mandatory, two bins and "Always Create Pick Line" enabled.
+        CreateLocationSetupWithBins(Location, false, false, false, false, true, 2, false);
+        Location.Validate("Always Create Pick Line", true);
+        Location."Prod. Consump. Whse. Handling" := "Prod. Consump. Whse. Handling"::"Inventory Pick/Movement";
+        Location.Modify(true);
+
+        // [GIVEN] Create a Production item with one component.
+        LibraryInventory.CreateItem(CompItem);
+        LibraryInventory.CreateItem(ParentItem);
+        LibraryManufacturing.CreateCertifiedProductionBOM(ProductionBOMHeader, CompItem."No.", ComponentQty);
+        ParentItem."Production BOM No." := ProductionBOMHeader."No.";
+        ParentItem."Replenishment System" := ParentItem."Replenishment System"::"Prod. Order";
+        ParentItem.Modify(true);
+
+        // [GIVEN] Post more than the demanded quantity of the component to the first bin.
+        Bin.SetRange("Location Code", Location.Code);
+        Bin.FindSet();
+        FromBin := Bin;
+        Bin.Next();
+        ToBin := Bin;
+        CreateAndPostItemJournalLine(
+            CompItem."No.", "Item Ledger Entry Type"::"Positive Adjmt.", BinStockQty + ExcessQty, Location.Code, FromBin.Code, '');
+
+        // [GIVEN] Tie up the excess in the bin with an open inventory movement, so the inventory stays available but only
+        // BinStockQty can be picked from the bin. This makes QtyAvailToPickBase exceed the component demand.
+        LibraryWarehouse.CreateInternalMovementHeader(InternalMovementHeader, Location.Code, ToBin.Code);
+        LibraryWarehouse.CreateInternalMovementLine(
+            InternalMovementHeader, InternalMovementLine, CompItem."No.", FromBin.Code, ToBin.Code, ExcessQty);
+        CreateInvtPickMovement.SetHideDialog(true);
+        CreateInvtPickMovement.CreateInvtMvntWithoutSource(InternalMovementHeader);
+
+        // [GIVEN] Create Released Production Order.
+        CreateAndRefreshProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, "Prod. Order Source Type"::Item,
+            ParentItem."No.", 1, Location.Code);
+
+        // [WHEN] Create Inventory Pick for the production order.
+        LibraryWarehouse.CreateInvtPutPickMovement(
+            "Warehouse Request Source Document"::"Prod. Consumption", ProductionOrder."No.", false, true, false);
+
+        // [THEN] Verify that a pick line from the bin is created for the available bin quantity.
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, ProductionOrder."No.",
+            WarehouseActivityLine."Activity Type"::"Invt. Pick", Location.Code,
+            WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityLine.SetRange("Bin Code", FromBin.Code);
+        Assert.RecordCount(WarehouseActivityLine, 1);
+        WarehouseActivityLine.FindFirst();
+        Assert.AreEqual(BinStockQty, WarehouseActivityLine."Qty. (Base)", BinPickQtyIsWrongErr);
+
+        // [THEN] Verify that a blank-bin shortage line is created for the remaining quantity.
+        WarehouseActivityLine.SetRange("Bin Code", '');
+        Assert.RecordCount(WarehouseActivityLine, 1);
+        WarehouseActivityLine.FindFirst();
+        Assert.AreEqual(
+            ComponentQty - BinStockQty, WarehouseActivityLine."Qty. (Base)",
+            ShortageLineQtyIsWrongErr);
+
+        Assert.ExpectedMessage(PickActivitiesCreatedMsg, LibraryVariableStorage.DequeueText());
+        LibraryVariableStorage.AssertEmpty();
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
**Issue:** With "Always Create Pick Line" on, the production inventory pick/movement is short — the blank-bin line for the un-pickable remainder is missing.

**Cause:** The fallback formula over-subtracts when availability exceeds the order's demand, driving the blank-bin quantity ≤ 0 so it's dropped.

**Solution:** Cap availability with Minimum(QtyAvailToPickBase, OriginalRemQtyToPickBase), restoring the shortage line without affecting the normal case.

Workitem: [Bug 649179](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649179): [29.x][ALL-E] Discrepancy in inventory picks when the quantity exceeds the available inventory.

Fixes [AB#649179](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649179)

