### PR TITLE
[28.4] Revert PEPPOL E-Document integration files

### DIFF
--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
@@ -7,10 +7,10 @@ namespace Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.eServices.EDocument;
 using Microsoft.Foundation.Attachment;
 using Microsoft.Foundation.Company;
-using Microsoft.Peppol;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
+using Microsoft.Sales.Peppol;
 using Microsoft.Service.History;
 using System.IO;
 using System.Reflection;
@@ -26,8 +26,8 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         ServiceInvoiceHeader: Record "Service Invoice Header";
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
-        PEPPOLValidation: Codeunit "PEPPOL30 Sales Validation";
-        PEPPOLServiceValidation: Codeunit "PEPPOL30 Service Validation";
+        PEPPOLValidation: Codeunit "PEPPOL Validation";
+        PEPPOLServiceValidation: Codeunit "PEPPOL Service Validation";
     begin
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
@@ -38,22 +38,22 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
             Database::"Sales Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesInvoiceHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesInvoiceHeader);
+                    PEPPOLValidation.CheckSalesInvoice(SalesInvoiceHeader);
                 end;
             Database::"Sales Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesCrMemoHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesCrMemoHeader);
+                    PEPPOLValidation.CheckSalesCreditMemo(SalesCrMemoHeader);
                 end;
             Database::"Service Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceInvoiceHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
+                    PEPPOLServiceValidation.CheckServiceInvoice(ServiceInvoiceHeader);
                 end;
             Database::"Service Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceCrMemoHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
+                    PEPPOLServiceValidation.CheckServiceCreditMemo(ServiceCrMemoHeader);
                 end;
         end;
     end;

--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.eServices.EDocument;
 using Microsoft.Foundation.Attachment;
 using Microsoft.Foundation.Company;
+using Microsoft.Peppol;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
@@ -26,14 +27,22 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         ServiceInvoiceHeader: Record "Service Invoice Header";
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
         PEPPOLValidation: Codeunit "PEPPOL Validation";
         PEPPOLServiceValidation: Codeunit "PEPPOL Service Validation";
+        SalesValidation: Interface "PEPPOL30 Validation";
+        ServiceValidation: Interface "PEPPOL30 Validation";
     begin
+        PeppolSetup.GetSetup();
+        SalesValidation := PeppolSetup."PEPPOL 3.0 Sales Format";
+        ServiceValidation := PeppolSetup."PEPPOL 3.0 Service Format";
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesHeader);
-                    PEPPOLValidation.Run(SalesHeader);
+                    SalesValidation.ValidateDocument(SalesHeader);
+                    SalesValidation.ValidateDocumentLines(SalesHeader);
                 end;
             Database::"Sales Invoice Header":
                 begin

--- a/src/Apps/W1/EDocument/App/src/DataExchange/PEPPOL Data Exchange Definition/EDocDEDPEPPOLSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/PEPPOL Data Exchange Definition/EDocDEDPEPPOLSubscribers.Codeunit.al
@@ -9,10 +9,10 @@ using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Calculation;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Attachment;
-using Microsoft.Peppol;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
+using Microsoft.Sales.Peppol;
 using Microsoft.Service.History;
 using System.IO;
 using System.Utilities;
@@ -451,7 +451,7 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                             OriginCountryIdCode,
                             OriginCountryIdCodeListID);
 
-                        PEPPOLMgt.GetLineItemClassifiedTaxCategoryBIS(
+                        PEPPOLMgt.GetLineItemClassfiedTaxCategoryBIS(
                             SalesLine,
                             ClassifiedTaxCategoryID,
                             DummyVar,
@@ -631,7 +631,7 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                                 TempSalesLineRounding.TransferFields(SalesLine);
                                 TempSalesLineRounding.Insert();
                             end else begin
-                                PEPPOLMgt.GetTaxTotals(SalesLine, TempVATAmtLine);
+                                PEPPOLMgt.GetTotals(SalesLine, TempVATAmtLine);
                                 PEPPOLMgt.GetTaxCategories(SalesLine, TempVATProductPostingGroup);
                             end;
                         until SalesInvoiceLine.Next() = 0;
@@ -650,12 +650,12 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                     if ServiceInvoiceLine.FindSet() then
                         repeat
                             PEPPOLMgt.TransferLineToSalesLine(ServiceInvoiceLine, SalesLine);
-                            SalesLine.Type := PEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceInvoiceLine.Type);
+                            SalesLine.Type := ServPEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceInvoiceLine.Type);
                             if IsRoundingLine(SalesLine) then begin
                                 TempSalesLineRounding.TransferFields(SalesLine);
                                 TempSalesLineRounding.Insert();
                             end else begin
-                                PEPPOLMgt.GetTaxTotals(SalesLine, TempVATAmtLine);
+                                PEPPOLMgt.GetTotals(SalesLine, TempVATAmtLine);
                                 PEPPOLMgt.GetTaxCategories(SalesLine, TempVATProductPostingGroup);
                             end;
                         until ServiceInvoiceLine.Next() = 0;
@@ -678,7 +678,7 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                                 TempSalesLineRounding.TransferFields(SalesLine);
                                 TempSalesLineRounding.Insert();
                             end else begin
-                                PEPPOLMgt.GetTaxTotals(SalesLine, TempVATAmtLine);
+                                PEPPOLMgt.GetTotals(SalesLine, TempVATAmtLine);
                                 PEPPOLMgt.GetTaxCategories(SalesLine, TempVATProductPostingGroup);
                             end;
                         until SalesCrMemoLine.Next() = 0;
@@ -697,12 +697,12 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                     if ServiceCrMemoLine.FindSet() then
                         repeat
                             PEPPOLMgt.TransferLineToSalesLine(ServiceCrMemoLine, SalesLine);
-                            SalesLine.Type := PEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceCrMemoLine.Type);
+                            SalesLine.Type := ServPEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceCrMemoLine.Type);
                             if IsRoundingLine(SalesLine) then begin
                                 TempSalesLineRounding.TransferFields(SalesLine);
                                 TempSalesLineRounding.Insert();
                             end else begin
-                                PEPPOLMgt.GetTaxTotals(SalesLine, TempVATAmtLine);
+                                PEPPOLMgt.GetTotals(SalesLine, TempVATAmtLine);
                                 PEPPOLMgt.GetTaxCategories(SalesLine, TempVATProductPostingGroup);
                             end;
                         until ServiceCrMemoLine.Next() = 0;
@@ -738,7 +738,7 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                     ServiceInvoiceLine.FindFirst();
 
                     PEPPOLMgt.TransferLineToSalesLine(ServiceInvoiceLine, SalesLine);
-                    SalesLine.Type := PEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceInvoiceLine.Type);
+                    SalesLine.Type := ServPEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceInvoiceLine.Type);
                 end;
             ProcessedDocType::"Sales Credit Memo":
                 begin
@@ -754,7 +754,7 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
                     ServiceCrMemoLine.FindFirst();
 
                     PEPPOLMgt.TransferLineToSalesLine(ServiceCrMemoLine, SalesLine);
-                    SalesLine.Type := PEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceCrMemoLine.Type);
+                    SalesLine.Type := ServPEPPOLMgt.MapServiceLineTypeToSalesLineType(ServiceCrMemoLine.Type);
                 end;
         end;
     end;
@@ -801,7 +801,8 @@ codeunit 6162 "E-Doc. DED PEPPOL Subscribers"
 #pragma warning restore AL0432
         TempSalesLineRounding: Record "Sales Line" temporary;
         TempVATProductPostingGroup: Record "VAT Product Posting Group" temporary;
-        PEPPOLMgt: Codeunit "PEPPOL30";
+        PEPPOLMgt: Codeunit "PEPPOL Management";
+        ServPEPPOLMgt: Codeunit "Serv. PEPPOL Management";
         ProcessedDocType: Enum "E-Document Type";
         DocumentAttachmentNumber, ProcessedDocTypeInt : Integer;
         AdditionalDocumentReferenceID, AdditionalDocRefDocumentType, URI, Filename, MimeCode, EmbeddedDocumentBinaryObject : Text;

--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -2,8 +2,12 @@ namespace Microsoft.eServices.EDocument.IO.Peppol;
 
 using Microsoft.eServices.EDocument;
 using Microsoft.EServices.EDocument.Format;
+using Microsoft.eServices.EDocument.RemittanceAdvice;
+using Microsoft.Finance.GeneralLedger.Journal;
 using Microsoft.Inventory.Transfer;
+using Microsoft.Peppol;
 using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Payables;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.History;
@@ -25,15 +29,24 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
         ReminderHeader: Record "Reminder Header";
         FinChargeMemoHeader: Record "Finance Charge Memo Header";
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
         PEPPOLValidation: Codeunit "PEPPOL Validation";
         PEPPOLServiceValidation: Codeunit "PEPPOL Service Validation";
         EDocPEPPOLValidation: Codeunit "E-Doc. PEPPOL Validation";
+        EDocRemittanceAdviceMgt: Codeunit "E-Doc. Remittance Advice Mgt.";
+        SalesValidation: Interface "PEPPOL30 Validation";
+        ServiceValidation: Interface "PEPPOL30 Validation";
     begin
+        SalesValidation := GetSalesFormat();
+        ServiceValidation := GetServiceFormat();
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesHeader);
-                    PEPPOLValidation.Run(SalesHeader);
+                    SalesValidation.ValidateDocument(SalesHeader);
+                    SalesValidation.ValidateDocumentLines(SalesHeader);
                 end;
             Database::"Sales Invoice Header":
                 begin
@@ -70,6 +83,18 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
                     SourceDocumentHeader.SetTable(ServiceHeader);
                     PEPPOLServiceValidation.CheckServiceHeader(ServiceHeader);
                 end;
+            Database::"Gen. Journal Line":
+                begin
+                    SourceDocumentHeader.SetTable(GenJournalLine);
+                    EDocRemittanceAdviceMgt.CheckJournalPayment(GenJournalLine);
+                    EDocPEPPOLValidation.CheckRemittanceAdvice(GenJournalLine);
+                end;
+            Database::"Vendor Ledger Entry":
+                begin
+                    SourceDocumentHeader.SetTable(VendorLedgerEntry);
+                    EDocRemittanceAdviceMgt.CheckPostedPayment(VendorLedgerEntry);
+                    EDocPEPPOLValidation.CheckRemittanceAdvice(VendorLedgerEntry);
+                end;
         end;
     end;
 
@@ -80,9 +105,13 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
     begin
         TempBlob.CreateOutStream(DocOutStream);
         case EDocument."Document Type" of
-            EDocument."Document Type"::"Sales Invoice", EDocument."Document Type"::"Service Invoice":
+            EDocument."Document Type"::"Sales Invoice":
                 GenerateInvoiceXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
-            EDocument."Document Type"::"Sales Credit Memo", EDocument."Document Type"::"Service Credit Memo":
+            EDocument."Document Type"::"Service Invoice":
+                GenerateInvoiceXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
+            EDocument."Document Type"::"Sales Credit Memo":
+                GenerateCrMemoXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
+            EDocument."Document Type"::"Service Credit Memo":
                 GenerateCrMemoXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
             EDocument."Document Type"::"Issued Reminder", EDocument."Document Type"::"Issued Finance Charge Memo":
                 GenerateFinancialResultsXMLFile(SourceDocumentHeader, DocOutStream);
@@ -90,6 +119,10 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
                 GenerateShipmentXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
             EDocument."Document Type"::"Transfer Shipment":
                 GenerateTransferShipmentXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
+            EDocument."Document Type"::"Purchase Order":
+                GeneratePurchaseOrderXMLFile(SourceDocumentHeader, DocOutStream, EDocumentService."Embed PDF in export");
+            EDocument."Document Type"::"Remittance Advice":
+                GenerateRemittanceAdviceXMLFile(SourceDocumentHeader, DocOutStream);
             else
                 EDocErrorHelper.LogSimpleErrorMessage(EDocument, StrSubstNo(DocumentTypeNotSupportedErr, EDocument.FieldCaption("Document Type"), EDocument."Document Type"));
         end;
@@ -139,6 +172,22 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         SalesCrMemoPEPPOLBIS30.Export();
     end;
 
+    local procedure GetSalesFormat(): Enum "PEPPOL 3.0 Format"
+    var
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+    begin
+        PeppolSetup.GetSetup();
+        exit(PeppolSetup."PEPPOL 3.0 Sales Format");
+    end;
+
+    local procedure GetServiceFormat(): Enum "PEPPOL 3.0 Format"
+    var
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+    begin
+        PeppolSetup.GetSetup();
+        exit(PeppolSetup."PEPPOL 3.0 Service Format");
+    end;
+
     local procedure GenerateFinancialResultsXMLFile(VariantRec: Variant; var OutStr: OutStream)
     var
         FinResultsPEPPOLBIS30: XMLport "Fin. Results - PEPPOL BIS 3.0";
@@ -171,6 +220,53 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         TransferShipmentExport.SetGeneratePDF(GeneratePDF);
         TransferShipmentExport.Run(TransferShipmentHeader);
         TransferShipmentExport.GetTransferShipmentXML(TempBlob);
+        CopyStream(DocOutStream, TempBlob.CreateInStream());
+    end;
+
+    local procedure GeneratePurchaseOrderXMLFile(var SourceDocumentHeader: RecordRef; DocOutStream: OutStream; GeneratePDF: Boolean)
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+        PurchaseOrderExport: Codeunit "Export Purchase Order PEPPOL30";
+        TempBlob: Codeunit "Temp Blob";
+    begin
+        PeppolSetup.GetSetup();
+        SourceDocumentHeader.SetTable(PurchaseHeader);
+        PurchaseOrderExport.SetFormat(PeppolSetup."PEPPOL 3.0 Purchase Format");
+        PurchaseOrderExport.SetGeneratePDF(GeneratePDF);
+        PurchaseOrderExport.Run(PurchaseHeader);
+        PurchaseOrderExport.GetPurchaseOrderXML(TempBlob);
+        CopyStream(DocOutStream, TempBlob.CreateInStream());
+    end;
+
+    local procedure GenerateRemittanceAdviceXMLFile(SourceDocumentHeader: RecordRef; DocOutStream: OutStream)
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendorLedgerEntry: Record "Vendor Ledger Entry";
+        TempRemitAdviceBuffer: Record "Remit. Advice Buffer" temporary;
+        RemitAdviceBufferMgt: Codeunit "Remit. Advice Buffer Mgt.";
+        ExportRemitAdvicePEPPOL30: Codeunit "Export Remit. Advice PEPPOL30";
+        EDocPEPPOLValidation: Codeunit "E-Doc. PEPPOL Validation";
+        TempBlob: Codeunit "Temp Blob";
+    begin
+        case SourceDocumentHeader.Number of
+            Database::"Gen. Journal Line":
+                begin
+                    SourceDocumentHeader.SetTable(GenJournalLine);
+                    EDocPEPPOLValidation.CheckRemittanceAdvice(GenJournalLine);
+                    RemitAdviceBufferMgt.BuildFromJournalPayment(GenJournalLine, TempRemitAdviceBuffer);
+                end;
+            Database::"Vendor Ledger Entry":
+                begin
+                    SourceDocumentHeader.SetTable(VendorLedgerEntry);
+                    EDocPEPPOLValidation.CheckRemittanceAdvice(VendorLedgerEntry);
+                    RemitAdviceBufferMgt.BuildFromPostedPayment(VendorLedgerEntry, TempRemitAdviceBuffer);
+                end;
+            else
+                exit;
+        end;
+
+        ExportRemitAdvicePEPPOL30.GenerateXml(TempRemitAdviceBuffer, TempBlob);
         CopyStream(DocOutStream, TempBlob.CreateInStream());
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -3,11 +3,11 @@ namespace Microsoft.eServices.EDocument.IO.Peppol;
 using Microsoft.eServices.EDocument;
 using Microsoft.EServices.EDocument.Format;
 using Microsoft.Inventory.Transfer;
-using Microsoft.Peppol;
 using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.History;
+using Microsoft.Sales.Peppol;
 using Microsoft.Sales.Reminder;
 using Microsoft.Service.Document;
 using Microsoft.Service.History;
@@ -25,8 +25,8 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
         ReminderHeader: Record "Reminder Header";
         FinChargeMemoHeader: Record "Finance Charge Memo Header";
-        PEPPOLValidation: Codeunit "PEPPOL30 Sales Validation";
-        PEPPOLServiceValidation: Codeunit "PEPPOL30 Service Validation";
+        PEPPOLValidation: Codeunit "PEPPOL Validation";
+        PEPPOLServiceValidation: Codeunit "PEPPOL Service Validation";
         EDocPEPPOLValidation: Codeunit "E-Doc. PEPPOL Validation";
     begin
         case SourceDocumentHeader.Number of
@@ -38,22 +38,22 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
             Database::"Sales Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesInvoiceHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesInvoiceHeader);
+                    PEPPOLValidation.CheckSalesInvoice(SalesInvoiceHeader);
                 end;
             Database::"Sales Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesCrMemoHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesCrMemoHeader);
+                    PEPPOLValidation.CheckSalesCreditMemo(SalesCrMemoHeader);
                 end;
             Database::"Service Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceInvoiceHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
+                    PEPPOLServiceValidation.CheckServiceInvoice(ServiceInvoiceHeader);
                 end;
             Database::"Service Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceCrMemoHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
+                    PEPPOLServiceValidation.CheckServiceCreditMemo(ServiceCrMemoHeader);
                 end;
             Database::"Reminder Header":
                 begin
@@ -68,7 +68,7 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
             Database::"Service Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceHeader);
-                    PEPPOLServiceValidation.Run(ServiceHeader);
+                    PEPPOLServiceValidation.CheckServiceHeader(ServiceHeader);
                 end;
         end;
     end;
@@ -121,24 +121,22 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
     var
-        SalesInvoicePEPPOL30: XMLport "Sales Invoice - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
+        SalesInvoicePEPPOLBIS30: XMLport "Sales Invoice - PEPPOL BIS 3.0";
     begin
-        SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
-        SalesInvoicePEPPOL30.SetGeneratePDF(GeneratePDF);
-        SalesInvoicePEPPOL30.SetDestination(OutStr);
-        SalesInvoicePEPPOL30.Export();
+        SalesInvoicePEPPOLBIS30.Initialize(VariantRec);
+        SalesInvoicePEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+        SalesInvoicePEPPOLBIS30.SetDestination(OutStr);
+        SalesInvoicePEPPOLBIS30.Export();
     end;
 
     local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
     var
-        SalesCrMemoPEPPOL30: XMLport "Sales Cr.Memo - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
+        SalesCrMemoPEPPOLBIS30: XMLport "Sales Cr.Memo - PEPPOL BIS 3.0";
     begin
-        SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
-        SalesCrMemoPEPPOL30.SetGeneratePDF(GeneratePDF);
-        SalesCrMemoPEPPOL30.SetDestination(OutStr);
-        SalesCrMemoPEPPOL30.Export();
+        SalesCrMemoPEPPOLBIS30.Initialize(VariantRec);
+        SalesCrMemoPEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+        SalesCrMemoPEPPOLBIS30.SetDestination(OutStr);
+        SalesCrMemoPEPPOLBIS30.Export();
     end;
 
     local procedure GenerateFinancialResultsXMLFile(VariantRec: Variant; var OutStr: OutStream)

--- a/src/Apps/W1/EDocument/App/src/Format/FinResultsPEPPOLBIS30.XmlPort.al
+++ b/src/Apps/W1/EDocument/App/src/Format/FinResultsPEPPOLBIS30.XmlPort.al
@@ -2,9 +2,9 @@ namespace Microsoft.EServices.EDocument.IO.Peppol;
 
 using Microsoft.Finance.VAT.Calculation;
 using Microsoft.Finance.VAT.Setup;
-using Microsoft.Peppol;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.FinanceCharge;
+using Microsoft.Sales.Peppol;
 using Microsoft.Sales.Reminder;
 using System.Utilities;
 
@@ -1036,7 +1036,7 @@ xmlport 6100 "Fin. Results - PEPPOL BIS 3.0"
 
                         trigger OnBeforePassVariable()
                         begin
-                            this.PEPPOLMgt.GetLineItemClassifiedTaxCategoryBIS(
+                            this.PEPPOLMgt.GetLineItemClassfiedTaxCategoryBIS(
                               this.GlobalSalesLine,
                               ClassifiedTaxCategoryID,
                               this.DummyVar,
@@ -1179,7 +1179,7 @@ xmlport 6100 "Fin. Results - PEPPOL BIS 3.0"
         GlobalIssuedFinChargeMemoHeader: Record "Issued Fin. Charge Memo Header";
         GlobalIssuedFinChargeMemoLine: Record "Issued Fin. Charge Memo Line";
         TempVATProductPostingGroup: Record "VAT Product Posting Group" temporary;
-        PEPPOLMgt: Codeunit "PEPPOL30";
+        PEPPOLMgt: Codeunit "PEPPOL Management";
         SourceRecRef: RecordRef;
         DummyVar: Text;
         IsReminder: Boolean;
@@ -1194,7 +1194,7 @@ xmlport 6100 "Fin. Results - PEPPOL BIS 3.0"
             if this.GlobalIssuedReminderLine.FindSet() then
                 repeat
                     this.CopyReminderLineToSalesLine(this.GlobalSalesLine, this.GlobalIssuedReminderHeader, this.GlobalIssuedReminderLine);
-                    this.PEPPOLMgt.GetTaxTotals(this.GlobalSalesLine, this.TempVATAmtLine);
+                    this.PEPPOLMgt.GetTotals(this.GlobalSalesLine, this.TempVATAmtLine);
                     this.PEPPOLMgt.GetTaxCategories(this.GlobalSalesLine, this.TempVATProductPostingGroup);
                 until this.GlobalIssuedReminderLine.Next() = 0;
         end;
@@ -1204,7 +1204,7 @@ xmlport 6100 "Fin. Results - PEPPOL BIS 3.0"
             if this.GlobalIssuedFinChargeMemoLine.FindSet() then
                 repeat
                     this.CopyFinChargeMemoLineToSalesLine(this.GlobalSalesLine, this.GlobalIssuedFinChargeMemoHeader, this.GlobalIssuedFinChargeMemoLine);
-                    this.PEPPOLMgt.GetTaxTotals(this.GlobalSalesLine, this.TempVATAmtLine);
+                    this.PEPPOLMgt.GetTotals(this.GlobalSalesLine, this.TempVATAmtLine);
                     this.PEPPOLMgt.GetTaxCategories(this.GlobalSalesLine, this.TempVATProductPostingGroup);
                 until this.GlobalIssuedFinChargeMemoLine.Next() = 0;
         end;


### PR DESCRIPTION
## Why

PR #10456, the `releases/28.4` backport of #10264, moved E-Document PEPPOL validation and export processing from the legacy BaseApp implementation to the standalone PEPPOL app. This bypassed Belgian Enterprise No. validation and partner subscribers to the legacy `PEPPOL Management` events.

This draft restores the four affected E-Document files exactly to their state before commit `d5f20fbfdda`. It overlaps the validation correction in #11048 and the export-event correction in #11052.

**Known blocker:** this branch is not merge-ready. Current 28.4 BaseApp symbols do not expose XMLports `Sales Invoice - PEPPOL BIS 3.0` and `Sales Cr.Memo - PEPPOL BIS 3.0`. The same references fail #11052 country builds with `AL0185`. Reverting the other files may also expose missing legacy `PEPPOL Management` symbols.

## Summary

- **Restored** legacy PEPPOL sales and service validation calls in both E-Document implementations.
- **Restored** legacy invoice and credit memo XMLport routing for partner event compatibility.
- **Restored** legacy `PEPPOL Management` calls in the Data Exchange Definition subscribers.
- **Restored** legacy `PEPPOL Management` calls in financial-results export.
- **Limited** the rollback to the four requested files; each exactly matches `d5f20fbfdda^`.


Fixes
[AB#649456](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649456)



