### PR TITLE
Bug 648962: Create transfer order shows generic error when existing transfers cover subcontracting demand

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
@@ -75,6 +75,7 @@ codeunit 20533 "Subc. Purchase Header Ext"
     begin
         TransferOrderErrorInfo.Title := NoNewTransferLinesTitleLbl;
         TransferOrderErrorInfo.Message := CoveredTransferDemandErr;
+        TransferOrderErrorInfo.DataClassification := DataClassification::SystemMetadata;
         TransferOrderErrorInfo.RecordId := PurchaseHeader.RecordId();
         TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
         TransferHeader.SetRange("Subc. Return Order", false);

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
@@ -66,6 +66,32 @@ codeunit 20533 "Subc. Purchase Header Ext"
         SubcTransferManagement.CheckStockAtSubcLocationForPurchHeader(Rec);
     end;
 
+    internal procedure CreateCoveredTransferErrorInfo(PurchaseHeader: Record "Purchase Header") TransferOrderErrorInfo: ErrorInfo
+    var
+        TransferHeader: Record "Transfer Header";
+        NoNewTransferLinesTitleLbl: Label 'There are no new subcontracting transfer lines to create';
+        CoveredTransferDemandMsg: Label 'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.';
+        ShowOpenTransferOrdersLbl: Label 'Show open transfer orders';
+    begin
+        TransferOrderErrorInfo.Title := NoNewTransferLinesTitleLbl;
+        TransferOrderErrorInfo.Message := CoveredTransferDemandMsg;
+        TransferOrderErrorInfo.RecordId := PurchaseHeader.RecordId();
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.SetRange("Subc. Return Order", false);
+        if not TransferHeader.IsEmpty() then
+            TransferOrderErrorInfo.AddAction(
+                ShowOpenTransferOrdersLbl, Codeunit::"Subc. Purchase Header Ext", 'ShowOutboundTransferOrdersForPurchHeader');
+    end;
+
+    internal procedure ShowOutboundTransferOrdersForPurchHeader(TransferOrderErrorInfo: ErrorInfo)
+    var
+        PurchaseHeader: Record "Purchase Header";
+        SubcPurchFactboxMgmt: Codeunit "Subc. Purch. Factbox Mgmt.";
+    begin
+        PurchaseHeader.Get(TransferOrderErrorInfo.RecordId);
+        SubcPurchFactboxMgmt.ShowTransferOrdersFromPurchaseOrder(PurchaseHeader, false);
+    end;
+
     internal procedure ShowTransferOrdersForPurchHeader(TransferOrderErrorInfo: ErrorInfo)
     var
         PurchaseHeader: Record "Purchase Header";

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseHeaderExt.Codeunit.al
@@ -70,11 +70,11 @@ codeunit 20533 "Subc. Purchase Header Ext"
     var
         TransferHeader: Record "Transfer Header";
         NoNewTransferLinesTitleLbl: Label 'There are no new subcontracting transfer lines to create';
-        CoveredTransferDemandMsg: Label 'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.';
+        CoveredTransferDemandErr: Label 'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.';
         ShowOpenTransferOrdersLbl: Label 'Show open transfer orders';
     begin
         TransferOrderErrorInfo.Title := NoNewTransferLinesTitleLbl;
-        TransferOrderErrorInfo.Message := CoveredTransferDemandMsg;
+        TransferOrderErrorInfo.Message := CoveredTransferDemandErr;
         TransferOrderErrorInfo.RecordId := PurchaseHeader.RecordId();
         TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
         TransferHeader.SetRange("Subc. Return Order", false);

--- a/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
+++ b/src/Apps/W1/Subcontracting/App/src/Transfer/SubcCreateTransfOrder.Report.al
@@ -36,13 +36,18 @@ report 20501 "Subc. Create Transf. Order"
                 end;
             }
             trigger OnAfterGetRecord()
+            var
+                SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
             begin
                 "Purchase Header".CalcFields("Subc. Order");
                 if not "Subc. Order" then
                     Error(OrderNoIsNotSubcontractorErr, PurchOrderNo);
 
-                if not CheckTransferCreated() then
+                if not CheckTransferCreated() then begin
+                    if HasCoveredDemand then
+                        Error(SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo("Purchase Header"));
                     Error(NothingToCreateErr);
+                end;
 
                 Vendor.Get("Purchase Header"."Buy-from Vendor No.");
             end;
@@ -78,6 +83,7 @@ report 20501 "Subc. Create Transf. Order"
         TransferHeader: Record "Transfer Header";
         TransferLine: Record "Transfer Line";
         Vendor: Record Vendor;
+        HasCoveredDemand: Boolean;
         PurchOrderNo: Code[20];
         LineNo: Integer;
         ExcessReservationsErr: Label 'The transfer quantity (%1) is less than the reserved quantity (%2) on the production order component for item %3. Cancel existing reservations on the component before creating a partial transfer.', Comment = '%1=Transfer Quantity, %2=Reserved Quantity, %3=Item No.';
@@ -175,6 +181,7 @@ report 20501 "Subc. Create Transf. Order"
     var
         PurchaseLine: Record "Purchase Line";
     begin
+        HasCoveredDemand := false;
         PurchaseLine.SetCurrentKey("Document Type", Type, "Prod. Order No.", "Prod. Order Line No.", "Routing No.", "Operation No.");
         PurchaseLine.SetRange("Document No.", PurchOrderNo);
         PurchaseLine.SetFilter("Prod. Order No.", '<>''''');
@@ -233,6 +240,12 @@ report 20501 "Subc. Create Transf. Order"
                 Item.Get(ProdOrderComponent."Item No.");
                 QtyToPost := MfgCostCalculationMgt.CalcActNeededQtyBase(ProdOrderLine, ProdOrderComponent, Round(PurchaseLine.Quantity * QtyPerUom, UnitofMeasureManagement.QtyRndPrecision()));
                 ProdOrderComponent.CalcFields("Subc. Qty.on TransOrder (Base)", "Subc. Qty. in Transit (Base)", "Subc. Qty. transf. to Subcontr");
+                if (QtyToPost > 0) and
+                   (QtyToPost <= (ProdOrderComponent."Subc. Qty.on TransOrder (Base)" +
+                                 ProdOrderComponent."Subc. Qty. in Transit (Base)" +
+                                 Abs(ProdOrderComponent."Subc. Qty. transf. to Subcontr")))
+                then
+                    HasCoveredDemand := true;
                 if QtyToPost > (ProdOrderComponent."Subc. Qty.on TransOrder (Base)" +
                                 ProdOrderComponent."Subc. Qty. in Transit (Base)" +
                                 Abs(ProdOrderComponent."Subc. Qty. transf. to Subcontr"))
@@ -601,6 +614,9 @@ report 20501 "Subc. Create Transf. Order"
 
         PostedWIPQtyBase := GetWIPQtyBase(PurchaseLine, TransferToLocationCode);
         OpenWIPLineQtyBase := GetOpenWIPTransferLineQtyBase(PurchaseLine, ProdOrderLine);
+
+        if (ExpectedQtyBase > 0) and ((PostedWIPQtyBase + OpenWIPLineQtyBase) >= ExpectedQtyBase) then
+            HasCoveredDemand := true;
 
         exit((PostedWIPQtyBase + OpenWIPLineQtyBase) < ExpectedQtyBase);
     end;

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -89,9 +89,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
 
         // [THEN] The error explains coverage and neither headers nor quantities are duplicated.
-        Assert.AreEqual(
-            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
-            GetLastErrorText(), 'Covered component demand must not report missing transfer demand.');
+        Assert.ExpectedError(SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader).Message);
         TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
         TransferHeader.SetRange("Subc. Return Order", false);
         Assert.AreEqual(1, TransferHeader.Count(), 'No duplicate outbound transfer order should be created.');

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -44,6 +44,231 @@ codeunit 139989 "Subc. Subcontracting Test"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandler,HandleTransferOrder')]
+    [Scope('OnPrem')]
+    procedure CoveredComponentsExplainWhyNoTransferIsCreated()
+    var
+        Item: Record Item;
+        ProductionLocation: Record Location;
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        RoutingLine: Record "Routing Line";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        WorkCenter: array[2] of Record "Work Center";
+        SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
+        TransferOrderErrorInfo: ErrorInfo;
+        TransferOrderNo: Code[20];
+        OriginalLineCount: Integer;
+        OriginalQuantity: Decimal;
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 648962] Fully covered eligible components produce an explanatory error without duplicate transfers.
+        Initialize();
+
+        // [GIVEN] Positive component demand covered by an existing outbound transfer, with WIP transfer disabled.
+        SetupSubcontractingForTransferOrderTests(Item, WorkCenter, ProductionLocation);
+        RoutingLine.SetRange("Routing No.", Item."Routing No.");
+        RoutingLine.ModifyAll("Transfer WIP Item", false);
+        TransferOrderNo := CreateProductionOrderWithSubcTransferOrder(
+            Item, WorkCenter, ProductionLocation.Code, true, ProductionOrder);
+        Assert.AreEqual(
+            'A purchase order was created.\\Do you want to view it?', LibraryVariableStorage.DequeueText(),
+            'Expected the subcontracting purchase order creation confirmation.');
+        TransferHeader.Get(TransferOrderNo);
+        PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, TransferHeader."Subcontr. Purch. Order No.");
+        TransferLine.SetRange("Document No.", TransferOrderNo);
+        OriginalLineCount := TransferLine.Count();
+        TransferLine.CalcSums(Quantity);
+        OriginalQuantity := TransferLine.Quantity;
+        Assert.IsTrue(OriginalQuantity > 0, 'The existing transfer must cover positive component demand.');
+        PurchaseOrder.OpenView();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+
+        // [WHEN] Creating the transfer again for the same subcontracting order.
+        asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] The error explains coverage and neither headers nor quantities are duplicated.
+        Assert.AreEqual(
+            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
+            GetLastErrorText(), 'Covered component demand must not report missing transfer demand.');
+        TransferHeader.SetRange("Subcontr. Purch. Order No.", PurchaseHeader."No.");
+        TransferHeader.SetRange("Subc. Return Order", false);
+        Assert.AreEqual(1, TransferHeader.Count(), 'No duplicate outbound transfer order should be created.');
+        Assert.AreEqual(OriginalLineCount, TransferLine.Count(), 'No duplicate transfer lines should be created.');
+        TransferLine.CalcSums(Quantity);
+        Assert.AreEqual(OriginalQuantity, TransferLine.Quantity, 'The covered transfer quantity must remain unchanged.');
+        PurchaseOrder.Close();
+        TransferOrderErrorInfo := SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader);
+        Assert.AreEqual(
+            'There are no new subcontracting transfer lines to create', TransferOrderErrorInfo.Title,
+            'Covered demand must have the explanatory title.');
+        Assert.AreEqual(PurchaseHeader.RecordId(), TransferOrderErrorInfo.RecordId, 'Navigation must identify the purchase order.');
+        OpenedTransferOrderNo := '';
+        SubcPurchaseHeaderExt.ShowOutboundTransferOrdersForPurchHeader(TransferOrderErrorInfo);
+        Assert.AreEqual(TransferOrderNo, OpenedTransferOrderNo, 'The action must open the existing outbound transfer card.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('HandleTransferOrder')]
+    [Scope('OnPrem')]
+    procedure CoveredTransferActionOpensReleasedOutboundOnly()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        UnrelatedPurchaseHeader: Record "Purchase Header";
+        TransferHeader: Record "Transfer Header";
+        OtherTransferHeader: Record "Transfer Header";
+        SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
+        TransferOrderErrorInfo: ErrorInfo;
+    begin
+        // [SCENARIO 648962] A released outbound order opens as a card, excluding returns and unrelated transfers.
+        Initialize();
+
+        // [GIVEN] One related released outbound document, a return, and an unrelated outbound document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, '');
+        LibraryPurchase.CreatePurchHeader(UnrelatedPurchaseHeader, UnrelatedPurchaseHeader."Document Type"::Order, '');
+        CreateLinkedTransferHeader(TransferHeader, PurchaseHeader."No.", false);
+        TransferHeader.Status := TransferHeader.Status::Released;
+        TransferHeader.Modify();
+        CreateLinkedTransferHeader(OtherTransferHeader, PurchaseHeader."No.", true);
+        CreateLinkedTransferHeader(OtherTransferHeader, UnrelatedPurchaseHeader."No.", false);
+        TransferOrderErrorInfo := SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader);
+        OpenedTransferOrderNo := '';
+
+        // [WHEN] Invoking the covered-demand error action.
+        SubcPurchaseHeaderExt.ShowOutboundTransferOrdersForPurchHeader(TransferOrderErrorInfo);
+
+        // [THEN] Only the related outbound document is opened.
+        Assert.AreEqual(TransferHeader."No.", OpenedTransferOrderNo, 'Released outbound transfers must remain navigable.');
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('HandleCoveredTransferOrdersList')]
+    [Scope('OnPrem')]
+    procedure CoveredTransferActionOpensFilteredOutboundList()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        UnrelatedPurchaseHeader: Record "Purchase Header";
+        TransferHeader: Record "Transfer Header";
+        SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
+        TransferOrderErrorInfo: ErrorInfo;
+    begin
+        // [SCENARIO 648962] Multiple outbound documents open in a list excluding return and unrelated orders.
+        Initialize();
+
+        // [GIVEN] Two related outbound documents, a return, and an unrelated outbound document.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, '');
+        LibraryPurchase.CreatePurchHeader(UnrelatedPurchaseHeader, UnrelatedPurchaseHeader."Document Type"::Order, '');
+        CreateLinkedTransferHeader(TransferHeader, PurchaseHeader."No.", false);
+        LibraryVariableStorage.Enqueue(TransferHeader."No.");
+        CreateLinkedTransferHeader(TransferHeader, PurchaseHeader."No.", false);
+        TransferHeader.Status := TransferHeader.Status::Released;
+        TransferHeader.Modify();
+        LibraryVariableStorage.Enqueue(TransferHeader."No.");
+        CreateLinkedTransferHeader(TransferHeader, PurchaseHeader."No.", true);
+        CreateLinkedTransferHeader(TransferHeader, UnrelatedPurchaseHeader."No.", false);
+        TransferOrderErrorInfo := SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader);
+
+        // [WHEN] Invoking the covered-demand error action.
+        SubcPurchaseHeaderExt.ShowOutboundTransferOrdersForPurchHeader(TransferOrderErrorInfo);
+
+        // [THEN] The handler verifies exactly the two related outbound documents.
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,HandleTransferOrder')]
+    [Scope('OnPrem')]
+    procedure ZeroComponentDemandRetainsGenericError()
+    var
+        Item: Record Item;
+        ProductionLocation: Record Location;
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        RoutingLine: Record "Routing Line";
+        TransferHeader: Record "Transfer Header";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 648962] Zero eligible demand keeps the generic error even when transfer documents exist.
+        Initialize();
+
+        // [GIVEN] Existing component transfers but no remaining purchase demand and no WIP eligibility.
+        SetupSubcontractingForTransferOrderTests(Item, WorkCenter, ProductionLocation);
+        RoutingLine.SetRange("Routing No.", Item."Routing No.");
+        RoutingLine.ModifyAll("Transfer WIP Item", false);
+        TransferHeader.Get(CreateProductionOrderWithSubcTransferOrder(
+            Item, WorkCenter, ProductionLocation.Code, true, ProductionOrder));
+        Assert.AreEqual(
+            'A purchase order was created.\\Do you want to view it?', LibraryVariableStorage.DequeueText(),
+            'Expected the subcontracting purchase order creation confirmation.');
+        PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, TransferHeader."Subcontr. Purch. Order No.");
+        PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
+        PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
+        PurchaseLine.ModifyAll(Quantity, 0);
+        PurchaseOrder.OpenView();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+
+        // [WHEN] Attempting to create a transfer without positive demand.
+        asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] Existing documents alone must not cause the covered-demand message.
+        Assert.AreEqual(
+            'Nothing to create. No components or WIP to transfer for the specified subcontracting order.',
+            GetLastErrorText(), 'Zero demand must retain the generic error.');
+        PurchaseOrder.Close();
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    [HandlerFunctions('ConfirmHandler,HandleTransferOrder')]
+    [Scope('OnPrem')]
+    procedure IneligibleComponentsRetainGenericError()
+    var
+        Item: Record Item;
+        ProductionLocation: Record Location;
+        ProdOrderComponent: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        RoutingLine: Record "Routing Line";
+        TransferHeader: Record "Transfer Header";
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 648962] Ineligible supply methods keep the generic error even when transfer documents exist.
+        Initialize();
+
+        // [GIVEN] Components are vendor-supplied and WIP transfer is disabled.
+        SetupSubcontractingForTransferOrderTests(Item, WorkCenter, ProductionLocation);
+        RoutingLine.SetRange("Routing No.", Item."Routing No.");
+        RoutingLine.ModifyAll("Transfer WIP Item", false);
+        TransferHeader.Get(CreateProductionOrderWithSubcTransferOrder(
+            Item, WorkCenter, ProductionLocation.Code, true, ProductionOrder));
+        Assert.AreEqual(
+            'A purchase order was created.\\Do you want to view it?', LibraryVariableStorage.DequeueText(),
+            'Expected the subcontracting purchase order creation confirmation.');
+        PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, TransferHeader."Subcontr. Purch. Order No.");
+        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderComponent.ModifyAll("Component Supply Method", ProdOrderComponent."Component Supply Method"::"Vendor-Supplied");
+        PurchaseOrder.OpenView();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+
+        // [WHEN] Attempting to create a transfer without eligible demand.
+        asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] Existing documents alone must not cause the covered-demand message.
+        Assert.AreEqual(
+            'Nothing to create. No components or WIP to transfer for the specified subcontracting order.',
+            GetLastErrorText(), 'Ineligible demand must retain the generic error.');
+        PurchaseOrder.Close();
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
     [HandlerFunctions('ConfirmHandler,HandleTransferOrder,HandleCreateTransferOrderMsg')]
     procedure DirectTransferPostingWithWIPItemDoesNotErrorOnQuantity()
     var
@@ -3340,6 +3565,26 @@ codeunit 139989 "Subc. Subcontracting Test"
         Assert.AreEqual(ExistingPurchaseOrderNo, ReopenedPurchaseOrderNo, 'Create Subcontracting Order should open the updated existing purchase order.');
 
         LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [PageHandler]
+    procedure HandleCoveredTransferOrdersList(var TransferOrders: TestPage "Transfer Orders")
+    begin
+        Assert.IsTrue(TransferOrders.First(), 'Expected the first related outbound transfer.');
+        Assert.AreEqual(LibraryVariableStorage.DequeueText(), TransferOrders."No.".Value(), 'Unexpected first transfer.');
+        Assert.IsTrue(TransferOrders.Next(), 'Expected the second related outbound transfer.');
+        Assert.AreEqual(LibraryVariableStorage.DequeueText(), TransferOrders."No.".Value(), 'Unexpected second transfer.');
+        Assert.IsFalse(TransferOrders.Next(), 'Return and unrelated orders must not appear.');
+        TransferOrders.OK().Invoke();
+    end;
+
+    local procedure CreateLinkedTransferHeader(var TransferHeader: Record "Transfer Header"; PurchaseOrderNo: Code[20]; IsReturn: Boolean)
+    begin
+        Clear(TransferHeader);
+        LibraryInventory.CreateTransferHeader(TransferHeader);
+        TransferHeader."Subcontr. Purch. Order No." := PurchaseOrderNo;
+        TransferHeader."Subc. Return Order" := IsReturn;
+        TransferHeader.Modify();
     end;
 
     [PageHandler]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -101,6 +101,9 @@ codeunit 139989 "Subc. Subcontracting Test"
         Assert.AreEqual(
             'There are no new subcontracting transfer lines to create', TransferOrderErrorInfo.Title,
             'Covered demand must have the explanatory title.');
+        Assert.AreEqual(
+            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
+            TransferOrderErrorInfo.Message, 'Covered demand must have the approved explanatory message.');
         Assert.AreEqual(PurchaseHeader.RecordId(), TransferOrderErrorInfo.RecordId, 'Navigation must identify the purchase order.');
         OpenedTransferOrderNo := '';
         SubcPurchaseHeaderExt.ShowOutboundTransferOrdersForPurchHeader(TransferOrderErrorInfo);

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -208,7 +208,12 @@ codeunit 139989 "Subc. Subcontracting Test"
         PurchaseHeader.Get(PurchaseHeader."Document Type"::Order, TransferHeader."Subcontr. Purch. Order No.");
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type");
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
-        PurchaseLine.ModifyAll(Quantity, 0);
+        Assert.IsTrue(PurchaseLine.FindSet(true), 'Expected subcontracting purchase lines.');
+        repeat
+            PurchaseLine.Validate(Quantity, 0);
+            PurchaseLine.UpdateAmounts();
+            PurchaseLine.Modify(true);
+        until PurchaseLine.Next() = 0;
         PurchaseOrder.OpenView();
         PurchaseOrder.GoToRecord(PurchaseHeader);
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcSubcontractingTest.Codeunit.al
@@ -222,9 +222,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
 
         // [THEN] Existing documents alone must not cause the covered-demand message.
-        Assert.AreEqual(
-            'Nothing to create. No components or WIP to transfer for the specified subcontracting order.',
-            GetLastErrorText(), 'Zero demand must retain the generic error.');
+        Assert.ExpectedError(NothingToCreateErr);
         PurchaseOrder.Close();
         LibraryVariableStorage.AssertEmpty();
     end;
@@ -267,9 +265,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
 
         // [THEN] Existing documents alone must not cause the covered-demand message.
-        Assert.AreEqual(
-            'Nothing to create. No components or WIP to transfer for the specified subcontracting order.',
-            GetLastErrorText(), 'Ineligible demand must retain the generic error.');
+        Assert.ExpectedError(NothingToCreateErr);
         PurchaseOrder.Close();
         LibraryVariableStorage.AssertEmpty();
     end;
@@ -4447,6 +4443,7 @@ codeunit 139989 "Subc. Subcontracting Test"
         UnitCostCalculation: Option Time,Units;
         ConfirmDialogCalledCount: Integer;
         AlreadySpecifiedErr: Label 'You cannot open Tracking Specification because this component is already specified in Transfer Order %1.', Comment = '|%1 = Transfer Order No.';
+        NothingToCreateErr: Label 'Nothing to create. No components or WIP to transfer for the specified subcontracting order.';
         PurchOrderRoutingErr: Label 'Purchase Order %1 should contain a line tied to Routing Reference No. %2', Comment = '%1 = Purchase Order No., %2 = Routing Reference No.';
 
 }

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -32,6 +32,117 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
     end;
 
     [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    [Scope('OnPrem')]
+    procedure CoveredWIPExplainsWhyNoTransferIsCreated()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        OriginalQuantity: Decimal;
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 648962] An existing WIP-only transfer fully covers positive eligible demand.
+        Initialize();
+
+        // [GIVEN] WIP demand with no eligible components is fully covered by an outbound transfer.
+        CreateWIPOnlyTransfer(PurchaseHeader, TransferHeader, TransferLine);
+        OriginalQuantity := TransferLine.Quantity;
+        Assert.IsTrue(OriginalQuantity > 0, 'The WIP transfer must cover positive demand.');
+        PurchaseOrder.OpenView();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+
+        // [WHEN] Attempting to create the same WIP transfer again.
+        asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] Coverage is explained and no duplicate WIP quantity is created.
+        Assert.AreEqual(
+            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
+            GetLastErrorText(), 'Covered WIP must not report missing demand.');
+        Assert.AreEqual(1, TransferLine.Count(), 'No duplicate WIP line should be created.');
+        TransferLine.FindFirst();
+        Assert.AreEqual(OriginalQuantity, TransferLine.Quantity, 'Covered WIP quantity must not change.');
+        PurchaseOrder.Close();
+    end;
+
+    [Test]
+    [HandlerFunctions('DoNotConfirmShowCreatedPurchOrderForSubcontracting,HandleTransferOrder')]
+    [Scope('OnPrem')]
+    procedure ShippedWIPCoverageExplainsAndNavigates()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
+        SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        // [SCENARIO 648962] WIP in transit explains coverage and the released unposted document remains navigable.
+        Initialize();
+
+        // [GIVEN] A WIP-only outbound transfer has been shipped but not received.
+        CreateWIPOnlyTransfer(PurchaseHeader, TransferHeader, TransferLine);
+        LibraryWarehouse.PostTransferOrder(TransferHeader, true, false);
+        TransferHeader.Get(TransferHeader."No.");
+        TransferLine.FindFirst();
+        Assert.AreEqual(TransferLine.Quantity, TransferLine."Quantity Shipped", 'The WIP transfer must be shipped.');
+        Assert.AreEqual(TransferHeader.Status::Released, TransferHeader.Status, 'The in-transit document must be released.');
+        PurchaseOrder.OpenView();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+
+        // [WHEN] Attempting another transfer while WIP is in transit.
+        asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
+
+        // [THEN] Coverage is explained and the action opens the existing shipped transfer.
+        Assert.AreEqual(
+            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
+            GetLastErrorText(), 'Shipped WIP must explain existing coverage.');
+        PurchaseOrder.Close();
+        OpenedTransferOrderNo := '';
+        SubcPurchaseHeaderExt.ShowOutboundTransferOrdersForPurchHeader(
+            SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader));
+        Assert.AreEqual(TransferHeader."No.", OpenedTransferOrderNo, 'The action must open the shipped outbound transfer.');
+    end;
+
+    local procedure CreateWIPOnlyTransfer(var PurchaseHeader: Record "Purchase Header"; var TransferHeader: Record "Transfer Header"; var TransferLine: Record "Transfer Line")
+    var
+        Item: Record Item;
+        MachineCenter: array[2] of Record "Machine Center";
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        Vendor: Record Vendor;
+        WorkCenter: array[2] of Record "Work Center";
+        PurchaseOrder: TestPage "Purchase Order";
+    begin
+        SubcWarehouseLibrary.CreateAndCalculateNeededWorkAndMachineCenter(WorkCenter, MachineCenter, true);
+        SubcWarehouseLibrary.CreateItemForProductionIncludeRoutingAndProdBOM(Item, WorkCenter, MachineCenter);
+        SetTransferWIPItemOnRoutingLine(Item."Routing No.", WorkCenter[2]."No.", true);
+        SubcontractingMgmtLibrary.UpdateVendorWithSubcontractingLocationCode(WorkCenter[2]);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released,
+            ProductionOrder."Source Type"::Item, Item."No.", LibraryRandom.RandInt(10) + 5);
+        SetProdOrderLocationToCompSetupLocationAndRefresh(ProductionOrder);
+        Vendor.Get(WorkCenter[2]."Subcontractor No.");
+        CreateAndUpdateTransferRoute(ProductionOrder."Location Code", Vendor."Subc. Location Code");
+        SubcontractingMgmtLibrary.CreateSubcontractingOrderFromProdOrderRtngPage(Item."Routing No.", WorkCenter[2]."No.");
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseOrder.OpenView();
+        PurchaseOrder.GoToRecord(PurchaseHeader);
+        PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
+        PurchaseOrder.Close();
+        TransferLine.SetRange("Subc. Prod. Order No.", ProductionOrder."No.");
+        TransferLine.SetRange("Transfer WIP Item", true);
+        TransferLine.SetRange("Subc. Return Order", false);
+        TransferLine.SetRange("Derived From Line No.", 0);
+        Assert.AreEqual(1, TransferLine.Count(), 'Expected exactly one WIP transfer line.');
+        TransferLine.FindFirst();
+        TransferHeader.Get(TransferLine."Document No.");
+    end;
+
+    [Test]
     procedure TransferWIPItemFlagFromRoutingLineToPurchaseLine()
     var
         Item: Record Item;
@@ -509,11 +620,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         WorkCenter: array[2] of Record "Work Center";
         PurchaseHeaderPage: TestPage "Purchase Order";
     begin
-        // [SCENARIO] When the posted WIP quantity equals the expected quantity at the destination,
-        // the CheckCreateWIPTransfer procedure should return false, and no new WIP Transfer Order
-        // should be created when "Create Transfer Order to Subcontractor" is invoked again.
-
-        // [GIVEN] Complete setup
+        // [SCENARIO 648962] Posted WIP covering positive eligible demand produces an explanatory error without a new transfer.
         Initialize();
 
         // [GIVEN] Work centers, machine centers, item with routing + BOM
@@ -571,16 +678,16 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         // [GIVEN] Delete the first transfer order to allow re-creation attempt
         TransferHeader.Get(TransferLine."Document No.");
         TransferHeader.Delete(true);
+        Assert.AreEqual(0, TransferLine.Count(), 'The posted-only setup must have no open WIP transfer lines.');
 
         // [WHEN] Attempt to create Transfer Order to Subcontractor again
         PurchaseHeaderPage.GoToRecord(PurchaseHeader);
         asserterror PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
 
-        // [THEN] No WIP Transfer Line is created, and an error message indicates that there is no WIP or components to transfer
-        Assert.ExpectedError('Nothing to create. No components or WIP to transfer for the specified subcontracting order.');
-
-        // [TEARDOWN]
-        WIPLedgerEntry.DeleteAll();
+        // [THEN] The error explains that transfer activity already covers the demand, and no WIP transfer is created.
+        Assert.AreEqual(
+            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
+            GetLastErrorText(), 'Posted WIP coverage must not report missing transfer demand.');
     end;
 
     [Test]
@@ -1984,6 +2091,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
     [PageHandler]
     procedure HandleTransferOrder(var TransfOrderPage: TestPage "Transfer Order")
     begin
+        OpenedTransferOrderNo := CopyStr(TransfOrderPage."No.".Value(), 1, MaxStrLen(OpenedTransferOrderNo));
         TransfOrderPage.OK().Invoke();
     end;
 
@@ -2126,5 +2234,6 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         SubSetupLibrary: Codeunit "Subc. Setup Library";
         SubcWarehouseLibrary: Codeunit "Subc. Warehouse Library";
         IsInitialized: Boolean;
+        OpenedTransferOrderNo: Code[20];
         ProdOrderRoutingTransferWIPEnabledErr: Label 'Transfer WIP Item should not be enabled for a Machine Center prod. order routing line.';
 }

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcWIPTransCreateTest.Codeunit.al
@@ -39,6 +39,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         PurchaseHeader: Record "Purchase Header";
         TransferHeader: Record "Transfer Header";
         TransferLine: Record "Transfer Line";
+        SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
         OriginalQuantity: Decimal;
         PurchaseOrder: TestPage "Purchase Order";
     begin
@@ -56,9 +57,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
 
         // [THEN] Coverage is explained and no duplicate WIP quantity is created.
-        Assert.AreEqual(
-            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
-            GetLastErrorText(), 'Covered WIP must not report missing demand.');
+        Assert.ExpectedError(SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader).Message);
         Assert.AreEqual(1, TransferLine.Count(), 'No duplicate WIP line should be created.');
         TransferLine.FindFirst();
         Assert.AreEqual(OriginalQuantity, TransferLine.Quantity, 'Covered WIP quantity must not change.');
@@ -94,9 +93,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         asserterror PurchaseOrder.CreateTransfOrdToSubcontractor.Invoke();
 
         // [THEN] Coverage is explained and the action opens the existing shipped transfer.
-        Assert.AreEqual(
-            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
-            GetLastErrorText(), 'Shipped WIP must explain existing coverage.');
+        Assert.ExpectedError(SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader).Message);
         PurchaseOrder.Close();
         OpenedTransferOrderNo := '';
         SubcPurchaseHeaderExt.ShowOutboundTransferOrdersForPurchHeader(
@@ -618,6 +615,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         TransferLine: Record "Transfer Line";
         Vendor: Record Vendor;
         WorkCenter: array[2] of Record "Work Center";
+        SubcPurchaseHeaderExt: Codeunit "Subc. Purchase Header Ext";
         PurchaseHeaderPage: TestPage "Purchase Order";
     begin
         // [SCENARIO 648962] Posted WIP covering positive eligible demand produces an explanatory error without a new transfer.
@@ -685,9 +683,7 @@ codeunit 149911 "Subc. WIP Trans. Create Test"
         asserterror PurchaseHeaderPage.CreateTransfOrdToSubcontractor.Invoke();
 
         // [THEN] The error explains that transfer activity already covers the demand, and no WIP transfer is created.
-        Assert.AreEqual(
-            'The components and WIP for this subcontracting order are already covered by open transfer orders, quantities in transit, or quantities transferred to the subcontractor.',
-            GetLastErrorText(), 'Posted WIP coverage must not report missing transfer demand.');
+        Assert.ExpectedError(SubcPurchaseHeaderExt.CreateCoveredTransferErrorInfo(PurchaseHeader).Message);
     end;
 
     [Test]


### PR DESCRIPTION
[AB#648962](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648962)

## What & why

When all positive component or WIP demand for a subcontracting purchase order was already covered by open, in-transit, or posted transfer activity, **Create Transfer Order to Subcontractor** showed the generic "Nothing to create" error. The report's dry run returned the same Boolean result both for truly ineligible/zero demand and for eligible demand that was fully covered.

This change tracks covered positive eligible demand separately. The generic error remains for setup, routing, quantity, and supply-method cases with no positive eligible demand. Fully covered demand now produces the requested actionable error and offers **Show open transfer orders** only when a related unposted outbound transfer header exists. Navigation reuses the existing subcontracting factbox helper, which opens one order as a card or multiple orders as a filtered list while excluding returns and unrelated orders.

## Linked work

[AB#648962](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648962)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Re-established TDD proof from clean commit `c6d92043e9` in an isolated worktree: the component regression failed because expected covered-demand guidance was replaced by the old generic error.
- Compiled both `Subcontracting` and `Subcontracting Test` with 0 errors and 0 warnings using the supported AL toolchain.
- Full `Subc. Subcontracting Test` codeunit: 62 passed, 0 failed.
- Full `Subc. WIP Trans. Create Test` codeunit: 26 passed, 0 failed.
- Existing partial-demand recreation test passed.
- Covered components; covered WIP with open, in-transit, and posted-only activity; zero demand; ineligible supply method; outbound card/list navigation; and exclusion of returns/unrelated orders are covered by focused regressions.
- Manual visual verification of the rendered actionable-error button in the Web client remains external; no shared environment deployment was authorized. The AL integration tests exercise the error text and the action callback/navigation behavior on the local BC service.

## Risk & compatibility

Low risk. The change is limited to the report's no-lines-created error selection and a new actionable-error callback. It does not change transfer quantity calculation or creation when any uncovered demand exists, adds no schema or upgrade changes, and is backward compatible.









