### PR TITLE
[28.5] Classify E-Document Message sensitivity

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -490,6 +490,7 @@ codeunit 6103 "E-Document Subscribers"
     begin
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Service Data Exch. Def.");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Message");
 #if not CLEAN28
 #pragma warning disable AL0432
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Documents Setup");


### PR DESCRIPTION
## Why

The NAV 28.5 validation fails in `Data Classs Demo Data Tests.TestDataSensitivities` because field 12 of table 6432 (`E-Document Message`.`Last Error`) remains `Unclassified`.

## Summary

- **Registered** the `E-Document Message` table in E-Document Core's evaluation-data sensitivity initialization.
- **Fixed** bug `648771` by assigning `Normal` sensitivity to the table's fields during demo-data setup.

Fixes [AB#648771](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648771)

