### PR TITLE
[main] Bug 649204 Validation missing for Deferral Code field on Released Purchase documents.

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2656,6 +2656,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2632,6 +2632,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2634,6 +2634,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2630,6 +2630,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2634,6 +2634,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2631,6 +2631,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2647,6 +2647,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2685,6 +2685,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/IT/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2574,6 +2574,7 @@
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
         GLAccount: Record "G/L Account";
         DeferralTemplateCode: Code[10];
     begin
@@ -2595,7 +2596,8 @@
 
         // [WHEN] Changing the Deferral Code on the Purchase Line
         DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
-        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        asserterror PurchaseLine2.Validate("Deferral Code", DeferralTemplateCode);
 
         // [THEN] The change is rejected because the Purchase Invoice is not open
         Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));

--- a/src/Layers/IT/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2568,6 +2568,39 @@
         PurchaseInvoice.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeferralCodeCannotBeChangedOnReleasedPurchaseInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Deferral Code cannot be changed on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
+        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+
+        // [THEN] The change is rejected because the Purchase Invoice is not open
+        Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2726,6 +2726,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/NA/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2551,6 +2551,7 @@ codeunit 134804 "RED Test Unit for Purch Doc"
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
         GLAccount: Record "G/L Account";
         DeferralTemplateCode: Code[10];
     begin
@@ -2572,7 +2573,8 @@ codeunit 134804 "RED Test Unit for Purch Doc"
 
         // [WHEN] Changing the Deferral Code on the Purchase Line
         DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
-        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        asserterror PurchaseLine2.Validate("Deferral Code", DeferralTemplateCode);
 
         // [THEN] The change is rejected because the Purchase Invoice is not open
         Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));

--- a/src/Layers/NA/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2545,6 +2545,39 @@ codeunit 134804 "RED Test Unit for Purch Doc"
         PurchaseInvoice.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeferralCodeCannotBeChangedOnReleasedPurchaseInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Deferral Code cannot be changed on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
+        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+
+        // [THEN] The change is rejected because the Purchase Invoice is not open
+        Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2630,6 +2630,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2634,6 +2634,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2635,6 +2635,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2635,7 +2635,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
-                TestStatusOpen();
+                PurchHeader.TestField(Status, PurchHeader.Status::Open);
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2636,7 +2636,7 @@ table 39 "Purchase Line"
             begin
                 GetPurchHeader();
                 if "Deferral Code" <> xRec."Deferral Code" then
-                    TestStatusOpen();
+                    PurchHeader.TestField(Status, PurchHeader.Status::Open);
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2635,7 +2635,10 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
-                if "Deferral Code" <> xRec."Deferral Code" then
+                if "Deferral Code" = xRec."Deferral Code" then begin
+                    if PurchHeader.Status = PurchHeader.Status::Released then
+                        exit;
+                end else
                     PurchHeader.TestField(Status, PurchHeader.Status::Open);
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2635,7 +2635,6 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
-                PurchHeader.TestField(Status, PurchHeader.Status::Open);
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(
@@ -12755,4 +12754,5 @@ table 39 "Purchase Line"
     local procedure OnAfterSetHideValidationDialog(var PurchaseLine: Record "Purchase Line"; NewHideValidationDialog: Boolean)
     begin
     end;
+
 }

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2635,6 +2635,8 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                if "Deferral Code" <> xRec."Deferral Code" then
+                    TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(
@@ -12754,5 +12756,4 @@ table 39 "Purchase Line"
     local procedure OnAfterSetHideValidationDialog(var PurchaseLine: Record "Purchase Line"; NewHideValidationDialog: Boolean)
     begin
     end;
-
 }

--- a/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
@@ -1203,7 +1203,7 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         CreatePurchDocWithLine(
           PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
           PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), WorkDate());
-        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        DeferralTemplateCode := LibraryERM.CreateDeferralTemplateCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
         PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
         PurchaseLine.Modify(true);
 
@@ -1317,23 +1317,6 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         GLAccount.Modify(true);
 
         exit(GLAccount."No.");
-    end;
-
-    local procedure CreateDeferralCode(CalcMethod: Enum "Deferral Calculation Method"; StartDate: Enum "Deferral Calculation Start Date"; NumOfPeriods: Integer): Code[10]
-    var
-        DeferralTemplate: Record "Deferral Template";
-    begin
-        DeferralTemplate.Init();
-        DeferralTemplate."Deferral Code" :=
-          LibraryUtility.GenerateRandomCode(DeferralTemplate.FieldNo("Deferral Code"), DATABASE::"Deferral Template");
-        DeferralTemplate."Deferral Account" := LibraryERM.CreateGLAccountNo();
-        DeferralTemplate."Calc. Method" := CalcMethod;
-        DeferralTemplate."Start Date" := StartDate;
-        DeferralTemplate."No. of Periods" := NumOfPeriods;
-        DeferralTemplate."Period Description" := 'Deferral Revenue for %4';
-
-        DeferralTemplate.Insert();
-        exit(DeferralTemplate."Deferral Code");
     end;
 
     local procedure CreateGLAccountWithVATPostSetup(var GLAccount: Record "G/L Account"; VATBusPostGrCode: Code[20]; VATPct: Decimal)

--- a/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
@@ -1184,6 +1184,41 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         Assert.AreEqual(DeferralHeader."Amount to Defer (LCY)", TotalLineAmountLCY, AmountLCYSumErr);
     end;
 
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReleasedPurchLineDeferralCodeSameValueDoesNotRecalculateRU()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Unchanged Deferral Code remains the same on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        PurchaseLine2.Validate("Deferral Code", PurchaseLine2."Deferral Code");
+
+        // [THEN] No Error is thrown and the Deferral Code remains the same
+        Assert.AreEqual(PurchaseLine2."Deferral Code", PurchaseLine2."Deferral Code");
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";

--- a/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
@@ -32,6 +32,7 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         FieldErrorErr: Label 'Calc. Method must not be 4 in Deferral Template Deferral Code';
         AmountLCYNotFilledErr: Label 'Amount (LCY) should be filled before posting.';
         AmountLCYSumErr: Label 'The sum of the deferral line Amount (LCY) values must equal the header Amount to Defer (LCY).';
+        DeferralCodeChangedErr: Label 'Deferral Code cannot be changed on a line with a deferral schedule.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1192,7 +1193,6 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         PurchaseLine2: Record "Purchase Line";
-        GLAccount: Record "G/L Account";
         DeferralTemplateCode: Code[10];
     begin
         // [FEATURE] [Deferral Code]
@@ -1200,10 +1200,9 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         Initialize();
 
         // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
-        CreateGLAccount(GLAccount);
         CreatePurchDocWithLine(
           PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
-          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+          PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), WorkDate());
         DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
         PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
         PurchaseLine.Modify(true);
@@ -1216,7 +1215,7 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         PurchaseLine2.Validate("Deferral Code", PurchaseLine2."Deferral Code");
 
         // [THEN] No Error is thrown and the Deferral Code remains the same
-        Assert.AreEqual(PurchaseLine2."Deferral Code", PurchaseLine2."Deferral Code");
+        Assert.AreEqual(PurchaseLine2."Deferral Code", PurchaseLine2."Deferral Code", DeferralCodeChangedErr);
     end;
 
     local procedure Initialize()
@@ -1318,6 +1317,23 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         GLAccount.Modify(true);
 
         exit(GLAccount."No.");
+    end;
+
+    local procedure CreateDeferralCode(CalcMethod: Enum "Deferral Calculation Method"; StartDate: Enum "Deferral Calculation Start Date"; NumOfPeriods: Integer): Code[10]
+    var
+        DeferralTemplate: Record "Deferral Template";
+    begin
+        DeferralTemplate.Init();
+        DeferralTemplate."Deferral Code" :=
+          LibraryUtility.GenerateRandomCode(DeferralTemplate.FieldNo("Deferral Code"), DATABASE::"Deferral Template");
+        DeferralTemplate."Deferral Account" := LibraryERM.CreateGLAccountNo();
+        DeferralTemplate."Calc. Method" := CalcMethod;
+        DeferralTemplate."Start Date" := StartDate;
+        DeferralTemplate."No. of Periods" := NumOfPeriods;
+        DeferralTemplate."Period Description" := 'Deferral Revenue for %4';
+
+        DeferralTemplate.Insert();
+        exit(DeferralTemplate."Deferral Code");
     end;
 
     local procedure CreateGLAccountWithVATPostSetup(var GLAccount: Record "G/L Account"; VATBusPostGrCode: Code[20]; VATPct: Decimal)

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2631,6 +2631,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2630,6 +2630,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/W1/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2551,6 +2551,7 @@ codeunit 134804 "RED Test Unit for Purch Doc"
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
         GLAccount: Record "G/L Account";
         DeferralTemplateCode: Code[10];
     begin
@@ -2572,7 +2573,8 @@ codeunit 134804 "RED Test Unit for Purch Doc"
 
         // [WHEN] Changing the Deferral Code on the Purchase Line
         DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
-        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        asserterror PurchaseLine2.Validate("Deferral Code", DeferralTemplateCode);
 
         // [THEN] The change is rejected because the Purchase Invoice is not open
         Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));

--- a/src/Layers/W1/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2545,6 +2545,39 @@ codeunit 134804 "RED Test Unit for Purch Doc"
         PurchaseInvoice.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeferralCodeCannotBeChangedOnReleasedPurchaseInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Deferral Code cannot be changed on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
+        asserterror PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+
+        // [THEN] The change is rejected because the Purchase Invoice is not open
+        Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";


### PR DESCRIPTION
[Bug 649204](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649204): [master][All-e]"Status must be equal to 'Open' in Purchase Header" validation missing for Deferral Code field on Released Purchase documents.

Fixes [AB#649204](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649204)

Issue 
"Status must be equal to 'Open' in Purchase Header" validation missing for Deferral Code field on Released Purchase documents.

Root Cause
TestStatusOpen(); missing for Field Deferral Code.

Solution
Added the function and related test automation













