### PR TITLE
Ruleset hardening: promote three mechanical rules to Error

### DIFF
--- a/src/Apps/IN/INGST/test/GSTPurchase/src/GSTOnPurchaseTests.Codeunit.al
+++ b/src/Apps/IN/INGST/test/GSTPurchase/src/GSTOnPurchaseTests.Codeunit.al
@@ -2552,31 +2552,27 @@ codeunit 18131 "GST On Purchase Tests"
     begin
         LibraryERM.CreateCurrency(Currency);
         LibraryERM.SetCurrencyGainLossAccounts(Currency);
-        with Currency do begin
-            Validate("Residual Gains Account", "Realized Gains Acc.");
-            Validate("Residual Losses Account", "Realized Losses Acc.");
-            Validate("Appln. Rounding Precision", ApplnRoundingPrecision);
-            Modify(true);
-        end;
+        Currency.Validate("Residual Gains Account", Currency."Realized Gains Acc.");
+        Currency.Validate("Residual Losses Account", Currency."Realized Losses Acc.");
+        Currency.Validate("Appln. Rounding Precision", ApplnRoundingPrecision);
+        Currency.Modify(true);
     end;
 
     local procedure CreateExchangeRate(CurrencyCode: Code[10]; StartingDate: Date; RelExchangeRateAmount: Decimal; RelAdjustmentExchangeRateAmount: Decimal)
     var
         CurrencyExchangeRate: Record "Currency Exchange Rate";
     begin
-        with CurrencyExchangeRate do begin
-            Init();
-            Validate("Currency Code", CurrencyCode);
-            Validate("Starting Date", StartingDate);
-            Insert(true);
+        CurrencyExchangeRate.Init();
+        CurrencyExchangeRate.Validate("Currency Code", CurrencyCode);
+        CurrencyExchangeRate.Validate("Starting Date", StartingDate);
+        CurrencyExchangeRate.Insert(true);
 
-            Validate("Exchange Rate Amount", 1);
-            Validate("Adjustment Exch. Rate Amount", 1);
+        CurrencyExchangeRate.Validate("Exchange Rate Amount", 1);
+        CurrencyExchangeRate.Validate("Adjustment Exch. Rate Amount", 1);
 
-            Validate("Relational Exch. Rate Amount", RelExchangeRateAmount);
-            Validate("Relational Adjmt Exch Rate Amt", RelAdjustmentExchangeRateAmount);
-            Modify(true);
-        end;
+        CurrencyExchangeRate.Validate("Relational Exch. Rate Amount", RelExchangeRateAmount);
+        CurrencyExchangeRate.Validate("Relational Adjmt Exch Rate Amt", RelAdjustmentExchangeRateAmount);
+        CurrencyExchangeRate.Modify(true);
     end;
 
     local procedure UpdateVendorCurrencyAndLocation(VendorNo: Code[20]; CurrencyCode: Code[10])

--- a/src/Apps/IN/INGST/test/GSTService/GSTServiceInvoiceTests.Codeunit.al
+++ b/src/Apps/IN/INGST/test/GSTService/GSTServiceInvoiceTests.Codeunit.al
@@ -317,15 +317,14 @@ codeunit 18481 "GST Service Invoice Tests"
         WrongDocumentTypeErr: Label 'Document type not supported: %1';
     begin
         LibraryService.SetCorrDocNoService(ServiceHeader);
-        with ServiceHeader do
-            case "Document Type" of
-                "Document Type"::Invoice:
-                    NoSeriesCode := "Posting No. Series";  // posted service invoice.
-                "Document Type"::"Credit Memo":
-                    NoSeriesCode := "Posting No. Series";
-                else
-                    Assert.Fail(StrSubstNo(WrongDocumentTypeErr, "Document Type"));
-            end;
+        case ServiceHeader."Document Type" of
+            ServiceHeader."Document Type"::Invoice:
+                NoSeriesCode := ServiceHeader."Posting No. Series";  // posted service invoice.
+            ServiceHeader."Document Type"::"Credit Memo":
+                NoSeriesCode := ServiceHeader."Posting No. Series";
+            else
+                Assert.Fail(StrSubstNo(WrongDocumentTypeErr, ServiceHeader."Document Type"));
+        end;
 
         if ServiceHeader."Posting No." = '' then
             DocumentNo := NoSeries.PeekNextNo(NoSeriesCode, GetNextNoSeriesServiceDate(NoSeriesCode))

--- a/src/Apps/IN/INGST/test/GSTService/GSTServiceShipToAddrTests.Codeunit.al
+++ b/src/Apps/IN/INGST/test/GSTService/GSTServiceShipToAddrTests.Codeunit.al
@@ -566,15 +566,14 @@ codeunit 18480 "GST Service Ship To Addr Tests"
         WrongDocumentTypeErr: Label 'Document type not supported: %1';
     begin
         LibraryService.SetCorrDocNoService(ServiceHeader);
-        with ServiceHeader do
-            case "Document Type" of
-                "Document Type"::Invoice:
-                    NoSeriesCode := "Posting No. Series";  // posted service invoice.
-                "Document Type"::"Credit Memo":
-                    NoSeriesCode := "Posting No. Series";
-                else
-                    Assert.Fail(StrSubstNo(WrongDocumentTypeErr, "Document Type"));
-            end;
+        case ServiceHeader."Document Type" of
+            ServiceHeader."Document Type"::Invoice:
+                NoSeriesCode := ServiceHeader."Posting No. Series";  // posted service invoice.
+            ServiceHeader."Document Type"::"Credit Memo":
+                NoSeriesCode := ServiceHeader."Posting No. Series";
+            else
+                Assert.Fail(StrSubstNo(WrongDocumentTypeErr, ServiceHeader."Document Type"));
+        end;
 
         if ServiceHeader."Posting No." = '' then
             DocumentNo := NoSeries.PeekNextNo(NoSeriesCode, GetNextNoSeriesServiceDate(NoSeriesCode))

--- a/src/Apps/NA/MX_DIOT/app/src/Install/DIOTInitialize.Codeunit.al
+++ b/src/Apps/NA/MX_DIOT/app/src/Install/DIOTInitialize.Codeunit.al
@@ -313,13 +313,11 @@ codeunit 27020 "DIOT - Initialize"
         DIOTCountryData: Record "DIOT Country/Region Data";
         DIOTDataMgt: Codeunit "DIOT Data Management";
     begin
-        with DIOTCountryData do begin
-            Init();
-            "Country/Region Code" := CountryCode;
-            Nationality := CopyStr(DIOTDataMgt.RemoveUnwantedCharacters(NewNationality, ' &´.'), 1, MaxStrLen(Nationality));
-            "BC Country/Region Code" := CountryCode;
-            "ISO A-3 Country/Region Code" := DIOTCountryCode;
-            if Insert(true) then;
-        end;
+        DIOTCountryData.Init();
+        DIOTCountryData."Country/Region Code" := CountryCode;
+        DIOTCountryData.Nationality := CopyStr(DIOTDataMgt.RemoveUnwantedCharacters(NewNationality, ' &´.'), 1, MaxStrLen(DIOTCountryData.Nationality));
+        DIOTCountryData."BC Country/Region Code" := CountryCode;
+        DIOTCountryData."ISO A-3 Country/Region Code" := DIOTCountryCode;
+        if DIOTCountryData.Insert(true) then;
     end;
 }

--- a/src/Apps/NA/MX_DIOT/app/src/Processing/DIOTDataManagement.Codeunit.al
+++ b/src/Apps/NA/MX_DIOT/app/src/Processing/DIOTDataManagement.Codeunit.al
@@ -177,15 +177,13 @@ codeunit 27021 "DIOT Data Management"
     var
         DIOTConcept: Record "DIOT Concept";
     begin
-        with DIOTConcept do begin
-            Init();
-            Validate("Concept No.", ConceptNo);
-            Validate("Column No.", Column);
-            Validate("Column Type", ColumnType);
-            Validate(Description, NewDescription);
-            Validate("Non-Deductible Pct", NonDeductiblePct);
-            if Insert(true) then;
-        end;
+        DIOTConcept.Init();
+        DIOTConcept.Validate("Concept No.", ConceptNo);
+        DIOTConcept.Validate("Column No.", Column);
+        DIOTConcept.Validate("Column Type", ColumnType);
+        DIOTConcept.Validate(Description, NewDescription);
+        DIOTConcept.Validate("Non-Deductible Pct", NonDeductiblePct);
+        if DIOTConcept.Insert(true) then;
     end;
 
     procedure GetDIOTSetupGuideTxt(): Text[250]
@@ -279,46 +277,43 @@ codeunit 27021 "DIOT Data Management"
     var
         Vendor: Record Vendor;
     begin
-        with TempDIOTReportVendorBuffer do
-            if not get(VendorNo, DIOTTypeOfOperation) then begin
-                Init();
-                Vendor.Get(VendorNo);
-                "Vendor No." := VendorNo;
-                "Type of Operation" := DIOTTypeOfOperation;
+        if not TempDIOTReportVendorBuffer.Get(VendorNo, DIOTTypeOfOperation) then begin
+            TempDIOTReportVendorBuffer.Init();
+            Vendor.Get(VendorNo);
+            TempDIOTReportVendorBuffer."Vendor No." := VendorNo;
+            TempDIOTReportVendorBuffer."Type of Operation" := DIOTTypeOfOperation;
 
-                "Type of Vendor Text" := GetTypeOfVendorText(Vendor."Country/Region Code");
+            TempDIOTReportVendorBuffer."Type of Vendor Text" := GetTypeOfVendorText(Vendor."Country/Region Code");
 
-                "Type of Operation Text" := GetTypeOfOperationCode(DIOTTypeOfOperation);
+            TempDIOTReportVendorBuffer."Type of Operation Text" := GetTypeOfOperationCode(DIOTTypeOfOperation);
 
-                "RFC Number" := CopyStr(Vendor."RFC No.", 1, MaxStrLen("RFC Number"));
+            TempDIOTReportVendorBuffer."RFC Number" := CopyStr(Vendor."RFC No.", 1, MaxStrLen(TempDIOTReportVendorBuffer."RFC Number"));
 
-                if Vendor."Country/Region Code" <> GetMXCountryCode() then begin
-                    "TAX Registration ID" := CopyStr(Vendor."VAT Registration No.", 1, MaxStrLen("TAX Registration ID"));
-                    "Vendor Name" := CopyStr(ConvertToDIOTVendorName(Vendor.Name), 1, MaxStrLen("Vendor Name"));
-                    "Country/Region Code" := ConvertToDIOTCountryCode(Vendor."Country/Region Code");
-                    if "Country/Region Code" = GetDIOTOtherCountryCode() then
-                        "Tax Jurisdiction Location" := Vendor."Tax Jurisdiction Location";
-                end;
-
-                "Tax Effects Applied" := Vendor."Tax Effects Applied";
-                Insert();
+            if Vendor."Country/Region Code" <> GetMXCountryCode() then begin
+                TempDIOTReportVendorBuffer."TAX Registration ID" := CopyStr(Vendor."VAT Registration No.", 1, MaxStrLen(TempDIOTReportVendorBuffer."TAX Registration ID"));
+                TempDIOTReportVendorBuffer."Vendor Name" := CopyStr(ConvertToDIOTVendorName(Vendor.Name), 1, MaxStrLen(TempDIOTReportVendorBuffer."Vendor Name"));
+                TempDIOTReportVendorBuffer."Country/Region Code" := ConvertToDIOTCountryCode(Vendor."Country/Region Code");
+                if TempDIOTReportVendorBuffer."Country/Region Code" = GetDIOTOtherCountryCode() then
+                    TempDIOTReportVendorBuffer."Tax Jurisdiction Location" := Vendor."Tax Jurisdiction Location";
             end;
+
+            TempDIOTReportVendorBuffer."Tax Effects Applied" := Vendor."Tax Effects Applied";
+            TempDIOTReportVendorBuffer.Insert();
+        end;
     end;
 
     local procedure InsertBufferConditionally(var TempDIOTReportBuffer: Record "DIOT Report Buffer" temporary; VendorNo: Code[20]; TypeOfOperation: Enum "DIOT Type of Operation"; ConceptNo: Integer; Amount: Decimal)
     begin
-        with TempDIOTReportBuffer do
-            if get(VendorNo, TypeOfOperation, ConceptNo) then begin
-                Validate(Value, Value + Amount);
-                Modify(true);
-            end
-            else begin
-                "Vendor No." := VendorNo;
-                "Type of Operation" := TypeOfOperation;
-                "DIOT Concept No." := ConceptNo;
-                Value := Amount;
-                Insert();
-            end;
+        if TempDIOTReportBuffer.Get(VendorNo, TypeOfOperation, ConceptNo) then begin
+            TempDIOTReportBuffer.Validate(Value, TempDIOTReportBuffer.Value + Amount);
+            TempDIOTReportBuffer.Modify(true);
+        end else begin
+            TempDIOTReportBuffer."Vendor No." := VendorNo;
+            TempDIOTReportBuffer."Type of Operation" := TypeOfOperation;
+            TempDIOTReportBuffer."DIOT Concept No." := ConceptNo;
+            TempDIOTReportBuffer.Value := Amount;
+            TempDIOTReportBuffer.Insert();
+        end;
     end;
 
     procedure CollectDIOTDataSet(var TempDIOTReportBuffer: Record "DIOT Report Buffer" temporary; var TempDIOTReportVendorBuffer: Record "DIOT Report Vendor Buffer" temporary; var TempErrorMessage: Record "Error Message" temporary; StartingDate: Date; EndingDate: Date)
@@ -449,19 +444,17 @@ codeunit 27021 "DIOT Data Management"
     var
         DummyVendor: Record Vendor;
     begin
-        with DIOTReportVendorBuffer do begin
-            if ("Type of Operation Text" = '') then
-                LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("DIOT Type of Operation"), BlankTypeOfOperationErr, "Vendor No.");
+        if DIOTReportVendorBuffer."Type of Operation Text" = '' then
+            LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("DIOT Type of Operation"), BlankTypeOfOperationErr, DIOTReportVendorBuffer."Vendor No.");
 
-            if ("Type of Operation Text" = '06') and ("Type of Vendor Text" = '05') then
-                LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("DIOT Type of Operation"), LeaseAndRentNonMXErr, "Vendor No.");
+        if (DIOTReportVendorBuffer."Type of Operation Text" = '06') and (DIOTReportVendorBuffer."Type of Vendor Text" = '05') then
+            LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("DIOT Type of Operation"), LeaseAndRentNonMXErr, DIOTReportVendorBuffer."Vendor No.");
 
-            if ("RFC Number" = '') and ("Type of Vendor Text" = '04') then
-                LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("RFC No."), MissingRFCNoErr, "Vendor No.");
+        if (DIOTReportVendorBuffer."RFC Number" = '') and (DIOTReportVendorBuffer."Type of Vendor Text" = '04') then
+            LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("RFC No."), MissingRFCNoErr, DIOTReportVendorBuffer."Vendor No.");
 
-            if ("Country/Region Code" = '') and ("Type of Vendor Text" = '05') then
-                LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("Country/Region Code"), CountryCodeNotValidErr, "Vendor No.");
-        end;
+        if (DIOTReportVendorBuffer."Country/Region Code" = '') and (DIOTReportVendorBuffer."Type of Vendor Text" = '05') then
+            LogErrorForVendor(TempErrorMessage, DummyVendor.FieldNo("Country/Region Code"), CountryCodeNotValidErr, DIOTReportVendorBuffer."Vendor No.");
     end;
 
     local procedure LogErrorForVendor(var TempErrorMessage: Record "Error Message" temporary; FieldNo: Integer; Message: Text; VendorNo: Code[20])
@@ -474,12 +467,11 @@ codeunit 27021 "DIOT Data Management"
 
     local procedure CheckDIOTReportBuffer(var TempDIOTReportBuffer: Record "DIOT Report Buffer"; var TempErrorMessage: Record "Error Message" temporary)
     begin
-        with TempDIOTReportBuffer do
-            if FindSet() then
-                repeat
-                    if Value < 0 then
-                        TempErrorMessage.LogDetailedMessage(TempDIOTReportBuffer, 0, TempErrorMessage."Message Type"::Error, StrSubstNo(NegativeAmountErr, "DIOT Concept No.", "Vendor No."), '', '');
-                until Next() = 0;
+        if TempDIOTReportBuffer.FindSet() then
+            repeat
+                if TempDIOTReportBuffer.Value < 0 then
+                    TempErrorMessage.LogDetailedMessage(TempDIOTReportBuffer, 0, TempErrorMessage."Message Type"::Error, StrSubstNo(NegativeAmountErr, TempDIOTReportBuffer."DIOT Concept No.", TempDIOTReportBuffer."Vendor No."), '', '');
+            until TempDIOTReportBuffer.Next() = 0;
     end;
 
     procedure WriteDIOTFile(var TempDIOTReportBuffer: Record "DIOT Report Buffer" temporary; var TempDIOTReportVendorBuffer: Record "DIOT Report Vendor Buffer" temporary)

--- a/src/Apps/NA/MX_DIOT/app/src/Processing/DIOTSubscribers.Codeunit.al
+++ b/src/Apps/NA/MX_DIOT/app/src/Processing/DIOTSubscribers.Codeunit.al
@@ -126,8 +126,7 @@ codeunit 27022 "DIOT Subscribers"
 
     local procedure CheckWHTIsNotMoreThanVAT(VATPostingSetup: Record "VAT Posting Setup")
     begin
-        with VATPostingSetup do
-            if "DIOT WHT %" > "VAT %" then
-                Error(WHTMoreThanVATErr, FieldCaption("DIOT WHT %"), FieldCaption("VAT %"));
+        if VATPostingSetup."DIOT WHT %" > VATPostingSetup."VAT %" then
+            Error(WHTMoreThanVATErr, VATPostingSetup.FieldCaption("DIOT WHT %"), VATPostingSetup.FieldCaption("VAT %"));
     end;
 }

--- a/src/Apps/NA/MX_DIOT/test/src/LibraryMXDIOT.Codeunit.al
+++ b/src/Apps/NA/MX_DIOT/test/src/LibraryMXDIOT.Codeunit.al
@@ -66,13 +66,11 @@ codeunit 148042 "Library - MX DIOT"
     var
         DIOTConceptLink: Record "DIOT Concept Link";
     begin
-        with DIOTConceptLink do begin
-            Init();
-            "DIOT Concept No." := ConceptNo;
-            "VAT Prod. Posting Group" := VATPostingSetup."VAT Prod. Posting Group";
-            "VAT Bus. Posting Group" := VATPostingSetup."VAT Bus. Posting Group";
-            Insert(true);
-        end;
+        DIOTConceptLink.Init();
+        DIOTConceptLink."DIOT Concept No." := ConceptNo;
+        DIOTConceptLink."VAT Prod. Posting Group" := VATPostingSetup."VAT Prod. Posting Group";
+        DIOTConceptLink."VAT Bus. Posting Group" := VATPostingSetup."VAT Bus. Posting Group";
+        DIOTConceptLink.Insert(true);
     end;
 
     procedure MockPurchaseVATEntry(var VATEntry: Record "VAT Entry"; VATPostingSetup: Record "VAT Posting Setup"; PostingDate: Date; VendorNo: Code[20])

--- a/src/Apps/NA/MX_DIOT/test/src/MXDIOTUT.Codeunit.al
+++ b/src/Apps/NA/MX_DIOT/test/src/MXDIOTUT.Codeunit.al
@@ -977,30 +977,26 @@ codeunit 148041 "MX DIOT UT"
     var
         DIOTDataMgmt: Codeunit "DIOT Data Management";
     begin
-        with DIOTReportVendorBuffer do begin
-            SetRange("Vendor No.", Vendor."No.");
-            SetRange("Type of Operation", DIOTTypeOfOperation);
-            FindFirst();
-            TestField("Type of Vendor Text", '05');
-            TestField("TAX Registration ID", Vendor."VAT Registration No.");
-            TestField("RFC Number", Vendor."RFC No.");
-            TestField("Vendor Name", Vendor.Name);
-            TestField("Country/Region Code", DIOTDataMgmt.ConvertToDIOTCountryCode(Vendor."Country/Region Code"));
-        end;
+        DIOTReportVendorBuffer.SetRange("Vendor No.", Vendor."No.");
+        DIOTReportVendorBuffer.SetRange("Type of Operation", DIOTTypeOfOperation);
+        DIOTReportVendorBuffer.FindFirst();
+        DIOTReportVendorBuffer.TestField("Type of Vendor Text", '05');
+        DIOTReportVendorBuffer.TestField("TAX Registration ID", Vendor."VAT Registration No.");
+        DIOTReportVendorBuffer.TestField("RFC Number", Vendor."RFC No.");
+        DIOTReportVendorBuffer.TestField("Vendor Name", Vendor.Name);
+        DIOTReportVendorBuffer.TestField("Country/Region Code", DIOTDataMgmt.ConvertToDIOTCountryCode(Vendor."Country/Region Code"));
     end;
 
     local procedure VerifyLocalVendorInfo(var DIOTReportVendorBuffer: Record "DIOT Report Vendor Buffer"; var Vendor: Record Vendor; DIOTTypeOfOperation: Option)
     begin
-        with DIOTReportVendorBuffer do begin
-            SetRange("Vendor No.", Vendor."No.");
-            SetRange("Type of Operation", DIOTTypeOfOperation);
-            FindFirst();
-            TestField("Type of Vendor Text", '04');
-            TestField("TAX Registration ID", '');
-            TestField("RFC Number", Vendor."RFC No.");
-            TestField("Vendor Name", '');
-            TestField("Country/Region Code", '');
-        end;
+        DIOTReportVendorBuffer.SetRange("Vendor No.", Vendor."No.");
+        DIOTReportVendorBuffer.SetRange("Type of Operation", DIOTTypeOfOperation);
+        DIOTReportVendorBuffer.FindFirst();
+        DIOTReportVendorBuffer.TestField("Type of Vendor Text", '04');
+        DIOTReportVendorBuffer.TestField("TAX Registration ID", '');
+        DIOTReportVendorBuffer.TestField("RFC Number", Vendor."RFC No.");
+        DIOTReportVendorBuffer.TestField("Vendor Name", '');
+        DIOTReportVendorBuffer.TestField("Country/Region Code", '');
     end;
 
     local procedure VerifyDIOTBufferAmount(var DIOTReportBuffer: Record "DIOT Report Buffer"; VendorNo: Code[20]; DIOTTypeOfOperation: Option; ConceptNo: Integer; Amount: Decimal)

--- a/src/Apps/W1/MasterDataManagement/app/src/codeunits/IntegrationMasterDataSynch.Codeunit.al
+++ b/src/Apps/W1/MasterDataManagement/app/src/codeunits/IntegrationMasterDataSynch.Codeunit.al
@@ -566,15 +566,13 @@ codeunit 7231 "Integration Master Data Synch."
         if AllowRemoval then
             exit;
 
-        with MasterDataMgtCoupling do begin
-            SetRange(Skipped, true);
-            SetRange("Last Synch. Job ID", IntegrationSynchJob.ID);
-            if IsEmpty() then begin
-                SetRange("Last Synch. Job ID");
-                SetRange("Last Synch. Int. Job ID", IntegrationSynchJob.ID);
-                if IsEmpty() then
-                    AllowRemoval := true;
-            end;
+        MasterDataMgtCoupling.SetRange(Skipped, true);
+        MasterDataMgtCoupling.SetRange("Last Synch. Job ID", IntegrationSynchJob.ID);
+        if MasterDataMgtCoupling.IsEmpty() then begin
+            MasterDataMgtCoupling.SetRange("Last Synch. Job ID");
+            MasterDataMgtCoupling.SetRange("Last Synch. Int. Job ID", IntegrationSynchJob.ID);
+            if MasterDataMgtCoupling.IsEmpty() then
+                AllowRemoval := true;
         end;
     end;
 

--- a/src/Apps/W1/MasterDataManagement/app/src/codeunits/MasterDataMgtSetupDefault.Codeunit.al
+++ b/src/Apps/W1/MasterDataManagement/app/src/codeunits/MasterDataMgtSetupDefault.Codeunit.al
@@ -1527,37 +1527,33 @@ codeunit 7230 "Master Data Mgt. Setup Default"
         "Field": Record "Field";
         IntegrationTableMapping: Record "Integration Table Mapping";
     begin
-        with IntegrationTableMapping do begin
-            Reset();
-            SetRange("Delete After Synchronization", false);
-            if TableID > 0 then
-                SetRange("Table ID", TableID);
-            if IntegrationTableID > 0 then
-                SetRange("Integration Table ID", IntegrationTableID);
-            SetRange("Int. Table UID Field Type", Field.Type::GUID);
-            if FindSet() then
-                repeat
-                    AddPrioritizedMappingToList(NameValueBuffer, Priority, Name);
-                until Next() = 0;
-        end;
+        IntegrationTableMapping.Reset();
+        IntegrationTableMapping.SetRange("Delete After Synchronization", false);
+        if TableID > 0 then
+            IntegrationTableMapping.SetRange("Table ID", TableID);
+        if IntegrationTableID > 0 then
+            IntegrationTableMapping.SetRange("Integration Table ID", IntegrationTableID);
+        IntegrationTableMapping.SetRange("Int. Table UID Field Type", Field.Type::GUID);
+        if IntegrationTableMapping.FindSet() then
+            repeat
+                AddPrioritizedMappingToList(NameValueBuffer, Priority, IntegrationTableMapping.Name);
+            until IntegrationTableMapping.Next() = 0;
     end;
 
     local procedure AddPrioritizedMappingToList(var NameValueBuffer: Record "Name/Value Buffer"; var Priority: Integer; MappingName: Code[20])
     begin
-        with NameValueBuffer do begin
-            SetRange(Value, MappingName);
+        NameValueBuffer.SetRange(Value, MappingName);
 
-            if not FindFirst() then begin
-                Init();
-                ID := Priority;
-                Name := Format(Priority);
-                Value := MappingName;
-                Insert();
-                Priority := Priority + 1;
-            end;
-
-            Reset();
+        if not NameValueBuffer.FindFirst() then begin
+            NameValueBuffer.Init();
+            NameValueBuffer.ID := Priority;
+            NameValueBuffer.Name := Format(Priority);
+            NameValueBuffer.Value := MappingName;
+            NameValueBuffer.Insert();
+            Priority := Priority + 1;
         end;
+
+        NameValueBuffer.Reset();
     end;
 
     local procedure ResetBCAccountConfigTemplate(TableNo: Integer): Code[10]

--- a/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Finance/GeneralLedger/Journal/GenJournalLine.Table.al
@@ -6294,7 +6294,7 @@ table 81 "Gen. Journal Line"
                         then
                             Error(
                               Text1500001,
-                              FieldName("Applies-to Doc. No."), FieldName("Adjustment Applies-to"));
+                              FieldCaption("Applies-to Doc. No."), FieldCaption("Adjustment Applies-to"));
                         "Applies-to Doc. Type" := CustLedgEntry."Document Type";
                         "BAS Adjustment" := BASManagement.CheckBASPeriod("Document Date", CustLedgEntry."Document Date");
                     end else
@@ -8118,7 +8118,7 @@ table 81 "Gen. Journal Line"
                         then
                             Error(
                               Text1500001,
-                              FieldName("Applies-to Doc. No."), FieldName("Adjustment Applies-to"));
+                              FieldCaption("Applies-to Doc. No."), FieldCaption("Adjustment Applies-to"));
                         "Applies-to Doc. Type" := CustLedgEntry."Document Type";
                         "BAS Adjustment" := BASManagement.CheckBASPeriod("Document Date", CustLedgEntry."Document Date");
                     end;

--- a/src/Layers/APAC/BaseApp/Local/FinancialMgt/GeneralLedger/Journal/RecurringAmountDistribute.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Local/FinancialMgt/GeneralLedger/Journal/RecurringAmountDistribute.Codeunit.al
@@ -21,7 +21,7 @@ codeunit 17100 "Recurring Amount - Distribute"
             GenJnlLine2."Recurring Method" := Rec."Recurring Method"::"RB Reversing Balance";
             Error(
               '%1 must be either %2 or %3.',
-              Rec.FieldName("Recurring Method"),
+              Rec.FieldCaption("Recurring Method"),
               GenJnlLine1."Recurring Method",
               GenJnlLine2."Recurring Method");
         end;

--- a/src/Layers/APAC/BaseApp/Sales/Document/SalesHeader.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/SalesHeader.Table.al
@@ -6807,7 +6807,7 @@ table 36 "Sales Header"
             then
                 Error(
                   Text1500000,
-                  FieldName("Applies-to Doc. No."), FieldName("Adjustment Applies-to"));
+                  FieldCaption("Applies-to Doc. No."), FieldCaption("Adjustment Applies-to"));
             "Applies-to Doc. Type" := CustLedgEntry."Document Type";
             "BAS Adjustment" := BASManagement.CheckBASPeriod("Document Date", CustLedgEntry."Document Date");
         end else begin

--- a/src/Layers/APAC/BaseApp/Sales/Receivables/CustEntryEdit.Codeunit.al
+++ b/src/Layers/APAC/BaseApp/Sales/Receivables/CustEntryEdit.Codeunit.al
@@ -199,7 +199,7 @@ codeunit 103 "Cust. Entry-Edit"
             then
                 Error(
                   NotIdenticalErr,
-                  CurrentSalesHeader.FieldName("Applies-to Doc. No."), CurrentSalesHeader.FieldName("Adjustment Applies-to"));
+                  CurrentSalesHeader.FieldCaption("Applies-to Doc. No."), CurrentSalesHeader.FieldCaption("Adjustment Applies-to"));
             CurrentSalesHeader."Applies-to Doc. Type" := CustLedgEntry."Document Type";
             CurrentSalesHeader."BAS Adjustment" := BASManagement.CheckBASPeriod(CurrentSalesHeader."Document Date", CustLedgEntry."Document Date");
 

--- a/src/Layers/CH/BaseApp/Finance/Currency/MapCurrencyExchangeRate.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/Currency/MapCurrencyExchangeRate.Codeunit.al
@@ -266,7 +266,7 @@ codeunit 1280 "Map Currency Exchange Rate"
             DataExchFieldMapping.SetRange("Data Exch. Def Code", DataExch."Data Exch. Def Code");
             DataExchFieldMapping.SetRange("Field ID", TempField."No.");
             if DataExchFieldMapping.IsEmpty() then
-                Error(FieldNotMappedErr, TempField.FieldName);
+                Error(FieldNotMappedErr, TempField."Field Caption");
         until TempField.Next() = 0;
     end;
 

--- a/src/Layers/CZ/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
+++ b/src/Layers/CZ/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
@@ -1902,6 +1902,89 @@ codeunit 138008 "Cust/Vend/Item/Empl Templates"
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure CustomerTemplCardControls()
+    var
+        CustomerCardPageControlField: Record "Page Control Field";
+        CustomerTemplCardPageControlField: Record "Page Control Field";
+        CustomerTemplField: Record Field;
+    begin
+        CustomerTemplCardPageControlField.SetRange(PageNo, Page::"Customer Templ. Card");
+
+        CustomerCardPageControlField.SetRange(PageNo, Page::"Customer Card");
+        CustomerCardPageControlField.SetFilter(FieldNo, '<>0');
+        if CustomerCardPageControlField.FindSet() then
+            repeat
+                if CustomerTemplField.Get(Database::"Customer Templ.", CustomerCardPageControlField.FieldNo) then begin
+                    CustomerTemplCardPageControlField.SetRange(FieldNo, CustomerCardPageControlField.FieldNo);
+                    if CustomerTemplCardPageControlField.IsEmpty() then
+                        Error('%1 should exist on the customer template card.', CustomerCardPageControlField.ControlName);
+                end;
+            until CustomerCardPageControlField.Next() = 0;
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure VendorTemplCardControls()
+    var
+        VendorCardPageControlField: Record "Page Control Field";
+        VendorTemplCardPageControlField: Record "Page Control Field";
+        VendorTemplField: Record Field;
+    begin
+        VendorTemplCardPageControlField.SetRange(PageNo, Page::"Vendor Templ. Card");
+
+        VendorCardPageControlField.SetRange(PageNo, Page::"Vendor Card");
+        VendorCardPageControlField.SetFilter(FieldNo, '<>0');
+        if VendorCardPageControlField.FindSet() then
+            repeat
+                if VendorTemplField.Get(Database::"Vendor Templ.", VendorCardPageControlField.FieldNo) then begin
+                    VendorTemplCardPageControlField.SetRange(FieldNo, VendorCardPageControlField.FieldNo);
+                    if VendorTemplCardPageControlField.IsEmpty() then
+                        Error('%1 should exist on the Vendor template card.', VendorCardPageControlField.ControlName);
+                end;
+            until VendorCardPageControlField.Next() = 0;
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ItemTemplCardControls()
+    var
+        ItemCardPageControlField: Record "Page Control Field";
+        ItemTemplCardPageControlField: Record "Page Control Field";
+        ItemField: Record Field;
+        ItemTemplField: Record Field;
+        FieldExclusionList: List of [Integer];
+    begin
+        FillItemFieldExclusionList(FieldExclusionList);
+
+        // Verify fields in "Item" and "Item Templ." tables, all fields should match or added in the exclusion list
+        ItemField.SetRange(TableNo, Database::Item);
+        ItemField.SetRange(Class, ItemField.Class::Normal);
+        ItemField.SetRange(ObsoleteState, ItemField.ObsoleteState::No);
+        ItemField.SetRange("No.", 1, 9999); // Only check w1 fields
+        if ItemField.FindSet() then
+            repeat
+                if not FieldExclusionList.Contains(ItemField."No.") then
+                    if not ItemTemplField.Get(Database::"Item Templ.", ItemField."No.") then
+                        Error('%1 field should exist in "Item Templ." table or added to exclusion list', ItemField."Field Caption");
+            until ItemField.Next() = 0;
+
+        // Verify controls on "Item Card" and "Item Templ. Card" pages, all controls should match or added in the exclusion list
+        ItemTemplCardPageControlField.SetRange(PageNo, Page::"Item Templ. Card");
+        ItemCardPageControlField.SetRange(PageNo, Page::"Item Card");
+        ItemCardPageControlField.SetFilter(FieldNo, '<>0');
+        if ItemCardPageControlField.FindSet() then
+            repeat
+                if not FieldExclusionList.Contains(ItemCardPageControlField.FieldNo) then
+                    if ItemTemplField.Get(Database::"Item Templ.", ItemCardPageControlField.FieldNo) then begin
+                        ItemTemplCardPageControlField.SetRange(FieldNo, ItemCardPageControlField.FieldNo);
+                        if ItemTemplCardPageControlField.IsEmpty() then
+                            Error('%1 control should exist on the item template card or added to exclusion list.', ItemCardPageControlField.ControlName);
+                    end;
+            until ItemCardPageControlField.Next() = 0;
+    end;
+
+    [Test]
     procedure CustomerRecordAfterApplyCustomerTemplate()
     var
         Customer: Record Customer;

--- a/src/Layers/CZ/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
+++ b/src/Layers/CZ/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
@@ -3084,6 +3084,55 @@ codeunit 138008 "Cust/Vend/Item/Empl Templates"
         Assert.RecordIsNotEmpty(ItemAttributeValueMapping);
     end;
 
+    local procedure FillItemFieldExclusionList(var FieldExclusionList: List of [Integer])
+    var
+        Item: Record Item;
+    begin
+        FieldExclusionList.Add(Item.FieldNo("Prevent Negative Inventory"));
+        FieldExclusionList.Add(Item.FieldNo("Stockout Warning"));
+        FieldExclusionList.Add(Item.FieldNo("Variant Mandatory if Exists"));
+        FieldExclusionList.Add(Item.FieldNo("No."));
+        FieldExclusionList.Add(Item.FieldNo("No. 2"));
+        FieldExclusionList.Add(Item.FieldNo("Alternative Item No."));
+        FieldExclusionList.Add(Item.FieldNo("Description"));
+        FieldExclusionList.Add(Item.FieldNo("Search Description"));
+        FieldExclusionList.Add(Item.FieldNo("Description 2"));
+        FieldExclusionList.Add(Item.FieldNo("Last Direct Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Cost is Adjusted"));
+        FieldExclusionList.Add(Item.FieldNo("Allow Online Adjustment"));
+        FieldExclusionList.Add(Item.FieldNo("Excluded from Cost Adjustment"));
+        FieldExclusionList.Add(Item.FieldNo("Last DateTime Modified"));
+        FieldExclusionList.Add(Item.FieldNo("Last Date Modified"));
+        FieldExclusionList.Add(Item.FieldNo("Last Time Modified"));
+        FieldExclusionList.Add(Item.FieldNo("Picture"));
+        FieldExclusionList.Add(Item.FieldNo("Application Wksh. User ID"));
+        FieldExclusionList.Add(Item.FieldNo("Low-Level Code"));
+        FieldExclusionList.Add(Item.FieldNo("Last Unit Cost Calc. Date"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Material Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Capacity Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Inventory Value Zero"));
+        FieldExclusionList.Add(Item.FieldNo("Sales Unit of Measure"));
+        FieldExclusionList.Add(Item.FieldNo("Purch. Unit of Measure"));
+        FieldExclusionList.Add(Item.FieldNo("Created From Nonstock Item"));
+        FieldExclusionList.Add(Item.FieldNo("Put-away Unit of Measure Code"));
+        FieldExclusionList.Add(Item.FieldNo("Last Counting Period Update"));
+        FieldExclusionList.Add(Item.FieldNo("Next Counting Start Date"));
+        FieldExclusionList.Add(Item.FieldNo("Next Counting End Date"));
+        FieldExclusionList.Add(Item.FieldNo("Unit of Measure Id"));
+        FieldExclusionList.Add(Item.FieldNo("Tax Group Id"));
+        FieldExclusionList.Add(Item.FieldNo("Item Category Id"));
+        FieldExclusionList.Add(Item.FieldNo("Inventory Posting Group Id"));
+        FieldExclusionList.Add(Item.FieldNo("Gen. Prod. Posting Group Id"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Material Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Capacity Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Subcontrd. Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Cap. Ovhd Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Mfg. Ovhd Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Subcontracted Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Mfg. Ovhd Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Cap. Overhead Cost"));
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Cust/Vend/Item/Empl Templates");

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Account/GLAccount.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Account/GLAccount.Table.al
@@ -76,7 +76,7 @@ table 15 "G/L Account"
                 if (xRec."No." <> '') then
                     if (StrLen("No.") > 5) <> (StrLen(xRec."No.") > 5) then
                         Error(Text1100001,
-                          FieldName("Account Type"));
+                          FieldCaption("Account Type"));
                 Evaluate(TestNo, CopyStr("No.", 1, 1));
                 if TestNo in [6 .. 7] then
                     "Income/Balance" := "Income/Balance"::"Income Statement"
@@ -1128,7 +1128,7 @@ table 15 "G/L Account"
                 if (GLEntry.Find('-')) and (Balance <> 0) then
                     if xRec."Ignore in 347 Report" <> "Ignore in 347 Report" then
                         Message(Text1100002 + Text1100003
-                          , FieldName(Balance));
+                          , FieldCaption(Balance));
             end;
         }
         field(10702; "Ignore Discounts"; Boolean)

--- a/src/Layers/ES/BaseApp/Finance/GeneralLedger/Setup/GeneralLedgerSetup.Table.al
+++ b/src/Layers/ES/BaseApp/Finance/GeneralLedger/Setup/GeneralLedgerSetup.Table.al
@@ -1867,14 +1867,14 @@ table 98 "General Ledger Setup"
         VATPostingSetup.SetRange("Adjust for Payment Discount", true);
         if VATPostingSetup.FindFirst() then
             Error(
-              '%1 %2 %3 use %4.', VATPostingSetup.TableName,
+              '%1 %2 %3 use %4.', VATPostingSetup.TableCaption,
               VATPostingSetup."VAT Bus. Posting Group", VATPostingSetup."VAT Prod. Posting Group",
-              VATPostingSetup.FieldName("Adjust for Payment Discount"));
+              VATPostingSetup.FieldCaption("Adjust for Payment Discount"));
         TaxJurisdiction.SetRange("Adjust for Payment Discount", true);
         if TaxJurisdiction.FindFirst() then
             Error(
-              '%1 %2 use %3.', TaxJurisdiction.TableName,
-              TaxJurisdiction.Code, TaxJurisdiction.FieldName("Adjust for Payment Discount"));
+              '%1 %2 use %3.', TaxJurisdiction.TableCaption,
+              TaxJurisdiction.Code, TaxJurisdiction.FieldCaption("Adjust for Payment Discount"));
     end;
 
     /// <summary>

--- a/src/Layers/IT/BaseApp/Sales/Document/CombineReturnReceipts.Report.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/CombineReturnReceipts.Report.al
@@ -111,7 +111,7 @@ report 6653 "Combine Return Receipts"
             trigger OnPreDataItem()
             begin
                 if GetFilter("Operation Type") <> '' then
-                    Error(Text1130009, FieldName("Operation Type"))
+                    Error(Text1130009, FieldCaption("Operation Type"))
                 else
                     SetRange("Operation Type", OperationType.Code);
 

--- a/src/Layers/IT/BaseApp/Sales/Document/CombineShipments.Report.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/CombineShipments.Report.al
@@ -188,7 +188,7 @@ report 295 "Combine Shipments"
             trigger OnPreDataItem()
             begin
                 if GetFilter("Operation Type") <> '' then
-                    Error(MissingFilterErr, FieldName("Operation Type"));
+                    Error(MissingFilterErr, FieldCaption("Operation Type"));
 
                 SetRange("Operation Type", OperationType.Code);
 

--- a/src/Layers/NA/BaseApp/Local/Projects/Project/Reports/OpenPurchaseInvoicesbyJob.Report.al
+++ b/src/Layers/NA/BaseApp/Local/Projects/Project/Reports/OpenPurchaseInvoicesbyJob.Report.al
@@ -25,6 +25,7 @@ report 10092 "Open Purchase Invoices by Job"
             column(FORMAT_TODAY_0_4_; Format(Today, 0, 4))
             {
             }
+
             column(TIME; Time)
             {
             }
@@ -169,7 +170,7 @@ report 10092 "Open Purchase Invoices by Job"
                         if not AlreadyDisplayedMessage then begin
                             Message(Text000 + ' ' +
                               Text001,
-                              TableName, FieldCaption("Job No."), FieldCaption("Document No."));
+                              TableCaption, FieldCaption("Job No."), FieldCaption("Document No."));
                             AlreadyDisplayedMessage := true;
                         end;
                     end;

--- a/src/Layers/NA/BaseApp/Purchases/Posting/PurchPostInvoice.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Purchases/Posting/PurchPostInvoice.Codeunit.al
@@ -1320,7 +1320,7 @@ codeunit 816 "Purch. Post Invoice" implements "Invoice Posting"
                             if PurchLine."Gen. Prod. Posting Group" = '' then
                                 Error(
                                   GenProdPostingGrDiscErr,
-                                  PurchLine.FieldName("Gen. Prod. Posting Group"), PurchLine.FieldName("Line No."), PurchLine."Line No.")
+                                  PurchLine.FieldCaption("Gen. Prod. Posting Group"), PurchLine.FieldCaption("Line No."), PurchLine."Line No.")
                             else
                                 GenPostingSetup.Get(PurchLine."Gen. Bus. Posting Group", PurchLine."Gen. Prod. Posting Group");
                     end else

--- a/src/Layers/NA/BaseApp/Sales/Posting/SalesPostInvoice.Codeunit.al
+++ b/src/Layers/NA/BaseApp/Sales/Posting/SalesPostInvoice.Codeunit.al
@@ -1026,7 +1026,7 @@ codeunit 815 "Sales Post Invoice" implements "Invoice Posting"
                             if SalesLine."Gen. Prod. Posting Group" = '' then
                                 Error(
                                   GenProdPostingGrDiscErr,
-                                  SalesLine.FieldName("Gen. Prod. Posting Group"), SalesLine.FieldName("Line No."), SalesLine."Line No.")
+                                  SalesLine.FieldCaption("Gen. Prod. Posting Group"), SalesLine.FieldCaption("Line No."), SalesLine."Line No.")
                             else
                                 GenPostingSetup.Get(SalesLine."Gen. Bus. Posting Group", SalesLine."Gen. Prod. Posting Group");
                     end else

--- a/src/Layers/NL/Tests/TestLibraries/NLXMLReadHelper.Codeunit.al
+++ b/src/Layers/NL/Tests/TestLibraries/NLXMLReadHelper.Codeunit.al
@@ -46,9 +46,9 @@ codeunit 143001 "NL XML Read Helper"
     var
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetNodeByElementName(ElementName, Node);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedError('Element is missing!');
     end;
 
@@ -68,9 +68,9 @@ codeunit 143001 "NL XML Read Helper"
     var
         Attribute: DotNet XmlAttribute;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetAttributeFromElement(ElementName, AttributeName, Attribute);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedError('Attribute is missing!');
     end;
 

--- a/src/Layers/NO/DemoTool/GLAccountsConversion.Table.al
+++ b/src/Layers/NO/DemoTool/GLAccountsConversion.Table.al
@@ -17,6 +17,7 @@ table 160800 "GL Accounts Conversion"
                 OpprettMidlertidigKontonr();
             end;
         }
+
         field(4; "Account Type"; Option)
         {
             Caption = 'Account Type';
@@ -28,7 +29,7 @@ table 160800 "GL Accounts Conversion"
             begin
                 if ("Original Account No." <> '') and (xRec."Account Type" = xRec."Account Type"::Posting) then
                     Error('Nei! Du kan ikke endre %1 fra %2 til %3.\Poster på kontoen kan da ikke flyttes på fornuftig måte.',
-                      FieldName("Account Type"), xRec."Account Type", "Account Type");
+                      FieldCaption("Account Type"), xRec."Account Type", "Account Type");
 
                 Totaling := '';
                 if "Account Type" = "Account Type"::Posting then begin

--- a/src/Layers/NO/Tests/TestLibraries/NOXMLReadHelper.Codeunit.al
+++ b/src/Layers/NO/Tests/TestLibraries/NOXMLReadHelper.Codeunit.al
@@ -47,9 +47,9 @@ codeunit 143001 "NO XML Read Helper"
     var
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetNodeByElementName(ElementName, Node);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedError(StrSubstNo(MissingElementErr, ElementName));
     end;
 
@@ -89,9 +89,9 @@ codeunit 143001 "NO XML Read Helper"
     var
         Attribute: DotNet XmlAttribute;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetAttributeFromElement(ElementName, AttributeName, Attribute);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedError('Attribute is missing!');
     end;
 

--- a/src/Layers/RU/BaseApp/FixedAssets/FixedAsset/FAGetJournal.Codeunit.al
+++ b/src/Layers/RU/BaseApp/FixedAssets/FixedAsset/FAGetJournal.Codeunit.al
@@ -190,7 +190,7 @@ codeunit 5639 "FA Get Journal"
            (BatchName = BatchName2) and
            (TemplateName = TemplateName2)
         then
-            Error(Text001, FAJnlSetup.TableName);
+            Error(Text001, FAJnlSetup.TableCaption);
     end;
 }
 

--- a/src/Layers/RU/DemoTool/InterfaceRussianAccounting.Codeunit.al
+++ b/src/Layers/RU/DemoTool/InterfaceRussianAccounting.Codeunit.al
@@ -78,28 +78,28 @@ codeunit 163400 "Interface Russian Accounting"
             if StatReport.FindSet() then
                 repeat
                     if Translate.ReportCode(StatReport.Code) = StatReport.FieldName(Code) then
-                        Error('Missing translation for %1 %2 %3', StatReport.TableName, StatReport.FieldName(Code), StatReport.Code);
+                        Error('Missing translation for %1 %2 %3', StatReport.TableCaption, StatReport.FieldCaption(Code), StatReport.Code);
                 until StatReport.Next() = 0;
 
             FormatVersion.Reset();
             if FormatVersion.FindSet() then
                 repeat
                     if Translate.ReportCode(FormatVersion.Code) = FormatVersion.FieldName(Code) then
-                        Error('Missing translation for %1 %2 %3', FormatVersion.TableName, FormatVersion.FieldName(Code), FormatVersion.Code);
+                        Error('Missing translation for %1 %2 %3', FormatVersion.TableCaption, FormatVersion.FieldCaption(Code), FormatVersion.Code);
                 until FormatVersion.Next() = 0;
 
             AccSchName.Reset();
             if AccSchName.FindSet() then
                 repeat
                     if Translate.ReportCode(AccSchName.Name) = AccSchName.FieldName(Name) then
-                        Error('Missing translation for %1 %2 %3', AccSchName.TableName, AccSchName.FieldName(Name), AccSchName.Name);
+                        Error('Missing translation for %1 %2 %3', AccSchName.TableCaption, AccSchName.FieldCaption(Name), AccSchName.Name);
                 until AccSchName.Next() = 0;
 
             ColumnLayoutName.Reset();
             if ColumnLayoutName.FindSet() then
                 repeat
                     if Translate.ReportCode(ColumnLayoutName.Name) = ColumnLayoutName.FieldName(Name) then
-                        Error('Missing translation for %1 %2 %3', ColumnLayoutName.TableName, ColumnLayoutName.FieldName(Name), ColumnLayoutName.Name);
+                        Error('Missing translation for %1 %2 %3', ColumnLayoutName.TableCaption, ColumnLayoutName.FieldCaption(Name), ColumnLayoutName.Name);
                 until ColumnLayoutName.Next() = 0;
         end;
 

--- a/src/Layers/RU/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
+++ b/src/Layers/RU/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
@@ -3410,6 +3410,55 @@ codeunit 138008 "Cust/Vend/Item/Empl Templates"
         Assert.RecordIsNotEmpty(ItemAttributeValueMapping);
     end;
 
+    local procedure FillItemFieldExclusionList(var FieldExclusionList: List of [Integer])
+    var
+        Item: Record Item;
+    begin
+        FieldExclusionList.Add(Item.FieldNo("Prevent Negative Inventory"));
+        FieldExclusionList.Add(Item.FieldNo("Stockout Warning"));
+        FieldExclusionList.Add(Item.FieldNo("Variant Mandatory if Exists"));
+        FieldExclusionList.Add(Item.FieldNo("No."));
+        FieldExclusionList.Add(Item.FieldNo("No. 2"));
+        FieldExclusionList.Add(Item.FieldNo("Alternative Item No."));
+        FieldExclusionList.Add(Item.FieldNo("Description"));
+        FieldExclusionList.Add(Item.FieldNo("Search Description"));
+        FieldExclusionList.Add(Item.FieldNo("Description 2"));
+        FieldExclusionList.Add(Item.FieldNo("Last Direct Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Cost is Adjusted"));
+        FieldExclusionList.Add(Item.FieldNo("Allow Online Adjustment"));
+        FieldExclusionList.Add(Item.FieldNo("Excluded from Cost Adjustment"));
+        FieldExclusionList.Add(Item.FieldNo("Last DateTime Modified"));
+        FieldExclusionList.Add(Item.FieldNo("Last Date Modified"));
+        FieldExclusionList.Add(Item.FieldNo("Last Time Modified"));
+        FieldExclusionList.Add(Item.FieldNo("Picture"));
+        FieldExclusionList.Add(Item.FieldNo("Application Wksh. User ID"));
+        FieldExclusionList.Add(Item.FieldNo("Low-Level Code"));
+        FieldExclusionList.Add(Item.FieldNo("Last Unit Cost Calc. Date"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Material Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Capacity Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Inventory Value Zero"));
+        FieldExclusionList.Add(Item.FieldNo("Sales Unit of Measure"));
+        FieldExclusionList.Add(Item.FieldNo("Purch. Unit of Measure"));
+        FieldExclusionList.Add(Item.FieldNo("Created From Nonstock Item"));
+        FieldExclusionList.Add(Item.FieldNo("Put-away Unit of Measure Code"));
+        FieldExclusionList.Add(Item.FieldNo("Last Counting Period Update"));
+        FieldExclusionList.Add(Item.FieldNo("Next Counting Start Date"));
+        FieldExclusionList.Add(Item.FieldNo("Next Counting End Date"));
+        FieldExclusionList.Add(Item.FieldNo("Unit of Measure Id"));
+        FieldExclusionList.Add(Item.FieldNo("Tax Group Id"));
+        FieldExclusionList.Add(Item.FieldNo("Item Category Id"));
+        FieldExclusionList.Add(Item.FieldNo("Inventory Posting Group Id"));
+        FieldExclusionList.Add(Item.FieldNo("Gen. Prod. Posting Group Id"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Material Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Capacity Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Subcontrd. Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Cap. Ovhd Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Single-Level Mfg. Ovhd Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Subcontracted Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Mfg. Ovhd Cost"));
+        FieldExclusionList.Add(Item.FieldNo("Rolled-up Cap. Overhead Cost"));
+    end;
+
     local procedure Initialize()
     begin
         LibraryTestInitialize.OnTestInitialize(Codeunit::"Cust/Vend/Item/Empl Templates");

--- a/src/Layers/RU/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
+++ b/src/Layers/RU/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
@@ -2177,6 +2177,89 @@ codeunit 138008 "Cust/Vend/Item/Empl Templates"
     end;
 
     [Test]
+    [Scope('OnPrem')]
+    procedure CustomerTemplCardControls()
+    var
+        CustomerCardPageControlField: Record "Page Control Field";
+        CustomerTemplCardPageControlField: Record "Page Control Field";
+        CustomerTemplField: Record Field;
+    begin
+        CustomerTemplCardPageControlField.SetRange(PageNo, Page::"Customer Templ. Card");
+
+        CustomerCardPageControlField.SetRange(PageNo, Page::"Customer Card");
+        CustomerCardPageControlField.SetFilter(FieldNo, '<>0');
+        if CustomerCardPageControlField.FindSet() then
+            repeat
+                if CustomerTemplField.Get(Database::"Customer Templ.", CustomerCardPageControlField.FieldNo) then begin
+                    CustomerTemplCardPageControlField.SetRange(FieldNo, CustomerCardPageControlField.FieldNo);
+                    if CustomerTemplCardPageControlField.IsEmpty() then
+                        Error('%1 should exist on the customer template card.', CustomerCardPageControlField.ControlName);
+                end;
+            until CustomerCardPageControlField.Next() = 0;
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure VendorTemplCardControls()
+    var
+        VendorCardPageControlField: Record "Page Control Field";
+        VendorTemplCardPageControlField: Record "Page Control Field";
+        VendorTemplField: Record Field;
+    begin
+        VendorTemplCardPageControlField.SetRange(PageNo, Page::"Vendor Templ. Card");
+
+        VendorCardPageControlField.SetRange(PageNo, Page::"Vendor Card");
+        VendorCardPageControlField.SetFilter(FieldNo, '<>0');
+        if VendorCardPageControlField.FindSet() then
+            repeat
+                if VendorTemplField.Get(Database::"Vendor Templ.", VendorCardPageControlField.FieldNo) then begin
+                    VendorTemplCardPageControlField.SetRange(FieldNo, VendorCardPageControlField.FieldNo);
+                    if VendorTemplCardPageControlField.IsEmpty() then
+                        Error('%1 should exist on the Vendor template card.', VendorCardPageControlField.ControlName);
+                end;
+            until VendorCardPageControlField.Next() = 0;
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ItemTemplCardControls()
+    var
+        ItemCardPageControlField: Record "Page Control Field";
+        ItemTemplCardPageControlField: Record "Page Control Field";
+        ItemField: Record Field;
+        ItemTemplField: Record Field;
+        FieldExclusionList: List of [Integer];
+    begin
+        FillItemFieldExclusionList(FieldExclusionList);
+
+        // Verify fields in "Item" and "Item Templ." tables, all fields should match or added in the exclusion list
+        ItemField.SetRange(TableNo, Database::Item);
+        ItemField.SetRange(Class, ItemField.Class::Normal);
+        ItemField.SetRange(ObsoleteState, ItemField.ObsoleteState::No);
+        ItemField.SetRange("No.", 1, 9999); // Only check w1 fields
+        if ItemField.FindSet() then
+            repeat
+                if not FieldExclusionList.Contains(ItemField."No.") then
+                    if not ItemTemplField.Get(Database::"Item Templ.", ItemField."No.") then
+                        Error('%1 field should exist in "Item Templ." table or added to exclusion list', ItemField."Field Caption");
+            until ItemField.Next() = 0;
+
+        // Verify controls on "Item Card" and "Item Templ. Card" pages, all controls should match or added in the exclusion list
+        ItemTemplCardPageControlField.SetRange(PageNo, Page::"Item Templ. Card");
+        ItemCardPageControlField.SetRange(PageNo, Page::"Item Card");
+        ItemCardPageControlField.SetFilter(FieldNo, '<>0');
+        if ItemCardPageControlField.FindSet() then
+            repeat
+                if not FieldExclusionList.Contains(ItemCardPageControlField.FieldNo) then
+                    if ItemTemplField.Get(Database::"Item Templ.", ItemCardPageControlField.FieldNo) then begin
+                        ItemTemplCardPageControlField.SetRange(FieldNo, ItemCardPageControlField.FieldNo);
+                        if ItemTemplCardPageControlField.IsEmpty() then
+                            Error('%1 control should exist on the item template card or added to exclusion list.', ItemCardPageControlField.ControlName);
+                    end;
+            until ItemCardPageControlField.Next() = 0;
+    end;
+
+    [Test]
     procedure CustomerRecordAfterApplyCustomerTemplate()
     var
         Customer: Record Customer;

--- a/src/Layers/W1/BaseApp/Finance/Currency/MapCurrencyExchangeRate.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Currency/MapCurrencyExchangeRate.Codeunit.al
@@ -256,7 +256,7 @@ codeunit 1280 "Map Currency Exchange Rate"
             DataExchFieldMapping.SetRange("Data Exch. Def Code", DataExch."Data Exch. Def Code");
             DataExchFieldMapping.SetRange("Field ID", TempField."No.");
             if DataExchFieldMapping.IsEmpty() then
-                Error(FieldNotMappedErr, TempField.FieldName);
+                Error(FieldNotMappedErr, TempField."Field Caption");
         until TempField.Next() = 0;
     end;
 

--- a/src/Layers/W1/BaseApp/Modules/System/JobQueue/JobQueueEntry.Table.al
+++ b/src/Layers/W1/BaseApp/Modules/System/JobQueue/JobQueueEntry.Table.al
@@ -771,16 +771,16 @@ table 472 "Job Queue Entry"
         DummyErrorMessage: Record "Error Message";
     begin
         if not DummyJobQueueEntry.WritePermission() then
-            Error(NoPermissionsErr, DummyJobQueueEntry.TableName());
+            Error(NoPermissionsErr, DummyJobQueueEntry.TableCaption());
 
         if not DummyJobQueueLogEntry.WritePermission() then
-            Error(NoPermissionsErr, DummyJobQueueLogEntry.TableName());
+            Error(NoPermissionsErr, DummyJobQueueLogEntry.TableCaption());
 
         if not DummyErrorMessageRegister.WritePermission() then
-            Error(NoPermissionsErr, DummyErrorMessageRegister.TableName());
+            Error(NoPermissionsErr, DummyErrorMessageRegister.TableCaption());
 
         if not DummyErrorMessage.WritePermission() then
-            Error(NoPermissionsErr, DummyErrorMessage.TableName());
+            Error(NoPermissionsErr, DummyErrorMessage.TableCaption());
     end;
 
     procedure HasRequiredPermissions(): Boolean

--- a/src/Layers/W1/BaseApp/Projects/Project/Setup/JobsSetupWizard.Page.al
+++ b/src/Layers/W1/BaseApp/Projects/Project/Setup/JobsSetupWizard.Page.al
@@ -38,6 +38,7 @@ page 1824 "Jobs Setup Wizard"
                     Editable = false;
                     ShowCaption = false;
                 }
+
             }
             group(Control98)
             {
@@ -86,7 +87,7 @@ page 1824 "Jobs Setup Wizard"
                         trigger OnValidate()
                         begin
                             if not NoSeries.Get(NoSeriesJob) then begin
-                                Message(ValueNotExistMsg, JobsSetup.FieldName("Job Nos."));
+                                Message(ValueNotExistMsg, JobsSetup.FieldCaption("Job Nos."));
                                 NoSeriesJob := ''
                             end
                         end;
@@ -100,7 +101,7 @@ page 1824 "Jobs Setup Wizard"
                         trigger OnValidate()
                         begin
                             if not NoSeries.Get(NoSeriesResource) then begin
-                                Message(ValueNotExistMsg, ResourcesSetup.FieldName("Resource Nos."));
+                                Message(ValueNotExistMsg, ResourcesSetup.FieldCaption("Resource Nos."));
                                 NoSeriesResource := ''
                             end
                         end;
@@ -114,7 +115,7 @@ page 1824 "Jobs Setup Wizard"
                         trigger OnValidate()
                         begin
                             if not NoSeries.Get(NoSeriesTimeSheet) then begin
-                                Message(ValueNotExistMsg, ResourcesSetup.FieldName("Time Sheet Nos."));
+                                Message(ValueNotExistMsg, ResourcesSetup.FieldCaption("Time Sheet Nos."));
                                 NoSeriesTimeSheet := ''
                             end
                         end;
@@ -128,7 +129,7 @@ page 1824 "Jobs Setup Wizard"
                         trigger OnValidate()
                         begin
                             if not NoSeries.Get(NoSeriesTimeSheet) then begin
-                                Message(ValueNotExistMsg, JobsSetup.FieldName("Job WIP Nos."));
+                                Message(ValueNotExistMsg, JobsSetup.FieldCaption("Job WIP Nos."));
                                 NoSeriesJobWIP := ''
                             end
                         end;
@@ -155,7 +156,7 @@ page 1824 "Jobs Setup Wizard"
                             JobPostingGroup: Record "Job Posting Group";
                         begin
                             if not JobPostingGroup.Get(DefaultJobPostingGroup) then begin
-                                Message(ValueNotExistMsg, JobsSetup.FieldName("Default Job Posting Group"));
+                                Message(ValueNotExistMsg, JobsSetup.FieldCaption("Default Job Posting Group"));
                                 DefaultJobPostingGroup := ''
                             end
                         end;
@@ -177,7 +178,7 @@ page 1824 "Jobs Setup Wizard"
                             JobWIPMethod: Record "Job WIP Method";
                         begin
                             if not JobWIPMethod.Get(DefaultWIPMethod) then begin
-                                Message(ValueNotExistMsg, JobsSetup.FieldName("Default WIP Posting Method"));
+                                Message(ValueNotExistMsg, JobsSetup.FieldCaption("Default WIP Posting Method"));
                                 DefaultWIPMethod := ''
                             end
                         end;

--- a/src/Layers/W1/BaseApp/System/Notifications/NotificationSchedule.Table.al
+++ b/src/Layers/W1/BaseApp/System/Notifications/NotificationSchedule.Table.al
@@ -339,9 +339,9 @@ table 1513 "Notification Schedule"
         DummyNotificationSetup: Record "Notification Setup";
     begin
         if not DummySentNotificationEntry.WritePermission() then
-            Error(NoPermissionsErr, WritePermissionTok, DummySentNotificationEntry.TableName());
+            Error(NoPermissionsErr, WritePermissionTok, DummySentNotificationEntry.TableCaption());
         if not DummyNotificationSetup.ReadPermission() then
-            Error(NoPermissionsErr, ReadPermissionTok, DummyNotificationSetup.TableName());
+            Error(NoPermissionsErr, ReadPermissionTok, DummyNotificationSetup.TableCaption());
     end;
 
     procedure ScheduleNotification(NotificationEntry: Record "Notification Entry")

--- a/src/Layers/W1/BaseApp/System/Utilities/TypeHelper.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/Utilities/TypeHelper.Codeunit.al
@@ -325,9 +325,13 @@ codeunit 10 "Type Helper"
     end;
 
     procedure TestFieldIsNotObsolete("Field": Record "Field")
+    var
+        RecordRef: RecordRef;
     begin
-        if Field.ObsoleteState = Field.ObsoleteState::Removed then
-            Error(ObsoleteFieldErr, Field."Field Caption", Field."Table Caption");
+        if Field.ObsoleteState = Field.ObsoleteState::Removed then begin
+            RecordRef.Open(Field.TableNo);
+            Error(ObsoleteFieldErr, Field."Field Caption", RecordRef.Caption());
+        end;
     end;
 
     procedure IsPhoneNumber(Input: Text): Boolean

--- a/src/Layers/W1/BaseApp/System/Utilities/TypeHelper.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/Utilities/TypeHelper.Codeunit.al
@@ -327,7 +327,7 @@ codeunit 10 "Type Helper"
     procedure TestFieldIsNotObsolete("Field": Record "Field")
     begin
         if Field.ObsoleteState = Field.ObsoleteState::Removed then
-            Error(ObsoleteFieldErr, Field."Field Caption", Field.TableName);
+            Error(ObsoleteFieldErr, Field."Field Caption", Field."Table Caption");
     end;
 
     procedure IsPhoneNumber(Input: Text): Boolean

--- a/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryAssembly.Codeunit.al
+++ b/src/Layers/W1/Tests/ApplicationTestLibrary/LibraryAssembly.Codeunit.al
@@ -234,9 +234,9 @@ codeunit 132207 "Library - Assembly"
         if ExpectedError = '' then
             BatchPostAssemblyOrders.RunModal()
         else begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror BatchPostAssemblyOrders.RunModal();
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ExpectedError) > 0, 'Actual:' + GetLastErrorText);
             ClearLastError();
         end;
@@ -1508,9 +1508,9 @@ codeunit 132207 "Library - Assembly"
         if ExpectedError = '' then
             AssemblyPost.Run(AssemblyHeader)
         else begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror AssemblyPost.Run(AssemblyHeader);
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ExpectedError) > 0,
               'Expected:' + ExpectedError + '. Actual:' + GetLastErrorText);
             ClearLastError();
@@ -1746,9 +1746,9 @@ codeunit 132207 "Library - Assembly"
         if ExpectedError = '' then
             AsmPostCtrl.Undo(PostedAssemblyHeader, RestoreAO)
         else begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror AsmPostCtrl.Undo(PostedAssemblyHeader, RestoreAO);
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ExpectedError) > 0, 'Actual:' + GetLastErrorText);
             ClearLastError();
         end;
@@ -1760,9 +1760,9 @@ codeunit 132207 "Library - Assembly"
     begin
         Commit();
         if AssemblyHeader.Quantity = 0 then begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror AssemblyHeader.UpdateUnitCost();
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             Assert.AreEqual(
               StrSubstNo(ErrorZeroQty, AssemblyHeader."No."), GetLastErrorText,
               'Actual:' + GetLastErrorText + '; Expected:' + StrSubstNo(ErrorZeroQty, AssemblyHeader."No."));
@@ -1774,9 +1774,9 @@ codeunit 132207 "Library - Assembly"
         if Item."Costing Method" <> Item."Costing Method"::Standard then
             AssemblyHeader.UpdateUnitCost()
         else begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror AssemblyHeader.UpdateUnitCost();
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             Assert.IsTrue(StrPos(GetLastErrorText, ErrorStdCost) > 0, 'Actual:' + GetLastErrorText + '; Expected:' + ErrorStdCost);
             ClearLastError();
         end;

--- a/src/Layers/W1/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
+++ b/src/Layers/W1/Tests/SMB/CustVendItemEmplTemplates.Codeunit.al
@@ -2242,7 +2242,7 @@ codeunit 138008 "Cust/Vend/Item/Empl Templates"
             repeat
                 if not FieldExclusionList.Contains(ItemField."No.") then
                     if not ItemTemplField.Get(Database::"Item Templ.", ItemField."No.") then
-                        Error('%1 field should exist in "Item Templ." table or added to exclusion list', ItemField.FieldName);
+                        Error('%1 field should exist in "Item Templ." table or added to exclusion list', ItemField."Field Caption");
             until ItemField.Next() = 0;
 
         // Verify controls on "Item Card" and "Item Templ. Card" pages, all controls should match or added in the exclusion list

--- a/src/Layers/W1/Tests/TestLibraries/LibraryCRMIntegration.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryCRMIntegration.Codeunit.al
@@ -1919,9 +1919,9 @@ codeunit 139164 "Library - CRM Integration"
         JobQueueEntryID := JobQueueEntry.ID;
         JobQueueEntry.SetStatus(JobQueueEntry.Status::Ready);
         if HandleError then begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror LibraryJobQueue.RunJobQueueDispatcher(JobQueueEntry);
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             LibraryJobQueue.RunJobQueueErrorHandler(JobQueueEntry);
         end else
             LibraryJobQueue.RunJobQueueDispatcher(JobQueueEntry);

--- a/src/Layers/W1/Tests/TestLibraries/LibraryJobQueue.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryJobQueue.Codeunit.al
@@ -71,9 +71,9 @@ codeunit 132458 "Library - Job Queue"
         JobQueueEntry.Status := JobQueueEntry.Status::Ready;
         JobQueueEntry.Modify();
         if WithErrorHandler then begin
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror RunJobQueueDispatcher(JobQueueEntry);
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
             RunJobQueueErrorHandler(JobQueueEntry);
         end
         else

--- a/src/Layers/W1/Tests/TestLibraries/LibraryPermissionsVerify.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryPermissionsVerify.Codeunit.al
@@ -101,9 +101,9 @@ codeunit 132216 "Library - Permissions Verify"
         RecordRef: RecordRef;
     begin
         RecordRef.Open(TableNo);
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror RecordRef.FindFirst();
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedError(StrSubstNo(MissingPermissionErr, Format(RecordRef.Caption)))
     end;
 
@@ -118,14 +118,14 @@ codeunit 132216 "Library - Permissions Verify"
     begin
         RecordRef.Init();
 
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror RecordRef.Insert(true);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.IsFalse(RecordRef.WritePermission, StrSubstNo(SupplementalPermissionErr, 'Insert', Format(RecordRef.Caption)));
 
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror RecordRef.Delete(true);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.IsFalse(RecordRef.WritePermission, StrSubstNo(SupplementalPermissionErr, 'Delete', Format(RecordRef.Caption)));
     end;
 }

--- a/src/Layers/W1/Tests/TestLibraries/LibraryPostPrevHandler.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryPostPrevHandler.Codeunit.al
@@ -65,13 +65,13 @@ codeunit 131011 "Library - Post. Prev. Handler"
         InsertRecord(RecVar);
         Assert.IsTrue(GenJnlPostPreview.IsActive(), 'GenJnlPostPreview.IsActive');
         if InvokeCommit then
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror Commit()
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
         else
-            #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+            #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
             asserterror GenJnlPostPreview.ThrowError();
-            #pragma warning restore AS0058, PTE0007
+            #pragma warning restore AA0161, AS0058, PTE0007
         Result := false;
     end;
 }

--- a/src/Layers/W1/Tests/TestLibraries/LibraryXMLRead.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryXMLRead.Codeunit.al
@@ -214,9 +214,9 @@ codeunit 131335 "Library - XML Read"
         [RunOnClient]
         XMLNode: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetNodeByElementName(NodeName, XMLNode);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -226,9 +226,9 @@ codeunit 131335 "Library - XML Read"
         [RunOnClient]
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(NotFoundAnyInSubtreeErr, NodeName, RootNodeName));
     end;
@@ -238,9 +238,9 @@ codeunit 131335 "Library - XML Read"
         [RunOnClient]
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -267,9 +267,9 @@ codeunit 131335 "Library - XML Read"
 
     procedure VerifyAttributeAbsenceInSubtree(RootNodeName: Text; NodeName: Text; AttributeName: Text)
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetAttributeValueInSubtree(RootNodeName, NodeName, AttributeName);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(AttributeNotFoundErr, NodeName, RootNodeName, AttributeName));
     end;

--- a/src/Layers/W1/Tests/TestLibraries/LibraryXMLReadOnServer.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryXMLReadOnServer.Codeunit.al
@@ -218,9 +218,9 @@ codeunit 131341 "Library - XML Read OnServer"
     var
         XMLNode: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetNodeByElementName(NodeName, XMLNode);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -230,9 +230,9 @@ codeunit 131341 "Library - XML Read OnServer"
     var
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(NotFoundAnyInSubtreeErr, NodeName, RootNodeName));
     end;
@@ -242,9 +242,9 @@ codeunit 131341 "Library - XML Read OnServer"
     var
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror LocateNodeInSubtree(Node, RootNodeName, NodeName, '', NodeMatchCriteria::FindByName);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(MissingElementErr, NodeName));
     end;
@@ -279,9 +279,9 @@ codeunit 131341 "Library - XML Read OnServer"
     [Scope('OnPrem')]
     procedure VerifyAttributeAbsenceInSubtree(RootNodeName: Text; NodeName: Text; AttributeName: Text)
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetAttributeValueInSubtree(RootNodeName, NodeName, AttributeName);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedErrorCode('Dialog');
         Assert.ExpectedError(StrSubstNo(AttributeNotFoundErr, NodeName, RootNodeName, AttributeName));
     end;

--- a/src/Layers/W1/Tests/TestLibraries/LibraryXPathXMLReader.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryXPathXMLReader.Codeunit.al
@@ -227,9 +227,9 @@ codeunit 131337 "Library - XPath XML Reader"
     var
         Node: DotNet XmlNode;
     begin
-        #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+        #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
         asserterror GetNodeByElementName(ElementName, Node);
-        #pragma warning restore AS0058, PTE0007
+        #pragma warning restore AA0161, AS0058, PTE0007
         Assert.ExpectedError('Element is missing!');
     end;
 

--- a/src/Layers/W1/Tests/TestLibraries/Referencedatafieldlist.Table.al
+++ b/src/Layers/W1/Tests/TestLibraries/Referencedatafieldlist.Table.al
@@ -9,6 +9,7 @@ table 130060 "Reference data - field list"
         {
             NotBlank = true;
         }
+
         field(2; "Table ID"; Integer)
         {
             TableRelation = AllObj."Object ID" where("Object Type" = const(Table));
@@ -61,9 +62,9 @@ table 130060 "Reference data - field list"
     local procedure CheckForZeroValues()
     begin
         if "Table ID" = 0 then
-            Error(Text001, FieldName("Table ID"));
+            Error(Text001, FieldCaption("Table ID"));
         if "Field ID" = 0 then
-            Error(Text001, FieldName("Field ID"));
+            Error(Text001, FieldCaption("Field ID"));
     end;
 }
 

--- a/src/Layers/W1/Tests/TestLibraries/TestProxyNotificationMgt.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/TestProxyNotificationMgt.Codeunit.al
@@ -69,9 +69,9 @@ codeunit 130231 "Test Proxy Notification Mgt."
             RemoveIgnoringNotifications();
             IsSuccess := not HasNotificationContextEntries();
             if not IsSuccess then
-                #pragma warning disable AS0058, PTE0007 // Accepted violation: this is a test library helper that intentionally wraps asserterror for use by test codeunits.
+                #pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this normal-subtype test helper intentionally executes assertions for reusable test infrastructure. Tracked by AB#640773.
                 asserterror Error(NotificationErr, GetFirstRecordIDText());
-                #pragma warning restore AS0058, PTE0007
+                #pragma warning restore AA0161, AS0058, PTE0007
         end;
     end;
 

--- a/src/Layers/W1/Tests/TestRunner-Internal/SnapTestRunner.Codeunit.al
+++ b/src/Layers/W1/Tests/TestRunner-Internal/SnapTestRunner.Codeunit.al
@@ -101,7 +101,7 @@ codeunit 130200 "Snap Test Runner"
 
         // File operations are not atomic, so this may still go wrong.
         Commit();
-#pragma warning disable AS0058, PTE0007 // Accepted violation: this test runner intentionally uses asserterror to detect whether the lock was acquired.
+#pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this test runner intentionally executes an assertion to detect lock acquisition for reusable test infrastructure. Tracked by AB#640773.
         asserterror
         begin
             LockFile.Create(LockFileName);
@@ -114,7 +114,7 @@ codeunit 130200 "Snap Test Runner"
             LockFile.Close();
             Error('Acquired')
         end;
-#pragma warning restore AS0058, PTE0007
+#pragma warning restore AA0161, AS0058, PTE0007
 
         // If we did not acquire the lock, we assume somebody else did and return false.
         Acquired := GetLastErrorText = 'Acquired';
@@ -289,9 +289,9 @@ codeunit 130200 "Snap Test Runner"
         if (FName <> '') and (FName <> 'OnRun') then begin
             PermissionErrors := PermissionTestCatalog.GetPermissionErrors(FTestPermissions);
             if Success and (PermissionErrors <> '') then begin
-#pragma warning disable AS0058, PTE0007 // Accepted violation: this test runner intentionally uses asserterror to surface permission errors as a test failure.
+#pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this test runner intentionally executes assertions to surface reusable test infrastructure failures. Tracked by AB#640773.
                 asserterror Error(PermissionErrors);
-#pragma warning restore AS0058, PTE0007
+#pragma warning restore AA0161, AS0058, PTE0007
                 Success := false;
             end;
         end;

--- a/src/Layers/W1/Tests/TestRunner-Internal/TestRunner.Codeunit.al
+++ b/src/Layers/W1/Tests/TestRunner-Internal/TestRunner.Codeunit.al
@@ -190,9 +190,9 @@ codeunit 130020 "Test Runner"
             // todo: move to subscribers
             PermissionErrors := PermissionTestCatalog.GetPermissionErrors(FunctionTestPermissions);
             if IsSuccess and (PermissionErrors <> '') then begin // Only show permission errors once everything else succeeds
-#pragma warning disable AS0058, PTE0007 // Accepted violation: this test runner intentionally uses asserterror to surface permission errors as a test failure.
+#pragma warning disable AA0161, AS0058, PTE0007 // Accepted: this test runner intentionally executes assertions to surface reusable test infrastructure failures. Tracked by AB#640773.
                 asserterror Error(PermissionErrors);
-#pragma warning restore AS0058, PTE0007
+#pragma warning restore AA0161, AS0058, PTE0007
                 IsSuccess := false;
             end;
 

--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -34,10 +34,6 @@
       "justification": "Use of implicit 'with' will be removed in the future. Qualify with 'Rec'."
     },
     {
-      "id": "AL0606",
-      "action": "Warning"
-    },
-    {
       "id": "AL0667",
       "action": "Warning",
       "justification": "'ObsoleteReason' is being deprecated in the versions: '1.0' or greater. This property is not allowed on areas. This warning will become an error in a future release."
@@ -139,11 +135,6 @@
     {
       "id": "AA0150",
       "action": "Warning"
-    },
-    {
-      "id": "AA0161",
-      "action": "Warning",
-      "justification": "Only use AssertError in Test Codeunits."
     },
     {
       "id": "AA0175",
@@ -254,11 +245,6 @@
       "id": "AA0245",
       "action": "Warning",
       "justification": "The name of the parameter is identical to a field, method, or action in the same scope."
-    },
-    {
-      "id": "AA0448",
-      "action": "Warning",
-      "justification": "Use FieldCaption instead of FieldName and TableCaption instead of TableName in methods that display messages."
     },
     {
       "id": "AA0462",


### PR DESCRIPTION
## Summary

Promote three rules from Warning to Error by removing their entries from `src/rulesets/base.ruleset.json`:

- **AL0606**: refactor all 17 diagnostic-derived suffix sites across 10 source files to remove deprecated `with` statements and qualify record members explicitly.
- **AA0161**: retain 29 intentional `AssertError` uses across 13 test-library/runner/helper files, each under the smallest existing ID-qualified pragma scope with an [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773) acceptance rationale.
- **AA0448**: replace 50 flagged `FieldName`/`TableName` expressions on 40 diagnostic-derived suffix lines across 21 suffix names with localized caption equivalents in user-displayed messages.

Fixes [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773).

## Diagnostic provenance and physical edits

The authoritative `uniq2.xml` census contains project/view multiplicity rather than one record per physical source file:

| Rule | Raw records | Suffix sites | Suffix names | Strategy |
|---|---:|---:|---:|---|
| AL0606 | 17 | 17 | 10 | Real explicit-receiver refactors; no suppressions |
| AA0161 | 579 | 29 | 13 | Narrow accepted scopes in reusable test infrastructure |
| AA0448 | 406 | 40 lines / 50 expressions | 21 | Real caption substitutions in display-only contexts |

AA0448 resolves to 22 directly edited physical sources because `MapCurrencyExchangeRate` has distinct W1 and CH implementations. Miapp propagation also required synchronized CZ and RU copies of `CustVendItemEmplTemplates`, bringing the related AA0448 physical-file total to 24. The Russian translation checks intentionally continue comparing technical `FieldName` values; only their displayed error arguments use captions.

## Contributor posture

After this change, new AL0606, AA0161, and AA0448 diagnostics fail compilation instead of accumulating as warnings. Deprecated `with` statements and technical field/table names in displayed messages must be fixed at source. Intentional `AssertError` use outside Test-subtype codeunits requires a narrow, ID-qualified, documented acceptance scope rather than a broad suppression.

`AL0424` is intentionally untouched and remains Warning. The ruleset count moves from 72 to 69.

## Validation

- Rebased the two logical implementation commits onto current `origin/main`; added one focused CI/review fix commit.
- Verified the PR delta contains exactly 17 removed `with` statements, 29 AA0161 disable/restore pairs, and 50 AA0448 technical-name replacements.
- Verified zero new bare `#pragma warning restore` directives.
- Preserved CRLF/BOM/trailing-newline characteristics and passed `git diff --check`.
- Ran `Invoke-MiSnapApp` with `RepoBranchName=main`: **SUCCESS: No missing files** across all 48 PR files.
- Targeted local AL diagnostics are dependency-limited because this worktree does not contain the required `.alpackages` cache; after the fix, the affected TypeHelper line no longer emits AL0132. The repository's **Clean + Default CI matrix is the hard gate** for complete analyzer and compilation validation.

## CI follow-up

The first head run exposed one Base Application compiler error: the virtual `Field` record has no `"Table Caption"` member. Commit `951b8c7206` now opens `Field.TableNo` as a `RecordRef` and supplies the localized `RecordRef.Caption()` to the displayed error, preserving the AA0448 intent without reverting to a technical table name.

The same commit also adds the exact W1 `FillItemFieldExclusionList` helper to the propagated CZ and RU `CustVendItemEmplTemplates` codeunits. Their new `ItemTemplCardControls` procedures are now self-contained; the helper call was the only missing local-procedure dependency in either propagated test body.

