### PR TITLE
Fix missing default item journal batch in Contoso Inventory setup

### DIFF
--- a/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Inventory/1.Setup Data/CreateItemJournalTemplate.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/app/DemoData/Inventory/1.Setup Data/CreateItemJournalTemplate.Codeunit.al
@@ -21,11 +21,14 @@ codeunit 5423 "Create Item Journal Template"
     var
         SourceCodeSetup: Record "Source Code Setup";
         ContosoItem: Codeunit "Contoso Item";
+        ContosoUtilities: Codeunit "Contoso Utilities";
         CreateNoSeries: Codeunit "Create No. Series";
     begin
         SourceCodeSetup.Get();
 
         ContosoItem.InsertItemJournalTemplate(ItemJournalTemplate(), ItemJournalLbl, Enum::"Item Journal Template Type"::Item, false, SourceCodeSetup."Item Journal", Report::"Inventory Posting - Test", Page::"Item Journal", Report::"Item Register - Quantity", CreateNoSeries.ItemJournal(), Report::"Warehouse Register - Quantity");
+
+        ContosoItem.InsertItemJournalBatch(ItemJournalTemplate(), ContosoUtilities.GetDefaultBatchNameLbl(), '');
     end;
 
     procedure ItemJournalTemplate(): Code[10]

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/ContosoItemJournalTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/ContosoItemJournalTest.Codeunit.al
@@ -7,7 +7,7 @@ using Microsoft.Foundation.AuditCodes;
 using Microsoft.Foundation.NoSeries;
 using Microsoft.Inventory.Journal;
 
-codeunit 148000 "Contoso Item Journal Test"
+codeunit 148451 "Contoso Item Journal Test"
 {
     Subtype = Test;
     TestPermissions = Disabled;

--- a/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/ContosoItemJournalTest.Codeunit.al
+++ b/src/Apps/W1/ContosoCoffeeDemoDataset/test/src/ContosoItemJournalTest.Codeunit.al
@@ -1,0 +1,113 @@
+namespace Microsoft.Test.DemoTool;
+
+using Microsoft.DemoData.Foundation;
+using Microsoft.DemoData.Inventory;
+using Microsoft.DemoTool.Helpers;
+using Microsoft.Foundation.AuditCodes;
+using Microsoft.Foundation.NoSeries;
+using Microsoft.Inventory.Journal;
+
+codeunit 148000 "Contoso Item Journal Test"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit Assert;
+        CreateItemJournalTemplate: Codeunit "Create Item Journal Template";
+        ContosoUtilities: Codeunit "Contoso Utilities";
+
+    [Test]
+    procedure ItemJournalSetupCreatesDefaultBatch()
+    var
+        ItemJournalTemplate: Record "Item Journal Template";
+        ItemJournalBatch: Record "Item Journal Batch";
+        CreateNoSeries: Codeunit "Create No. Series";
+    begin
+        // [SCENARIO] Inventory setup creates its own default batch without other modules.
+        Initialize();
+
+        // [WHEN] The item journal template producer runs with no existing template or batch.
+        Codeunit.Run(Codeunit::"Create Item Journal Template");
+
+        // [THEN] The template and localized default batch exist, without copying template numbering to the batch.
+        ItemJournalTemplate.Get(CreateItemJournalTemplate.ItemJournalTemplate());
+        ItemJournalTemplate.TestField("No. Series", CreateNoSeries.ItemJournal());
+        ItemJournalBatch.Get(CreateItemJournalTemplate.ItemJournalTemplate(), ContosoUtilities.GetDefaultBatchNameLbl());
+        ItemJournalBatch.TestField(Description, '');
+        ItemJournalBatch.TestField("No. Series", '');
+        ItemJournalBatch.TestField("Posting No. Series", '');
+    end;
+
+    [Test]
+    procedure ItemJournalSetupCreatesMissingBatchForExistingTemplate()
+    var
+        ItemJournalTemplate: Record "Item Journal Template";
+        ItemJournalBatch: Record "Item Journal Batch";
+    begin
+        // [SCENARIO] An existing template does not prevent the producer from creating its missing batch.
+        Initialize();
+        ItemJournalTemplate.Validate(Name, CreateItemJournalTemplate.ItemJournalTemplate());
+        ItemJournalTemplate.Validate(Description, 'Existing item journal');
+        ItemJournalTemplate.Insert(true);
+
+        // [WHEN] The item journal template producer runs.
+        Codeunit.Run(Codeunit::"Create Item Journal Template");
+
+        // [THEN] The batch exists and the existing template is unchanged.
+        ItemJournalBatch.Get(CreateItemJournalTemplate.ItemJournalTemplate(), ContosoUtilities.GetDefaultBatchNameLbl());
+        ItemJournalTemplate.Get(CreateItemJournalTemplate.ItemJournalTemplate());
+        ItemJournalTemplate.TestField(Description, 'Existing item journal');
+    end;
+
+    [Test]
+    procedure ItemJournalSetupPreservesExistingBatchOnRepeatedExecution()
+    var
+        ItemJournalBatch: Record "Item Journal Batch";
+        ExistingItemJournalBatch: Record "Item Journal Batch";
+        LibraryUtility: Codeunit "Library - Utility";
+        CreateNoSeries: Codeunit "Create No. Series";
+    begin
+        // [SCENARIO] Repeated producer execution preserves a customized default batch.
+        Initialize();
+        Codeunit.Run(Codeunit::"Create Item Journal Template");
+        ItemJournalBatch.Get(CreateItemJournalTemplate.ItemJournalTemplate(), ContosoUtilities.GetDefaultBatchNameLbl());
+        ItemJournalBatch.Validate(Description, 'Keep existing batch settings');
+        ItemJournalBatch.Validate("No. Series", LibraryUtility.GetGlobalNoSeriesCode());
+        ItemJournalBatch.Validate("Posting No. Series", CreateNoSeries.ItemJournal());
+        ItemJournalBatch.Validate("Item Tracking on Lines", true);
+        ItemJournalBatch.Modify(true);
+        ExistingItemJournalBatch := ItemJournalBatch;
+
+        // [WHEN] The producer runs again, including a subsequent repeated execution.
+        Codeunit.Run(Codeunit::"Create Item Journal Template");
+        Codeunit.Run(Codeunit::"Create Item Journal Template");
+
+        // [THEN] The same batch retains its description, numbering and tracking settings.
+        ItemJournalBatch.Get(CreateItemJournalTemplate.ItemJournalTemplate(), ContosoUtilities.GetDefaultBatchNameLbl());
+        Assert.AreEqual(ExistingItemJournalBatch.SystemId, ItemJournalBatch.SystemId, 'The existing batch must not be replaced.');
+        ItemJournalBatch.TestField(Description, ExistingItemJournalBatch.Description);
+        ItemJournalBatch.TestField("No. Series", ExistingItemJournalBatch."No. Series");
+        ItemJournalBatch.TestField("Posting No. Series", ExistingItemJournalBatch."Posting No. Series");
+        ItemJournalBatch.TestField("Item Tracking on Lines", ExistingItemJournalBatch."Item Tracking on Lines");
+    end;
+
+    local procedure Initialize()
+    var
+        SourceCodeSetup: Record "Source Code Setup";
+        NoSeries: Record "No. Series";
+        ItemJournalTemplate: Record "Item Journal Template";
+        CreateNoSeries: Codeunit "Create No. Series";
+    begin
+        if not SourceCodeSetup.Get() then
+            SourceCodeSetup.Insert();
+
+        if not NoSeries.Get(CreateNoSeries.ItemJournal()) then begin
+            NoSeries.Validate(Code, CreateNoSeries.ItemJournal());
+            NoSeries.Insert(true);
+        end;
+
+        if ItemJournalTemplate.Get(CreateItemJournalTemplate.ItemJournalTemplate()) then
+            ItemJournalTemplate.Delete(true);
+    end;
+}


### PR DESCRIPTION
## What & why
Create Inventory's default item journal batch alongside its template so fresh Common/Warehouse generation no longer relies on Manufacturing, Service, or Jobs to create it. Reuses the existing helper and preserves existing batch settings.

## Linked work
[AB#644169](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/644169)

## How I validated this
- [x] Reviewed the diff, including an adversarial review.
- [x] Built the production and test apps with no new analyzer warnings.
- [ ] Ran the deployed production change in Business Central.
- [x] Added three regression tests: batch creation, an existing template without a batch, and preservation of customized settings.

Reproduced the original failures. All three tests and complete Common/Warehouse generation passed using an isolated harness with the identical patched producer. Direct patched-app execution and full-all-modules validation remain outstanding.

## Risk & compatibility
No numbering or dependency changes. Previously generated setup and staged-generation G/L-mapping recovery remain out of scope.



