### PR TITLE
[29.x] Prevent Sales Order Agent from skipping emails moved into monitored folders

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOARetrieveEmails.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOARetrieveEmails.Codeunit.al
@@ -93,7 +93,6 @@ codeunit 4582 "SOA Retrieve Emails"
         end;
 
         AddEmailInboxToSOAEmails(SOASetup, EmailInbox);
-        UpdateSOAEarliestSyncAt(SOASetup, EmailInbox.Count());
         Commit();
 
         SOAEmail.SetRange(Processed, false);
@@ -114,17 +113,6 @@ codeunit 4582 "SOA Retrieve Emails"
             end;
         until SOAEmail.Next() = 0;
         Commit();
-    end;
-
-    local procedure UpdateSOAEarliestSyncAt(var SOASetup: Record "SOA Setup"; EmailsProcessed: Integer)
-    begin
-        SOASetup.Get(SOASetup.ID);
-        // Only move the earliest sync time forward if we processed fewer emails than the limit
-        // This ensures we'll re-query and get any we missed
-        if EmailsProcessed < SOAMailSetup.GetMaxNoOfEmails() then
-            SOASetup."Earliest Sync At" := CurrentDateTime();
-
-        SOASetup.Modify();
     end;
 
     local procedure AddEmailToAgentTask(SOASetup: Record "SOA Setup"; var SOAEmail: Record "SOA Email")


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Stop advancing **Earliest Sync At** after email polling. Moved emails retain their original received timestamp, so advancing this value could permanently exclude them from later retrieval.

The configured Start Date remains the retrieval lower bound, while Graph excludes emails already categorized as processed. Added regression tests for empty and under-full polling.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#649175](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649175)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Low risk. No schema, API, setup, or connector changes. Existing Start Date behavior during setup, reactivation, and mailbox changes remains unchanged. Previously processed emails continue to be excluded server-side by their Outlook category.

