### PR TITLE
[29.x][All-e][FTE][SaaS] Cannot Rename User Due to Financial Report Audit Log Permissions

### DIFF
--- a/src/Layers/RU/BaseApp/System/User/UserManagement.Codeunit.al
+++ b/src/Layers/RU/BaseApp/System/User/UserManagement.Codeunit.al
@@ -157,6 +157,7 @@ codeunit 418 "User Management"
                   Tabledata "Sales Header Archive" = rm,
                   Tabledata "Purchase Header Archive" = rm,
                   Tabledata "Manufacturing User Template" = rm,
+                  Tabledata "Financial Report Audit Log" = rm,                 
                   Tabledata "Field Monitoring Setup" = rm;
 
     trigger OnRun()
@@ -525,6 +526,7 @@ codeunit 418 "User Management"
             Database::"Sales Header Archive",
             Database::"Purchase Header Archive",
             Database::"Manufacturing User Template",
+            Database::"Financial Report Audit Log",
             Database::"Field Monitoring Setup":
                 begin
                     RenameField(TableID, FieldID, OldUserName, NewUserName, CompanyName);

--- a/src/Layers/W1/BaseApp/System/User/UserManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/User/UserManagement.Codeunit.al
@@ -160,6 +160,7 @@ codeunit 418 "User Management"
                   Tabledata "Employee Ledger Entry" = rm,
                   Tabledata "Detailed Employee Ledger Entry" = rm,
                   Tabledata "Manufacturing User Template" = rm,
+                  Tabledata "Financial Report Audit Log" = rm,                 
                   Tabledata "Field Monitoring Setup" = rm;
 
     trigger OnRun()
@@ -522,6 +523,7 @@ codeunit 418 "User Management"
             Database::"Employee Ledger Entry",
             Database::"Detailed Employee Ledger Entry",
             Database::"Manufacturing User Template",
+            Database::"Financial Report Audit Log",
             Database::"Field Monitoring Setup":
                 begin
                     RenameField(TableID, FieldID, OldUserName, NewUserName, CompanyName);


### PR DESCRIPTION
[Bug 649367](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649367): [29.x][All-e][FTE][SaaS] Cannot Rename User Due to Financial Report Audit Log Permissions - Copy

Fixes [AB#649367](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649367)

Issue:
When a user was renamed, existing Financial Report Audit Log entries continued to reference the old user name.

Cause:
The Financial Report Audit Log table was missing from the Base Application’s user-renaming logic and required permissions.

Solution:
Added the table to the user-renaming handler and granted the required modify/rename permissions. Added a test verifying that audit-log entries are updated with the new user name.


