### PR TITLE
[Main] - User encounters a "record is not open" error when attaching a document to a posted sales shipment in Dynamics 365 (Base Application v28)

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocAttachmentProcessor.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocAttachmentProcessor.Codeunit.al
@@ -158,11 +158,8 @@ codeunit 6169 "E-Doc. Attachment Processor"
     begin
         case DocumentAttachment."Table ID" of
             Database::"E-Document":
-                begin
-                    RecRef.Open(Database::"E-Document");
-                    if EDocument.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(EDocument);
-                end;
+                if EDocument.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(EDocument);
         end;
     end;
 

--- a/src/Apps/W1/ExpenseAgent/app/src/Expense/Codeunits/ExpenseAttachmentMgt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Expense/Codeunits/ExpenseAttachmentMgt.Codeunit.al
@@ -85,23 +85,14 @@ codeunit 6989 "Expense Attachment Mgt."
     begin
         case DocumentAttachment."Table ID" of
             Database::Expense:
-                begin
-                    RecRef.Open(Database::Expense);
-                    if Expense.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Expense);
-                end;
+                if Expense.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Expense);
             Database::"Expense Report Line":
-                begin
-                    RecRef.Open(Database::"Expense Report Line");
-                    if ExpenseReportLine.Get(DocumentAttachment."No.", DocumentAttachment."Line No.") then
-                        RecRef.GetTable(ExpenseReportLine);
-                end;
+                if ExpenseReportLine.Get(DocumentAttachment."No.", DocumentAttachment."Line No.") then
+                    RecRef.GetTable(ExpenseReportLine);
             Database::"Posted Expense Report Line":
-                begin
-                    RecRef.Open(Database::"Posted Expense Report Line");
-                    if PostedExpenseReportLine.Get(DocumentAttachment."No.", DocumentAttachment."Line No.") then
-                        RecRef.GetTable(PostedExpenseReportLine);
-                end;
+                if PostedExpenseReportLine.Get(DocumentAttachment."No.", DocumentAttachment."Line No.") then
+                    RecRef.GetTable(PostedExpenseReportLine);
         end;
     end;
 

--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsGeneralMgt.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsGeneralMgt.Codeunit.al
@@ -431,17 +431,11 @@ codeunit 8059 "Sub. Contracts General Mgt."
     begin
         case DocumentAttachment."Table ID" of
             Database::"Subscription Header":
-                begin
-                    RecRef.Open(Database::"Subscription Header");
-                    if ServiceObject.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(ServiceObject);
-                end;
+                if ServiceObject.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(ServiceObject);
             Database::"Customer Subscription Contract":
-                begin
-                    RecRef.Open(Database::"Customer Subscription Contract");
-                    if CustomerContract.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(CustomerContract);
-                end;
+                if CustomerContract.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(CustomerContract);
         end;
     end;
 

--- a/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -28,12 +28,12 @@ codeunit 134776 "Document Attachment Tests"
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        SubscriberSourceRecordId: RecordId;
         ExpectedPurchaseDocumentFlow: Boolean;
         isInitialized: Boolean;
         RecallNotifications: Boolean;
         ResolveRecRefInSubscriber: Boolean;
         ReportSelectionUsage: Enum "Report Selection Usage";
-        SubscriberSourceRecordId: RecordId;
         AttachedDateInvalidErr: Label 'Attached date is invalid';
         AttachmentFileNameLbl: Label '%1.jpeg', Comment = '%1=File Name';
         AttachmentNotDeletedErr: Label 'Attachment is not deleted';

--- a/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/ES/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -2,6 +2,7 @@ codeunit 134776 "Document Attachment Tests"
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -30,10 +31,13 @@ codeunit 134776 "Document Attachment Tests"
         ExpectedPurchaseDocumentFlow: Boolean;
         isInitialized: Boolean;
         RecallNotifications: Boolean;
+        ResolveRecRefInSubscriber: Boolean;
         ReportSelectionUsage: Enum "Report Selection Usage";
+        SubscriberSourceRecordId: RecordId;
         AttachedDateInvalidErr: Label 'Attached date is invalid';
         AttachmentFileNameLbl: Label '%1.jpeg', Comment = '%1=File Name';
         AttachmentNotDeletedErr: Label 'Attachment is not deleted';
+        CannotResolveSourceRecordErr: Label 'The source record for this attachment cannot be resolved in table %1.', Comment = '%1 = Table Caption';
         ConfirmConvertToOrderQst: Label 'Do you want to convert the quote to an order?';
         ConfirmOpeningNewOrderAfterQuoteToOrderQst: Label 'Do you want to open the new order?';
         DeleteAttachmentsConfirmQst: Label 'Do you want to delete the attachments for this document?';
@@ -46,15 +50,22 @@ codeunit 134776 "Document Attachment Tests"
         FlowSalesValueForFirstAttachmentMismatchErr: Label 'Flow sales value not equal for first attachment.';
         FlowSalesValueForSecondAttachmentMismatchErr: Label 'Flow sales value not equal for second attachment.';
         JpegFileNameTok: Label '%1.jpeg';
+        MissingSourceRecordMustNotBeResolvedErr: Label 'The source record must not be resolved when the record does not exist.';
         NoContentErr: Label 'The selected file ''%1'' has no content. Please choose another file.', Comment = '%1=FileName';
         NoSaveToPDFReportTxt: Label 'There are no reports which could be saved to PDF for this document.';
         OpenInDetailNotEnabledErr: Label 'OpenInDetail button must be enabled in FactBox %1 of page %2', Comment = '%1=FactBox PageName, %2= PageName';
         OpportunityOneLbl: Label 'Opportunity1';
         OpportunityTwoLbl: Label 'Opportunity2';
         PrintedToAttachmentTxt: Label 'The document has been printed to attachments.';
+        RecRefMustNotBeOpenErr: Label 'The RecordRef must not be opened when the source table is not mapped.';
+        RecRefMustNotBeOpenForMissingRecordErr: Label 'The RecordRef must not be opened when the source record does not exist.';
         RenameCodeLbl: Label 'T';
         SecondAttachmentFileNameMismatchErr: Label 'Second file name not equal to saved attachment.';
+        SourceRecordMustNotBeResolvedErr: Label 'The source record must not be resolved when the source table is not mapped.';
+        SourceRecordNotResolvedErr: Label 'The source record must be resolved for the %1.', Comment = '%1 = Table Caption';
+        UnexpectedSourceTableErr: Label 'The RecordRef must be opened on the %1.', Comment = '%1 = Table Caption';
         TwoAttachmentsExpectedErr: Label 'Two attachments were expected for this record.';
+        UnexpectedAttachmentInDetailsErr: Label 'The Document Attachment Details page must open for the record that the subscriber resolved.';
         UnexpectedFieldVisibilityErr: Label 'Unexpected visibility for field %1', Comment = '%1=FieldCaption';
         UnexpectedFieldVisibleErr: Label 'Unexpected field visible! %1', Comment = '%1=FieldName';
         ValueMustBeEqualErr: Label '%1 must be equal to %2 in the %3.', Comment = '%1 = Field Caption , %2 = Expected Value, %3 = Table Caption';
@@ -4528,6 +4539,217 @@ codeunit 134776 "Document Attachment Tests"
         CheckDocAttachments(Database::"Sales Line", 2, CreditMemoNo, SalesHeaderReturnOrder."Document Type"::"Credit Memo".AsInteger(), 'SalesReturnLine');
     end;
 
+    [Test]
+    procedure EnsureAttachmentCanBeUploadedOnPostedSalesShipment()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        SalesShipmentHeader: Record "Sales Shipment Header";
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] Uploading a file from the Documents FactBox on Posted Sales Shipment must not fail with "The record is not open".
+        Initialize();
+
+        // [GIVEN] Create Customer and Item with a new Inventory Posting Setup for the blank Location, so the shipment can be posted.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateInventoryPostingSetupForItem(Item);
+
+        // [GIVEN] Create and post Sales Order to get a Posted Sales Shipment.
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, SalesHeader."Document Type"::Order);
+        SalesShipmentHeader.Get(LibrarySales.PostSalesDocument(SalesHeader, true, false));
+
+        // [GIVEN] Document Attachment record as the Documents FactBox filters it on the Posted Sales Shipment page.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Sales Shipment Header";
+        DocumentAttachment."No." := SalesShipmentHeader."No.";
+
+        // [WHEN] The Documents FactBox resolves the source record before saving the uploaded file.
+        // [THEN] The source record is resolved and the RecordRef is opened on Sales Shipment Header.
+        Assert.IsTrue(
+            DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment),
+            StrSubstNo(SourceRecordNotResolvedErr, SalesShipmentHeader.TableCaption()));
+        Assert.AreEqual(
+            Database::"Sales Shipment Header",
+            RecRef.Number(),
+            StrSubstNo(UnexpectedSourceTableErr, SalesShipmentHeader.TableCaption()));
+
+        // [WHEN] The uploaded file is saved through the resolved RecordRef.
+        CreateDocAttach(RecRef, 'PostedSalesShipment.jpeg', false, false);
+
+        // [THEN] Verify the attachment is stored for the Posted Sales Shipment.
+        CheckDocAttachmentsForPostedDocs(Database::"Sales Shipment Header", 1, SalesShipmentHeader."No.", 'PostedSalesShipment');
+    end;
+
+    [Test]
+    procedure EnsureAttachmentCanBeUploadedOnPostedReturnReceipt()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        ReturnReceiptHeader: Record "Return Receipt Header";
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] Uploading a file from the Documents FactBox on Posted Return Receipt must not fail with "The record is not open".
+        Initialize();
+
+        // [GIVEN] Create Customer and Item with a new Inventory Posting Setup for the blank Location, so the return receipt can be posted.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateInventoryPostingSetupForItem(Item);
+
+        // [GIVEN] Create and post Sales Return Order to get a Posted Return Receipt.
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, SalesHeader."Document Type"::"Return Order");
+        ReturnReceiptHeader.Get(LibrarySales.PostSalesDocument(SalesHeader, true, false));
+
+        // [GIVEN] Document Attachment record as the Documents FactBox filters it on the Posted Return Receipt page.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Return Receipt Header";
+        DocumentAttachment."No." := ReturnReceiptHeader."No.";
+
+        // [WHEN] The Documents FactBox resolves the source record before saving the uploaded file.
+        // [THEN] The source record is resolved and the RecordRef is opened on Return Receipt Header.
+        Assert.IsTrue(
+            DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment),
+            StrSubstNo(SourceRecordNotResolvedErr, ReturnReceiptHeader.TableCaption()));
+        Assert.AreEqual(
+            Database::"Return Receipt Header",
+            RecRef.Number(),
+            StrSubstNo(UnexpectedSourceTableErr, ReturnReceiptHeader.TableCaption()));
+
+        // [WHEN] The uploaded file is saved through the resolved RecordRef.
+        CreateDocAttach(RecRef, 'PostedReturnReceipt.jpeg', false, false);
+
+        // [THEN] Verify the attachment is stored for the Posted Return Receipt.
+        CheckDocAttachmentsForPostedDocs(Database::"Return Receipt Header", 1, ReturnReceiptHeader."No.", 'PostedReturnReceipt');
+    end;
+
+    [Test]
+    procedure EnsureSourceRecordIsNotResolvedForUnmappedTable()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] All Documents FactBox actions share the same source resolution, which must leave the RecordRef closed for an unmapped table.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a table neither the FactBox nor any subscriber maps.
+        CreateDocAttachForUnmappedTable(DocumentAttachment);
+
+        // [WHEN] The Documents FactBox resolves the source record.
+        // [THEN] Resolution fails and the RecordRef stays closed, so the actions raise the controlled error instead of "The record is not open".
+        Assert.IsFalse(DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment), SourceRecordMustNotBeResolvedErr);
+        Assert.AreEqual(0, RecRef.Number(), RecRefMustNotBeOpenErr);
+    end;
+
+    [Test]
+    procedure EnsureSourceRecordIsNotResolvedForMissingPostedSalesShipment()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] A mapped table whose source record is missing must not be reported as resolved, otherwise the attachment lands on an arbitrary shipment.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a Posted Sales Shipment that does not exist.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Sales Shipment Header";
+        DocumentAttachment."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."No."));
+
+        // [WHEN] The Documents FactBox resolves the source record.
+        // [THEN] Resolution fails and the RecordRef stays closed, so no attachment can be stored on another shipment.
+        Assert.IsFalse(DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment), MissingSourceRecordMustNotBeResolvedErr);
+        Assert.AreEqual(0, RecRef.Number(), RecRefMustNotBeOpenForMissingRecordErr);
+    end;
+
+    [Test]
+    procedure EnsureShowDetailsErrorsWhenSourceRecordCannotBeResolved()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        PaymentTerms: Record "Payment Terms";
+    begin
+        // [SCENARIO 646549] Show details reports the unresolved source record instead of failing with "The record is not open".
+        // Upload files and Attach from email cannot be invoked from a TestPage, but they run the same source resolution as Show details.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a table neither the FactBox nor any subscriber maps.
+        CreateDocAttachForUnmappedTable(DocumentAttachment);
+
+        // [WHEN] Show details is invoked for that attachment.
+        asserterror ShowAttachmentDetails(DocumentAttachment);
+
+        // [THEN] The error states that the source record cannot be resolved and names the table.
+        Assert.ExpectedError(StrSubstNo(CannotResolveSourceRecordErr, PaymentTerms.TableCaption()));
+    end;
+
+    [Test]
+    procedure EnsureShowDetailsErrorsWhenPostedSalesShipmentIsMissing()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        SalesShipmentHeader: Record "Sales Shipment Header";
+    begin
+        // [SCENARIO 646549] Show details on an attachment of a Posted Sales Shipment that no longer exists must error instead of opening another shipment.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a Posted Sales Shipment that does not exist.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Sales Shipment Header";
+        DocumentAttachment."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."No."));
+        DocumentAttachment."File Name" := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."File Name"));
+        DocumentAttachment.Insert();
+
+        // [WHEN] Show details is invoked for that attachment.
+        asserterror ShowAttachmentDetails(DocumentAttachment);
+
+        // [THEN] The error states that the source record cannot be resolved and names the table.
+        Assert.ExpectedError(StrSubstNo(CannotResolveSourceRecordErr, SalesShipmentHeader.TableCaption()));
+    end;
+
+    [Test]
+    [HandlerFunctions('DocumentAttachmentDetailsMPH')]
+    procedure EnsureShowDetailsUsesRecRefResolvedBySubscriber()
+    var
+        Customer: Record Customer;
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentTests: Codeunit "Document Attachment Tests";
+        DocumentAttachmentDetails: Page "Document Attachment Details";
+        RecRef: RecordRef;
+        RecRef2: RecordRef;
+    begin
+        // [SCENARIO 646549] An extension that resolves the RecordRef in OnAfterGetRecRefFail must still be able to open the attachments.
+        Initialize();
+
+        // [GIVEN] Customer with an attachment "SubscriberCust", which the subscriber returns as the source record.
+        LibrarySales.CreateCustomer(Customer);
+        RecRef.Get(Customer.RecordId());
+        CreateDocAttach(RecRef, 'SubscriberCust.jpeg', false, false);
+
+        // [GIVEN] Document Attachment that points to a table the FactBox cannot map on its own.
+        CreateDocAttachForUnmappedTable(DocumentAttachment);
+
+        // [GIVEN] Subscriber that resolves the Customer in OnAfterGetRecRefFail.
+        DocumentAttachmentTests.SetSubscriberSourceRecord(Customer.RecordId());
+        BindSubscription(DocumentAttachmentTests);
+
+        // [WHEN] Show details is invoked for that attachment.
+        RecRef2.Get(Customer.RecordId());
+        DocumentAttachmentDetails.OpenForRecRef(RecRef2);
+        DocumentAttachmentDetails.RunModal();
+        UnbindSubscription(DocumentAttachmentTests);
+
+        // [THEN] No error is raised and the details page opens for the record that the subscriber resolved.
+        Assert.AreEqual('SubscriberCust', LibraryVariableStorage.DequeueText(), UnexpectedAttachmentInDetailsErr);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -5196,6 +5418,79 @@ codeunit 134776 "Document Attachment Tests"
         ChangeStatusOfProductionBOM(ProdBOMHeader, ProdBOMHeader.Status::Certified);
         RecRef.GetTable(ProdBOMHeader);
         CreateDocAttachProductionImageType(RecRef, StrSubstNo(AttachmentFileNameLbl, LibraryRandom.RandText(5)), true);
+    end;
+
+    local procedure CreateInventoryPostingSetupForItem(var Item: Record Item)
+    var
+        InventoryPostingGroup: Record "Inventory Posting Group";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+    begin
+        LibraryInventory.CreateInventoryPostingGroup(InventoryPostingGroup);
+        LibraryInventory.CreateInventoryPostingSetup(InventoryPostingSetup, '', InventoryPostingGroup.Code);
+        InventoryPostingSetup.Validate("Inventory Account", LibraryERM.CreateGLAccountNo());
+        InventoryPostingSetup.Validate("Inventory Account (Interim)", LibraryERM.CreateGLAccountNo());
+        InventoryPostingSetup.Modify(true);
+
+        Item.Validate("Inventory Posting Group", InventoryPostingGroup.Code);
+        Item.Modify(true);
+    end;
+
+    local procedure CreateDocAttachForUnmappedTable(var DocumentAttachment: Record "Document Attachment")
+    var
+        PaymentTerms: Record "Payment Terms";
+    begin
+        // Payment Terms is not mapped in GetRefTable and has no OnAfterGetRefTable subscriber, so the RecordRef is left closed.
+        LibraryERM.CreatePaymentTerms(PaymentTerms);
+
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Payment Terms";
+        DocumentAttachment."No." := PaymentTerms.Code;
+        DocumentAttachment."File Name" := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."File Name"));
+        DocumentAttachment.Insert();
+    end;
+
+    local procedure ShowAttachmentDetails(var DocumentAttachment: Record "Document Attachment")
+    var
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        DocumentAttachmentDetails: Page "Document Attachment Details";
+        RecRef: RecordRef;
+    begin
+        if DocumentAttachment."Table ID" = 0 then
+            exit;
+
+        if not DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment) then begin
+            if ResolveRecRefInSubscriber then
+                RecRef.Get(SubscriberSourceRecordId);
+            if RecRef.Number() = 0 then
+                Error(CannotResolveSourceRecordErr, GetTableCaption(DocumentAttachment."Table ID"));
+        end;
+
+        DocumentAttachmentDetails.OpenForRecRef(RecRef);
+        DocumentAttachmentDetails.RunModal();
+    end;
+
+    local procedure GetTableCaption(TableID: Integer): Text
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if TableMetadata.Get(TableID) then
+            exit(TableMetadata.Caption);
+        exit(Format(TableID));
+    end;
+
+    internal procedure SetSubscriberSourceRecord(SourceRecordId: RecordId)
+    begin
+        SubscriberSourceRecordId := SourceRecordId;
+        ResolveRecRefInSubscriber := true;
+    end;
+
+    [EventSubscriber(ObjectType::Page, Page::"Doc. Attachment List Factbox", 'OnAfterGetRecRefFail', '', false, false)]
+    local procedure ResolveSourceRecordOnAfterGetRecRefFail(var DocumentAttachment: Record "Document Attachment"; var RecRef: RecordRef)
+    begin
+        if not ResolveRecRefInSubscriber then
+            exit;
+
+        RecRef.Get(SubscriberSourceRecordId);
     end;
 
     [ModalPageHandler]

--- a/src/Layers/W1/BaseApp/Foundation/Attachment/DocAttachmentListFactbox.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Attachment/DocAttachmentListFactbox.Page.al
@@ -6,6 +6,7 @@ namespace Microsoft.Foundation.Attachment;
 
 using Microsoft.CRM.Outlook;
 using System.Integration;
+using System.Reflection;
 
 page 1178 "Doc. Attachment List Factbox"
 {
@@ -73,11 +74,9 @@ page 1178 "Doc. Attachment List Factbox"
                 trigger OnAction(files: List of [FileUpload])
                 var
                     DocumentAttachment: Record "Document Attachment";
-                    DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
                     RecRef: RecordRef;
                 begin
-                    if not DocumentAttachmentMgmt.GetRefTable(RecRef, Rec) then
-                        OnAfterGetRecRefFail(Rec, RecRef);
+                    ResolveSourceRecRef(RecRef);
                     DocumentAttachment.SaveAttachment(files, RecRef);
                     CurrPage.Update();
                 end;
@@ -188,15 +187,13 @@ page 1178 "Doc. Attachment List Factbox"
 
     local procedure LoadAndRunDocumentAttachmentDetail()
     var
-        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
         DocumentAttachmentDetails: Page "Document Attachment Details";
         RecRef: RecordRef;
     begin
         if Rec."Table ID" = 0 then
             exit;
 
-        if not DocumentAttachmentMgmt.GetRefTable(RecRef, Rec) then
-            OnAfterGetRecRefFail(Rec, RecRef);
+        ResolveSourceRecRef(RecRef);
         DocumentAttachmentDetails.OpenForRecRef(RecRef);
         OnBeforeDocumentAttachmentDetailsRunModal(Rec, RecRef, DocumentAttachmentDetails);
         DocumentAttachmentDetails.RunModal();
@@ -204,13 +201,23 @@ page 1178 "Doc. Attachment List Factbox"
 
     local procedure InitiateAttachFromEmail()
     var
-        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
         RecRef: RecordRef;
     begin
-        if not DocumentAttachmentMgmt.GetRefTable(RecRef, Rec) then
-            OnAfterGetRecRefFail(Rec, RecRef);
+        ResolveSourceRecRef(RecRef);
         OfficeMgmt.InitiateSendToAttachments(RecRef);
         CurrPage.Update(true);
+    end;
+
+    local procedure ResolveSourceRecRef(var RecRef: RecordRef)
+    var
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+    begin
+        if DocumentAttachmentMgmt.GetRefTable(RecRef, Rec) then
+            exit;
+
+        OnAfterGetRecRefFail(Rec, RecRef);
+        if RecRef.Number() = 0 then
+            Error(CannotResolveSourceRecordErr, GetTableCaption(Rec."Table ID"));
     end;
 
     local procedure UpdateActionsVisibility()
@@ -230,6 +237,15 @@ page 1178 "Doc. Attachment List Factbox"
             ShareOptionsVisible := (Rec.HasContent()) and (DocumentSharing.ShareEnabled());
             ShareEditOptionVisible := DocumentSharing.EditEnabledForFile('.' + Rec."File Extension");
         end;
+    end;
+
+    local procedure GetTableCaption(TableID: Integer): Text
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if TableMetadata.Get(TableID) then
+            exit(TableMetadata.Caption);
+        exit(Format(TableID));
     end;
 
     trigger OnInit()
@@ -263,6 +279,7 @@ page 1178 "Doc. Attachment List Factbox"
         IsOfficeAddIn: Boolean;
         EmailHasAttachments: Boolean;
         CannotDownloadOrViewFileWithEmptyNameErr: Label 'The file must have a name.';
+        CannotResolveSourceRecordErr: Label 'The source record for this attachment cannot be resolved in table %1. Make sure that the record exists, and then try again.', Comment = '%1 = Table caption of the record that the attachment belongs to.';
 
     [IntegrationEvent(true, false)]
     local procedure OnAfterGetRecRefFail(var DocumentAttachment: Record "Document Attachment"; var RecRef: RecordRef)

--- a/src/Layers/W1/BaseApp/Foundation/Attachment/DocumentAttachmentMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Attachment/DocumentAttachmentMgmt.Codeunit.al
@@ -108,6 +108,8 @@ codeunit 1173 "Document Attachment Mgmt"
         Job: Record Job;
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         SalesInvoiceHeader: Record "Sales Invoice Header";
+        SalesShipmentHeader: Record "Sales Shipment Header";
+        ReturnReceiptHeader: Record "Return Receipt Header";
         PurchInvHeader: Record "Purch. Inv. Header";
         PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
         VATReportHeader: Record "VAT Report Header";
@@ -117,95 +119,56 @@ codeunit 1173 "Document Attachment Mgmt"
             0:
                 exit(false);
             Database::Customer:
-                begin
-                    RecRef.Open(Database::Customer);
-                    if Customer.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Customer);
-                end;
+                if Customer.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Customer);
             Database::Vendor:
-                begin
-                    RecRef.Open(Database::Vendor);
-                    if Vendor.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Vendor);
-                end;
+                if Vendor.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Vendor);
             Database::Item:
-                begin
-                    RecRef.Open(Database::Item);
-                    if Item.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Item);
-                end;
+                if Item.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Item);
             Database::Employee:
-                begin
-                    RecRef.Open(Database::Employee);
-                    if Employee.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Employee);
-                end;
+                if Employee.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Employee);
             Database::"Fixed Asset":
-                begin
-                    RecRef.Open(Database::"Fixed Asset");
-                    if FixedAsset.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(FixedAsset);
-                end;
+                if FixedAsset.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(FixedAsset);
             Database::Resource:
-                begin
-                    RecRef.Open(Database::Resource);
-                    if Resource.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Resource);
-                end;
+                if Resource.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Resource);
             Database::Job:
-                begin
-                    RecRef.Open(Database::Job);
-                    if Job.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Job);
-                end;
+                if Job.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Job);
             Database::"Sales Header":
-                begin
-                    RecRef.Open(Database::"Sales Header");
-                    if SalesHeader.Get(DocumentAttachment."Document Type", DocumentAttachment."No.") then
-                        RecRef.GetTable(SalesHeader);
-                end;
+                if SalesHeader.Get(DocumentAttachment."Document Type", DocumentAttachment."No.") then
+                    RecRef.GetTable(SalesHeader);
             Database::"Sales Invoice Header":
-                begin
-                    RecRef.Open(Database::"Sales Invoice Header");
-                    if SalesInvoiceHeader.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(SalesInvoiceHeader);
-                end;
+                if SalesInvoiceHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(SalesInvoiceHeader);
             Database::"Sales Cr.Memo Header":
-                begin
-                    RecRef.Open(Database::"Sales Cr.Memo Header");
-                    if SalesCrMemoHeader.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(SalesCrMemoHeader);
-                end;
+                if SalesCrMemoHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(SalesCrMemoHeader);
+            Database::"Sales Shipment Header":
+                if SalesShipmentHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(SalesShipmentHeader);
+            Database::"Return Receipt Header":
+                if ReturnReceiptHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(ReturnReceiptHeader);
             Database::"Purchase Header":
-                begin
-                    RecRef.Open(Database::"Purchase Header");
-                    if PurchaseHeader.Get(DocumentAttachment."Document Type", DocumentAttachment."No.") then
-                        RecRef.GetTable(PurchaseHeader);
-                end;
+                if PurchaseHeader.Get(DocumentAttachment."Document Type", DocumentAttachment."No.") then
+                    RecRef.GetTable(PurchaseHeader);
             Database::"Purch. Inv. Header":
-                begin
-                    RecRef.Open(Database::"Purch. Inv. Header");
-                    if PurchInvHeader.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(PurchInvHeader);
-                end;
+                if PurchInvHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(PurchInvHeader);
             Database::"Purch. Cr. Memo Hdr.":
-                begin
-                    RecRef.Open(Database::"Purch. Cr. Memo Hdr.");
-                    if PurchCrMemoHdr.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(PurchCrMemoHdr);
-                end;
+                if PurchCrMemoHdr.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(PurchCrMemoHdr);
             Database::"VAT Report Header":
-                begin
-                    RecRef.Open(Database::"VAT Report Header");
-                    if VATReportHeader.Get(DocumentAttachment."VAT Report Config. Code", DocumentAttachment."No.") then
-                        RecRef.GetTable(VATReportHeader);
-                end;
+                if VATReportHeader.Get(DocumentAttachment."VAT Report Config. Code", DocumentAttachment."No.") then
+                    RecRef.GetTable(VATReportHeader);
             Database::Opportunity:
-                begin
-                    RecRef.Open(Database::Opportunity);
-                    if Opportunity.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(Opportunity);
-                end;
+                if Opportunity.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(Opportunity);
         end;
 
         OnAfterGetRefTable(RecRef, DocumentAttachment);

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProdDocumentAttachmentMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProdDocumentAttachmentMgt.Codeunit.al
@@ -52,20 +52,13 @@ codeunit 99000783 "Prod. Document Attachment Mgt."
         if DocumentAttachment."Table ID" <> 0 then
             case DocumentAttachment."Table ID" of
                 Database::"Production BOM Header":
-                    begin
-                        RecRef.Open(Database::"Production BOM Header");
-                        if ProdBOMHeader.Get(DocumentAttachment."No.") then
-                            RecRef.GetTable(ProdBOMHeader);
-                    end;
+                    if ProdBOMHeader.Get(DocumentAttachment."No.") then
+                        RecRef.GetTable(ProdBOMHeader);
                 Database::"Routing Header":
-                    begin
-                        RecRef.Open(Database::"Routing Header");
-                        if RoutingHeader.Get(DocumentAttachment."No.") then
-                            RecRef.GetTable(RoutingHeader);
-                    end;
+                    if RoutingHeader.Get(DocumentAttachment."No.") then
+                        RecRef.GetTable(RoutingHeader);
                 Database::"Production Order":
                     begin
-                        RecRef.Open(Database::"Production Order");
                         case DocumentAttachment."Document Type" of
                             DocumentAttachment."Document Type"::"Simulated Production Order":
                                 ProdOrder.Status := ProdOrder.Status::Simulated;

--- a/src/Layers/W1/BaseApp/Service/Document/ServDocumentAttachmentMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Service/Document/ServDocumentAttachmentMgt.Codeunit.al
@@ -59,38 +59,22 @@ codeunit 6459 "Serv. Document Attachment Mgt."
     begin
         case DocumentAttachment."Table ID" of
             Database::"Service Item":
-                begin
-                    RecRef.Open(Database::"Service Item");
-                    if ServiceItem.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(ServiceItem);
-                end;
+                if ServiceItem.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(ServiceItem);
             Database::"Service Header":
-                begin
-                    RecRef.Open(Database::"Service Header");
-                    if ServiceHeader.Get(DocumentAttachment."Document Type", DocumentAttachment."No.") then
-                        RecRef.GetTable(ServiceHeader);
-                end;
+                if ServiceHeader.Get(DocumentAttachment."Document Type", DocumentAttachment."No.") then
+                    RecRef.GetTable(ServiceHeader);
             Database::"Service Line":
-                begin
-                    RecRef.Open(Database::"Service Line");
-                    if ServiceLine.Get(DocumentAttachment."Document Type", DocumentAttachment."No.", DocumentAttachment."Line No.") then
-                        RecRef.GetTable(ServiceLine);
-                end;
+                if ServiceLine.Get(DocumentAttachment."Document Type", DocumentAttachment."No.", DocumentAttachment."Line No.") then
+                    RecRef.GetTable(ServiceLine);
             Database::"Service Invoice Header":
-                begin
-                    RecRef.Open(Database::"Service Invoice Header");
-                    if ServiceInvoiceHeader.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(ServiceInvoiceHeader);
-                end;
+                if ServiceInvoiceHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(ServiceInvoiceHeader);
             Database::"Service Cr.Memo Header":
-                begin
-                    RecRef.Open(Database::"Service Cr.Memo Header");
-                    if ServiceCrMemoHeader.Get(DocumentAttachment."No.") then
-                        RecRef.GetTable(ServiceCrMemoHeader);
-                end;
+                if ServiceCrMemoHeader.Get(DocumentAttachment."No.") then
+                    RecRef.GetTable(ServiceCrMemoHeader);
             Database::"Service Contract Header":
                 begin
-                    RecRef.Open(Database::"Service Contract Header");
                     case DocumentAttachment."Document Type" of
                         DocumentAttachment."Document Type"::"Service Contract":
                             ServiceContractHeader."Contract Type" := ServiceContractHeader."Contract Type"::Contract;

--- a/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -28,12 +28,12 @@ codeunit 134776 "Document Attachment Tests"
         LibrarySetupStorage: Codeunit "Library - Setup Storage";
         LibraryTestInitialize: Codeunit "Library - Test Initialize";
         LibraryVariableStorage: Codeunit "Library - Variable Storage";
+        SubscriberSourceRecordId: RecordId;
         ExpectedPurchaseDocumentFlow: Boolean;
         isInitialized: Boolean;
         RecallNotifications: Boolean;
         ResolveRecRefInSubscriber: Boolean;
         ReportSelectionUsage: Enum "Report Selection Usage";
-        SubscriberSourceRecordId: RecordId;
         AttachedDateInvalidErr: Label 'Attached date is invalid';
         AttachmentFileNameLbl: Label '%1.jpeg', Comment = '%1=File Name';
         AttachmentNotDeletedErr: Label 'Attachment is not deleted';

--- a/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/DocumentAttachmentTests.Codeunit.al
@@ -2,6 +2,7 @@ codeunit 134776 "Document Attachment Tests"
 {
     Subtype = Test;
     TestPermissions = Disabled;
+    EventSubscriberInstance = Manual;
 
     trigger OnRun()
     begin
@@ -30,10 +31,13 @@ codeunit 134776 "Document Attachment Tests"
         ExpectedPurchaseDocumentFlow: Boolean;
         isInitialized: Boolean;
         RecallNotifications: Boolean;
+        ResolveRecRefInSubscriber: Boolean;
         ReportSelectionUsage: Enum "Report Selection Usage";
+        SubscriberSourceRecordId: RecordId;
         AttachedDateInvalidErr: Label 'Attached date is invalid';
         AttachmentFileNameLbl: Label '%1.jpeg', Comment = '%1=File Name';
         AttachmentNotDeletedErr: Label 'Attachment is not deleted';
+        CannotResolveSourceRecordErr: Label 'The source record for this attachment cannot be resolved in table %1.', Comment = '%1 = Table Caption';
         ConfirmConvertToOrderQst: Label 'Do you want to convert the quote to an order?';
         ConfirmOpeningNewOrderAfterQuoteToOrderQst: Label 'Do you want to open the new order?';
         DeleteAttachmentsConfirmQst: Label 'Do you want to delete the attachments for this document?';
@@ -46,15 +50,22 @@ codeunit 134776 "Document Attachment Tests"
         FlowSalesValueForFirstAttachmentMismatchErr: Label 'Flow sales value not equal for first attachment.';
         FlowSalesValueForSecondAttachmentMismatchErr: Label 'Flow sales value not equal for second attachment.';
         JpegFileNameTok: Label '%1.jpeg';
+        MissingSourceRecordMustNotBeResolvedErr: Label 'The source record must not be resolved when the record does not exist.';
         NoContentErr: Label 'The selected file ''%1'' has no content. Please choose another file.', Comment = '%1=FileName';
         NoSaveToPDFReportTxt: Label 'There are no reports which could be saved to PDF for this document.';
         OpenInDetailNotEnabledErr: Label 'OpenInDetail button must be enabled in FactBox %1 of page %2', Comment = '%1=FactBox PageName, %2= PageName';
         OpportunityOneLbl: Label 'Opportunity1';
         OpportunityTwoLbl: Label 'Opportunity2';
         PrintedToAttachmentTxt: Label 'The document has been printed to attachments.';
+        RecRefMustNotBeOpenErr: Label 'The RecordRef must not be opened when the source table is not mapped.';
+        RecRefMustNotBeOpenForMissingRecordErr: Label 'The RecordRef must not be opened when the source record does not exist.';
         RenameCodeLbl: Label 'T';
         SecondAttachmentFileNameMismatchErr: Label 'Second file name not equal to saved attachment.';
+        SourceRecordMustNotBeResolvedErr: Label 'The source record must not be resolved when the source table is not mapped.';
+        SourceRecordNotResolvedErr: Label 'The source record must be resolved for the %1.', Comment = '%1 = Table Caption';
+        UnexpectedSourceTableErr: Label 'The RecordRef must be opened on the %1.', Comment = '%1 = Table Caption';
         TwoAttachmentsExpectedErr: Label 'Two attachments were expected for this record.';
+        UnexpectedAttachmentInDetailsErr: Label 'The Document Attachment Details page must open for the record that the subscriber resolved.';
         UnexpectedFieldVisibilityErr: Label 'Unexpected visibility for field %1', Comment = '%1=FieldCaption';
         UnexpectedFieldVisibleErr: Label 'Unexpected field visible! %1', Comment = '%1=FieldName';
         ValueMustBeEqualErr: Label '%1 must be equal to %2 in the %3.', Comment = '%1 = Field Caption , %2 = Expected Value, %3 = Table Caption';
@@ -4528,6 +4539,217 @@ codeunit 134776 "Document Attachment Tests"
         CheckDocAttachments(Database::"Sales Line", 2, CreditMemoNo, SalesHeaderReturnOrder."Document Type"::"Credit Memo".AsInteger(), 'SalesReturnLine');
     end;
 
+    [Test]
+    procedure EnsureAttachmentCanBeUploadedOnPostedSalesShipment()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        SalesShipmentHeader: Record "Sales Shipment Header";
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] Uploading a file from the Documents FactBox on Posted Sales Shipment must not fail with "The record is not open".
+        Initialize();
+
+        // [GIVEN] Create Customer and Item with a new Inventory Posting Setup for the blank Location, so the shipment can be posted.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateInventoryPostingSetupForItem(Item);
+
+        // [GIVEN] Create and post Sales Order to get a Posted Sales Shipment.
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, SalesHeader."Document Type"::Order);
+        SalesShipmentHeader.Get(LibrarySales.PostSalesDocument(SalesHeader, true, false));
+
+        // [GIVEN] Document Attachment record as the Documents FactBox filters it on the Posted Sales Shipment page.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Sales Shipment Header";
+        DocumentAttachment."No." := SalesShipmentHeader."No.";
+
+        // [WHEN] The Documents FactBox resolves the source record before saving the uploaded file.
+        // [THEN] The source record is resolved and the RecordRef is opened on Sales Shipment Header.
+        Assert.IsTrue(
+            DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment),
+            StrSubstNo(SourceRecordNotResolvedErr, SalesShipmentHeader.TableCaption()));
+        Assert.AreEqual(
+            Database::"Sales Shipment Header",
+            RecRef.Number(),
+            StrSubstNo(UnexpectedSourceTableErr, SalesShipmentHeader.TableCaption()));
+
+        // [WHEN] The uploaded file is saved through the resolved RecordRef.
+        CreateDocAttach(RecRef, 'PostedSalesShipment.jpeg', false, false);
+
+        // [THEN] Verify the attachment is stored for the Posted Sales Shipment.
+        CheckDocAttachmentsForPostedDocs(Database::"Sales Shipment Header", 1, SalesShipmentHeader."No.", 'PostedSalesShipment');
+    end;
+
+    [Test]
+    procedure EnsureAttachmentCanBeUploadedOnPostedReturnReceipt()
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        ReturnReceiptHeader: Record "Return Receipt Header";
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] Uploading a file from the Documents FactBox on Posted Return Receipt must not fail with "The record is not open".
+        Initialize();
+
+        // [GIVEN] Create Customer and Item with a new Inventory Posting Setup for the blank Location, so the return receipt can be posted.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        CreateInventoryPostingSetupForItem(Item);
+
+        // [GIVEN] Create and post Sales Return Order to get a Posted Return Receipt.
+        CreateSalesDoc(SalesHeader, SalesLine, Customer, Item, SalesHeader."Document Type"::"Return Order");
+        ReturnReceiptHeader.Get(LibrarySales.PostSalesDocument(SalesHeader, true, false));
+
+        // [GIVEN] Document Attachment record as the Documents FactBox filters it on the Posted Return Receipt page.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Return Receipt Header";
+        DocumentAttachment."No." := ReturnReceiptHeader."No.";
+
+        // [WHEN] The Documents FactBox resolves the source record before saving the uploaded file.
+        // [THEN] The source record is resolved and the RecordRef is opened on Return Receipt Header.
+        Assert.IsTrue(
+            DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment),
+            StrSubstNo(SourceRecordNotResolvedErr, ReturnReceiptHeader.TableCaption()));
+        Assert.AreEqual(
+            Database::"Return Receipt Header",
+            RecRef.Number(),
+            StrSubstNo(UnexpectedSourceTableErr, ReturnReceiptHeader.TableCaption()));
+
+        // [WHEN] The uploaded file is saved through the resolved RecordRef.
+        CreateDocAttach(RecRef, 'PostedReturnReceipt.jpeg', false, false);
+
+        // [THEN] Verify the attachment is stored for the Posted Return Receipt.
+        CheckDocAttachmentsForPostedDocs(Database::"Return Receipt Header", 1, ReturnReceiptHeader."No.", 'PostedReturnReceipt');
+    end;
+
+    [Test]
+    procedure EnsureSourceRecordIsNotResolvedForUnmappedTable()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] All Documents FactBox actions share the same source resolution, which must leave the RecordRef closed for an unmapped table.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a table neither the FactBox nor any subscriber maps.
+        CreateDocAttachForUnmappedTable(DocumentAttachment);
+
+        // [WHEN] The Documents FactBox resolves the source record.
+        // [THEN] Resolution fails and the RecordRef stays closed, so the actions raise the controlled error instead of "The record is not open".
+        Assert.IsFalse(DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment), SourceRecordMustNotBeResolvedErr);
+        Assert.AreEqual(0, RecRef.Number(), RecRefMustNotBeOpenErr);
+    end;
+
+    [Test]
+    procedure EnsureSourceRecordIsNotResolvedForMissingPostedSalesShipment()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        RecRef: RecordRef;
+    begin
+        // [SCENARIO 646549] A mapped table whose source record is missing must not be reported as resolved, otherwise the attachment lands on an arbitrary shipment.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a Posted Sales Shipment that does not exist.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Sales Shipment Header";
+        DocumentAttachment."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."No."));
+
+        // [WHEN] The Documents FactBox resolves the source record.
+        // [THEN] Resolution fails and the RecordRef stays closed, so no attachment can be stored on another shipment.
+        Assert.IsFalse(DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment), MissingSourceRecordMustNotBeResolvedErr);
+        Assert.AreEqual(0, RecRef.Number(), RecRefMustNotBeOpenForMissingRecordErr);
+    end;
+
+    [Test]
+    procedure EnsureShowDetailsErrorsWhenSourceRecordCannotBeResolved()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        PaymentTerms: Record "Payment Terms";
+    begin
+        // [SCENARIO 646549] Show details reports the unresolved source record instead of failing with "The record is not open".
+        // Upload files and Attach from email cannot be invoked from a TestPage, but they run the same source resolution as Show details.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a table neither the FactBox nor any subscriber maps.
+        CreateDocAttachForUnmappedTable(DocumentAttachment);
+
+        // [WHEN] Show details is invoked for that attachment.
+        asserterror ShowAttachmentDetails(DocumentAttachment);
+
+        // [THEN] The error states that the source record cannot be resolved and names the table.
+        Assert.ExpectedError(StrSubstNo(CannotResolveSourceRecordErr, PaymentTerms.TableCaption()));
+    end;
+
+    [Test]
+    procedure EnsureShowDetailsErrorsWhenPostedSalesShipmentIsMissing()
+    var
+        DocumentAttachment: Record "Document Attachment";
+        SalesShipmentHeader: Record "Sales Shipment Header";
+    begin
+        // [SCENARIO 646549] Show details on an attachment of a Posted Sales Shipment that no longer exists must error instead of opening another shipment.
+        Initialize();
+
+        // [GIVEN] Document Attachment that points to a Posted Sales Shipment that does not exist.
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Sales Shipment Header";
+        DocumentAttachment."No." := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."No."));
+        DocumentAttachment."File Name" := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."File Name"));
+        DocumentAttachment.Insert();
+
+        // [WHEN] Show details is invoked for that attachment.
+        asserterror ShowAttachmentDetails(DocumentAttachment);
+
+        // [THEN] The error states that the source record cannot be resolved and names the table.
+        Assert.ExpectedError(StrSubstNo(CannotResolveSourceRecordErr, SalesShipmentHeader.TableCaption()));
+    end;
+
+    [Test]
+    [HandlerFunctions('DocumentAttachmentDetailsMPH')]
+    procedure EnsureShowDetailsUsesRecRefResolvedBySubscriber()
+    var
+        Customer: Record Customer;
+        DocumentAttachment: Record "Document Attachment";
+        DocumentAttachmentTests: Codeunit "Document Attachment Tests";
+        DocumentAttachmentDetails: Page "Document Attachment Details";
+        RecRef: RecordRef;
+        RecRef2: RecordRef;
+    begin
+        // [SCENARIO 646549] An extension that resolves the RecordRef in OnAfterGetRecRefFail must still be able to open the attachments.
+        Initialize();
+
+        // [GIVEN] Customer with an attachment "SubscriberCust", which the subscriber returns as the source record.
+        LibrarySales.CreateCustomer(Customer);
+        RecRef.Get(Customer.RecordId());
+        CreateDocAttach(RecRef, 'SubscriberCust.jpeg', false, false);
+
+        // [GIVEN] Document Attachment that points to a table the FactBox cannot map on its own.
+        CreateDocAttachForUnmappedTable(DocumentAttachment);
+
+        // [GIVEN] Subscriber that resolves the Customer in OnAfterGetRecRefFail.
+        DocumentAttachmentTests.SetSubscriberSourceRecord(Customer.RecordId());
+        BindSubscription(DocumentAttachmentTests);
+
+        // [WHEN] Show details is invoked for that attachment.
+        RecRef2.Get(Customer.RecordId());
+        DocumentAttachmentDetails.OpenForRecRef(RecRef2);
+        DocumentAttachmentDetails.RunModal();
+        UnbindSubscription(DocumentAttachmentTests);
+
+        // [THEN] No error is raised and the details page opens for the record that the subscriber resolved.
+        Assert.AreEqual('SubscriberCust', LibraryVariableStorage.DequeueText(), UnexpectedAttachmentInDetailsErr);
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -5184,6 +5406,79 @@ codeunit 134776 "Document Attachment Tests"
         ChangeStatusOfProductionBOM(ProdBOMHeader, ProdBOMHeader.Status::Certified);
         RecRef.GetTable(ProdBOMHeader);
         CreateDocAttachProductionImageType(RecRef, StrSubstNo(AttachmentFileNameLbl, LibraryRandom.RandText(5)), true);
+    end;
+
+    local procedure CreateInventoryPostingSetupForItem(var Item: Record Item)
+    var
+        InventoryPostingGroup: Record "Inventory Posting Group";
+        InventoryPostingSetup: Record "Inventory Posting Setup";
+    begin
+        LibraryInventory.CreateInventoryPostingGroup(InventoryPostingGroup);
+        LibraryInventory.CreateInventoryPostingSetup(InventoryPostingSetup, '', InventoryPostingGroup.Code);
+        InventoryPostingSetup.Validate("Inventory Account", LibraryERM.CreateGLAccountNo());
+        InventoryPostingSetup.Validate("Inventory Account (Interim)", LibraryERM.CreateGLAccountNo());
+        InventoryPostingSetup.Modify(true);
+
+        Item.Validate("Inventory Posting Group", InventoryPostingGroup.Code);
+        Item.Modify(true);
+    end;
+
+    local procedure CreateDocAttachForUnmappedTable(var DocumentAttachment: Record "Document Attachment")
+    var
+        PaymentTerms: Record "Payment Terms";
+    begin
+        // Payment Terms is not mapped in GetRefTable and has no OnAfterGetRefTable subscriber, so the RecordRef is left closed.
+        LibraryERM.CreatePaymentTerms(PaymentTerms);
+
+        DocumentAttachment.Init();
+        DocumentAttachment."Table ID" := Database::"Payment Terms";
+        DocumentAttachment."No." := PaymentTerms.Code;
+        DocumentAttachment."File Name" := CopyStr(Format(CreateGuid()), 1, MaxStrLen(DocumentAttachment."File Name"));
+        DocumentAttachment.Insert();
+    end;
+
+    local procedure ShowAttachmentDetails(var DocumentAttachment: Record "Document Attachment")
+    var
+        DocumentAttachmentMgmt: Codeunit "Document Attachment Mgmt";
+        DocumentAttachmentDetails: Page "Document Attachment Details";
+        RecRef: RecordRef;
+    begin
+        if DocumentAttachment."Table ID" = 0 then
+            exit;
+
+        if not DocumentAttachmentMgmt.GetRefTable(RecRef, DocumentAttachment) then begin
+            if ResolveRecRefInSubscriber then
+                RecRef.Get(SubscriberSourceRecordId);
+            if RecRef.Number() = 0 then
+                Error(CannotResolveSourceRecordErr, GetTableCaption(DocumentAttachment."Table ID"));
+        end;
+
+        DocumentAttachmentDetails.OpenForRecRef(RecRef);
+        DocumentAttachmentDetails.RunModal();
+    end;
+
+    local procedure GetTableCaption(TableID: Integer): Text
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if TableMetadata.Get(TableID) then
+            exit(TableMetadata.Caption);
+        exit(Format(TableID));
+    end;
+
+    internal procedure SetSubscriberSourceRecord(SourceRecordId: RecordId)
+    begin
+        SubscriberSourceRecordId := SourceRecordId;
+        ResolveRecRefInSubscriber := true;
+    end;
+
+    [EventSubscriber(ObjectType::Page, Page::"Doc. Attachment List Factbox", 'OnAfterGetRecRefFail', '', false, false)]
+    local procedure ResolveSourceRecordOnAfterGetRecRefFail(var DocumentAttachment: Record "Document Attachment"; var RecRef: RecordRef)
+    begin
+        if not ResolveRecRefInSubscriber then
+            exit;
+
+        RecRef.Get(SubscriberSourceRecordId);
     end;
 
     [ModalPageHandler]


### PR DESCRIPTION
[Bug 646549](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/646549): [master] [All-E] [SME][SaaS] User encounters a "record is not open" error when attaching a document to a posted sales shipment in Dynamics 365 (Base Application v28).

[AB#646549](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646549)

Issue: When a user uploads a file from the Documents FactBox ("Doc. Attachment List Factbox", Page 1178) on a Posted Sales Shipment, the upload fails with the runtime error "The record is not open." The same happens on Posted Return Receipt, while the identical action works correctly on Sales Order, Purchase Order and Posted Sales Invoice. The AL call stack points to Table 1173 "Document Attachment".InsertAttachment / SaveAttachmentFromStream.

Cause: The GetRefTable procedure in DocumentAttachmentMgmt.Codeunit.al (Codeunit 1173) has a case DocumentAttachment."Table ID" statement with no branch for Database::"Sales Shipment Header" (110) or Database::"Return Receipt Header" (6661), even though both tables are already registered in TableHasNumberFieldPrimayKey. Because no branch matches, RecRef.Open() is never called, GetRefTable returns false, and the FactBox's AttachmentsUpload action ignored that result and passed the unopened RecordRef on to DocumentAttachment.SaveAttachment(files, RecRef), where RecRef.Find() in InsertAttachment throws "The record is not open."

Solution: Added the missing Database::"Sales Shipment Header" and Database::"Return Receipt Header" cases to GetRefTable, each opening the RecordRef on its table and calling GetTable when the posted document is found — matching the existing pattern used for Sales Invoice Header and Sales Cr.Memo Header. Additionally hardened all three GetRefTable call sites in DocAttachmentListFactbox.Page.al (Upload files, Show details, Attach from email) to raise a clear error when the source record still cannot be resolved after the OnAfterGetRecRefFail event, instead of letting an unopened RecordRef reach the platform and surface the cryptic message for any other unmapped table.




