### PR TITLE
[29.x][BE][Purchase Ledger Report] Wrong VAT Amounts on the report

### DIFF
--- a/src/Layers/BE/BaseApp/Local/Purchases/Reports/PurchaseLedger.Report.al
+++ b/src/Layers/BE/BaseApp/Local/Purchases/Reports/PurchaseLedger.Report.al
@@ -802,10 +802,9 @@ report 11301 "Purchase Ledger"
         GLEntryVATEntryLink.SetRange("G/L Entry No.", GLEntryNo);
         if GLEntryVATEntryLink.FindSet() then
             repeat
-                if VATEntry.Get(GLEntryVATEntryLink."VAT Entry No.") then begin
-                    VATDetailBaseAmount += VATEntry.Base;
-                    VATDetailVATAmount += VATEntry.Amount;
-                end;
+                VATEntry.Get(GLEntryVATEntryLink."VAT Entry No.");
+                VATDetailBaseAmount += VATEntry.Base;
+                VATDetailVATAmount += VATEntry.Amount;
             until GLEntryVATEntryLink.Next() = 0;
     end;
 

--- a/src/Layers/BE/BaseApp/Local/Purchases/Reports/PurchaseLedger.Report.al
+++ b/src/Layers/BE/BaseApp/Local/Purchases/Reports/PurchaseLedger.Report.al
@@ -70,11 +70,11 @@ report 11301 "Purchase Ledger"
                     {
                         AutoFormatType = 1;
                     }
-                    column(VATDetailBase; VATDetail.Base)
+                    column(VATDetailBase; VATDetailBaseAmount)
                     {
                         AutoFormatType = 1;
                     }
-                    column(VATDetailAmount; VATDetail.Amount)
+                    column(VATDetailAmount; VATDetailVATAmount)
                     {
                         AutoFormatType = 1;
                     }
@@ -231,26 +231,10 @@ report 11301 "Purchase Ledger"
                                 GLPostingDescription := GLPostingDescription + ' ' + Vendor.Name;
                         end;
 
-                        if not UseAmtsInAddCurr then begin
-                            Clear(VATDetail.Base);
-                            Clear(VATDetail.Amount);
-
-                            if OldTransactionNo <> "Transaction No." then begin
-                                MultipleVATEntries := 0;
-                                OldTransactionNo := "Transaction No.";
-                            end;
-
-                            if ("VAT Bus. Posting Group" <> '') or ("VAT Prod. Posting Group" <> '') then begin
-                                VATDetail.SetCurrentKey("Transaction No.");
-                                VATDetail.SetRange("Transaction No.", "Transaction No.");
-                                if MultipleVATEntries > 0 then begin
-                                    if VATDetail.Next() <> 0 then
-                                        MultipleVATEntries := MultipleVATEntries + 1;
-                                end else
-                                    if VATDetail.Find('-') then
-                                        MultipleVATEntries := MultipleVATEntries + 1;
-                            end;
-                        end;
+                        Clear(VATDetailBaseAmount);
+                        Clear(VATDetailVATAmount);
+                        if not UseAmtsInAddCurr then
+                            CalculateVATDetailAmounts("Entry No.");
                     end;
 
                     trigger OnPreDataItem()
@@ -750,7 +734,6 @@ report 11301 "Purchase Ledger"
         VendorLedgerEntry: Record "Vendor Ledger Entry";
         GLSetup: Record "General Ledger Setup";
         VATSumBuffer: Record "VAT Summary Buffer" temporary;
-        VATDetail: Record "VAT Entry";
         SourceCodeSetup: Record "Source Code Setup";
         VATStmt: Report "VAT Statement";
         VATStmtAddCurr: Report "VAT Statement";
@@ -774,8 +757,8 @@ report 11301 "Purchase Ledger"
         NoOfPeriods: Integer;
         PeriodLength: DateFormula;
         Startpage: Integer;
-        MultipleVATEntries: Integer;
-        OldTransactionNo: Integer;
+        VATDetailBaseAmount: Decimal;
+        VATDetailVATAmount: Decimal;
         GLPostingDescription: Text;
         DateCaption: Text;
         ExcludeDeferrals: Boolean;
@@ -810,5 +793,20 @@ report 11301 "Purchase Ledger"
     protected var
         PeriodStartDate: Date;
         PeriodEndDate: Date;
+
+    local procedure CalculateVATDetailAmounts(GLEntryNo: Integer)
+    var
+        GLEntryVATEntryLink: Record "G/L Entry - VAT Entry Link";
+        VATEntry: Record "VAT Entry";
+    begin
+        GLEntryVATEntryLink.SetRange("G/L Entry No.", GLEntryNo);
+        if GLEntryVATEntryLink.FindSet() then
+            repeat
+                if VATEntry.Get(GLEntryVATEntryLink."VAT Entry No.") then begin
+                    VATDetailBaseAmount += VATEntry.Base;
+                    VATDetailVATAmount += VATEntry.Amount;
+                end;
+            until GLEntryVATEntryLink.Next() = 0;
+    end;
 
 }

--- a/src/Layers/BE/BaseApp/Local/Purchases/Reports/PurchaseLedger.rdlc
+++ b/src/Layers/BE/BaseApp/Local/Purchases/Reports/PurchaseLedger.rdlc
@@ -1372,7 +1372,9 @@
                                                     </Style>
                                                   </TextRun>
                                                 </TextRuns>
-                                                <Style />
+                                                <Style>
+                                                  <TextAlign>Right</TextAlign>
+                                                </Style>
                                               </Paragraph>
                                             </Paragraphs>
                                             <ZIndex>25</ZIndex>
@@ -1950,7 +1952,9 @@
                                                     </Style>
                                                   </TextRun>
                                                 </TextRuns>
-                                                <Style />
+                                                <Style>
+                                                  <TextAlign>Right</TextAlign>
+                                                </Style>
                                               </Paragraph>
                                             </Paragraphs>
                                             <ZIndex>11</ZIndex>
@@ -1979,7 +1983,9 @@
                                                     </Style>
                                                   </TextRun>
                                                 </TextRuns>
-                                                <Style />
+                                                <Style>
+                                                  <TextAlign>Right</TextAlign>
+                                                </Style>
                                               </Paragraph>
                                             </Paragraphs>
                                             <ZIndex>10</ZIndex>

--- a/src/Layers/BE/Tests/Local/LedgerReports.Codeunit.al
+++ b/src/Layers/BE/Tests/Local/LedgerReports.Codeunit.al
@@ -102,6 +102,7 @@ codeunit 144044 "Ledger Reports"
     end;
 
     [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
     [HandlerFunctions('PurchaseLedgerReportRequestPageHandler')]
     [Scope('OnPrem')]
     procedure PurchaseLedgerReportVATDetailFollowsGLEntryVATLink()

--- a/src/Layers/BE/Tests/Local/LedgerReports.Codeunit.al
+++ b/src/Layers/BE/Tests/Local/LedgerReports.Codeunit.al
@@ -102,6 +102,65 @@ codeunit 144044 "Ledger Reports"
     end;
 
     [Test]
+    [HandlerFunctions('PurchaseLedgerReportRequestPageHandler')]
+    [Scope('OnPrem')]
+    procedure PurchaseLedgerReportVATDetailFollowsGLEntryVATLink()
+    var
+        VATEntry: Record "VAT Entry";
+        Acc21No: Code[20];
+        Acc0No: Code[20];
+        VATProdGroup21: Code[20];
+        VATProdGroup0: Code[20];
+        DocumentNo: Code[20];
+        Base21: Decimal;
+        Amount21: Decimal;
+        Base0: Decimal;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO] Each Purchase Ledger detail line prints the VAT Base/Amount of the VAT Entry linked to that G/L Entry, not the next VAT entry in transaction order
+        Initialize();
+
+        // [GIVEN] Posted purchase invoice with two lines in one transaction: one taxed at 21% and one at 0%
+        DocumentNo := CreateAndPostPurchInvoiceWithTwoVATRates(Acc21No, Acc0No, VATProdGroup21, VATProdGroup0);
+
+        // [GIVEN] The VAT Entry amounts posted for each rate
+        VATEntry.SetRange("Document No.", DocumentNo);
+        VATEntry.SetRange("VAT Prod. Posting Group", VATProdGroup21);
+        VATEntry.FindFirst();
+        Base21 := VATEntry.Base;
+        Amount21 := VATEntry.Amount;
+        VATEntry.SetRange("VAT Prod. Posting Group", VATProdGroup0);
+        VATEntry.FindFirst();
+        Base0 := VATEntry.Base;
+        Assert.AreEqual(0, VATEntry.Amount, 'Expected the 0% VAT entry to carry no VAT amount.');
+
+        // [WHEN] Run the Purchase Ledger report
+        LibraryVariableStorage.Clear();
+        LibraryVariableStorage.Enqueue('<1D>');
+        LibraryVariableStorage.Enqueue(false);
+        LibraryVariableStorage.Enqueue(false);
+        Commit();
+        REPORT.Run(REPORT::"Purchase Ledger", true, false);
+        LibraryReportDataset.LoadDataSetFile();
+
+        // [THEN] The 21% line shows the base and amount of its own VAT entry
+        LibraryReportDataset.Reset();
+        LibraryReportDataset.SetRange('GLAccountNo_GLEntry', Acc21No);
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.AssertCurrentRowValueEquals('VATDetailBase', Base21);
+        LibraryReportDataset.AssertCurrentRowValueEquals('VATDetailAmount', Amount21);
+
+        // [THEN] The 0% line shows its own base and no VAT amount, instead of the 21% amount from the other line
+        LibraryReportDataset.Reset();
+        LibraryReportDataset.SetRange('GLAccountNo_GLEntry', Acc0No);
+        LibraryReportDataset.GetNextRow();
+        LibraryReportDataset.AssertCurrentRowValueEquals('VATDetailBase', Base0);
+        LibraryReportDataset.AssertCurrentRowValueEquals('VATDetailAmount', 0);
+
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
     [HandlerFunctions('SalesLedgerReportRequestPageHandler')]
     [Scope('OnPrem')]
     procedure SalesLedgerReportTest()
@@ -962,6 +1021,55 @@ codeunit 144044 "Ledger Reports"
 
         DocNo := LibraryPurchase.PostPurchaseDocument(PurchHeader, true, true);
         VATPostingSetup.Delete();
+    end;
+
+    local procedure CreateAndPostPurchInvoiceWithTwoVATRates(var Acc21No: Code[20]; var Acc0No: Code[20]; var VATProdGroup21: Code[20]; var VATProdGroup0: Code[20]) DocNo: Code[20]
+    var
+        GeneralPostingSetup: Record "General Posting Setup";
+        VATPostingSetup21: Record "VAT Posting Setup";
+        VATPostingSetup0: Record "VAT Posting Setup";
+        VATProductPostingGroup: Record "VAT Product Posting Group";
+        PurchHeader: Record "Purchase Header";
+    begin
+        CreateGeneralPostingSetup(GeneralPostingSetup);
+
+        // Two VAT rates sharing one VAT Bus. Posting Group so both lines post in the same document/transaction
+        LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup21, VATPostingSetup21."VAT Calculation Type"::"Normal VAT", 21);
+        LibraryERM.CreateVATProductPostingGroup(VATProductPostingGroup);
+        VATPostingSetup0.Init();
+        VATPostingSetup0.Validate("VAT Bus. Posting Group", VATPostingSetup21."VAT Bus. Posting Group");
+        VATPostingSetup0.Validate("VAT Prod. Posting Group", VATProductPostingGroup.Code);
+        VATPostingSetup0.Validate("VAT Calculation Type", VATPostingSetup0."VAT Calculation Type"::"Normal VAT");
+        VATPostingSetup0.Validate("VAT %", 0);
+        VATPostingSetup0.Validate("VAT Identifier", VATProductPostingGroup.Code);
+        VATPostingSetup0.Validate("Purchase VAT Account", LibraryERM.CreateGLAccountNo());
+        VATPostingSetup0.Insert(true);
+
+        VATProdGroup21 := VATPostingSetup21."VAT Prod. Posting Group";
+        VATProdGroup0 := VATPostingSetup0."VAT Prod. Posting Group";
+
+        LibraryPurchase.CreatePurchHeader(
+          PurchHeader, PurchHeader."Document Type"::Invoice,
+          CreateVendor(GeneralPostingSetup."Gen. Bus. Posting Group", VATPostingSetup21."VAT Bus. Posting Group"));
+        PurchHeader.Validate("Vendor Invoice No.", LibraryUtility.GenerateGUID());
+        PurchHeader.Validate("Posting Date", WorkDate());
+        PurchHeader.Modify(true);
+
+        Acc21No := CreateGLAccWithSetup(GeneralPostingSetup."Gen. Prod. Posting Group", VATProdGroup21);
+        AddPurchLineForGLAccount(PurchHeader, Acc21No);
+        Acc0No := CreateGLAccWithSetup(GeneralPostingSetup."Gen. Prod. Posting Group", VATProdGroup0);
+        AddPurchLineForGLAccount(PurchHeader, Acc0No);
+
+        DocNo := LibraryPurchase.PostPurchaseDocument(PurchHeader, true, true);
+    end;
+
+    local procedure AddPurchLineForGLAccount(PurchHeader: Record "Purchase Header"; GLAccNo: Code[20])
+    var
+        PurchLine: Record "Purchase Line";
+    begin
+        LibraryPurchase.CreatePurchaseLine(PurchLine, PurchHeader, PurchLine.Type::"G/L Account", GLAccNo, LibraryRandom.RandIntInRange(2, 5));
+        PurchLine.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(100, 1000, 2));
+        PurchLine.Modify(true);
     end;
 
     local procedure CreateAndPostGenJnlLine(AccountNo: Code[20]; AccountType: Enum "Gen. Journal Account Type"; Amount: Decimal): Code[20]


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

Fixing an issue with Belgium-specific Purchase Ledger report that was:

using stale VAT amount values for certain lines
having wrong alignment of two RDLC cells


## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#649339](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649339)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->
I added or updated tests for the new behavior

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->


