### PR TITLE
Deliverable 638799: Requisitions in Base App: Missed dataclassification on user field

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequest.Table.al
+++ b/src/Layers/W1/BaseApp/Finance/SpendRequest/SpendRequest.Table.al
@@ -168,8 +168,8 @@ table 6840 "Spend Request"
         field(15; "Approved/Rejected by User ID"; Guid)
         {
             Caption = 'Approved/Rejected by User ID';
-            DataClassification = EndUserIdentifiableInformation;
             ToolTip = 'Specifies the user ID who approved or rejected the spend request.';
+            DataClassification = EndUserIdentifiableInformation;
             Editable = false;
             TableRelation = User."User Security ID";
 
@@ -182,6 +182,7 @@ table 6840 "Spend Request"
         {
             Caption = 'Approved/Rejected by User Name';
             ToolTip = 'Specifies the user name who approved or rejected the spend request.';
+            DataClassification = EndUserIdentifiableInformation;
             Editable = false;
         }
         field(17; "Approved/Rejected At"; DateTime)
@@ -447,6 +448,7 @@ table 6840 "Spend Request"
         Rec.Status := Rec.Status::Approved;
         Rec."Approved/Rejected At" := CurrentDateTime();
         Rec."Approved/Rejected by User ID" := UserSecurityId();
+        Rec."Approved/Rejected by User Name" := CopyStr(UserId(), 1, MaxStrLen(Rec."Approved/Rejected by User Name"));
         Rec.Modify();
     end;
 
@@ -461,6 +463,7 @@ table 6840 "Spend Request"
         Rec.Status := Rec.Status::Rejected;
         Rec."Approved/Rejected At" := CurrentDateTime();
         Rec."Approved/Rejected by User ID" := UserSecurityId();
+        Rec."Approved/Rejected by User Name" := CopyStr(UserId(), 1, MaxStrLen(Rec."Approved/Rejected by User Name"));
         Rec.Modify();
     end;
 


### PR DESCRIPTION
Due to some back-and-forth changes to a approver name field on the Spend Request, the DataClassification we lost. Reintroduced.

Fixes [AB#638799](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/638799)



