### PR TITLE
[Master]-"The record in table Reminder Line already exists." error appears if you Create Reminders for a Customer with all the Open Entries On Hold and no Reminder Free applied on the Reminder Terms used

### DIFF
--- a/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderCommunication.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Sales/Reminder/TermsAndLevels/ReminderCommunication.Codeunit.al
@@ -110,8 +110,13 @@ codeunit 1890 "Reminder Communication"
 
         if ReminderLine.FindLast() then
             NextLineNo := ReminderLine."Line No."
-        else
-            NextLineNo := 0;
+        else begin
+            ReminderLine.SetRange("Line Type", ReminderLine."Line Type"::"Beginning Text");
+            if ReminderLine.FindLast() then
+                NextLineNo := ReminderLine."Line No."
+            else
+                NextLineNo := 0;
+        end;
 
         ReminderLine.SetRange("Line Type");
         ReminderLine2 := ReminderLine;


### PR DESCRIPTION
Fixes [AB#649320](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649320)


