### PR TITLE
Fix AL0254 compile error in Stock Register for Job Work report

### DIFF
--- a/src/Apps/IN/INGST/app/GSTSubcontracting/src/Reports/StockRegisterforJobWork.Report.al
+++ b/src/Apps/IN/INGST/app/GSTSubcontracting/src/Reports/StockRegisterforJobWork.Report.al
@@ -321,7 +321,9 @@ report 18468 "Stock Register for Job Work"
             dataitem("Purch. Rcpt. Line"; "Purch. Rcpt. Line")
             {
                 DataItemLink = "Prod. Order No." = field("Production Order No."), "Prod. Order Line No." = field("Production Order Line No.");
+#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                 DataItemTableView = sorting("Prod. Order No.", "Prod. Order Line No.") Order(Ascending);
+#pragma warning restore AL0254
                 column(Vendor__No___________Vendor_Name_________Vendor_Address________Vendor__Address_2__Control1280014; Vendor."No." + '  ' + Vendor.Name + '  ' + Vendor.Address + '  ' + Vendor."Address 2")
                 {
                 }


### PR DESCRIPTION
## What & why

Platform 30.x uptake fails to compile `StockRegisterforJobWork.Report.al` (GST Subcontracting, IN localization) with two AL0254 errors on line 324:

```
StockRegisterforJobWork.Report.al(324,37): error AL0254: Sorting field 'Prod. Order No.' should be part of the keys for table 'Purch. Rcpt. Line'. Add the field to a key definition to improve performance.
StockRegisterforJobWork.Report.al(324,37): error AL0254: Sorting field 'Prod. Order Line No.' should be part of the keys for table 'Purch. Rcpt. Line'. Add the field to a key definition to improve performance.
```

The `Purch. Rcpt. Line` data item sorts on `"Prod. Order No."` (5401) and `"Prod. Order Line No."` (99000754). Those fields exist only on the Manufacturing table extension `Mfg. Purch. Receipt Line` (which extends `Purch. Rcpt. Line`) and are not covered by any key on the base table. Recent AL compilers tightened **AL0254** to also validate sort fields introduced by a **table extension** (earlier compilers only checked base-table fields). Combined with AL0254 defaulting to Error (after the global `AL0254 → Warning` ruleset override was removed in #10878), the report no longer compiles. No app logic changed — this only surfaces under the newer compiler.

The fix wraps the `DataItemTableView` sort in a scoped `#pragma warning disable/restore AL0254`, matching the accepted suppression already used for the Item Ledger Entry sort a few lines above in the same report (added in #10878):

```al
#pragma warning disable AL0254 // Accepted: Object-specific sorting; adding a shared-table key risks schema and performance changes.
                DataItemTableView = sorting("Prod. Order No.", "Prod. Order Line No.") Order(Ascending);
#pragma warning restore AL0254
```

A covering key is intentionally **not** added, since altering a shared base/extension table's keys risks schema and performance changes.

## Linked work

[AB#649216](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649216)

## How I validated this

- [ ] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [ ] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

Local build was **not** performed in this environment (the NAV enlistment initialization requires elevation that isn't available in the current session). The change is a 2-line, comment-annotated `#pragma` identical in pattern to the existing accepted AL0254 suppression at line 224 of the same report; it only suppresses the diagnostic and does not alter the report's runtime behavior or its sort order. No tests added — this is a compile-only suppression with no behavior change. **Please build the app locally and confirm before requesting review**; CI on this PR is the safety net.

## Risk & compatibility

Minimal. Pragma/comment-only change with no functional, schema, or data impact. It suppresses AL0254 for one object-specific sort whose sort fields come from a table extension without a covering key. Follow-up: once the newly-flagged AL0254 sort sites across BCApps are addressed, the AL0254 Error hardening from #10878 can stay in place.

