### PR TITLE
[Expense Agent] Adding approval limits (November '26')

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.ExpenseAgent;
-using System.Security.User;
 
 codeunit 6901 "Expense Report Approval Mgmt"
 {
@@ -30,6 +29,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
         InterimApproverActorErr: Label 'Only the expense report owner %1 can assign an interim approver.', Comment = '%1 = Expense User No. of the report owner';
         InterimApproverAssignedCommentTxt: Label 'Interim approver set to %1 (%2).', Comment = '%1 = Interim Approver No., %2 = Interim Approver Name';
+        ApproverApprovalLimitErr: Label 'Expense report %1 exceeds the %2 for approver %3.', Comment = '%1 = Expense report number, %2 = Approval Limit field caption, %3 = Expense User number';
+        ApproverRequiredErr: Label 'Expense report %1 exceeds the %2 for approver %3. Configure the approver in Expense Approval Setup.', Comment = '%1 = Expense report number, %2 = Approval Limit field caption, %3 = Expense User number';
 
     procedure ProcessAction(var ExpenseReportHeader: Record "Expense Report Header"; ActionType: Enum "Expense Approval Action")
     begin
@@ -101,7 +102,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ExpenseUser.Get(SubmitterExpenseUserNo);
         ExpenseReportHeader.TestApprovalStatus();
         ExpenseReportHeader.UpdateApproverID();
-        ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
+        SetApproverBasedOnApprovalLimit(ExpenseReportHeader);
         RouteToInterimIfAssigned(ExpenseReportHeader);
 
         UpdateSubmitterComment(ExpenseReportHeader, SubmissionComment);
@@ -151,7 +152,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
     )
     begin
         ExpenseReportHeader.UpdateApproverID();
-        ExpenseReportHeader."Final Approver No." := ExpenseReportHeader."Approver Expense User No.";
+        SetApproverBasedOnApprovalLimit(ExpenseReportHeader);
         RouteToInterimIfAssigned(ExpenseReportHeader);
         ExpenseReportHeader.Status := ExpenseReportHeader.Status::"Pending Approval";
         ExpenseReportHeader.Modify(true);
@@ -209,6 +210,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ApproverExpenseUserNo := GetExpenseUserNo();
         CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
         CheckActorIsActiveApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+        CheckApproverApprovalLimit(ExpenseReportHeader, ApproverExpenseUserNo);
 
         if ShouldRouteToFinalApprover(ExpenseReportHeader) then begin
             RouteToFinalApprover(ExpenseReportHeader, ApproverExpenseUserNo);
@@ -230,6 +232,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         CheckApproverPermissions(ExpenseUser);
         CheckActorIsNotInterimApprover(ExpenseReportHeader, ApproverExpenseUserNo);
         CheckActorIsActiveApprover(ExpenseReportHeader, ApproverExpenseUserNo);
+        CheckApproverApprovalLimit(ExpenseReportHeader, ApproverExpenseUserNo);
 
         if ShouldRouteToFinalApprover(ExpenseReportHeader) then begin
             RouteToFinalApprover(ExpenseReportHeader, ApproverExpenseUserNo);
@@ -266,6 +269,9 @@ codeunit 6901 "Expense Report Approval Mgmt"
 
         InterimApprover.Get(NewApproverExpenseUserNo);
         CheckApproverPermissions(InterimApprover);
+        ExpenseReportHeader.CalcFields("Amount (LCY)");
+        if not InterimApprover."Unlimited Approval" and (ExpenseReportHeader."Amount (LCY)" > InterimApprover."Approval Limit") then
+            Error(ApproverApprovalLimitErr, ExpenseReportHeader."No.", InterimApprover.FieldCaption("Approval Limit"), InterimApprover."No.");
 
         SetInterimApproverInExpenseReport(ExpenseReportHeader, InterimApprover);
         LogInterimApproverAssigned(ExpenseReportHeader, InterimApprover, ActorExpenseUserNo);
@@ -333,6 +339,48 @@ codeunit 6901 "Expense Report Approval Mgmt"
             (ExpenseReportHeader."Final Approver No." <> ExpenseReportHeader."Interim Approver No."));
     end;
 
+    local procedure SetApproverBasedOnApprovalLimit(var ExpenseReportHeader: Record "Expense Report Header")
+    var
+        ApproverExpenseUser: Record "Expense User";
+        NextApproverNo: Code[20];
+    begin
+        ApproverExpenseUser.Get(ExpenseReportHeader."Approver Expense User No.");
+        ExpenseReportHeader."Final Approver No." := ApproverExpenseUser."No.";
+
+        if ApproverExpenseUser."Unlimited Approval" then
+            exit;
+
+        ExpenseReportHeader.CalcFields("Amount (LCY)");
+        if ExpenseReportHeader."Amount (LCY)" <= ApproverExpenseUser."Approval Limit" then
+            exit;
+
+        NextApproverNo := GetNextApproverNo(ApproverExpenseUser."No.");
+        if (NextApproverNo = '') or (NextApproverNo = ApproverExpenseUser."No.") then
+            Error(ApproverRequiredErr, ExpenseReportHeader."No.", ApproverExpenseUser.FieldCaption("Approval Limit"), ApproverExpenseUser."No.");
+
+        ApproverExpenseUser.Get(NextApproverNo);
+        if not ApproverExpenseUser."Unlimited Approval" and (ExpenseReportHeader."Amount (LCY)" > ApproverExpenseUser."Approval Limit") then
+            Error(ApproverRequiredErr, ExpenseReportHeader."No.", ApproverExpenseUser.FieldCaption("Approval Limit"), ApproverExpenseUser."No.");
+
+        ApproverExpenseUser.TestField("User Id For Approvals");
+
+        ExpenseReportHeader."Final Approver No." := ApproverExpenseUser."No.";
+        ExpenseReportHeader."Approver Expense User No." := ApproverExpenseUser."No.";
+        ExpenseReportHeader."Approver Expense User ID" := ApproverExpenseUser."User Id For Approvals";
+    end;
+
+    local procedure GetNextApproverNo(CurrentApproverNo: Code[20]): Code[20]
+    var
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        if ExpenseApprovalSetup.Get(CurrentApproverNo) and (ExpenseApprovalSetup."Approver No." <> '') then
+            exit(ExpenseApprovalSetup."Approver No.");
+
+        ExpenseAgentSetup.GetRecordOnce();
+        exit(ExpenseAgentSetup."Default Approver No.");
+    end;
+
     local procedure RouteToFinalApprover(var ExpenseReportHeader: Record "Expense Report Header"; InterimApproverExpenseUserNo: Code[20])
     var
         FinalApprover: Record "Expense User";
@@ -378,6 +426,19 @@ codeunit 6901 "Expense Report Approval Mgmt"
 
         if ActingApproverExpenseUserNo <> ExpenseReportHeader."Approver Expense User No." then
             Error(ActorNotActiveApproverErr, ExpenseReportHeader."Approver Expense User No.");
+    end;
+
+    local procedure CheckApproverApprovalLimit(ExpenseReportHeader: Record "Expense Report Header"; ApproverExpenseUserNo: Code[20])
+    var
+        ApproverExpenseUser: Record "Expense User";
+    begin
+        ApproverExpenseUser.Get(ApproverExpenseUserNo);
+        if ApproverExpenseUser."Unlimited Approval" then
+            exit;
+
+        ExpenseReportHeader.CalcFields("Amount (LCY)");
+        if ExpenseReportHeader."Amount (LCY)" > ApproverExpenseUser."Approval Limit" then
+            Error(ApproverApprovalLimitErr, ExpenseReportHeader."No.", ApproverExpenseUser.FieldCaption("Approval Limit"), ApproverExpenseUser."No.");
     end;
 
     local procedure SetApprovalStatusInExpenseReport(var ExpenseReportHeader: Record "Expense Report Header"; ExpenseReportStatus: Enum "Expense Report Status"; ApproverExpenseUserNo: Code[20]; ApproverUserId: Code[50])
@@ -500,17 +561,23 @@ codeunit 6901 "Expense Report Approval Mgmt"
     end;
 
     local procedure GetRecallActorRole(ExpenseReportHeader: Record "Expense Report Header"): Enum "Expense Activity Actor Role"
-    var
-        UserSetup: Record "User Setup";
     begin
         if ExpenseReportHeader."Submitter Expense User Id" = UserId() then
             exit(Enum::"Expense Activity Actor Role"::Submitter);
 
-        UserSetup.SetLoadFields("Unlimited Expense Approval");
-        if UserSetup.Get(UserId()) and UserSetup."Unlimited Expense Approval" then
+        if IsApprovalAdministrator() then
             exit(Enum::"Expense Activity Actor Role"::Administrator);
 
-        Error(NotAuthorizedToRecallExpReportErr, UserSetup.FieldCaption("Unlimited Expense Approval"));
+        Error(NotAuthorizedToRecallExpReportErr, 'Unlimited Approval');
+    end;
+
+    internal procedure IsApprovalAdministrator(): Boolean
+    var
+        ExpenseUser: Record "Expense User";
+    begin
+        ExpenseUser.SetRange("User Id For Approvals", UserId());
+        ExpenseUser.SetRange("Unlimited Approval", true);
+        exit(not ExpenseUser.IsEmpty());
     end;
 
     internal procedure NoExpenseLinesToProcess(ExpenseApprovalAction: Enum "Expense Approval Action")

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -359,6 +359,9 @@ codeunit 6901 "Expense Report Approval Mgmt"
             Error(ApproverRequiredErr, ExpenseReportHeader."No.", ApproverExpenseUser.FieldCaption("Approval Limit"), ApproverExpenseUser."No.");
 
         ApproverExpenseUser.Get(NextApproverNo);
+        if not ApproverExpenseUser."Can Approve" then
+            Error(ApproverMustBeEnabledInExpenseUserErr, ApproverExpenseUser.FieldCaption("Can Approve"), ApproverExpenseUser.TableCaption());
+
         if not ApproverExpenseUser."Unlimited Approval" and (ExpenseReportHeader."Amount (LCY)" > ApproverExpenseUser."Approval Limit") then
             Error(ApproverRequiredErr, ExpenseReportHeader."No.", ApproverExpenseUser.FieldCaption("Approval Limit"), ApproverExpenseUser."No.");
 
@@ -576,6 +579,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
         ExpenseUser: Record "Expense User";
     begin
         ExpenseUser.SetRange("User Id For Approvals", UserId());
+        ExpenseUser.SetRange("Can Approve", true);
         ExpenseUser.SetRange("Unlimited Approval", true);
         exit(not ExpenseUser.IsEmpty());
     end;

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReport.Page.al
@@ -8,7 +8,6 @@ using Microsoft.Finance.Dimension;
 using Microsoft.Foundation.Attachment;
 using Microsoft.Foundation.Enums;
 using Microsoft.Utilities;
-using System.Security.User;
 
 page 6980 "Manager Expense Report"
 {
@@ -497,20 +496,17 @@ page 6980 "Manager Expense Report"
     trigger OnOpenPage()
     var
         ExpenseUser: Record "Expense User";
-        UserSetup: Record "User Setup";
         ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
         ExpenseAgentSetup.GetRecordOnce();
 
-        if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
-            if not UserSetup."Unlimited Expense Approval" then begin
+        if ExpenseAgentSetup."Enable Approval Workflow" then
+            if not ExpenseReportApprovalMgmt.IsApprovalAdministrator() then begin
                 CheckSetDefaultOwnerFilter();
                 ExpenseUserNo := ExpenseReportApprovalMgmt.GetExpenseUserNo();
                 ExpenseUser.Get(ExpenseUserNo);
             end else
                 ManagerExpense := true;
-        end;
 
         SetDocNoVisible();
         UpdateControls();

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReports.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReports.Page.al
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.ExpenseAgent;
 
-using System.Security.User;
 
 page 6981 "Manager Expense Reports"
 {
@@ -191,15 +190,12 @@ page 6981 "Manager Expense Reports"
     trigger OnOpenPage()
     var
         ExpenseAgentSetup: Record "Expense Agent Setup";
-        UserSetup: Record "User Setup";
         ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
         ExpenseAgentSetup.GetRecordOnce();
 
-        if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
-            if not UserSetup."Unlimited Expense Approval" then
+        if ExpenseAgentSetup."Enable Approval Workflow" then
+            if not ExpenseReportApprovalMgmt.IsApprovalAdministrator() then
                 ExpenseReportApprovalMgmt.FilterExpenseReports(Rec, Rec.FieldNo("Approver Expense User ID"))
-        end;
     end;
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Common/Extensions/ExpApprovalUserSetup.PageExt.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Common/Extensions/ExpApprovalUserSetup.PageExt.al
@@ -1,3 +1,4 @@
+#if not CLEAN30
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -16,12 +17,19 @@ pageextension 6977 "Exp. Approval User Setup" extends "Approval User Setup"
             {
                 ApplicationArea = Suite;
                 ToolTip = 'Specifies the maximum amount in local currency this user can approve for the record.';
+                ObsoleteState = Pending;
+                ObsoleteReason = 'Replaced by the Approval Limit field on Expense User.';
+                ObsoleteTag = '30.0';
             }
             field("Unlimited Expense Approval"; Rec."Unlimited Expense Approval")
             {
                 ApplicationArea = Suite;
                 ToolTip = 'Specifies that the user can approve expense records without a maximum amount. When selected, leave the Expense Amount Approval Limit field empty.';
+                ObsoleteState = Pending;
+                ObsoleteReason = 'Replaced by the approval settings on Expense User.';
+                ObsoleteTag = '30.0';
             }
         }
     }
 }
+#endif

--- a/src/Apps/W1/ExpenseAgent/app/src/Common/Extensions/UserSetupExt.TableExt.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Common/Extensions/UserSetupExt.TableExt.al
@@ -12,10 +12,14 @@ tableextension 6903 "User Setup Ext" extends "User Setup"
 {
     fields
     {
+#if not CLEAN30
         field(6900; "Unlimited Expense Approval"; Boolean)
         {
             Caption = 'Unlimited Expense Approval';
             DataClassification = CustomerContent;
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by the approval settings on Expense User.';
+            ObsoleteTag = '30.0';
         }
         field(6901; "Expense Amount Approval Limit"; Decimal)
         {
@@ -23,13 +27,20 @@ tableextension 6903 "User Setup Ext" extends "User Setup"
             BlankZero = true;
             Caption = 'Expense Amount Approval Limit';
             DataClassification = CustomerContent;
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by the Approval Limit field on Expense User.';
+            ObsoleteTag = '30.0';
         }
         field(6902; "Interim Approver ID"; Code[50])
         {
             Caption = 'Interim Approver ID';
             TableRelation = "User Setup";
             DataClassification = EndUserIdentifiableInformation;
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by the interim approver settings on Expense Report.';
+            ObsoleteTag = '30.0';
         }
+#endif
         field(6903; "Employee No."; Code[20])
         {
             Caption = 'Employee No.';

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
@@ -9,7 +9,6 @@ using Microsoft.Finance.Dimension;
 using Microsoft.Foundation.Attachment;
 using Microsoft.Foundation.Enums;
 using Microsoft.Utilities;
-using System.Security.User;
 
 page 6910 "Expense Report"
 {
@@ -706,19 +705,16 @@ page 6910 "Expense Report"
     trigger OnOpenPage()
     var
         ExpenseUser: Record "Expense User";
-        UserSetup: Record "User Setup";
         ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
         ExpenseAgentSetup.GetRecordOnce();
 
-        if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
-            if not UserSetup."Unlimited Expense Approval" then begin
+        if ExpenseAgentSetup."Enable Approval Workflow" then
+            if not ExpenseReportApprovalMgmt.IsApprovalAdministrator() then begin
                 CheckSetDefaultOwnerFilter();
                 ExpenseUserNo := ExpenseReportApprovalMgmt.GetExpenseUserNo();
                 ExpenseUser.Get(ExpenseUserNo);
             end;
-        end;
 
         SetDocNoVisible();
         UpdateControls();

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportList.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportList.Page.al
@@ -5,7 +5,6 @@
 namespace Microsoft.ExpenseAgent;
 
 using Microsoft.Utilities;
-using System.Security.User;
 
 page 6979 "Expense Report List"
 {
@@ -151,15 +150,12 @@ page 6979 "Expense Report List"
     trigger OnOpenPage()
     var
         ExpenseAgentSetup: Record "Expense Agent Setup";
-        UserSetup: Record "User Setup";
         ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
         ExpenseAgentSetup.GetRecordOnce();
 
-        if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
-            if not UserSetup."Unlimited Expense Approval" then
+        if ExpenseAgentSetup."Enable Approval Workflow" then
+            if not ExpenseReportApprovalMgmt.IsApprovalAdministrator() then
                 ExpenseReportApprovalMgmt.FilterExpenseReports(Rec, Rec.FieldNo("Created By"));
-        end;
     end;
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReports.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReports.Page.al
@@ -5,7 +5,6 @@
 namespace Microsoft.ExpenseAgent;
 
 using Microsoft.Foundation.BatchProcessing;
-using System.Security.User;
 
 page 6997 "Expense Reports"
 {
@@ -299,16 +298,13 @@ page 6997 "Expense Reports"
     trigger OnOpenPage()
     var
         ExpenseAgentSetup: Record "Expense Agent Setup";
-        UserSetup: Record "User Setup";
         ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
         ExpenseAgentSetup.GetRecordOnce();
 
-        if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
-            if not UserSetup."Unlimited Expense Approval" then
+        if ExpenseAgentSetup."Enable Approval Workflow" then
+            if not ExpenseReportApprovalMgmt.IsApprovalAdministrator() then
                 ExpenseReportApprovalMgmt.FilterExpenseReports(Rec, Rec.FieldNo("Created By"));
-        end;
     end;
 
     var

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
@@ -19,7 +19,6 @@ using Microsoft.Utilities;
 using System.Globalization;
 using System.Reflection;
 using System.Security.AccessControl;
-using System.Security.User;
 using System.Utilities;
 
 table 6906 "Expense Report Header"
@@ -1305,16 +1304,15 @@ table 6906 "Expense Report Header"
 
     local procedure CheckExpenseUserWhenApprovalIsEnabled()
     var
-        UserSetup: Record "User Setup";
         ExpenseUser: Record "Expense User";
     begin
         ExpenseAgentSetup.GetRecordOnce();
         if not ExpenseAgentSetup."Enable Approval Workflow" then
             exit;
 
-        UserSetup.SetLoadFields("Unlimited Expense Approval");
-        UserSetup.Get(UserId);
-        if UserSetup."Unlimited Expense Approval" then
+        ExpenseUser.SetRange("User Id For Approvals", UserId);
+        ExpenseUser.SetRange("Unlimited Approval", true);
+        if not ExpenseUser.IsEmpty() then
             exit;
 
         ExpenseUser.Get(Rec."Expense User No.");

--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
@@ -145,6 +145,20 @@ page 6949 "Expense User"
                     ToolTip = 'Specifies whether a welcome email has been queued, sent, or failed for the expense user.';
                 }
             }
+            group("Approval Information")
+            {
+                Caption = 'Approval Information';
+                Visible = Rec."Can Approve";
+
+                field("Approval Limit"; Rec."Approval Limit")
+                {
+                    ApplicationArea = Basic, Suite;
+                }
+                field("Unlimited Approval"; Rec."Unlimited Approval")
+                {
+                    ApplicationArea = Basic, Suite;
+                }
+            }
             part(ExpenseApprovalSetup; "Expense Approval Setups Part")
             {
                 ApplicationArea = Basic, Suite;

--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Tables/ExpenseUser.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Tables/ExpenseUser.Table.al
@@ -203,6 +203,33 @@ table 6923 "Expense User"
             Editable = false;
             ToolTip = 'Specifies the identifier used to correlate the welcome email with its delivery from the outbox.';
         }
+        field(60; "Approval Limit"; Decimal)
+        {
+            Caption = 'Approval Limit';
+            ToolTip = 'Specifies the maximum expense report amount this user can approve. Leave empty when Unlimited Approval is selected.';
+            AutoFormatType = 0;
+            BlankZero = true;
+
+            trigger OnValidate()
+            begin
+                if Rec."Approval Limit" < 0 then
+                    Error(ApprovalLimitMustNotBeNegativeErr, Rec.FieldCaption("Approval Limit"));
+
+                if Rec."Approval Limit" <> 0 then
+                    Rec."Unlimited Approval" := false;
+            end;
+        }
+        field(61; "Unlimited Approval"; Boolean)
+        {
+            Caption = 'Unlimited Approval';
+            ToolTip = 'Specifies that this user can approve expense reports without a maximum amount.';
+
+            trigger OnValidate()
+            begin
+                if Rec."Unlimited Approval" then
+                    Rec."Approval Limit" := 0;
+            end;
+        }
     }
 
     keys
@@ -240,6 +267,7 @@ table 6923 "Expense User"
         NoNoreplyAccountErr: Label 'No account is set for sending emails. Set the send mail account for the Expense Agent before sending welcome emails.';
         CurrentBCUserHasNoAuthEmailErr: Label 'Your Business Central user account is not linked to an authentication email, so it cannot be matched to an Expense User. Ask your administrator to set the Authentication Email on your user record in Business Central.';
         CurrentBCUserNotMatchedToExpenseUserErr: Label 'No Expense User exists for the email %1 used by your Business Central account. Ask your administrator to create an Expense User with this email, or to update the email on the existing Expense User to match.', Comment = '%1 = authentication email of the current Business Central user';
+        ApprovalLimitMustNotBeNegativeErr: Label '%1 must not be negative.', Comment = '%1 = Approval Limit field caption';
 
     trigger OnDelete()
     var

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseInterimApprovalTest.Codeunit.al
@@ -39,6 +39,12 @@ codeunit 148346 "Expense Interim Approval Test"
         InterimApproverConflictErr: Label 'The %1 cannot be the same as the %2 (value: %3).', Comment = '%1 = Interim Approver No. caption, %2 = conflicting field caption, %3 = conflicting field value';
         InterimApproverCannotFinalizeErr: Label '%1 %2 cannot give final approval. Final approval must be completed by a different approver.', Comment = '%1 = Interim Approver No. caption, %2 = Interim Approver No.';
         ActorNotActiveApproverErr: Label 'This expense report is awaiting approval from %1. Only that approver can approve or reject it.', Comment = '%1 = Expense User No. of the approver the report is currently assigned to';
+        ApprovalLimitMustNotBeNegativeErr: Label '%1 must not be negative.', Comment = '%1 = Approval Limit field caption';
+        ApproverRequiredErr: Label 'Expense report %1 exceeds the %2 for approver %3. Configure the approver in Expense Approval Setup.', Comment = '%1 = Expense report number, %2 = Approval Limit field caption, %3 = Expense User number';
+        ApproverMustBeEnabledInExpenseUserErr: Label '%1 must be enabled to approve or reject expense reports in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
+        ApproverApprovalLimitErr: Label 'Expense report %1 exceeds the %2 for approver %3.', Comment = '%1 = Expense report number, %2 = Approval Limit field caption, %3 = Expense User number';
+        NotAuthorizedToRecallExpReportErr: Label 'Only the original submitter or a user with %1 can recall a submitted expense report.', Comment = '%1 = Unlimited Approval field caption';
+        ExpenseUserConfiguredForDifferentUserErr: Label '%1 must be %2 to select this %3 %4.', Comment = '%1 = Field Caption, %2 = User Id, %3 = Table Caption, %4 = Field Value';
 
     [Test]
     [HandlerFunctions('ExpensesModalPageHandler')]
@@ -433,6 +439,788 @@ codeunit 148346 "Expense Interim Approval Test"
         VerifyActiveApprover(ExpenseReportHeader, InterimApprover);
     end;
 
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionWithinLimitUsesConfiguredApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A report equal to the configured approver's approval limit does not escalate.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has configured approver "A1" with an approval limit of 100 and a released expense report for 100.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 100, 100);
+
+        // [WHEN] "S" submits the expense report.
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is pending approval with "A1" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, Approver, Approver);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitRoutesToUnlimitedNextApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A report above the configured approver's limit escalates to an unlimited next approver.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has approver "A1" with a limit of 100, "A1" has next approver "A2" with unlimited approval, and the released report amount is 200.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(NextApprover);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+
+        // [WHEN] "S" submits the expense report.
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is pending approval with "A2" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, NextApprover, NextApprover);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitRoutesToSufficientLimitedNextApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A report above the configured approver's limit routes to a next approver whose limit covers the amount.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has approver "A1" with a limit of 100, "A1" has next approver "A2" with a limit of 200, and the released report amount is 200.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(NextApprover);
+        SetApprovalLimit(NextApprover, 200);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+
+        // [WHEN] "S" submits the expense report.
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is pending approval with "A2" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, NextApprover, NextApprover);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitWithoutNextApproverFails()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Submission fails when a report exceeds the configured approver's limit and no next approver exists.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has approver "A1" with a limit of 100, no next or default approver is configured, and the released report amount is 200.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+
+        // [WHEN] "S" submits the expense report.
+        asserterror ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] An error explains that a next approver must be configured for "A1".
+        Assert.ExpectedError(StrSubstNo(ApproverRequiredErr, ExpenseReportHeader."No.", Approver.FieldCaption("Approval Limit"), Approver."No."));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitWithInsufficientNextApproverFails()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Submission fails when the next approver's approval limit is insufficient.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has approver "A1" with a limit of 100, "A1" has next approver "A2" with a limit of 100, and the released report amount is 200.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(NextApprover);
+        SetApprovalLimit(NextApprover, 100);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+
+        // [WHEN] "S" submits the expense report.
+        asserterror ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] An error explains that another approver must be configured for "A2".
+        Assert.ExpectedError(StrSubstNo(ApproverRequiredErr, ExpenseReportHeader."No.", NextApprover.FieldCaption("Approval Limit"), NextApprover."No."));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverWithInsufficientLimitCannotBeAssigned()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An interim approver cannot be assigned when the report exceeds their approval limit.
+        Initialize();
+
+        // [GIVEN] A submitted report for 200 has final approver "A2", and interim approver "I" has an approval limit of 100.
+        CreateSubmittedUnlimitedApprovalScenario(Submitter, FinalApprover, ExpenseReportHeader, 200);
+        CreateApproverExpenseUser(InterimApprover);
+        SetApprovalLimit(InterimApprover, 100);
+
+        // [WHEN] Submitter "S" assigns "I" as the interim approver.
+        asserterror ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [THEN] An error explains that the report exceeds "I"'s approval limit.
+        Assert.ExpectedError(StrSubstNo(ApproverApprovalLimitErr, ExpenseReportHeader."No.", InterimApprover.FieldCaption("Approval Limit"), InterimApprover."No."));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ApproverWhoseLimitWasReducedCannotApprove()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An active approver cannot approve a report after their approval limit is reduced below its amount.
+        Initialize();
+
+        // [GIVEN] A report for 100 is pending approval with active approver "A1", whose approval limit is then reduced from 200 to 50.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 100, 200);
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+        SetApprovalLimit(Approver, 50);
+
+        // [WHEN] "A1" approves the expense report.
+        asserterror ExpenseReportHeader.PerformManualApproved(Approver."No.", true);
+
+        // [THEN] An error explains that the report exceeds "A1"'s approval limit.
+        Assert.ExpectedError(StrSubstNo(ApproverApprovalLimitErr, ExpenseReportHeader."No.", Approver.FieldCaption("Approval Limit"), Approver."No."));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ReopenApprovedRecalculatesEscalatedApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Reopening an approved report recalculates escalation using the current approval limits.
+        Initialize();
+
+        // [GIVEN] Approver "A1" approved a report for 200 with a limit of 300, then "A1"'s limit is reduced to 100 and unlimited next approver "A2" is configured.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 300);
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+        ExpenseReportHeader.PerformManualApproved(Approver."No.", true);
+        SetApprovalLimit(Approver, 100);
+        CreateApproverExpenseUser(NextApprover);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+        SetCurrentUser(Approver);
+
+        // [WHEN] The approved expense report is reopened.
+        ExpenseReportApprovalMgmt.ReopenApproved(ExpenseReportHeader);
+
+        // [THEN] The report is pending approval with "A2" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, NextApprover, NextApprover);
+    end;
+
+    [Test]
+    procedure UnlimitedApprovalWithoutCanApproveIsNotAdministrator()
+    var
+        Approver: Record "Expense User";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Unlimited approval alone does not grant approval-administrator access.
+        Initialize();
+
+        // [GIVEN] Expense user "A1" has unlimited approval and approval rights are removed.
+        CreateApproverExpenseUser(Approver);
+        SetCurrentUser(Approver);
+        Approver."Can Approve" := false;
+        Approver.Modify();
+
+        // [WHEN] Approval-administrator access is evaluated for "A1".
+
+        // [THEN] "A1" is not an approval administrator.
+        Assert.IsFalse(ExpenseReportApprovalMgmt.IsApprovalAdministrator(), 'Unlimited approval without approval rights must not grant administrator access.');
+    end;
+
+    [Test]
+    procedure NegativeApprovalLimitCannotBeSet()
+    var
+        Approver: Record "Expense User";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An approval limit cannot be negative.
+        Initialize();
+
+        // [GIVEN] Approver "A1" exists.
+        CreateApproverExpenseUser(Approver);
+
+        // [WHEN] The approval limit of "A1" is set to -100.
+        asserterror Approver.Validate("Approval Limit", -100);
+
+        // [THEN] An error explains that the approval limit must not be negative.
+        Assert.ExpectedError(StrSubstNo(ApprovalLimitMustNotBeNegativeErr, Approver.FieldCaption("Approval Limit")));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    procedure SettingApprovalLimitClearsUnlimitedApproval()
+    var
+        Approver: Record "Expense User";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Setting a positive approval limit removes unlimited approval.
+        Initialize();
+
+        // [GIVEN] Approver "A1" has unlimited approval.
+        CreateApproverExpenseUser(Approver);
+
+        // [WHEN] The approval limit of "A1" is set to 100.
+        Approver.Validate("Approval Limit", 100);
+        Approver.Modify();
+
+        // [THEN] The approval limit is 100 and unlimited approval is disabled.
+        Approver.Get(Approver."No.");
+        Approver.TestField("Approval Limit", 100);
+        Approver.TestField("Unlimited Approval", false);
+    end;
+
+    [Test]
+    procedure EnablingUnlimitedApprovalClearsApprovalLimit()
+    var
+        Approver: Record "Expense User";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Enabling unlimited approval clears an existing approval limit.
+        Initialize();
+
+        // [GIVEN] Approver "A1" has an approval limit of 100.
+        CreateApproverExpenseUser(Approver);
+        Approver.Validate("Approval Limit", 100);
+
+        // [WHEN] Unlimited approval is enabled for "A1".
+        Approver.Validate("Unlimited Approval", true);
+        Approver.Modify();
+
+        // [THEN] Unlimited approval is enabled and the approval limit is 0.
+        Approver.Get(Approver."No.");
+        Approver.TestField("Unlimited Approval", true);
+        Approver.TestField("Approval Limit", 0);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionBelowLimitUsesConfiguredApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A report below the configured approver's approval limit does not escalate.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has configured approver "A1" with a limit of 200 and a released expense report for 100.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 100, 200);
+
+        // [WHEN] "S" submits the expense report.
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is pending approval with "A1" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, Approver, Approver);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionWithUnlimitedConfiguredApproverDoesNotEscalate()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A configured approver with unlimited approval receives the report without escalation.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has unlimited configured approver "A1" and a released expense report for 200.
+        CreateSubmitterExpenseUser(Submitter);
+        CreateApproverExpenseUser(Approver);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Submitter."No.", Approver."No.");
+        CreateAndReleaseExpenseReportWithAmount(Submitter, ExpenseReportHeader, 200);
+
+        // [WHEN] "S" submits the expense report.
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is pending approval with "A1" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, Approver, Approver);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitUsesUnlimitedDefaultApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        DefaultApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Escalation uses the unlimited default approver when the current approver has no configured next approver.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has approver "A1" with a limit of 100, "A1" has no next approver, default approver "A2" has unlimited approval, and the released report amount is 200.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(DefaultApprover);
+        SetDefaultApprover(DefaultApprover."No.");
+
+        // [WHEN] "S" submits the expense report.
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] The report is pending approval with "A2" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, DefaultApprover, DefaultApprover);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitWithCurrentApproverAsNextFails()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Submission fails when escalation resolves back to the current approver.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has approver "A1" with a limit of 100, "A1" is configured as their own next approver, and the released report amount is 200.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", Approver."No.");
+
+        // [WHEN] "S" submits the expense report.
+        asserterror ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] An error explains that a different next approver must be configured for "A1".
+        Assert.ExpectedError(StrSubstNo(ApproverRequiredErr, ExpenseReportHeader."No.", Approver.FieldCaption("Approval Limit"), Approver."No."));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitWithNextApproverWithoutUserIdFails()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Submission fails when the unlimited next approver has no approval user ID.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has limited approver "A1", whose unlimited next approver "A2" has no user ID for approvals, and the released report amount exceeds "A1"'s limit.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(NextApprover);
+        NextApprover."User Id For Approvals" := '';
+        NextApprover.Modify();
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+
+        // [WHEN] "S" submits the expense report.
+        asserterror ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] An error explains that the user ID for approvals must be configured for "A2".
+        Assert.ExpectedError(NextApprover.FieldCaption("User Id For Approvals"));
+        Assert.ExpectedErrorCode('TestField');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure SubmissionExceedingLimitWithIneligibleNextApproverFails()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Submission fails when the unlimited next approver no longer has approval rights.
+        Initialize();
+
+        // [GIVEN] Submitter "S" has limited approver "A1", whose unlimited next approver "A2" cannot approve, and the released report amount exceeds "A1"'s limit.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(NextApprover);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+        NextApprover."Can Approve" := false;
+        NextApprover.Modify();
+
+        // [WHEN] "S" submits the expense report.
+        asserterror ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [THEN] An error explains that approval rights must be enabled for "A2".
+        Assert.ExpectedError(StrSubstNo(ApproverMustBeEnabledInExpenseUserErr, NextApprover.FieldCaption("Can Approve"), NextApprover.TableCaption()));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure InterimApproverAtLimitCanBeAssigned()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An interim approver can be assigned when the report amount equals their approval limit.
+        Initialize();
+
+        // [GIVEN] A submitted report for 100 has final approver "A2", and interim approver "I" has an approval limit of 100.
+        CreateSubmittedUnlimitedApprovalScenario(Submitter, FinalApprover, ExpenseReportHeader, 100);
+        CreateApproverExpenseUser(InterimApprover);
+        SetApprovalLimit(InterimApprover, 100);
+
+        // [WHEN] Submitter "S" assigns "I" as the interim approver.
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [THEN] "I" becomes the active interim approver and the report remains pending approval.
+        VerifyApprovalRouting(ExpenseReportHeader, InterimApprover, FinalApprover);
+        VerifyInterimApprover(ExpenseReportHeader, InterimApprover."No.");
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure UnlimitedInterimApproverCanBeAssignedAboveAmount()
+    var
+        Submitter: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An interim approver with unlimited approval can be assigned for any report amount.
+        Initialize();
+
+        // [GIVEN] A submitted report for 200 has final approver "A2", and interim approver "I" has unlimited approval.
+        CreateSubmittedUnlimitedApprovalScenario(Submitter, FinalApprover, ExpenseReportHeader, 200);
+        CreateApproverExpenseUser(InterimApprover);
+
+        // [WHEN] Submitter "S" assigns "I" as the interim approver.
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+
+        // [THEN] "I" becomes the active interim approver and the report remains pending approval.
+        VerifyApprovalRouting(ExpenseReportHeader, InterimApprover, FinalApprover);
+        VerifyInterimApprover(ExpenseReportHeader, InterimApprover."No.");
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ApproverAtLimitCanApprove()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An active approver can approve a report equal to their approval limit.
+        Initialize();
+
+        // [GIVEN] A report for 100 is pending approval with active approver "A1", whose approval limit is 100.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 100, 100);
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+
+        // [WHEN] "A1" approves the expense report.
+        ExpenseReportHeader.PerformManualApproved(Approver."No.", true);
+
+        // [THEN] The expense report is approved.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Approved);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure UnlimitedApproverCanApproveAboveAmount()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An active approver with unlimited approval can approve any report amount.
+        Initialize();
+
+        // [GIVEN] A report for 200 is pending approval with unlimited active approver "A1".
+        CreateSubmittedUnlimitedApprovalScenario(Submitter, Approver, ExpenseReportHeader, 200);
+
+        // [WHEN] "A1" approves the expense report.
+        ExpenseReportHeader.PerformManualApproved(Approver."No.", true);
+
+        // [THEN] The expense report is approved.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Approved);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure LimitedApproverCanRejectAfterLimitReduction()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Approval limits do not prevent an active approver from rejecting a report.
+        Initialize();
+
+        // [GIVEN] A report for 100 is pending approval with active approver "A1", whose approval limit is then reduced from 200 to 50.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 100, 200);
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+        SetApprovalLimit(Approver, 50);
+
+        // [WHEN] "A1" rejects the expense report.
+        ExpenseReportHeader.PerformManualRejected(Approver."No.", 'Limit reduced.');
+
+        // [THEN] The expense report is rejected.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Rejected);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ReopenApprovedUsesConfiguredApproverAfterLimitIncrease()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        NextApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Reopening an approved report removes escalation when the configured approver's limit now covers the amount.
+        Initialize();
+
+        // [GIVEN] Unlimited approver "A2" approved a report for 200 after escalation from "A1", then "A1"'s approval limit is increased to 300.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(NextApprover);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", NextApprover."No.");
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+        ExpenseReportHeader.PerformManualApproved(NextApprover."No.", true);
+        SetApprovalLimit(Approver, 300);
+        SetCurrentUser(NextApprover);
+
+        // [WHEN] The approved expense report is reopened.
+        ExpenseReportApprovalMgmt.ReopenApproved(ExpenseReportHeader);
+
+        // [THEN] The report is pending approval with configured approver "A1" as both the active and final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, Approver, Approver);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure ReopenApprovedRoutesToInterimBeforeEscalatedFinalApprover()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        InterimApprover: Record "Expense User";
+        FinalApprover: Record "Expense User";
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] Reopening an approved report restarts its interim stage before the recalculated final approver.
+        Initialize();
+
+        // [GIVEN] A report for 200 has assigned interim approver "I", limited configured approver "A1", unlimited final approver "A2", and status Approved.
+        CreateApprovalLimitScenario(Submitter, Approver, ExpenseReportHeader, 200, 100);
+        CreateApproverExpenseUser(FinalApprover);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Approver."No.", FinalApprover."No.");
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+        CreateApproverExpenseUser(InterimApprover);
+        ExpenseReportHeader.AssignInterimApprover(InterimApprover."No.", Submitter."No.");
+        ExpenseReportHeader.PerformManualApproved(InterimApprover."No.", true);
+        ExpenseReportHeader.PerformManualApproved(FinalApprover."No.", true);
+        SetCurrentUser(FinalApprover);
+
+        // [WHEN] The approved expense report is reopened.
+        ExpenseReportApprovalMgmt.ReopenApproved(ExpenseReportHeader);
+
+        // [THEN] The report is pending approval with "I" active and "A2" retained as final approver.
+        VerifyApprovalRouting(ExpenseReportHeader, InterimApprover, FinalApprover);
+        VerifyInterimApprover(ExpenseReportHeader, InterimApprover."No.");
+    end;
+
+    [Test]
+    procedure UnlimitedApproverIsAdministrator()
+    var
+        Approver: Record "Expense User";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An approver with unlimited approval is an approval administrator.
+        Initialize();
+
+        // [GIVEN] Expense user "A1" can approve and has unlimited approval.
+        CreateApproverExpenseUser(Approver);
+        SetCurrentUser(Approver);
+
+        // [WHEN] Approval-administrator access is evaluated for "A1".
+
+        // [THEN] "A1" is an approval administrator.
+        Assert.IsTrue(ExpenseReportApprovalMgmt.IsApprovalAdministrator(), 'An unlimited approver must have administrator access.');
+    end;
+
+    [Test]
+    procedure LimitedApproverIsNotAdministrator()
+    var
+        Approver: Record "Expense User";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A limited approver is not an approval administrator.
+        Initialize();
+
+        // [GIVEN] Expense user "A1" can approve and has an approval limit of 100.
+        CreateApproverExpenseUser(Approver);
+        SetApprovalLimit(Approver, 100);
+        SetCurrentUser(Approver);
+
+        // [WHEN] Approval-administrator access is evaluated for "A1".
+
+        // [THEN] "A1" is not an approval administrator.
+        Assert.IsFalse(ExpenseReportApprovalMgmt.IsApprovalAdministrator(), 'A limited approver must not have administrator access.');
+    end;
+
+    [Test]
+    procedure UnlimitedApproverCanCreateReportForAnotherExpenseUser()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An unlimited approver can create an expense report for another expense user while approval workflow is enabled.
+        Initialize();
+
+        // [GIVEN] Approval workflow is enabled, expense user "A1" can approve with unlimited approval, and expense user "S" exists.
+        EnableApprovalWorkflow();
+        CreateApproverExpenseUser(Approver);
+        SetCurrentUser(Approver);
+        CreateSubmitterExpenseUser(Submitter);
+
+        // [WHEN] "A1" creates an expense report for "S".
+        ExpenseReportHeader.Init();
+        ExpenseReportHeader.Validate("Expense User No.", Submitter."No.");
+        ExpenseReportHeader.Insert(true);
+
+        // [THEN] The expense report is created for "S" without an authorization error.
+        ExpenseReportHeader.TestField("Expense User No.", Submitter."No.");
+    end;
+
+    [Test]
+    procedure LimitedApproverCannotCreateReportForAnotherExpenseUser()
+    var
+        Submitter: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A limited approver cannot create an expense report for another expense user while approval workflow is enabled.
+        Initialize();
+
+        // [GIVEN] Approval workflow is enabled, expense user "A1" has an approval limit of 100, and expense user "S" exists.
+        EnableApprovalWorkflow();
+        CreateApproverExpenseUser(Approver);
+        SetApprovalLimit(Approver, 100);
+        SetCurrentUser(Approver);
+        CreateSubmitterExpenseUser(Submitter);
+
+        // [WHEN] "A1" creates an expense report for "S".
+        ExpenseReportHeader.Init();
+        asserterror ExpenseReportHeader.Validate("Expense User No.", Submitter."No.");
+
+        // [THEN] An authorization error explains that "S" is configured for a different user.
+        Assert.ExpectedError(StrSubstNo(ExpenseUserConfiguredForDifferentUserErr, Submitter.FieldCaption("User Id For Approvals"), UserId(), Submitter.TableCaption(), Submitter."No."));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure UnlimitedApproverCanRecallAnotherUsersReport()
+    var
+        Submitter: Record "Expense User";
+        ReportApprover: Record "Expense User";
+        Administrator: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+        ExpenseActivityLogEntry: Record "Expense Activity Log Entry";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] An unlimited approver can recall another expense user's submitted report as administrator.
+        Initialize();
+
+        // [GIVEN] Expense user "A1" can approve with unlimited approval and submitter "S" has a pending expense report.
+        CreateSubmittedUnlimitedApprovalScenario(Submitter, ReportApprover, ExpenseReportHeader, 100);
+        CreateApproverExpenseUser(Administrator);
+        SetCurrentUser(Administrator);
+
+        // [WHEN] "A1" recalls the expense report.
+        ExpenseReportApprovalMgmt.ReopenSubmitted(ExpenseReportHeader);
+
+        // [THEN] The report is open and the recall is logged with the administrator role.
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::Open);
+        ExpenseActivityLogEntry.SetRange("Subject System ID", ExpenseReportHeader.SystemId);
+        ExpenseActivityLogEntry.FindLast();
+        ExpenseActivityLogEntry.TestField("Event Type", Enum::"Expense Activity Event Type"::Recalled);
+        ExpenseActivityLogEntry.TestField("Actor Role", Enum::"Expense Activity Actor Role"::Administrator);
+    end;
+
+    [Test]
+    [HandlerFunctions('ExpensesModalPageHandler')]
+    procedure LimitedApproverCannotRecallAnotherUsersReport()
+    var
+        Submitter: Record "Expense User";
+        ReportApprover: Record "Expense User";
+        Approver: Record "Expense User";
+        ExpenseReportHeader: Record "Expense Report Header";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 640938] A limited approver cannot recall another expense user's submitted report.
+        Initialize();
+
+        // [GIVEN] Expense user "A1" has an approval limit of 100 and submitter "S" has a pending expense report.
+        CreateSubmittedUnlimitedApprovalScenario(Submitter, ReportApprover, ExpenseReportHeader, 100);
+        CreateApproverExpenseUser(Approver);
+        SetApprovalLimit(Approver, 100);
+        SetCurrentUser(Approver);
+
+        // [WHEN] "A1" recalls the expense report.
+        asserterror ExpenseReportApprovalMgmt.ReopenSubmitted(ExpenseReportHeader);
+
+        // [THEN] An authorization error explains that only the submitter or an unlimited approver can recall it.
+        Assert.ExpectedError(StrSubstNo(NotAuthorizedToRecallExpReportErr, Approver.FieldCaption("Unlimited Approval")));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
     local procedure Initialize()
     var
         UserSetup: Record "User Setup";
@@ -503,6 +1291,7 @@ codeunit 148346 "Expense Interim Approval Test"
         LibraryExpense.CreateExpenseUser(ExpenseUser);
         ExpenseUser.Validate("E-mail", UserEmail);
         ExpenseUser.Validate("Can Approve", true);
+        ExpenseUser.Validate("Unlimited Approval", true);
         ExpenseUser.Validate("Entra Id", CreateGuid());
         ExpenseUser.Modify();
     end;
@@ -512,6 +1301,76 @@ codeunit 148346 "Expense Interim Approval Test"
         CreateAndReleaseExpenseReport(Submitter, ExpenseReportHeader);
         ExpenseReportHeader.PerformManualPendingApproval(Submitter."No.");
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+    end;
+
+    local procedure CreateApprovalLimitScenario(var Submitter: Record "Expense User"; var Approver: Record "Expense User"; var ExpenseReportHeader: Record "Expense Report Header"; Amount: Decimal; ApprovalLimit: Decimal)
+    var
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+    begin
+        CreateSubmitterExpenseUser(Submitter);
+        CreateApproverExpenseUser(Approver);
+        SetApprovalLimit(Approver, ApprovalLimit);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Submitter."No.", Approver."No.");
+        CreateAndReleaseExpenseReportWithAmount(Submitter, ExpenseReportHeader, Amount);
+    end;
+
+    local procedure CreateSubmittedUnlimitedApprovalScenario(var Submitter: Record "Expense User"; var Approver: Record "Expense User"; var ExpenseReportHeader: Record "Expense Report Header"; Amount: Decimal)
+    var
+        ExpenseApprovalSetup: Record "Expense Approval Setup";
+    begin
+        CreateSubmitterExpenseUser(Submitter);
+        CreateApproverExpenseUser(Approver);
+        LibraryExpense.CreateExpenseApprovalSetup(ExpenseApprovalSetup, Submitter."No.", Approver."No.");
+        CreateAndReleaseExpenseReportWithAmount(Submitter, ExpenseReportHeader, Amount);
+        ExpenseReportApprovalMgmt.Submit(ExpenseReportHeader, Submitter."No.");
+        ExpenseReportHeader.Get(ExpenseReportHeader."No.");
+    end;
+
+    local procedure SetApprovalLimit(var Approver: Record "Expense User"; ApprovalLimit: Decimal)
+    begin
+        Approver.Validate("Approval Limit", ApprovalLimit);
+        Approver.Modify();
+    end;
+
+    local procedure SetDefaultApprover(ApproverNo: Code[20])
+    var
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        ExpenseAgentSetup.GetRecordOnce();
+        ExpenseAgentSetup.Validate("Default Approver No.", ApproverNo);
+        ExpenseAgentSetup.Modify();
+    end;
+
+    local procedure SetCurrentUser(var ExpenseUser: Record "Expense User")
+    begin
+        ExpenseUser."User Id For Approvals" := CopyStr(UserId(), 1, MaxStrLen(ExpenseUser."User Id For Approvals"));
+        ExpenseUser.Modify();
+    end;
+
+    local procedure EnableApprovalWorkflow()
+    var
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        ExpenseAgentSetup.GetRecordOnce();
+        ExpenseAgentSetup."Enable Approval Workflow" := true;
+        ExpenseAgentSetup.Modify();
+    end;
+
+    local procedure CreateAndReleaseExpenseReportWithAmount(Submitter: Record "Expense User"; var ExpenseReportHeader: Record "Expense Report Header"; Amount: Decimal)
+    var
+        Expense: Record Expense;
+        CreateExpenseReport: Codeunit "Create Expense Report";
+        ReleaseExpenseDocument: Codeunit "Release Expense Document";
+        ReleaseExpenseReportDocument: Codeunit "Release Exp. Report Document";
+    begin
+        CreateExpense(Expense, Submitter, Amount);
+        ReleaseExpenseDocument.PerformManualCheckAndRelease(Expense);
+
+        LibraryExpense.CreateExpenseReport(ExpenseReportHeader, Submitter."No.", Expense."Currency Code", Expense."VAT Bus. Posting Group");
+        CreateExpenseReport.AddExpensesToReport(ExpenseReportHeader);
+        ReleaseExpenseReportDocument.PerformManualCheckAndRelease(ExpenseReportHeader);
+        ExpenseReportHeader.CalcFields("Amount (LCY)");
+        Assert.AreEqual(Amount, ExpenseReportHeader."Amount (LCY)", 'The expense report amount must match the scenario amount.');
     end;
 
     local procedure CreateAndReleaseExpenseReport(Submitter: Record "Expense User"; var ExpenseReportHeader: Record "Expense Report Header")
@@ -591,6 +1450,13 @@ codeunit 148346 "Expense Interim Approval Test"
         ExpenseReportHeader.Get(ExpenseReportHeader."No.");
         ExpenseReportHeader.TestField("Approver Expense User No.", Approver."No.");
         ExpenseReportHeader.TestField("Approver Expense User ID", Approver."User Id For Approvals");
+    end;
+
+    local procedure VerifyApprovalRouting(var ExpenseReportHeader: Record "Expense Report Header"; ActiveApprover: Record "Expense User"; FinalApprover: Record "Expense User")
+    begin
+        VerifyStatus(ExpenseReportHeader, ExpenseReportHeader.Status::"Pending Approval");
+        VerifyActiveApprover(ExpenseReportHeader, ActiveApprover);
+        ExpenseReportHeader.TestField("Final Approver No.", FinalApprover."No.");
     end;
 
     local procedure VerifyInterimApprover(var ExpenseReportHeader: Record "Expense Report Header"; ExpectedInterimNo: Code[20])


### PR DESCRIPTION
## Work item

[Slice 640938: Expense Agent - Adding approval limits (November '26)](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/640938)

## Summary

Adds amount-based approval limits to Expense Agent approvers and routes reports to the appropriate approver when the configured approver cannot approve the report amount.

## What changed

- Added **Approval Limit** and **Unlimited Approval** settings to Expense Users and exposed them on the Expense User page.
- Added amount-based routing during submission and reopening. Reports stay with the configured approver when within the limit and move to the configured next or default approver when escalation is required.
- Enforced approval limits when assigning interim approvers and when approving reports.
- Recalculated final and interim routing when approved reports are reopened or rejected reports are resubmitted.
- Required escalated approvers and approval administrators to retain approval rights.
- Replaced runtime use of the legacy User Setup approval fields and marked those fields for CLEAN30 removal.
- Added 31 Slice 640938 scenarios covering field validation, limit boundaries, escalation, interim approval, reopen routing, authorization, and error cases.

## Validation

- Expense Agent app package builds successfully with CodeCop and UICop and no warnings.
- AL diagnostics report no errors in the changed app and test files.
- `git diff --check` passes.
- The repository build for **Expense Agent Tests** is currently blocked before AL compilation because the local extension cache cannot find the **System Application** package, so publishing and executing the test codeunit was not possible in this enlistment.
