### PR TITLE
Fix SubcontractingMigrationIT code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -207,6 +207,7 @@
 
 # Localization apps that are not Finance.
 /src/Apps/BE/ShopifyBE/ @microsoft/d365-bc-integrations
+/src/Apps/IT/SubcontractingMigrationIT/ @microsoft/d365-bc-scm
 
 # Demo data. Every team contributes demo data for its own area, so it has no
 # single owner. This line has no owner on purpose: it releases demo data


### PR DESCRIPTION
## Summary

- route the full `src/Apps/IT/SubcontractingMigrationIT/` application family to `@microsoft/d365-bc-scm`
- keep the exception after the broad localization Finance default so GitHub's last-match precedence selects SCM

## Root cause

#11001 changes both the app and test projects under `src/Apps/IT/SubcontractingMigrationIT/`. The existing `/src/Apps/*/` rule classified those paths as Finance, while the SCM exception only covered `/src/Apps/W1/Subcontracting/`.

The corresponding source-of-truth correction is in microsoft/BCAppsTriage#64 so future CODEOWNERS regeneration retains this route.

## Validation

- GitHub CODEOWNERS errors API returned no errors for this branch
- verified the App and Test paths changed by #11001 both resolve to `@microsoft/d365-bc-scm` by last-match precedence


Fixes [AB#649291](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649291)
