### PR TITLE
[29.x] - [Bug 649370] Slice 648538: [Expense Agent] Add mileage setup to Expense Agent wizard

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/MileageRateSetup.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/MileageRateSetup.Page.al
@@ -42,4 +42,17 @@ page 7128 "Mileage Rate Setup"
             }
         }
     }
+
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    var
+        MileageRateSetup: Record "Mileage Rate Setup";
+    begin
+        if not MileageRateSetup.IsEmpty() then
+            exit(true);
+
+        exit(Confirm(MissingMileageRateSetupQst, true));
+    end;
+
+    var
+        MissingMileageRateSetupQst: Label 'No mileage rates have been configured. The standard mileage rate will be used. Do you want to continue?';
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
@@ -738,6 +738,19 @@ page 6991 "Expense Agent Setup Wizard"
                         ConfigUpdated();
                     end;
                 }
+                field(MileageRateSetupLink; MileageRateSetupLinkTxt)
+                {
+                    ShowCaption = false;
+                    Editable = false;
+                    ToolTip = 'Specifies where to configure mileage rates by vehicle type.';
+
+                    trigger OnDrillDown()
+                    var
+                        MileageRateSetup: Page "Mileage Rate Setup";
+                    begin
+                        MileageRateSetup.RunModal();
+                    end;
+                }
             }
             group(ProjectGroup)
             {
@@ -973,6 +986,7 @@ page 6991 "Expense Agent Setup Wizard"
         ExpensePoliciesLinkTxt: Label 'View expense policies';
         NoSeriesLinkTxt: Label 'Preview the default number series that will be added';
         NoSeriesAppliedLinkTxt: Label 'View number series including new defaults';
+        MileageRateSetupLinkTxt: Label 'Configure mileage rates by vehicle type';
         ExpenseDashboardLinkTxt: Label 'Go to Expense app (opens in new window)';
         ExpenseDashboardUrlOnPremTxt: Label 'http://localhost:5173/', Locked = true;
         ExpenseDashboardUrlProdTxt: Label 'https://go.microsoft.com/fwlink/?LinkId=2365219', Locked = true;


### PR DESCRIPTION
Fixes [AB#649370](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649370)

### Problem

The Expense Agent setup wizard does not provide the mileage configuration needed to set up mileage rates, date ranges, and vehicle types. The mileage setup action is missing from the wizard, and closing Mileage Rate Setup without configuring any mileage rates does not warn the user.

### Changes

- Added a mileage configuration link to the Expense Agent setup wizard.
- Added a confirmation when users close Mileage Rate Setup without configuring any mileage rates.

### Backport

Backport of #11027 to `releases/29.x`.

Cherry-picked with `git cherry-pick -x`:

- `09d1d4758478d686baed9a82e22e4b3f3464b40a`

The commit applied cleanly with no conflicts or hand edits. The change is limited to the two Expense Agent page files.
