### PR TITLE
Disable VAT period checks in E-Document item charge tests

### DIFF
--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocItemChargeTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocItemChargeTests.Codeunit.al
@@ -959,6 +959,8 @@ codeunit 139786 "E-Doc. Item Charge Tests"
         if IsInitialized then
             exit;
 
+        // Item charge tests do not exercise VAT date behavior. Disable it to avoid localization-specific
+        // VAT period validation during posting, such as the CZ check for the current work date.
         GeneralLedgerSetup.Get();
         GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
         GeneralLedgerSetup.Modify();

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocItemChargeTests.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocItemChargeTests.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.eServices.EDocument.Test;
 
 using Microsoft.eServices.EDocument;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Finance.VAT.Setup;
 using Microsoft.Foundation.Enums;
 using Microsoft.Inventory.Item;
@@ -952,10 +953,15 @@ codeunit 139786 "E-Doc. Item Charge Tests"
 
     local procedure Initialize()
     var
+        GeneralLedgerSetup: Record "General Ledger Setup";
         InventorySetup: Record "Inventory Setup";
     begin
         if IsInitialized then
             exit;
+
+        GeneralLedgerSetup.Get();
+        GeneralLedgerSetup."VAT Reporting Date Usage" := GeneralLedgerSetup."VAT Reporting Date Usage"::Disabled;
+        GeneralLedgerSetup.Modify();
 
         LibrarySales.SetStockoutWarning(false);
         LibrarySales.SetCreditWarningsToNoWarnings();


### PR DESCRIPTION
## Why

The E-Document item charge tests fail under the Czech localization because sales posting validates the current VAT reporting date against localization-specific VAT periods. These W1 tests exercise item charge mapping, not VAT-date behavior, and must not depend on localized VAT periods covering the moving work date.

Cross-app review confirmed that disabling VAT Reporting Date is the established normalization for localization-neutral posting tests: it is used throughout E-Document core, PEPPOL, and connector test suites. Tests that exercise VAT reporting itself keep the feature enabled and create valid periods in their localization-specific test libraries.

## Summary

- **Disabled** VAT Reporting Date in the shared item charge test initializer so sales posting does not invoke country-specific VAT period validation.
- **Documented** the test boundary and why creating Czech VAT periods is not appropriate for this W1 test suite.
- **Aligned** the setup with the existing cross-localization pattern used by E-Document and connector tests.

Fixes
[AB#649216](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649216)


