### PR TITLE
[Master][All-e][FTE][SaaS] Last name of the employee relative is not editable when customized using “Profile (Role)”.

### DIFF
--- a/src/Layers/CZ/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/CZ/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -744,6 +744,40 @@ codeunit 136400 "Resource Employee"
         Resource.TestField(City, PostCode.City);
     end;
 
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure EditEmployeeRelativeLastName()
+    var
+        Employee: Record Employee;
+        EmployeeRelative: Record "Employee Relative";
+        EmployeeRelatives: TestPage "Employee Relatives";
+        LastName: Text[30];
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO 649253] The last name of an employee relative can be edited on the Employee Relatives page.
+        Initialize();
+
+        // [GIVEN] An employee with a relative.
+        LibraryHumanResource.CreateEmployee(Employee);
+        EmployeeRelative."Employee No." := Employee."No.";
+        EmployeeRelative."Line No." := 10000;
+        EmployeeRelative.Insert();
+        LastName := CopyStr(LibraryUtility.GenerateRandomText(MaxStrLen(EmployeeRelative."Last Name")), 1, MaxStrLen(EmployeeRelative."Last Name"));
+        Commit();
+
+        // [WHEN] The relative's last name is edited on the Employee Relatives page.
+        EmployeeRelatives.OpenEdit();
+        EmployeeRelatives.FILTER.SetFilter("Employee No.", Employee."No.");
+        EmployeeRelatives.GotoRecord(EmployeeRelative);
+        EmployeeRelatives."Last Name".SetValue(LastName);
+        EmployeeRelatives.Close();
+
+        // [THEN] The relative's last name is saved.
+        EmployeeRelative.Get(EmployeeRelative."Employee No.", EmployeeRelative."Line No.");
+        EmployeeRelative.TestField("Last Name", LastName);
+    end;
+
     [Normal]
     local procedure Initialize()
     var

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelative.Table.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelative.Table.al
@@ -46,6 +46,7 @@ table 5205 "Employee Relative"
         field(6; "First Family Name"; Text[30])
         {
             Caption = 'First Family Name';
+            ToolTip = 'Specifies the first part of the family name.';
         }
         field(7; "Birth Date"; Date)
         {

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -31,19 +31,13 @@ page 5209 "Employee Relatives"
                 }
                 field("First Family Name"; Rec."First Family Name")
                 {
-                    ApplicationArea = Basic, Suite;
+                    ApplicationArea = BasicHR;
                     ToolTip = 'Specifies the first part of the family name.';
                 }
                 field("Second Family Name"; Rec."Second Family Name")
                 {
                     ApplicationArea = BasicHR;
                     ToolTip = 'Specifies the middle name of the employee''s relative.';
-                }
-                field("Last Name"; Rec."First Family Name")
-                {
-                    ApplicationArea = BasicHR;
-                    ToolTip = 'Specifies the last name of the employee''s relative.';
-                    Visible = false;
                 }
                 field("Birth Date"; Rec."Birth Date")
                 {

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -39,6 +39,14 @@ page 5209 "Employee Relatives"
                     ApplicationArea = BasicHR;
                     ToolTip = 'Specifies the middle name of the employee''s relative.';
                 }
+                field("Last Name"; Rec."Last Name")
+                {
+                    ApplicationArea = BasicHR;
+                }
+                field("Last Name"; Rec."Last Name")
+                {
+                    ApplicationArea = BasicHR;
+                }
                 field("Birth Date"; Rec."Birth Date")
                 {
                     ApplicationArea = BasicHR;

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -43,6 +43,7 @@ page 5209 "Employee Relatives"
                 {
                     ApplicationArea = BasicHR;
                     ToolTip = 'Specifies the last name of the employee''s relative.';
+                    Visible = false;
                 }
                 field("Birth Date"; Rec."Birth Date")
                 {

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -39,7 +39,7 @@ page 5209 "Employee Relatives"
                     ApplicationArea = BasicHR;
                     ToolTip = 'Specifies the middle name of the employee''s relative.';
                 }
-                field("Last Name"; Rec."Last Name")
+                field("Last Name"; Rec."First Family Name")
                 {
                     ApplicationArea = BasicHR;
                     ToolTip = 'Specifies the last name of the employee''s relative.';

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -42,6 +42,7 @@ page 5209 "Employee Relatives"
                 field("Last Name"; Rec."Last Name")
                 {
                     ApplicationArea = BasicHR;
+                    ToolTip = 'Specifies the last name of the employee''s relative.';
                 }
                 field("Birth Date"; Rec."Birth Date")
                 {

--- a/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/ES/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -43,10 +43,6 @@ page 5209 "Employee Relatives"
                 {
                     ApplicationArea = BasicHR;
                 }
-                field("Last Name"; Rec."Last Name")
-                {
-                    ApplicationArea = BasicHR;
-                }
                 field("Birth Date"; Rec."Birth Date")
                 {
                     ApplicationArea = BasicHR;

--- a/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -749,7 +749,6 @@ codeunit 136400 "Resource Employee"
 
 
     [Test]
-    [Scope('OnPrem')]
     procedure EditEmployeeRelativeLastName()
     var
         Employee: Record Employee;
@@ -771,7 +770,7 @@ codeunit 136400 "Resource Employee"
 
         // [WHEN] The relative's last name is edited on the Employee Relatives page.
         EmployeeRelatives.OpenEdit();
-        EmployeeRelatives.FILTER.SetFilter("Employee No.", Employee."No.");
+        EmployeeRelatives.Filter.SetFilter("Employee No.", Employee."No.");
         EmployeeRelatives.GotoRecord(EmployeeRelative);
         EmployeeRelatives."First Family Name".SetValue(LastName);
         EmployeeRelatives.Close();

--- a/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -773,7 +773,7 @@ codeunit 136400 "Resource Employee"
         EmployeeRelatives.OpenEdit();
         EmployeeRelatives.FILTER.SetFilter("Employee No.", Employee."No.");
         EmployeeRelatives.GotoRecord(EmployeeRelative);
-        EmployeeRelatives."Last Name".SetValue(LastName);
+        EmployeeRelatives."First Family Name".SetValue(LastName);
         EmployeeRelatives.Close();
 
         // [THEN] The relative's last name is saved.

--- a/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -766,7 +766,7 @@ codeunit 136400 "Resource Employee"
         EmployeeRelative."Employee No." := Employee."No.";
         EmployeeRelative."Line No." := 10000;
         EmployeeRelative.Insert();
-        LastName := CopyStr(LibraryUtility.GenerateRandomText(MaxStrLen(EmployeeRelative."Last Name")), 1, MaxStrLen(EmployeeRelative."Last Name"));
+        LastName := CopyStr(LibraryUtility.GenerateRandomText(MaxStrLen(EmployeeRelative."First Family Name")), 1, MaxStrLen(EmployeeRelative."First Family Name"));
         Commit();
 
         // [WHEN] The relative's last name is edited on the Employee Relatives page.
@@ -778,7 +778,7 @@ codeunit 136400 "Resource Employee"
 
         // [THEN] The relative's last name is saved.
         EmployeeRelative.Get(EmployeeRelative."Employee No.", EmployeeRelative."Line No.");
-        EmployeeRelative.TestField("Last Name", LastName);
+        EmployeeRelative.TestField("First Family Name", LastName);
     end;
 
     [Normal]

--- a/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/ES/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -747,6 +747,40 @@ codeunit 136400 "Resource Employee"
         Resource.TestField(City, PostCode.City);
     end;
 
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure EditEmployeeRelativeLastName()
+    var
+        Employee: Record Employee;
+        EmployeeRelative: Record "Employee Relative";
+        EmployeeRelatives: TestPage "Employee Relatives";
+        LastName: Text[30];
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO 649253] The last name of an employee relative can be edited on the Employee Relatives page.
+        Initialize();
+
+        // [GIVEN] An employee with a relative.
+        LibraryHumanResource.CreateEmployee(Employee);
+        EmployeeRelative."Employee No." := Employee."No.";
+        EmployeeRelative."Line No." := 10000;
+        EmployeeRelative.Insert();
+        LastName := CopyStr(LibraryUtility.GenerateRandomText(MaxStrLen(EmployeeRelative."Last Name")), 1, MaxStrLen(EmployeeRelative."Last Name"));
+        Commit();
+
+        // [WHEN] The relative's last name is edited on the Employee Relatives page.
+        EmployeeRelatives.OpenEdit();
+        EmployeeRelatives.FILTER.SetFilter("Employee No.", Employee."No.");
+        EmployeeRelatives.GotoRecord(EmployeeRelative);
+        EmployeeRelatives."Last Name".SetValue(LastName);
+        EmployeeRelatives.Close();
+
+        // [THEN] The relative's last name is saved.
+        EmployeeRelative.Get(EmployeeRelative."Employee No.", EmployeeRelative."Line No.");
+        EmployeeRelative.TestField("Last Name", LastName);
+    end;
+
     [Normal]
     local procedure Initialize()
     var

--- a/src/Layers/RU/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/RU/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -570,6 +570,40 @@ codeunit 136400 "Resource Employee"
         Resource.TestField(City, PostCode.City);
     end;
 
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure EditEmployeeRelativeLastName()
+    var
+        Employee: Record Employee;
+        EmployeeRelative: Record "Employee Relative";
+        EmployeeRelatives: TestPage "Employee Relatives";
+        LastName: Text[30];
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO 649253] The last name of an employee relative can be edited on the Employee Relatives page.
+        Initialize();
+
+        // [GIVEN] An employee with a relative.
+        LibraryHumanResource.CreateEmployee(Employee);
+        EmployeeRelative."Employee No." := Employee."No.";
+        EmployeeRelative."Line No." := 10000;
+        EmployeeRelative.Insert();
+        LastName := CopyStr(LibraryUtility.GenerateRandomText(MaxStrLen(EmployeeRelative."Last Name")), 1, MaxStrLen(EmployeeRelative."Last Name"));
+        Commit();
+
+        // [WHEN] The relative's last name is edited on the Employee Relatives page.
+        EmployeeRelatives.OpenEdit();
+        EmployeeRelatives.FILTER.SetFilter("Employee No.", Employee."No.");
+        EmployeeRelatives.GotoRecord(EmployeeRelative);
+        EmployeeRelatives."Last Name".SetValue(LastName);
+        EmployeeRelatives.Close();
+
+        // [THEN] The relative's last name is saved.
+        EmployeeRelative.Get(EmployeeRelative."Employee No.", EmployeeRelative."Line No.");
+        EmployeeRelative.TestField("Last Name", LastName);
+    end;
+
     [Normal]
     local procedure Initialize()
     var

--- a/src/Layers/W1/BaseApp/HumanResources/Employee/EmployeeRelative.Table.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Employee/EmployeeRelative.Table.al
@@ -46,6 +46,7 @@ table 5205 "Employee Relative"
         field(6; "Last Name"; Text[30])
         {
             Caption = 'Last Name';
+            ToolTip = 'Specifies the last name of the employee''s relative.';
         }
         field(7; "Birth Date"; Date)
         {

--- a/src/Layers/W1/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -34,6 +34,10 @@ page 5209 "Employee Relatives"
                     ApplicationArea = BasicHR;
                     Visible = false;
                 }
+                field("Last Name"; Rec."Last Name")
+                {
+                    ApplicationArea = BasicHR;
+                }
                 field("Birth Date"; Rec."Birth Date")
                 {
                     ApplicationArea = BasicHR;

--- a/src/Layers/W1/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
+++ b/src/Layers/W1/BaseApp/HumanResources/Employee/EmployeeRelatives.Page.al
@@ -37,6 +37,7 @@ page 5209 "Employee Relatives"
                 field("Last Name"; Rec."Last Name")
                 {
                     ApplicationArea = BasicHR;
+                    ToolTip = 'Specifies the last name of the employee''s relative.';
                 }
                 field("Birth Date"; Rec."Birth Date")
                 {

--- a/src/Layers/W1/Tests/Resource/ResourceEmployee.Codeunit.al
+++ b/src/Layers/W1/Tests/Resource/ResourceEmployee.Codeunit.al
@@ -747,6 +747,40 @@ codeunit 136400 "Resource Employee"
         Resource.TestField(City, PostCode.City);
     end;
 
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure EditEmployeeRelativeLastName()
+    var
+        Employee: Record Employee;
+        EmployeeRelative: Record "Employee Relative";
+        EmployeeRelatives: TestPage "Employee Relatives";
+        LastName: Text[30];
+    begin
+        // [FEATURE] [AI TEST]
+        // [SCENARIO 649253] The last name of an employee relative can be edited on the Employee Relatives page.
+        Initialize();
+
+        // [GIVEN] An employee with a relative.
+        LibraryHumanResource.CreateEmployee(Employee);
+        EmployeeRelative."Employee No." := Employee."No.";
+        EmployeeRelative."Line No." := 10000;
+        EmployeeRelative.Insert();
+        LastName := CopyStr(LibraryUtility.GenerateRandomText(MaxStrLen(EmployeeRelative."Last Name")), 1, MaxStrLen(EmployeeRelative."Last Name"));
+        Commit();
+
+        // [WHEN] The relative's last name is edited on the Employee Relatives page.
+        EmployeeRelatives.OpenEdit();
+        EmployeeRelatives.FILTER.SetFilter("Employee No.", Employee."No.");
+        EmployeeRelatives.GotoRecord(EmployeeRelative);
+        EmployeeRelatives."Last Name".SetValue(LastName);
+        EmployeeRelatives.Close();
+
+        // [THEN] The relative's last name is saved.
+        EmployeeRelative.Get(EmployeeRelative."Employee No.", EmployeeRelative."Line No.");
+        EmployeeRelative.TestField("Last Name", LastName);
+    end;
+
     [Normal]
     local procedure Initialize()
     var


### PR DESCRIPTION
[Bug 649253](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649253): [Master][All-e][FTE][SaaS] Last name of the employee relative is not editable when customized using “Profile (Role)”.

Fixes [AB#649253](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649253)

Issue:
The Last Name field is not available on the Employee Relatives page, so users cannot view or edit an employee relative’s last name.

Cause:
The Employee Relative table contains the Last Name field, but the field was not included in the page layout.

Solution:
Added the Last Name field to the Employee Relatives page and added an automated UI test to verify that the value can be edited and saved successfully.








