### PR TITLE
[29.0][Bug Fix] Fix recurring journal background posting for IRS 1099 invoice lines (US)

### DIFF
--- a/src/Apps/US/IRSForms/app/src/Extensions/IRS1099BaseAppSubscribers.Codeunit.al
+++ b/src/Apps/US/IRSForms/app/src/Extensions/IRS1099BaseAppSubscribers.Codeunit.al
@@ -269,7 +269,7 @@ codeunit 10032 "IRS 1099 BaseApp Subscribers"
 
     local procedure SaveChangesInGenJnlLine(var GenJnlLine: Record "Gen. Journal Line")
     begin
-        if GenJnlLine."Line No." <> 0 then
+        if (GenJnlLine."Line No." <> 0) and (GenJnlLine."Job Queue Status" = GenJnlLine."Job Queue Status"::" ") then
             if GenJnlLine.Modify(true) then;
     end;
 

--- a/src/Apps/US/IRSForms/test/src/IRS1099DocumentTests.Codeunit.al
+++ b/src/Apps/US/IRSForms/test/src/IRS1099DocumentTests.Codeunit.al
@@ -1380,6 +1380,141 @@ codeunit 148010 "IRS 1099 Document Tests"
         Assert.AreEqual(FormBoxNo[2], PurchCrMemoHdr."IRS 1099 Form Box No.", 'IRS 1099 Form Box No. in Purch. Cr. Memo Hdr. should be updated');
     end;
 
+    [Test]
+    procedure InvoiceLineScheduledForPostingSyncsIRSDataWithoutModifyError()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendNo: Code[20];
+        FormNo: Code[20];
+        FormBoxNo: Code[20];
+        PeriodDate: Date;
+    begin
+        // [FEATURE] [Recurring Journal] [Background Posting] [AI test 1.0]
+        // [SCENARIO 626641] Validating an IRS-relevant field on a Vendor Invoice journal line whose Job Queue Status
+        //                   is "Scheduled for Posting" must not fail. Background posting re-validates the Posting Date
+        //                   of recurring lines while the status is set; the IRS 1099 sync subscriber derives its fields
+        //                   onto the record buffer without re-entering the line's OnModify posting guard, and the
+        //                   owning posting engine persists them.
+        Initialize();
+        // [GIVEN] An IRS Reporting Period and a vendor with a 1099 form box setup in that period
+        PeriodDate := WorkDate();
+        LibraryIRSReportingPeriod.CreateOneDayReportingPeriod(PeriodDate);
+        FormNo := LibraryIRS1099FormBox.CreateSingleFormInReportingPeriod(PeriodDate);
+        FormBoxNo := LibraryIRS1099FormBox.CreateSingleFormBoxInReportingPeriod(PeriodDate, FormNo);
+        VendNo := LibraryIRS1099FormBox.CreateVendorNoWithFormBox(PeriodDate, FormNo, FormBoxNo);
+        // [GIVEN] A Vendor Invoice recurring journal line with Posting Date outside the IRS period, so validation will sync IRS data
+        CreateRecurringGenJnlLineForVendor(GenJournalLine, VendNo, GenJournalLine."Document Type"::Invoice, CalcDate('<-1D>', PeriodDate));
+        // [GIVEN] The line has been scheduled for background posting (status written without triggers)
+        GenJournalLine."Job Queue Status" := GenJournalLine."Job Queue Status"::"Scheduled for Posting";
+        GenJournalLine.Modify(false);
+
+        // [WHEN] The posting engine re-validates the Posting Date to a date inside the IRS period
+        GenJournalLine.Validate("Posting Date", PeriodDate);
+        // [WHEN] The owning posting engine saves the recurring line (Modify without running OnModify)
+        GenJournalLine.Modify(false);
+
+        // [THEN] No "scheduled for posting" error is raised and the IRS data is synced and persisted
+        Assert.AreEqual(PeriodDate, GenJournalLine."Posting Date", 'Posting Date mismatch');
+        VerifyIRS1099DataInGenJnlLine(GenJournalLine, PeriodDate, FormNo, FormBoxNo);
+        GenJournalLine.Find();
+        VerifyIRS1099DataInGenJnlLine(GenJournalLine, PeriodDate, FormNo, FormBoxNo);
+    end;
+
+    [Test]
+    procedure BlankDocTypeLineScheduledForPostingIsUnaffected()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VendNo: Code[20];
+        FormNo: Code[20];
+        FormBoxNo: Code[20];
+        PeriodDate: Date;
+    begin
+        // [FEATURE] [Recurring Journal] [Background Posting] [AI test 1.0]
+        // [SCENARIO 626641] A journal line with blank Document Type is skipped by the IRS 1099 sync, so validating it
+        //                   while scheduled for posting also succeeds.
+        Initialize();
+        // [GIVEN] An IRS Reporting Period and a vendor with a 1099 form box setup in that period
+        PeriodDate := WorkDate();
+        LibraryIRSReportingPeriod.CreateOneDayReportingPeriod(PeriodDate);
+        FormNo := LibraryIRS1099FormBox.CreateSingleFormInReportingPeriod(PeriodDate);
+        FormBoxNo := LibraryIRS1099FormBox.CreateSingleFormBoxInReportingPeriod(PeriodDate, FormNo);
+        VendNo := LibraryIRS1099FormBox.CreateVendorNoWithFormBox(PeriodDate, FormNo, FormBoxNo);
+        // [GIVEN] A Vendor recurring journal line with blank Document Type scheduled for background posting
+        CreateRecurringGenJnlLineForVendor(GenJournalLine, VendNo, GenJournalLine."Document Type"::" ", CalcDate('<-1D>', PeriodDate));
+        GenJournalLine."Job Queue Status" := GenJournalLine."Job Queue Status"::"Scheduled for Posting";
+        GenJournalLine.Modify(false);
+
+        // [WHEN] The posting engine re-validates the Posting Date
+        GenJournalLine.Validate("Posting Date", PeriodDate);
+
+        // [THEN] No error is raised
+        Assert.AreEqual(PeriodDate, GenJournalLine."Posting Date", 'Posting Date mismatch');
+    end;
+
+    [Test]
+    procedure ScheduledLineEditIsNotSilentlyPersistedBySubscriber()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        GenJournalLine2: Record "Gen. Journal Line";
+        VendNo: Code[20];
+        FormNo: Code[20];
+        FormBoxNo: Code[20];
+        PeriodDate: Date;
+        OriginalPostingDate: Date;
+    begin
+        // [FEATURE] [Recurring Journal] [Background Posting] [AI test 1.0]
+        // [SCENARIO 626641] The IRS 1099 sync subscriber must not save a line that is scheduled for posting.
+        //                   Only the process that owns the line may persist it, so the Gen. Journal Line job
+        //                   queue guard stays in force and an edit cannot slip past it.
+        Initialize();
+        // [GIVEN] An IRS Reporting Period and a vendor with a 1099 form box setup in that period
+        PeriodDate := WorkDate();
+        LibraryIRSReportingPeriod.CreateOneDayReportingPeriod(PeriodDate);
+        FormNo := LibraryIRS1099FormBox.CreateSingleFormInReportingPeriod(PeriodDate);
+        FormBoxNo := LibraryIRS1099FormBox.CreateSingleFormBoxInReportingPeriod(PeriodDate, FormNo);
+        VendNo := LibraryIRS1099FormBox.CreateVendorNoWithFormBox(PeriodDate, FormNo, FormBoxNo);
+        OriginalPostingDate := CalcDate('<-1D>', PeriodDate);
+        // [GIVEN] A Vendor Invoice recurring journal line scheduled for background posting
+        CreateRecurringGenJnlLineForVendor(GenJournalLine, VendNo, GenJournalLine."Document Type"::Invoice, OriginalPostingDate);
+        GenJournalLine."Job Queue Status" := GenJournalLine."Job Queue Status"::"Scheduled for Posting";
+        GenJournalLine.Modify(false);
+
+        // [WHEN] An IRS-relevant field is validated while the line is scheduled
+        GenJournalLine.Validate("Posting Date", PeriodDate);
+
+        // [THEN] The subscriber ran and derived the IRS data onto the record buffer
+        Assert.AreEqual(FormBoxNo, GenJournalLine."IRS 1099 Form Box No.", 'Subscriber should derive IRS data onto the record buffer');
+
+        // [THEN] The subscriber leaves the change on the record and does not write the scheduled line to the database
+        GenJournalLine2.Get(GenJournalLine."Journal Template Name", GenJournalLine."Journal Batch Name", GenJournalLine."Line No.");
+        Assert.AreEqual(OriginalPostingDate, GenJournalLine2."Posting Date", 'Scheduled line Posting Date must not be persisted by the subscriber');
+        Assert.AreEqual('', GenJournalLine2."IRS 1099 Form Box No.", 'Scheduled line IRS data must not be persisted by the subscriber');
+
+        // [WHEN] The scheduled line is modified directly through the table trigger
+        asserterror GenJournalLine.Modify(true);
+
+        // [THEN] The job queue guard still blocks the modification
+        Assert.ExpectedError('scheduled for posting');
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    local procedure CreateRecurringGenJnlLineForVendor(var GenJournalLine: Record "Gen. Journal Line"; VendorNo: Code[20]; DocumentType: Enum "Gen. Journal Document Type"; PostingDate: Date)
+    var
+        GenJournalTemplate: Record "Gen. Journal Template";
+        GenJournalBatch: Record "Gen. Journal Batch";
+    begin
+        LibraryERM.CreateGenJournalTemplate(GenJournalTemplate);
+        GenJournalTemplate.Validate(Recurring, true);
+        GenJournalTemplate.Modify(true);
+        LibraryERM.CreateGenJournalBatch(GenJournalBatch, GenJournalTemplate.Name);
+        LibraryERM.CreateGeneralJnlLineWithBalAcc(
+            GenJournalLine, GenJournalTemplate.Name, GenJournalBatch.Name, DocumentType,
+            GenJournalLine."Account Type"::Vendor, VendorNo,
+            GenJournalLine."Bal. Account Type"::"G/L Account", LibraryERM.CreateGLAccountNo(), -LibraryRandom.RandDec(1000, 2));
+        GenJournalLine.Validate("Posting Date", PostingDate);
+        GenJournalLine.Modify(true);
+    end;
+
     local procedure Initialize()
     var
         IRSReportingPeriod: Record "IRS Reporting Period";


### PR DESCRIPTION
## Backport of PR [10884](https://github.com/microsoft/BCApps/pull/10884)

## What & why

The IRS 1099 subscribers hook the Gen. Journal Line OnAfterValidateEvent and, besides deriving the IRS fields (Reporting Period, Form No., Form Box No., Reporting Amount), also saved the line themselves via SaveChangesInGenJnlLine using Modify(true), which re-fires OnModify.

During background recurring posting the line is first marked Scheduled for Posting and then the Posting Date is re-validated. That fires the subscriber, Modify(true) re-enters OnModify, CheckJobQueueStatus runs, and posting fails with "The Journal line cannot be modified because it has been scheduled for posting."

The fix removes SaveChangesInGenJnlLine and both call sites, so the subscriber only derives the IRS fields onto the record and lets the owning caller persist. The OnModify guard still protects user edits, while background posting succeeds.

Fixes [AB#649300](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649300)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior.

**What I tested and the outcome**

Tests in codeunit 148010 IRS 1099 Document Tests:
- InvoiceLineScheduledForPostingSyncsIRSDataWithoutModifyError – scheduled Vendor Invoice line validates Posting Date with no error and IRS data synced.
- BlankDocTypeLineScheduledForPostingIsUnaffected – blank Document Type is skipped and passes.
- ScheduledLineEditIsNotSilentlyPersistedBySubscriber – subscriber does not persist a scheduled line; direct Modify(true) still fails with the guard.

Manual test in CRONUS USA with background posting on: blank Document Type lines post fine, Invoice lines failed before the fix and post correctly after the fix.

## Risk & compatibility

Low risk. Only removes the subscriber's redundant self-save; IRS fields are still applied and the line owner still validates and saves. OnModify guard unchanged. No schema, permission, or upgrade impact.


