### PR TITLE
The Word add-in shouldn't show the columns that are obsoleted in the data picker

### DIFF
--- a/src/System Application/App/Word Templates/src/WordTemplateFieldSelection.Codeunit.al
+++ b/src/System Application/App/Word Templates/src/WordTemplateFieldSelection.Codeunit.al
@@ -165,6 +165,7 @@ codeunit 9989 "Word Template Field Selection"
         ExcludedFields: Integer;
     begin
         Field.SetRange(TableNo, TableId);
+        Field.SetRange(ObsoleteState, Field.ObsoleteState::No);
         TableFields := Field.Count();
 
         WordTemplateCustomField.SetCurrentTableId(TableId);
@@ -175,7 +176,13 @@ codeunit 9989 "Word Template Field Selection"
         TempWordTemplateField.Reset();
         TempWordTemplateField.SetRange("Table ID", TableId);
         TempWordTemplateField.SetRange(Exclude, true);
-        ExcludedFields := TempWordTemplateField.Count();
+        if TempWordTemplateField.FindSet() then
+            repeat
+                if (TempWordTemplateField."Field No." = 0) or
+                   (Field.Get(TableId, TempWordTemplateField."Field No.") and (Field.ObsoleteState = Field.ObsoleteState::No))
+                then
+                    ExcludedFields += 1;
+            until TempWordTemplateField.Next() = 0;
 
         exit(TableFields + CustomTableFields - ExcludedFields);
     end;
@@ -193,6 +200,7 @@ codeunit 9989 "Word Template Field Selection"
 
         // Add existing table fields
         Field.SetRange(TableNo, TableId);
+        Field.SetRange(ObsoleteState, Field.ObsoleteState::No);
         if Field.FindSet() then
             repeat
                 if IsFieldSupported(Field) then begin

--- a/src/System Application/Test Library/Word Templates/src/WordTemplatesTestTable.Table.al
+++ b/src/System Application/Test Library/Word Templates/src/WordTemplatesTestTable.Table.al
@@ -18,5 +18,17 @@ table 130443 "Word Templates Test Table"
         {
             AutoIncrement = true;
         }
+        field(2; "Pending Field"; Text[100])
+        {
+            ObsoleteReason = 'This field is obsolete.';
+            ObsoleteState = Pending;
+            ObsoleteTag = '30.0';
+        }
+        field(3; "Removed Field"; Text[100])
+        {
+            ObsoleteReason = 'This field is obsolete.';
+            ObsoleteState = Removed;
+            ObsoleteTag = '30.0';
+        }
     }
 }

--- a/src/System Application/Test/Word Templates/src/WordTemplatesTest.Codeunit.al
+++ b/src/System Application/Test/Word Templates/src/WordTemplatesTest.Codeunit.al
@@ -165,6 +165,50 @@ codeunit 130443 "Word Templates Test"
     end;
 
     [Test]
+    procedure GetAllTableFieldsExcludesObsoleteFields()
+    var
+        TempWordTemplateField: Record "Word Template Field" temporary;
+        WordTemplateFieldSelection: Codeunit "Word Template Field Selection";
+    begin
+        // [SCENARIO] Obsolete fields are not available for Word template field selection
+
+        // [WHEN] The fields available for selection are retrieved
+        WordTemplateFieldSelection.GetAllTableFields(Database::"Word Templates Test Table", TempWordTemplateField);
+
+        // [THEN] Current fields are available, while pending and removed fields are not
+        Assert.IsTrue(TempWordTemplateField.Get('', Database::"Word Templates Test Table", 'No.'), 'The current field should be available.');
+        Assert.IsFalse(TempWordTemplateField.Get('', Database::"Word Templates Test Table", 'Pending Field'), 'The pending field should not be available.');
+        Assert.IsFalse(TempWordTemplateField.Get('', Database::"Word Templates Test Table", 'Removed Field'), 'The removed field should not be available.');
+    end;
+
+    [Test]
+    procedure CalculateNoSelectedFieldsIgnoresObsoleteExcludedFields()
+    var
+        TempWordTemplateField: Record "Word Template Field" temporary;
+        WordTemplateFieldSelection: Codeunit "Word Template Field Selection";
+        ExpectedSelectedFields: Integer;
+    begin
+        // [SCENARIO] Saved exclusions for obsolete fields do not reduce the selected field count
+
+        // [GIVEN] The number of selectable fields
+        ExpectedSelectedFields := WordTemplateFieldSelection.CalculateNoSelectedFields(Database::"Word Templates Test Table", TempWordTemplateField);
+
+        // [GIVEN] Saved exclusions for pending and removed fields
+        TempWordTemplateField."Table ID" := Database::"Word Templates Test Table";
+        TempWordTemplateField."Field Name" := 'Pending Field';
+        TempWordTemplateField."Field No." := 2;
+        TempWordTemplateField.Exclude := true;
+        TempWordTemplateField.Insert();
+        TempWordTemplateField."Field Name" := 'Removed Field';
+        TempWordTemplateField."Field No." := 3;
+        TempWordTemplateField.Insert();
+
+        // [WHEN] The number of selected fields is recalculated
+        // [THEN] Obsolete exclusions do not affect the count
+        Assert.AreEqual(ExpectedSelectedFields, WordTemplateFieldSelection.CalculateNoSelectedFields(Database::"Word Templates Test Table", TempWordTemplateField), 'Obsolete fields should not affect the selected field count.');
+    end;
+
+    [Test]
     procedure TestCreateDocumentInternalsForRecord()
     var
         TempWordTemplateFields: Record "Word Template Field" temporary;


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->
The Word add-in shouldn't show the columns that are obsoleted in the data picker.

Currently, if you open BC's Word data pane, you are able to select columns from **all** the columns in the dataset. Feedback from engineers and partners is that obsolete columns should not be shown in the data picker.
The idea behind this PR is that we want to prevent end users to use obsolete columns for their layouts. And this shouldn't be a problem because if they are obsolete, there should be a non-obsoleted column that they can use.

New logic on `TempWordTemplateField` prevents obsolete or deleted fields from corrupting the selected-field count.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

[AB#611990](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/611990)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

As mentioned, hiding obsolete fields should not cause problem because there should be alternative non-obsolete columns

