### PR TITLE
Fix generation rule source table validation 

### DIFF
--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
@@ -291,13 +291,16 @@ table 20404 "Qlty. Inspection Gen. Rule"
     var
         PersistedQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
     begin
-        if Rec.IsTemporary() then begin
-            if xRec."Source Table No." <> 0 then
-                CheckSourceTableNoIsSet();
-        end else
-            if PersistedQltyInspectionGenRule.Get(Rec."Entry No.") then
-                if PersistedQltyInspectionGenRule."Source Table No." <> 0 then
+        if Rec."Source Table No." = 0 then
+            if Rec.IsTemporary() then begin
+                if xRec."Source Table No." <> 0 then
                     CheckSourceTableNoIsSet();
+            end else begin
+                PersistedQltyInspectionGenRule.SetLoadFields("Source Table No.");
+                if PersistedQltyInspectionGenRule.Get(Rec."Entry No.") then
+                    if PersistedQltyInspectionGenRule."Source Table No." <> 0 then
+                        CheckSourceTableNoIsSet();
+            end;
         UpdateSortOrder();
         if (xRec."Source Table No." <> Rec."Source Table No.") or (Rec.Intent = Rec.Intent::Unknown) or not GuiAllowed() then
             SetIntentAndDefaultTriggerValuesFromSetup();

--- a/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
+++ b/src/Apps/W1/Quality Management/app/src/Configuration/GenerationRule/QltyInspectionGenRule.Table.al
@@ -288,9 +288,16 @@ table 20404 "Qlty. Inspection Gen. Rule"
     end;
 
     trigger OnModify()
+    var
+        PersistedQltyInspectionGenRule: Record "Qlty. Inspection Gen. Rule";
     begin
-        if xRec."Source Table No." <> 0 then
-            CheckSourceTableNoIsSet();
+        if Rec.IsTemporary() then begin
+            if xRec."Source Table No." <> 0 then
+                CheckSourceTableNoIsSet();
+        end else
+            if PersistedQltyInspectionGenRule.Get(Rec."Entry No.") then
+                if PersistedQltyInspectionGenRule."Source Table No." <> 0 then
+                    CheckSourceTableNoIsSet();
         UpdateSortOrder();
         if (xRec."Source Table No." <> Rec."Source Table No.") or (Rec.Intent = Rec.Intent::Unknown) or not GuiAllowed() then
             SetIntentAndDefaultTriggerValuesFromSetup();


### PR DESCRIPTION
Fixes [AB#642736](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642736)

`OnModify` relied on `xRec` to determine whether a generation rule previously had a source table. During programmatic modifications, `xRec` can already contain the changed value, allowing an existing source table to be cleared without raising an error.

The validation now reads the persisted generation rule to preserve both intended behaviors:

- Clearing the source table of a valid rule raises an error.
- Legacy rules already stored without a source table remain editable.

Temporary records retain the previous behavior.



