### PR TITLE
Restore E-Document vendor invoice field compatibility

### DIFF
--- a/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/EDocumentPINTANZHandler.Codeunit.al
+++ b/src/Apps/APAC/EDocumentFormats/PINT A-NZ/app/src/Core/EDocumentPINTANZHandler.Codeunit.al
@@ -132,7 +132,7 @@ codeunit 28008 "E-Document PINT A-NZ Handler" implements IStructuredFormatReader
         EDocument."Document Type" := EDocument."Document Type"::"Purchase Credit Memo";
         EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Sales Invoice No."), EDocumentPurchaseHeader."Sales Invoice No.");
         EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:OrderReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Purchase Order No."), EDocumentPurchaseHeader."Purchase Order No.");
-        EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Applies-to Ext. Invoice No."), EDocumentPurchaseHeader."Applies-to Ext. Invoice No.");
+        EDocumentXMLHelper.SetStringValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Vendor Invoice No."), EDocumentPurchaseHeader."Vendor Invoice No.");
         EDocumentXMLHelper.SetDateValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cbc:IssueDate', EDocumentPurchaseHeader."Document Date");
         EDocumentXMLHelper.SetDateValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', EDocumentPurchaseHeader."Due Date");
         EDocumentXMLHelper.SetCurrencyValueInField(PINTANZXml, XmlNamespaces, '/cn:CreditNote/cbc:DocumentCurrencyCode', MaxStrLen(EDocumentPurchaseHeader."Currency Code"), EDocumentPurchaseHeader."Currency Code");

--- a/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/EDocumentZUGFeRDHandler.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/app/src/ZUGFeRD/EDocumentZUGFeRDHandler.Codeunit.al
@@ -246,7 +246,7 @@ codeunit 11041 "E-Document ZUGFeRD Handler" implements IStructuredFormatReader, 
     begin
         Header."Sales Invoice No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, '//rsm:ExchangedDocument/ram:ID'), 1, MaxStrLen(Header."Sales Invoice No."));
         Header."Purchase Order No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, AgreementPathTok + '/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID'), 1, MaxStrLen(Header."Purchase Order No."));
-        Header."Applies-to Ext. Invoice No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, SettlementPathTok + '/ram:InvoiceReferencedDocument/ram:IssuerAssignedID'), 1, MaxStrLen(Header."Applies-to Ext. Invoice No."));
+        Header."Vendor Invoice No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, SettlementPathTok + '/ram:InvoiceReferencedDocument/ram:IssuerAssignedID'), 1, MaxStrLen(Header."Vendor Invoice No."));
         // BT-10 Buyer reference, which carries the Leitweg-ID for German public sector buyers
         Header."Buyer Reference DE" := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, AgreementPathTok + '/ram:BuyerReference'), 1, MaxStrLen(Header."Buyer Reference DE"));
     end;

--- a/src/Apps/DE/EDocumentDE/test/src/EDocDEStructImportTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/EDocDEStructImportTests.Codeunit.al
@@ -144,7 +144,7 @@ codeunit 148501 "E-Doc. DE Struct. Import Tests"
         Assert.AreEqual(Format("E-Doc. Process Draft"::"Purchase Credit Memo"), Format(EDocument."Process Draft Impl."), 'The draft should be processed as a purchase credit memo.');
         EDocumentPurchaseHeader.GetFromEDocument(EDocument);
         Assert.AreEqual('ZF-CRM-2001', EDocumentPurchaseHeader."Sales Invoice No.", 'Wrong document number.');
-        Assert.AreEqual('ZF-INV-1001', EDocumentPurchaseHeader."Applies-to Ext. Invoice No.", 'Wrong applies-to external invoice number.');
+        Assert.AreEqual('ZF-INV-1001', EDocumentPurchaseHeader."Vendor Invoice No.", 'Wrong applies-to external invoice number.');
     end;
 
     [Test]

--- a/src/Apps/DE/EDocumentDE/test/src/EDocDEStructImportTests.Codeunit.al
+++ b/src/Apps/DE/EDocumentDE/test/src/EDocDEStructImportTests.Codeunit.al
@@ -144,7 +144,7 @@ codeunit 148501 "E-Doc. DE Struct. Import Tests"
         Assert.AreEqual(Format("E-Doc. Process Draft"::"Purchase Credit Memo"), Format(EDocument."Process Draft Impl."), 'The draft should be processed as a purchase credit memo.');
         EDocumentPurchaseHeader.GetFromEDocument(EDocument);
         Assert.AreEqual('ZF-CRM-2001', EDocumentPurchaseHeader."Sales Invoice No.", 'Wrong document number.');
-        Assert.AreEqual('ZF-INV-1001', EDocumentPurchaseHeader."Vendor Invoice No.", 'Wrong applies-to external invoice number.');
+        Assert.AreEqual('ZF-INV-1001', EDocumentPurchaseHeader."Vendor Invoice No.", 'Wrong vendor invoice number.');
     end;
 
     [Test]

--- a/src/Apps/DK/EDocumentFormatOIOUBL/app/src/EDocumentOIOUBLHandler.Codeunit.al
+++ b/src/Apps/DK/EDocumentFormatOIOUBL/app/src/EDocumentOIOUBLHandler.Codeunit.al
@@ -141,7 +141,7 @@ codeunit 13913 "E-Document OIOUBL Handler" implements IStructuredFormatReader
         EDocumentXMLHelper.SetDateValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cac:PaymentMeans/cbc:PaymentDueDate', EDocumentPurchaseHeader."Due Date");
         EDocumentXMLHelper.SetCurrencyValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cbc:DocumentCurrencyCode', MaxStrLen(EDocumentPurchaseHeader."Currency Code"), EDocumentPurchaseHeader."Currency Code");
         EDocumentXMLHelper.SetStringValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cac:OrderReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Purchase Order No."), EDocumentPurchaseHeader."Purchase Order No.");
-        EDocumentXMLHelper.SetStringValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Applies-to Ext. Invoice No."), EDocumentPurchaseHeader."Applies-to Ext. Invoice No.");
+        EDocumentXMLHelper.SetStringValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(EDocumentPurchaseHeader."Vendor Invoice No."), EDocumentPurchaseHeader."Vendor Invoice No.");
 #pragma warning restore AA0139
         EDocumentXMLHelper.SetNumberValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount', EDocumentPurchaseHeader."Sub Total");
         EDocumentXMLHelper.SetNumberValueInField(OIOUBLXml, XmlNamespaces, '/cn:CreditNote/cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount', EDocumentPurchaseHeader.Total);

--- a/src/Apps/DK/EDocumentFormatOIOUBL/test/src/OIOUBLStructuredValidations.Codeunit.al
+++ b/src/Apps/DK/EDocumentFormatOIOUBL/test/src/OIOUBLStructuredValidations.Codeunit.al
@@ -111,7 +111,7 @@ codeunit 148062 "OIOUBL Structured Validations"
         EDocumentPurchaseHeader: Record "E-Document Purchase Header";
     begin
         EDocumentPurchaseHeader.Get(EDocumentEntryNo);
-        Assert.AreEqual(SalesInvoiceNoTok, EDocumentPurchaseHeader."Applies-to Ext. Invoice No.", StrSubstNo(MockDataMismatchErr, EDocumentPurchaseHeader.FieldCaption("Applies-to Ext. Invoice No."), EDocumentPurchaseHeader.TableCaption(), SalesInvoiceNoTok, EDocumentPurchaseHeader."Applies-to Ext. Invoice No."));
+        Assert.AreEqual(SalesInvoiceNoTok, EDocumentPurchaseHeader."Vendor Invoice No.", StrSubstNo(MockDataMismatchErr, EDocumentPurchaseHeader.FieldCaption("Vendor Invoice No."), EDocumentPurchaseHeader.TableCaption(), SalesInvoiceNoTok, EDocumentPurchaseHeader."Vendor Invoice No."));
         Assert.AreEqual('', EDocumentPurchaseHeader."Applies-to Doc. No.", StrSubstNo(MockDataMismatchErr, EDocumentPurchaseHeader.FieldCaption("Applies-to Doc. No."), EDocumentPurchaseHeader.TableCaption(), '', EDocumentPurchaseHeader."Applies-to Doc. No."));
     end;
 

--- a/src/Apps/ES/EDocumentFormats/FacturaE/app/src/Core/EDocumentFacturaEHandler.Codeunit.al
+++ b/src/Apps/ES/EDocumentFormats/FacturaE/app/src/Core/EDocumentFacturaEHandler.Codeunit.al
@@ -113,7 +113,7 @@ codeunit 10766 "E-Document Factura-E Handler" implements IStructuredFormatReader
         EDocumentXMLHelper.SetNumberValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceTotals/InvoiceTotal', EDocumentPurchaseHeader.Total);
         EDocumentXMLHelper.SetNumberValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceTotals/TotalOutstandingAmount', EDocumentPurchaseHeader."Amount Due");
         EDocumentXMLHelper.SetDateValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceHeader/InvoiceDocumentReference/ReferencedDocumentDate', EDocumentPurchaseHeader."Due Date");
-        EDocumentXMLHelper.SetStringValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceHeader/Corrective/InvoiceNumber', MaxStrLen(EDocumentPurchaseHeader."Applies-to Ext. Invoice No."), EDocumentPurchaseHeader."Applies-to Ext. Invoice No.");
+        EDocumentXMLHelper.SetStringValueInField(FacturaEXML, XmlNamespaces, '/namespace:Facturae/Invoices/Invoice/InvoiceHeader/Corrective/InvoiceNumber', MaxStrLen(EDocumentPurchaseHeader."Vendor Invoice No."), EDocumentPurchaseHeader."Vendor Invoice No.");
 
         if VendorNo <> '' then
             EDocumentPurchaseHeader."[BC] Vendor No." := VendorNo;

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Formats/FacturX/EDocumentFacturXHandler.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Formats/FacturX/EDocumentFacturXHandler.Codeunit.al
@@ -246,7 +246,7 @@ codeunit 10986 "E-Document Factur-X Handler" implements IStructuredFormatReader,
     begin
         Header."Sales Invoice No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, '//rsm:ExchangedDocument/ram:ID'), 1, MaxStrLen(Header."Sales Invoice No."));
         Header."Purchase Order No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, AgreementPathTok + '/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID'), 1, MaxStrLen(Header."Purchase Order No."));
-        Header."Applies-to Ext. Invoice No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, SettlementPathTok + '/ram:InvoiceReferencedDocument/ram:IssuerAssignedID'), 1, MaxStrLen(Header."Applies-to Ext. Invoice No."));
+        Header."Vendor Invoice No." := CopyStr(GetNodeValue(CIIXml, XmlNamespaces, SettlementPathTok + '/ram:InvoiceReferencedDocument/ram:IssuerAssignedID'), 1, MaxStrLen(Header."Vendor Invoice No."));
     end;
 
     local procedure PopulateSupplierInfo(CIIXml: XmlDocument; XmlNamespaces: XmlNamespaceManager; var Header: Record "E-Document Purchase Header")

--- a/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Formats/PEPPOL/EDocPeppolBIS30FRHdlr.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/app/src/Formats/PEPPOL/EDocPeppolBIS30FRHdlr.Codeunit.al
@@ -134,7 +134,7 @@ codeunit 10985 "E-Doc. Peppol BIS 3.0 FR Hdlr" implements IStructuredFormatReade
 #pragma warning disable AA0139 // false positive: overflow handled by SetStringValueInField
         EDocumentXMLHelper.SetStringValueInField(PeppolXml, XmlNamespaces, DocumentPath + '/cbc:ID', MaxStrLen(Header."Sales Invoice No."), Header."Sales Invoice No.");
         EDocumentXMLHelper.SetStringValueInField(PeppolXml, XmlNamespaces, DocumentPath + '/cac:OrderReference/cbc:ID', MaxStrLen(Header."Purchase Order No."), Header."Purchase Order No.");
-        EDocumentXMLHelper.SetStringValueInField(PeppolXml, XmlNamespaces, DocumentPath + '/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(Header."Applies-to Ext. Invoice No."), Header."Applies-to Ext. Invoice No.");
+        EDocumentXMLHelper.SetStringValueInField(PeppolXml, XmlNamespaces, DocumentPath + '/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', MaxStrLen(Header."Vendor Invoice No."), Header."Vendor Invoice No.");
 #pragma warning restore AA0139
         EDocumentXMLHelper.SetDateValueInField(PeppolXml, XmlNamespaces, DocumentPath + '/cbc:IssueDate', Header."Document Date");
         EDocumentXMLHelper.SetDateValueInField(PeppolXml, XmlNamespaces, DocumentPath + '/cbc:DueDate', Header."Due Date");

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/EDocFRStructImportTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/EDocFRStructImportTests.Codeunit.al
@@ -88,7 +88,7 @@ codeunit 148149 "E-Doc. FR Struct. Import Tests"
         Assert.AreEqual(Format("E-Doc. Process Draft"::"Purchase Credit Memo"), Format(ProcessDraft), 'The draft should be processed as a purchase credit memo.');
         EDocumentPurchaseHeader.GetFromEDocument(EDocument);
         Assert.AreEqual('FX-AVR-4001', EDocumentPurchaseHeader."Sales Invoice No.", 'Wrong document number.');
-        Assert.AreEqual('FX-INV-3001', EDocumentPurchaseHeader."Applies-to Ext. Invoice No.", 'Wrong applies-to external invoice number.');
+        Assert.AreEqual('FX-INV-3001', EDocumentPurchaseHeader."Vendor Invoice No.", 'Wrong applies-to external invoice number.');
     end;
 
     [Test]

--- a/src/Apps/FR/EDocument_FR/EReportingFR/test/src/EDocFRStructImportTests.Codeunit.al
+++ b/src/Apps/FR/EDocument_FR/EReportingFR/test/src/EDocFRStructImportTests.Codeunit.al
@@ -88,7 +88,7 @@ codeunit 148149 "E-Doc. FR Struct. Import Tests"
         Assert.AreEqual(Format("E-Doc. Process Draft"::"Purchase Credit Memo"), Format(ProcessDraft), 'The draft should be processed as a purchase credit memo.');
         EDocumentPurchaseHeader.GetFromEDocument(EDocument);
         Assert.AreEqual('FX-AVR-4001', EDocumentPurchaseHeader."Sales Invoice No.", 'Wrong document number.');
-        Assert.AreEqual('FX-INV-3001', EDocumentPurchaseHeader."Vendor Invoice No.", 'Wrong applies-to external invoice number.');
+        Assert.AreEqual('FX-INV-3001', EDocumentPurchaseHeader."Vendor Invoice No.", 'Wrong vendor invoice number.');
     end;
 
     [Test]

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchCrMemo.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/FinishDraft/EDocCreatePurchCrMemo.Codeunit.al
@@ -124,8 +124,8 @@ codeunit 6404 "E-Doc. Create Purch. Cr. Memo" implements IEDocumentFinishDraft, 
         if EDocumentPurchaseHeader."Applies-to Doc. No." <> '' then
             PurchaseHeader."Applies-to Doc. No." := CopyStr(EDocumentPurchaseHeader."Applies-to Doc. No.", 1, MaxStrLen(PurchaseHeader."Applies-to Doc. No."))
         else
-            if EDocumentPurchaseHeader."Applies-to Ext. Invoice No." <> '' then
-                ResolveAppliesToFromExtInvoiceNo(EDocumentPurchaseHeader."Applies-to Ext. Invoice No.", PurchaseHeader);
+            if EDocumentPurchaseHeader."Vendor Invoice No." <> '' then
+                ResolveAppliesToFromExtInvoiceNo(EDocumentPurchaseHeader."Vendor Invoice No.", PurchaseHeader);
 
         PurchaseHeader.Modify();
 

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocReadablePurchaseDoc.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocReadablePurchaseDoc.Page.al
@@ -131,9 +131,9 @@ page 6182 "E-Doc. Readable Purchase Doc."
                     Caption = 'Purchase Order No.';
                     ToolTip = 'Specifies the purchase order number.';
                 }
-                field("Applies-to Ext. Invoice No."; Rec."Applies-to Ext. Invoice No.")
+                field("Vendor Invoice No."; Rec."Vendor Invoice No.")
                 {
-                    Caption = 'Applies-to Ext. Invoice No.';
+                    Caption = 'Vendor Invoice No.';
                     ToolTip = 'Specifies the vendor''s original invoice number that this credit memo references.';
                 }
                 field("Invoice Date"; Rec."Invoice Date")

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocReadablePurchaseDoc.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocReadablePurchaseDoc.Page.al
@@ -134,7 +134,7 @@ page 6182 "E-Doc. Readable Purchase Doc."
                 field("Vendor Invoice No."; Rec."Vendor Invoice No.")
                 {
                     Caption = 'Vendor Invoice No.';
-                    ToolTip = 'Specifies the vendor''s original invoice number that this credit memo references.';
+                    ToolTip = 'Specifies the vendor invoice number.';
                 }
                 field("Invoice Date"; Rec."Invoice Date")
                 {

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
@@ -230,9 +230,9 @@ table 6100 "E-Document Purchase Header"
             Caption = 'Applies-to Doc. No.';
             DataClassification = CustomerContent;
         }
-        field(40; "Applies-to Ext. Invoice No."; Text[100])
+        field(40; "Vendor Invoice No."; Text[100])
         {
-            Caption = 'Applies-to Ext. Invoice No.';
+            Caption = 'Vendor Invoice No.';
             DataClassification = CustomerContent;
         }
         #endregion Purchase fields

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
@@ -230,11 +230,15 @@ table 6100 "E-Document Purchase Header"
             Caption = 'Applies-to Doc. No.';
             DataClassification = CustomerContent;
         }
+#pragma warning disable AS0125
+#pragma warning disable AS0005
         field(40; "Vendor Invoice No."; Text[100])
         {
             Caption = 'Vendor Invoice No.';
             DataClassification = CustomerContent;
         }
+#pragma warning restore AS0005
+#pragma warning restore AS0125
         #endregion Purchase fields
 
         #region Business Central Data - Validated fields [101-200]

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentPEPPOLHandler.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/StructureReceivedEDocument/EDocumentPEPPOLHandler.Codeunit.al
@@ -149,8 +149,8 @@ codeunit 6173 "E-Document PEPPOL Handler" implements IStructuredFormatReader, IE
         if PeppolUtility.TryGetStringValue(PeppolXML, XmlNamespaces, '/cre:CreditNote/cac:OrderReference/cbc:ID', Value) then
             Header."Purchase Order No." := CopyStr(Value, 1, MaxStrLen(Header."Purchase Order No."));
         if PeppolUtility.TryGetStringValue(PeppolXML, XmlNamespaces, '/cre:CreditNote/cac:BillingReference/cac:InvoiceDocumentReference/cbc:ID', Value) then
-            Header."Applies-to Ext. Invoice No." := CopyStr(Value, 1, MaxStrLen(Header."Applies-to Ext. Invoice No."));
-        if Header."Applies-to Ext. Invoice No." = '' then
+            Header."Vendor Invoice No." := CopyStr(Value, 1, MaxStrLen(Header."Vendor Invoice No."));
+        if Header."Vendor Invoice No." = '' then
             Session.LogMessage('0000SNJ', BillingReferenceEmptyTelemetryTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', 'E-Document');
     end;
 

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/docs/business-logic.md
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/docs/business-logic.md
@@ -190,7 +190,7 @@ Manual dimensions are preserved because the helper combines the purchase line's 
 
 ### Purchase credit memo finalization
 
-`E-Doc. Create Purch. Cr. Memo` uses the same purchase helper for lines, dimensions, attachments, default posting date, currency validation, and record links. It creates a purchase credit memo, validates duplicate external document numbers against posted vendor ledger entries, carries `Posting Description`, and resolves `Applies-to Doc. No.` directly or through `Applies-to Ext. Invoice No.` when possible.
+`E-Doc. Create Purch. Cr. Memo` uses the same purchase helper for lines, dimensions, attachments, default posting date, currency validation, and record links. It creates a purchase credit memo, validates duplicate external document numbers against posted vendor ledger entries, carries `Posting Description`, and resolves `Applies-to Doc. No.` directly or through `Vendor Invoice No.` when possible.
 
 ### Sales order finalization
 

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocStructuredValidations.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocStructuredValidations.Codeunit.al
@@ -167,7 +167,7 @@ codeunit 139894 "EDoc Structured Validations"
         Assert.AreEqual(DMY2Date(15, 03, 2026), EDocumentPurchaseHeader."Due Date", 'The due date does not match the mock data.');
         Assert.AreEqual('XYZ', EDocumentPurchaseHeader."Currency Code", 'The currency code does not match the mock data.');
         Assert.AreEqual('5', EDocumentPurchaseHeader."Purchase Order No.", 'The order reference does not match the mock data.');
-        Assert.AreEqual('103033', EDocumentPurchaseHeader."Applies-to Ext. Invoice No.", 'The billing reference (vendor invoice no.) does not match the mock data.');
+        Assert.AreEqual('103033', EDocumentPurchaseHeader."Vendor Invoice No.", 'The billing reference (vendor invoice no.) does not match the mock data.');
         Assert.AreEqual('CRONUS International', EDocumentPurchaseHeader."Vendor Company Name", 'The vendor name does not match the mock data.');
         Assert.AreEqual('Main Street, 14', EDocumentPurchaseHeader."Vendor Address", 'The vendor street does not match the mock data.');
         Assert.AreEqual('GB123456789', EDocumentPurchaseHeader."Vendor VAT Id", 'The vendor VAT id does not match the mock data.');
@@ -441,7 +441,7 @@ codeunit 139894 "EDoc Structured Validations"
         // CreditNote without PaymentMeans/PaymentDueDate: DueDate should be blank
         Assert.AreEqual(0D, EDocumentPurchaseHeader."Due Date", 'Due Date should be blank when CreditNote has no PaymentMeans/PaymentDueDate.');
         Assert.AreEqual(ExpectedCurrencyCode('EUR', GLSetup."LCY Code"), EDocumentPurchaseHeader."Currency Code", 'The currency code does not match.');
-        Assert.AreEqual('Snippet1', EDocumentPurchaseHeader."Applies-to Ext. Invoice No.", 'The BillingReference (Vendor Invoice No.) does not match.');
+        Assert.AreEqual('Snippet1', EDocumentPurchaseHeader."Vendor Invoice No.", 'The BillingReference (Vendor Invoice No.) does not match.');
         Assert.AreEqual('SupplierTradingName Ltd.', EDocumentPurchaseHeader."Vendor Company Name", 'The vendor name does not match.');
         Assert.AreEqual('GB1232434', EDocumentPurchaseHeader."Vendor VAT Id", 'The vendor VAT id does not match.');
         Assert.AreEqual(1656.25, EDocumentPurchaseHeader.Total, 'The total does not match.');


### PR DESCRIPTION
## Why

The E-Document Purchase Header field 40 was renamed from `Vendor Invoice No.` to `Applies-to Ext. Invoice No.`, which breaks upgrade, extension, and translation compatibility with the established field identity. Restore the compatible field name on `main` and align all affected handlers, tests, UI, and documentation.

This ports the compatibility correction from #11054 and #11078 to `main`.

## Summary

- Restores field 40 and W1 E-Document processing to use `Vendor Invoice No.`.
- Updates APAC, DE, DK, ES, and FR handlers and tests.
- Aligns the E-Document purchase credit memo UI and documentation.

Related to #11078.

Fixes
[AB#649189](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649189)

