### PR TITLE
[Main][All-E][Repair Item] Posted Purchase Invoice Order No. is blank when invoice rounding creates a generated line

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8598,6 +8598,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8614,13 +8615,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/BE/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/BE/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8182,6 +8182,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8198,13 +8199,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/BE/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/BE/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9409,6 +9409,94 @@ codeunit 134327 "ERM Purchase Order"
         PurchaseLineOrder.TestField("Qty. to Invoice", 0);
     end;
 
+    [Test]
+    procedure OrderNoIsPopulatedOnPurchaseInvoiceWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchInvLine: Record "Purch. Inv. Line";
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A generated invoice rounding line does not prevent copying the source order number to the posted invoice.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", PurchaseHeader."No.");
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PurchInvLine.SetRange("Document No.", InvoiceNo);
+        PurchInvLine.SetRange(Type, PurchInvLine.Type::"G/L Account");
+        PurchInvLine.SetRange("No.", VendorPostingGroup."Invoice Rounding Account");
+        PurchInvLine.FindFirst();
+        PurchInvLine.TestField("System-Created Entry", true);
+        PurchInvLine.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceFromTwoOrdersWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: array[2] of Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A rounding line does not hide that a purchase invoice contains receipts from two orders.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[1], Vendor."No.", 100.2);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[2], Vendor."No.", 100.2);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader[1]);
+        AddPostedPurchaseOrderToInvoice(InvoicePurchaseHeader, PurchaseHeader[2]);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceWithManualBlankOrderLineAndInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A manual blank-order line is not mistaken for a generated invoice rounding line.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, InvoicePurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", 1);
+        PurchaseLine.Modify(true);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -9551,6 +9639,31 @@ codeunit 134327 "ERM Purchase Order"
             PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
             PurchGetReceipt.CreateInvLines(PurchRcptLine);
         until PurchRcptHeader.Next() = 0;
+    end;
+
+    local procedure AddPostedPurchaseOrderToInvoice(var InvoicePurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")
+    var
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+    begin
+        PurchGetReceipt.SetPurchHeader(InvoicePurchaseHeader);
+        PurchRcptHeader.SetRange("Order No.", PostedPurchaseHeader."No.");
+        PurchRcptHeader.FindFirst();
+        PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+    end;
+
+    local procedure CreateAndReceivePurchaseOrder(var PurchaseHeader: Record "Purchase Header"; VendorNo: Code[20]; DirectUnitCost: Decimal)
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, VendorNo);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
     end;
 
     local procedure CrMemoPostedPurchaseReturnOrder(var CrMemoPurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")

--- a/src/Layers/CH/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8165,6 +8165,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8181,13 +8182,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/CZ/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/CZ/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9293,6 +9293,94 @@
         PurchaseLineOrder.TestField("Qty. to Invoice", 0);
     end;
 
+    [Test]
+    procedure OrderNoIsPopulatedOnPurchaseInvoiceWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchInvLine: Record "Purch. Inv. Line";
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A generated invoice rounding line does not prevent copying the source order number to the posted invoice.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", PurchaseHeader."No.");
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PurchInvLine.SetRange("Document No.", InvoiceNo);
+        PurchInvLine.SetRange(Type, PurchInvLine.Type::"G/L Account");
+        PurchInvLine.SetRange("No.", VendorPostingGroup."Invoice Rounding Account");
+        PurchInvLine.FindFirst();
+        PurchInvLine.TestField("System-Created Entry", true);
+        PurchInvLine.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceFromTwoOrdersWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: array[2] of Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A rounding line does not hide that a purchase invoice contains receipts from two orders.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[1], Vendor."No.", 100.2);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[2], Vendor."No.", 100.2);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader[1]);
+        AddPostedPurchaseOrderToInvoice(InvoicePurchaseHeader, PurchaseHeader[2]);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceWithManualBlankOrderLineAndInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A manual blank-order line is not mistaken for a generated invoice rounding line.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, InvoicePurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", 1);
+        PurchaseLine.Modify(true);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -9435,6 +9523,31 @@
             PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
             PurchGetReceipt.CreateInvLines(PurchRcptLine);
         until PurchRcptHeader.Next() = 0;
+    end;
+
+    local procedure AddPostedPurchaseOrderToInvoice(var InvoicePurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")
+    var
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+    begin
+        PurchGetReceipt.SetPurchHeader(InvoicePurchaseHeader);
+        PurchRcptHeader.SetRange("Order No.", PostedPurchaseHeader."No.");
+        PurchRcptHeader.FindFirst();
+        PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+    end;
+
+    local procedure CreateAndReceivePurchaseOrder(var PurchaseHeader: Record "Purchase Header"; VendorNo: Code[20]; DirectUnitCost: Decimal)
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, VendorNo);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
     end;
 
     local procedure CrMemoPostedPurchaseReturnOrder(var CrMemoPurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")

--- a/src/Layers/ES/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/ES/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8340,6 +8340,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8356,13 +8357,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/FI/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/FI/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8140,6 +8140,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8156,13 +8157,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/GB/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/GB/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8167,6 +8167,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8183,13 +8184,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/IT/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/IT/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8497,6 +8497,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8513,13 +8514,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/IT/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9440,6 +9440,94 @@ codeunit 134327 "ERM Purchase Order"
         PurchaseLineOrder.TestField("Qty. to Invoice", 0);
     end;
 
+    [Test]
+    procedure OrderNoIsPopulatedOnPurchaseInvoiceWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchInvLine: Record "Purch. Inv. Line";
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A generated invoice rounding line does not prevent copying the source order number to the posted invoice.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", PurchaseHeader."No.");
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PurchInvLine.SetRange("Document No.", InvoiceNo);
+        PurchInvLine.SetRange(Type, PurchInvLine.Type::"G/L Account");
+        PurchInvLine.SetRange("No.", VendorPostingGroup."Invoice Rounding Account");
+        PurchInvLine.FindFirst();
+        PurchInvLine.TestField("System-Created Entry", true);
+        PurchInvLine.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceFromTwoOrdersWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: array[2] of Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A rounding line does not hide that a purchase invoice contains receipts from two orders.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[1], Vendor."No.", 100.2);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[2], Vendor."No.", 100.2);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader[1]);
+        AddPostedPurchaseOrderToInvoice(InvoicePurchaseHeader, PurchaseHeader[2]);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceWithManualBlankOrderLineAndInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A manual blank-order line is not mistaken for a generated invoice rounding line.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, InvoicePurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", 1);
+        PurchaseLine.Modify(true);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -9582,6 +9670,31 @@ codeunit 134327 "ERM Purchase Order"
             PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
             PurchGetReceipt.CreateInvLines(PurchRcptLine);
         until PurchRcptHeader.Next() = 0;
+    end;
+
+    local procedure AddPostedPurchaseOrderToInvoice(var InvoicePurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")
+    var
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+    begin
+        PurchGetReceipt.SetPurchHeader(InvoicePurchaseHeader);
+        PurchRcptHeader.SetRange("Order No.", PostedPurchaseHeader."No.");
+        PurchRcptHeader.FindFirst();
+        PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+    end;
+
+    local procedure CreateAndReceivePurchaseOrder(var PurchaseHeader: Record "Purchase Header"; VendorNo: Code[20]; DirectUnitCost: Decimal)
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, VendorNo);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
     end;
 
     local procedure CrMemoPostedPurchaseReturnOrder(var CrMemoPurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")

--- a/src/Layers/NA/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8833,6 +8833,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8849,13 +8850,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/NA/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9473,6 +9473,94 @@ codeunit 134327 "ERM Purchase Order"
         PurchaseLineOrder.TestField("Qty. to Invoice", 0);
     end;
 
+    [Test]
+    procedure OrderNoIsPopulatedOnPurchaseInvoiceWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchInvLine: Record "Purch. Inv. Line";
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A generated invoice rounding line does not prevent copying the source order number to the posted invoice.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", PurchaseHeader."No.");
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PurchInvLine.SetRange("Document No.", InvoiceNo);
+        PurchInvLine.SetRange(Type, PurchInvLine.Type::"G/L Account");
+        PurchInvLine.SetRange("No.", VendorPostingGroup."Invoice Rounding Account");
+        PurchInvLine.FindFirst();
+        PurchInvLine.TestField("System-Created Entry", true);
+        PurchInvLine.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceFromTwoOrdersWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: array[2] of Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A rounding line does not hide that a purchase invoice contains receipts from two orders.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[1], Vendor."No.", 100.2);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[2], Vendor."No.", 100.2);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader[1]);
+        AddPostedPurchaseOrderToInvoice(InvoicePurchaseHeader, PurchaseHeader[2]);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceWithManualBlankOrderLineAndInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A manual blank-order line is not mistaken for a generated invoice rounding line.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, InvoicePurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", 1);
+        PurchaseLine.Modify(true);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -9615,6 +9703,31 @@ codeunit 134327 "ERM Purchase Order"
             PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
             PurchGetReceipt.CreateInvLines(PurchRcptLine);
         until PurchRcptHeader.Next() = 0;
+    end;
+
+    local procedure AddPostedPurchaseOrderToInvoice(var InvoicePurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")
+    var
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+    begin
+        PurchGetReceipt.SetPurchHeader(InvoicePurchaseHeader);
+        PurchRcptHeader.SetRange("Order No.", PostedPurchaseHeader."No.");
+        PurchRcptHeader.FindFirst();
+        PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+    end;
+
+    local procedure CreateAndReceivePurchaseOrder(var PurchaseHeader: Record "Purchase Header"; VendorNo: Code[20]; DirectUnitCost: Decimal)
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, VendorNo);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
     end;
 
     local procedure CrMemoPostedPurchaseReturnOrder(var CrMemoPurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")

--- a/src/Layers/RU/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/RU/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8913,6 +8913,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8929,13 +8930,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/W1/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Purchases/Posting/PurchPost.Codeunit.al
@@ -8134,6 +8134,7 @@ codeunit 90 "Purch.-Post"
     local procedure PostUpdateOrderNo(var PurchInvHeader: Record "Purch. Inv. Header")
     var
         PurchInvLine: Record "Purch. Inv. Line";
+        OrderNo: Code[20];
     begin
         if PurchInvHeader."No." = '' then
             exit;
@@ -8150,13 +8151,32 @@ codeunit 90 "Purch.-Post"
         PurchInvLine.SetFilter("Order No.", '<>%1', '');
         if not PurchInvLine.FindFirst() then
             exit;
+        OrderNo := PurchInvLine."Order No.";
 
         // If all the lines have the same 'Order No.' then set 'Order No.' field on the header
-        PurchInvLine.SetFilter("Order No.", '<>%1', PurchInvLine."Order No.");
-        if PurchInvLine.IsEmpty() then begin
-            PurchInvHeader.Validate("Order No.", PurchInvLine."Order No.");
-            PurchInvHeader.Modify(true);
-        end;
+        PurchInvLine.SetFilter("Order No.", '<>%1', OrderNo);
+        if PurchInvLine.FindSet() then
+            repeat
+                if not IsInvoiceRoundingLine(PurchInvHeader."Vendor Posting Group", PurchInvLine) then
+                    exit;
+            until PurchInvLine.Next() = 0;
+
+        PurchInvHeader.Validate("Order No.", OrderNo);
+        PurchInvHeader.Modify(true);
+    end;
+
+    local procedure IsInvoiceRoundingLine(VendorPostingGroupCode: Code[20]; PurchInvLine: Record "Purch. Inv. Line"): Boolean
+    var
+        VendorPostingGroup: Record "Vendor Posting Group";
+    begin
+        if (PurchInvLine."Order No." <> '') or
+           (PurchInvLine.Type <> PurchInvLine.Type::"G/L Account") or
+           not PurchInvLine."System-Created Entry"
+        then
+            exit(false);
+
+        VendorPostingGroup.Get(VendorPostingGroupCode);
+        exit(PurchInvLine."No." = VendorPostingGroup."Invoice Rounding Account");
     end;
 
     /// <summary>

--- a/src/Layers/W1/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Purchase/ERMPurchaseOrder.Codeunit.al
@@ -9344,6 +9344,94 @@ codeunit 134327 "ERM Purchase Order"
         PurchaseLineOrder.TestField("Qty. to Invoice", 0);
     end;
 
+    [Test]
+    procedure OrderNoIsPopulatedOnPurchaseInvoiceWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        PurchInvLine: Record "Purch. Inv. Line";
+        Vendor: Record Vendor;
+        VendorPostingGroup: Record "Vendor Posting Group";
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A generated invoice rounding line does not prevent copying the source order number to the posted invoice.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", PurchaseHeader."No.");
+        VendorPostingGroup.Get(Vendor."Vendor Posting Group");
+        PurchInvLine.SetRange("Document No.", InvoiceNo);
+        PurchInvLine.SetRange(Type, PurchInvLine.Type::"G/L Account");
+        PurchInvLine.SetRange("No.", VendorPostingGroup."Invoice Rounding Account");
+        PurchInvLine.FindFirst();
+        PurchInvLine.TestField("System-Created Entry", true);
+        PurchInvLine.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceFromTwoOrdersWithInvoiceRoundingLine()
+    var
+        PurchaseHeader: array[2] of Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A rounding line does not hide that a purchase invoice contains receipts from two orders.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[1], Vendor."No.", 100.2);
+        CreateAndReceivePurchaseOrder(PurchaseHeader[2], Vendor."No.", 100.2);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader[1]);
+        AddPostedPurchaseOrderToInvoice(InvoicePurchaseHeader, PurchaseHeader[2]);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
+    [Test]
+    procedure OrderNoIsBlankOnPurchaseInvoiceWithManualBlankOrderLineAndInvoiceRoundingLine()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        InvoicePurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvHeader: Record "Purch. Inv. Header";
+        Vendor: Record Vendor;
+        InvoiceNo: Code[20];
+    begin
+        // [FEATURE] [Invoice Rounding] [Get Receipt Lines] [AI]
+        // [SCENARIO 647878] A manual blank-order line is not mistaken for a generated invoice rounding line.
+        Initialize();
+        LibraryERM.SetInvRoundingPrecisionLCY(1);
+        LibraryPurchase.SetInvoiceRounding(true);
+        LibraryPurchase.CreateVendor(Vendor);
+        CreateAndReceivePurchaseOrder(PurchaseHeader, Vendor."No.", 100.4);
+        InvoicePostedPurchaseOrder(InvoicePurchaseHeader, PurchaseHeader);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, InvoicePurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", 1);
+        PurchaseLine.Modify(true);
+
+        InvoiceNo := LibraryPurchase.PostPurchaseDocument(InvoicePurchaseHeader, false, true);
+
+        PurchInvHeader.Get(InvoiceNo);
+        PurchInvHeader.TestField("Order No.", '');
+    end;
+
     local procedure Initialize()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -9486,6 +9574,31 @@ codeunit 134327 "ERM Purchase Order"
             PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
             PurchGetReceipt.CreateInvLines(PurchRcptLine);
         until PurchRcptHeader.Next() = 0;
+    end;
+
+    local procedure AddPostedPurchaseOrderToInvoice(var InvoicePurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")
+    var
+        PurchRcptHeader: Record "Purch. Rcpt. Header";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+    begin
+        PurchGetReceipt.SetPurchHeader(InvoicePurchaseHeader);
+        PurchRcptHeader.SetRange("Order No.", PostedPurchaseHeader."No.");
+        PurchRcptHeader.FindFirst();
+        PurchRcptLine.SetRange("Document No.", PurchRcptHeader."No.");
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+    end;
+
+    local procedure CreateAndReceivePurchaseOrder(var PurchaseHeader: Record "Purchase Header"; VendorNo: Code[20]; DirectUnitCost: Decimal)
+    var
+        PurchaseLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, VendorNo);
+        LibraryPurchase.CreatePurchaseLine(
+          PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), 1);
+        PurchaseLine.Validate("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, false);
     end;
 
     local procedure CrMemoPostedPurchaseReturnOrder(var CrMemoPurchaseHeader: Record "Purchase Header"; PostedPurchaseHeader: Record "Purchase Header")


### PR DESCRIPTION
[Bug 647878](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/647878): [All-E][Repair Item] Posted Purchase Invoice Order No. is blank when invoice rounding creates a generated line

Fixes [AB#647878](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647878)

Issue:
When posting a purchase invoice created from a purchase order receipt, the posted purchase invoice’s Order No. is blank if invoice rounding generates an additional line.

Cause:
The logic that copies Order No. to the posted purchase invoice header requires all posted invoice lines to have the same order number. The system-generated invoice rounding line has a blank Order No., so it is incorrectly treated as a line from a different source.

Solution:
Ignore valid system-generated invoice rounding lines when determining whether all posted purchase invoice lines belong to the same purchase order. Other lines with a blank or different Order No. continue to prevent the header from being populated. Added [AI] regression tests for single-order, multiple-order, and manual-line scenarios.

