### PR TITLE
[Master][ALL-E] Document Type is Quote in Document Attachment table (1173) after posting a Sales Invoice with attachments.

### DIFF
--- a/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -53,6 +53,8 @@ codeunit 134776 "Document Attachment Tests"
         OpportunityTwoLbl: Label 'Opportunity2';
         PrintedToAttachmentTxt: Label 'The document has been printed to attachments.';
         RenameCodeLbl: Label 'T';
+        SalesInvoiceHeaderFileNameLbl: Label 'salesinvoiceheader', Locked = true;
+        SalesInvoiceLineFileNameLbl: Label 'salesinvoiceline', Locked = true;
         SecondAttachmentFileNameMismatchErr: Label 'Second file name not equal to saved attachment.';
         TwoAttachmentsExpectedErr: Label 'Two attachments were expected for this record.';
         UnexpectedFieldVisibilityErr: Label 'Unexpected visibility for field %1', Comment = '%1=FieldCaption';
@@ -4526,6 +4528,40 @@ codeunit 134776 "Document Attachment Tests"
 
         // [THEN] Verify Sales Credit Memo lines have two document attachments (one per each line inserted from Sales Return Order).
         CheckDocAttachments(Database::"Sales Line", 2, CreditMemoNo, SalesHeaderReturnOrder."Document Type"::"Credit Memo".AsInteger(), 'SalesReturnLine');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsInvoiceAfterPostingSalesInvoice()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        RecRef: RecordRef;
+        PostedInvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Invoice for attachments transferred to a posted sales invoice.
+        Initialize();
+
+        // [GIVEN] A sales invoice with attachments on the header and line.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, SalesHeader."Document Type"::Invoice);
+        RecRef.GetTable(SalesHeader);
+        CreateDocAttach(RecRef, StrSubstNo(JpegFileNameTok, SalesInvoiceHeaderFileNameLbl), false, false);
+        RecRef.GetTable(SalesLine);
+        CreateDocAttach(RecRef, StrSubstNo(JpegFileNameTok, SalesInvoiceLineFileNameLbl), false, false);
+
+        // [WHEN] The sales invoice is posted.
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The posted invoice header and line attachments have document type Invoice.
+        CheckDocAttachments(
+            Database::"Sales Invoice Header", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceHeaderFileNameLbl);
+        CheckDocAttachments(
+            Database::"Sales Invoice Line", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceLineFileNameLbl);
     end;
 
     local procedure Initialize()

--- a/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -53,8 +53,13 @@ codeunit 134776 "Document Attachment Tests"
         OpportunityTwoLbl: Label 'Opportunity2';
         PrintedToAttachmentTxt: Label 'The document has been printed to attachments.';
         RenameCodeLbl: Label 'T';
+        PurchaseCreditMemoFileNamePrefixLbl: Label 'purchasecreditmemo', Locked = true;
+        PurchaseInvoiceFileNamePrefixLbl: Label 'purchaseinvoice', Locked = true;
+        SalesCreditMemoFileNamePrefixLbl: Label 'salescreditmemo', Locked = true;
         SalesInvoiceHeaderFileNameLbl: Label 'salesinvoiceheader', Locked = true;
         SalesInvoiceLineFileNameLbl: Label 'salesinvoiceline', Locked = true;
+        ServiceCreditMemoFileNamePrefixLbl: Label 'servicecreditmemo', Locked = true;
+        ServiceInvoiceFileNamePrefixLbl: Label 'serviceinvoice', Locked = true;
         SecondAttachmentFileNameMismatchErr: Label 'Second file name not equal to saved attachment.';
         TwoAttachmentsExpectedErr: Label 'Two attachments were expected for this record.';
         UnexpectedFieldVisibilityErr: Label 'Unexpected visibility for field %1', Comment = '%1=FieldCaption';
@@ -4562,6 +4567,147 @@ codeunit 134776 "Document Attachment Tests"
             Database::"Sales Invoice Header", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceHeaderFileNameLbl);
         CheckDocAttachments(
             Database::"Sales Invoice Line", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceLineFileNameLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsCreditMemoAfterPostingSalesCreditMemo()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Credit Memo for attachments transferred to a posted sales credit memo.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingSalesDocument(
+            Enum::"Sales Document Type"::"Credit Memo", Database::"Sales Cr.Memo Header", Database::"Sales Cr.Memo Line",
+            Enum::"Attachment Document Type"::"Credit Memo", SalesCreditMemoFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsInvoiceAfterPostingPurchaseInvoice()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Invoice for attachments transferred to a posted purchase invoice.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingPurchaseDocument(
+            Enum::"Purchase Document Type"::Invoice, Database::"Purch. Inv. Header", Database::"Purch. Inv. Line",
+            Enum::"Attachment Document Type"::Invoice, PurchaseInvoiceFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsCreditMemoAfterPostingPurchaseCreditMemo()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Credit Memo for attachments transferred to a posted purchase credit memo.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingPurchaseDocument(
+            Enum::"Purchase Document Type"::"Credit Memo", Database::"Purch. Cr. Memo Hdr.", Database::"Purch. Cr. Memo Line",
+            Enum::"Attachment Document Type"::"Credit Memo", PurchaseCreditMemoFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsInvoiceAfterPostingServiceInvoice()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Invoice for attachments transferred to a posted service invoice.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingServiceDocument(
+            Enum::"Service Document Type"::Invoice, Database::"Service Invoice Header", Database::"Service Invoice Line",
+            Enum::"Attachment Document Type"::Invoice, ServiceInvoiceFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsCreditMemoAfterPostingServiceCreditMemo()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Credit Memo for attachments transferred to a posted service credit memo.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingServiceDocument(
+            Enum::"Service Document Type"::"Credit Memo", Database::"Service Cr.Memo Header", Database::"Service Cr.Memo Line",
+            Enum::"Attachment Document Type"::"Credit Memo", ServiceCreditMemoFileNamePrefixLbl);
+    end;
+
+    local procedure VerifyDocumentTypeAfterPostingSalesDocument(DocumentType: Enum "Sales Document Type"; PostedHeaderTableId: Integer; PostedLineTableId: Integer; ExpectedDocumentType: Enum "Attachment Document Type"; FileNamePrefix: Text)
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        RecordRef: RecordRef;
+        PostedDocumentNo: Code[20];
+    begin
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, DocumentType);
+        RecordRef.GetTable(SalesHeader);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'header.jpeg', false, false);
+        RecordRef.GetTable(SalesLine);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'line.jpeg', false, false);
+
+        PostedDocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        CheckDocAttachments(PostedHeaderTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'header');
+        CheckDocAttachments(PostedLineTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'line');
+    end;
+
+    local procedure VerifyDocumentTypeAfterPostingPurchaseDocument(DocumentType: Enum "Purchase Document Type"; PostedHeaderTableId: Integer; PostedLineTableId: Integer; ExpectedDocumentType: Enum "Attachment Document Type"; FileNamePrefix: Text)
+    var
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+        RecordRef: RecordRef;
+        PostedDocumentNo: Code[20];
+    begin
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        CreatePurchDoc(PurchaseHeader, PurchaseLine, Vendor, Item, DocumentType);
+        RecordRef.GetTable(PurchaseHeader);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'header.jpeg', false, false);
+        RecordRef.GetTable(PurchaseLine);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'line.jpeg', false, false);
+
+        PostedDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        CheckDocAttachments(PostedHeaderTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'header');
+        CheckDocAttachments(PostedLineTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'line');
+    end;
+
+    local procedure VerifyDocumentTypeAfterPostingServiceDocument(DocumentType: Enum "Service Document Type"; PostedHeaderTableId: Integer; PostedLineTableId: Integer; ExpectedDocumentType: Enum "Attachment Document Type"; FileNamePrefix: Text)
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        ServiceHeader: Record "Service Header";
+        ServiceLine: Record "Service Line";
+        RecordRef: RecordRef;
+        PostedDocumentNo: Code[20];
+    begin
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        LibraryService.CreateServiceHeader(ServiceHeader, DocumentType, Customer."No.");
+        LibraryService.CreateServiceLineWithQuantity(ServiceLine, ServiceHeader, ServiceLine.Type::Item, Item."No.", 1);
+        ServiceLine.Validate("Unit Price", LibraryRandom.RandIntInRange(3, 5));
+        ServiceLine.Modify(true);
+        RecordRef.GetTable(ServiceHeader);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'header.jpeg', false, false);
+        RecordRef.GetTable(ServiceLine);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'line.jpeg', false, false);
+        PostedDocumentNo := ServiceHeader."No.";
+
+        LibraryService.PostServiceOrder(
+            ServiceHeader, DocumentType = DocumentType::Invoice, false, DocumentType = DocumentType::Invoice);
+        if ServiceHeader."Last Posting No." <> '' then
+            PostedDocumentNo := ServiceHeader."Last Posting No.";
+
+        CheckDocAttachments(PostedHeaderTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'header');
+        CheckDocAttachments(PostedLineTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'line');
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/BaseApp/Foundation/Attachment/DocumentAttachmentMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Attachment/DocumentAttachmentMgmt.Codeunit.al
@@ -1627,7 +1627,13 @@ codeunit 1173 "Document Attachment Mgmt"
     end;
 
     local procedure SetDocumentTypeForPostedDocument(var DocumentAttachment: Record "Document Attachment"; PostedDocumentTableID: Integer)
+    var
+        IsHandled: Boolean;
     begin
+        OnBeforeSetDocumentTypeForPostedDocument(DocumentAttachment, PostedDocumentTableID, IsHandled);
+        if IsHandled then
+            exit;
+
         case PostedDocumentTableID of
             Database::"Sales Invoice Header",
             Database::"Purch. Inv. Header":
@@ -1787,6 +1793,11 @@ codeunit 1173 "Document Attachment Mgmt"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCopyAttachmentsForPostedDocsLines(var FromRecRef: RecordRef; var ToRecRef: RecordRef; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeSetDocumentTypeForPostedDocument(var DocumentAttachment: Record "Document Attachment"; PostedDocumentTableID: Integer; var IsHandled: Boolean)
     begin
     end;
 

--- a/src/Layers/W1/BaseApp/Foundation/Attachment/DocumentAttachmentMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Attachment/DocumentAttachmentMgmt.Codeunit.al
@@ -1564,7 +1564,7 @@ codeunit 1173 "Document Attachment Mgmt"
                 ToFieldRef := ToRecRef.Field(3);
                 ToNo := ToFieldRef.Value();
                 ToDocumentAttachment.Validate("No.", ToNo);
-                Clear(ToDocumentAttachment."Document Type");
+                SetDocumentTypeForPostedDocument(ToDocumentAttachment, ToRecRef.Number);
                 OnCopyAttachmentsForPostedDocsOnBeforeToDocumentAttachmentInsert(FromDocumentAttachment, ToDocumentAttachment);
                 ToDocumentAttachment.Insert(true);
                 OnCopyAttachmentsForPostedDocsOnAfterToDocumentAttachmentInsert(FromDocumentAttachment, ToDocumentAttachment);
@@ -1619,11 +1619,25 @@ codeunit 1173 "Document Attachment Mgmt"
                 end;
                 OnCopyAttachmentsForPostedDocsLinesOnAfterSetToTableID(ToRecRef, ToDocumentAttachmentLine);
 
-                Clear(ToDocumentAttachmentLine."Document Type");
+                SetDocumentTypeForPostedDocument(ToDocumentAttachmentLine, ToRecRef.Number);
                 ToDocumentAttachmentLine.Validate("No.", ToNo);
 
                 if ToDocumentAttachmentLine.Insert(true) then;
             until FromDocumentAttachmentLine.Next() = 0;
+    end;
+
+    local procedure SetDocumentTypeForPostedDocument(var DocumentAttachment: Record "Document Attachment"; PostedDocumentTableID: Integer)
+    begin
+        case PostedDocumentTableID of
+            Database::"Sales Invoice Header",
+            Database::"Purch. Inv. Header":
+                DocumentAttachment.Validate("Document Type", DocumentAttachment."Document Type"::Invoice);
+            Database::"Sales Cr.Memo Header",
+            Database::"Purch. Cr. Memo Hdr.":
+                DocumentAttachment.Validate("Document Type", DocumentAttachment."Document Type"::"Credit Memo");
+            else
+                Clear(DocumentAttachment."Document Type");
+        end;
     end;
 
     procedure MoveAttachmentsWithinSameRecordType(var MoveFromRecRef: RecordRef; var MoveToRecRef: RecordRef)

--- a/src/Layers/W1/BaseApp/Service/Document/ServDocumentAttachmentMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Document/ServDocumentAttachmentMgt.Codeunit.al
@@ -412,6 +412,23 @@ codeunit 6459 "Serv. Document Attachment Mgt."
         end;
     end;
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Document Attachment Mgmt", 'OnBeforeSetDocumentTypeForPostedDocument', '', true, false)]
+    local procedure OnBeforeSetDocumentTypeForPostedDocument(var DocumentAttachment: Record "Document Attachment"; PostedDocumentTableID: Integer; var IsHandled: Boolean)
+    begin
+        case PostedDocumentTableID of
+            Database::"Service Invoice Header":
+                begin
+                    DocumentAttachment.Validate("Document Type", DocumentAttachment."Document Type"::Invoice);
+                    IsHandled := true;
+                end;
+            Database::"Service Cr.Memo Header":
+                begin
+                    DocumentAttachment.Validate("Document Type", DocumentAttachment."Document Type"::"Credit Memo");
+                    IsHandled := true;
+                end;
+        end;
+    end;
+
     #region [Service Management event subscribers]
     [EventSubscriber(ObjectType::Table, Database::"Service Item", 'OnAfterDeleteEvent', '', true, false)]
     local procedure DeleteAttachedDocumentsOnAfterDeleteServiceItem(var Rec: Record "Service Item"; RunTrigger: Boolean)

--- a/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -53,6 +53,8 @@ codeunit 134776 "Document Attachment Tests"
         OpportunityTwoLbl: Label 'Opportunity2';
         PrintedToAttachmentTxt: Label 'The document has been printed to attachments.';
         RenameCodeLbl: Label 'T';
+        SalesInvoiceHeaderFileNameLbl: Label 'salesinvoiceheader', Locked = true;
+        SalesInvoiceLineFileNameLbl: Label 'salesinvoiceline', Locked = true;
         SecondAttachmentFileNameMismatchErr: Label 'Second file name not equal to saved attachment.';
         TwoAttachmentsExpectedErr: Label 'Two attachments were expected for this record.';
         UnexpectedFieldVisibilityErr: Label 'Unexpected visibility for field %1', Comment = '%1=FieldCaption';
@@ -4526,6 +4528,40 @@ codeunit 134776 "Document Attachment Tests"
 
         // [THEN] Verify Sales Credit Memo lines have two document attachments (one per each line inserted from Sales Return Order).
         CheckDocAttachments(Database::"Sales Line", 2, CreditMemoNo, SalesHeaderReturnOrder."Document Type"::"Credit Memo".AsInteger(), 'SalesReturnLine');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsInvoiceAfterPostingSalesInvoice()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        RecRef: RecordRef;
+        PostedInvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Invoice for attachments transferred to a posted sales invoice.
+        Initialize();
+
+        // [GIVEN] A sales invoice with attachments on the header and line.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, SalesHeader."Document Type"::Invoice);
+        RecRef.GetTable(SalesHeader);
+        CreateDocAttach(RecRef, StrSubstNo(JpegFileNameTok, SalesInvoiceHeaderFileNameLbl), false, false);
+        RecRef.GetTable(SalesLine);
+        CreateDocAttach(RecRef, StrSubstNo(JpegFileNameTok, SalesInvoiceLineFileNameLbl), false, false);
+
+        // [WHEN] The sales invoice is posted.
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The posted invoice header and line attachments have document type Invoice.
+        CheckDocAttachments(
+            Database::"Sales Invoice Header", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceHeaderFileNameLbl);
+        CheckDocAttachments(
+            Database::"Sales Invoice Line", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceLineFileNameLbl);
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -53,8 +53,13 @@ codeunit 134776 "Document Attachment Tests"
         OpportunityTwoLbl: Label 'Opportunity2';
         PrintedToAttachmentTxt: Label 'The document has been printed to attachments.';
         RenameCodeLbl: Label 'T';
+        PurchaseCreditMemoFileNamePrefixLbl: Label 'purchasecreditmemo', Locked = true;
+        PurchaseInvoiceFileNamePrefixLbl: Label 'purchaseinvoice', Locked = true;
+        SalesCreditMemoFileNamePrefixLbl: Label 'salescreditmemo', Locked = true;
         SalesInvoiceHeaderFileNameLbl: Label 'salesinvoiceheader', Locked = true;
         SalesInvoiceLineFileNameLbl: Label 'salesinvoiceline', Locked = true;
+        ServiceCreditMemoFileNamePrefixLbl: Label 'servicecreditmemo', Locked = true;
+        ServiceInvoiceFileNamePrefixLbl: Label 'serviceinvoice', Locked = true;
         SecondAttachmentFileNameMismatchErr: Label 'Second file name not equal to saved attachment.';
         TwoAttachmentsExpectedErr: Label 'Two attachments were expected for this record.';
         UnexpectedFieldVisibilityErr: Label 'Unexpected visibility for field %1', Comment = '%1=FieldCaption';
@@ -4562,6 +4567,147 @@ codeunit 134776 "Document Attachment Tests"
             Database::"Sales Invoice Header", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceHeaderFileNameLbl);
         CheckDocAttachments(
             Database::"Sales Invoice Line", 1, PostedInvoiceNo, Enum::"Attachment Document Type"::Invoice.AsInteger(), SalesInvoiceLineFileNameLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsCreditMemoAfterPostingSalesCreditMemo()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Credit Memo for attachments transferred to a posted sales credit memo.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingSalesDocument(
+            Enum::"Sales Document Type"::"Credit Memo", Database::"Sales Cr.Memo Header", Database::"Sales Cr.Memo Line",
+            Enum::"Attachment Document Type"::"Credit Memo", SalesCreditMemoFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsInvoiceAfterPostingPurchaseInvoice()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Invoice for attachments transferred to a posted purchase invoice.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingPurchaseDocument(
+            Enum::"Purchase Document Type"::Invoice, Database::"Purch. Inv. Header", Database::"Purch. Inv. Line",
+            Enum::"Attachment Document Type"::Invoice, PurchaseInvoiceFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsCreditMemoAfterPostingPurchaseCreditMemo()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Credit Memo for attachments transferred to a posted purchase credit memo.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingPurchaseDocument(
+            Enum::"Purchase Document Type"::"Credit Memo", Database::"Purch. Cr. Memo Hdr.", Database::"Purch. Cr. Memo Line",
+            Enum::"Attachment Document Type"::"Credit Memo", PurchaseCreditMemoFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsInvoiceAfterPostingServiceInvoice()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Invoice for attachments transferred to a posted service invoice.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingServiceDocument(
+            Enum::"Service Document Type"::Invoice, Database::"Service Invoice Header", Database::"Service Invoice Line",
+            Enum::"Attachment Document Type"::Invoice, ServiceInvoiceFileNamePrefixLbl);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DocumentTypeIsCreditMemoAfterPostingServiceCreditMemo()
+    begin
+        // [FEATURE] [Document Attachment] [AI Test]
+        // [SCENARIO] Document type is Credit Memo for attachments transferred to a posted service credit memo.
+        Initialize();
+
+        VerifyDocumentTypeAfterPostingServiceDocument(
+            Enum::"Service Document Type"::"Credit Memo", Database::"Service Cr.Memo Header", Database::"Service Cr.Memo Line",
+            Enum::"Attachment Document Type"::"Credit Memo", ServiceCreditMemoFileNamePrefixLbl);
+    end;
+
+    local procedure VerifyDocumentTypeAfterPostingSalesDocument(DocumentType: Enum "Sales Document Type"; PostedHeaderTableId: Integer; PostedLineTableId: Integer; ExpectedDocumentType: Enum "Attachment Document Type"; FileNamePrefix: Text)
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        RecordRef: RecordRef;
+        PostedDocumentNo: Code[20];
+    begin
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, DocumentType);
+        RecordRef.GetTable(SalesHeader);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'header.jpeg', false, false);
+        RecordRef.GetTable(SalesLine);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'line.jpeg', false, false);
+
+        PostedDocumentNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        CheckDocAttachments(PostedHeaderTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'header');
+        CheckDocAttachments(PostedLineTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'line');
+    end;
+
+    local procedure VerifyDocumentTypeAfterPostingPurchaseDocument(DocumentType: Enum "Purchase Document Type"; PostedHeaderTableId: Integer; PostedLineTableId: Integer; ExpectedDocumentType: Enum "Attachment Document Type"; FileNamePrefix: Text)
+    var
+        Item: Record Item;
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+        RecordRef: RecordRef;
+        PostedDocumentNo: Code[20];
+    begin
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        CreatePurchDoc(PurchaseHeader, PurchaseLine, Vendor, Item, DocumentType);
+        RecordRef.GetTable(PurchaseHeader);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'header.jpeg', false, false);
+        RecordRef.GetTable(PurchaseLine);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'line.jpeg', false, false);
+
+        PostedDocumentNo := LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        CheckDocAttachments(PostedHeaderTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'header');
+        CheckDocAttachments(PostedLineTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'line');
+    end;
+
+    local procedure VerifyDocumentTypeAfterPostingServiceDocument(DocumentType: Enum "Service Document Type"; PostedHeaderTableId: Integer; PostedLineTableId: Integer; ExpectedDocumentType: Enum "Attachment Document Type"; FileNamePrefix: Text)
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        ServiceHeader: Record "Service Header";
+        ServiceLine: Record "Service Line";
+        RecordRef: RecordRef;
+        PostedDocumentNo: Code[20];
+    begin
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        LibraryService.CreateServiceHeader(ServiceHeader, DocumentType, Customer."No.");
+        LibraryService.CreateServiceLineWithQuantity(ServiceLine, ServiceHeader, ServiceLine.Type::Item, Item."No.", 1);
+        ServiceLine.Validate("Unit Price", LibraryRandom.RandIntInRange(3, 5));
+        ServiceLine.Modify(true);
+        RecordRef.GetTable(ServiceHeader);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'header.jpeg', false, false);
+        RecordRef.GetTable(ServiceLine);
+        CreateDocAttach(RecordRef, FileNamePrefix + 'line.jpeg', false, false);
+        PostedDocumentNo := ServiceHeader."No.";
+
+        LibraryService.PostServiceOrder(
+            ServiceHeader, DocumentType = DocumentType::Invoice, false, DocumentType = DocumentType::Invoice);
+        if ServiceHeader."Last Posting No." <> '' then
+            PostedDocumentNo := ServiceHeader."Last Posting No.";
+
+        CheckDocAttachments(PostedHeaderTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'header');
+        CheckDocAttachments(PostedLineTableId, 1, PostedDocumentNo, ExpectedDocumentType.AsInteger(), FileNamePrefix + 'line');
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
[Bug 649254](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649254): [Master][ALL-E] Document Type is Quote in Document Attachment table (1173) after posting a Sales Invoice with attachments.

Fixes [AB#649254](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649254)

Issue:
After posting a sales invoice containing header or line attachments, the resulting records in the Document Attachment table had the Document Type incorrectly set to Quote instead of Invoice.

Cause:
During attachment transfer to the posted document, the Document Type was cleared. Because Quote is enum value 0, clearing the field implicitly assigned Quote.

Solution:
Set the Document Type according to the posted document table instead of clearing it. Posted invoice attachments are now assigned Invoice, while posted credit memo attachments are assigned Credit Memo. A regression test verifies both sales invoice header and line attachments.



