### PR TITLE
[Backport 29.x] Bug 648535: Reprice subcontracting lines after scheduling (#10917)

### DIFF
--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -29,6 +29,23 @@ codeunit 20516 "Subc. Req. Wksh. Make Ord."
         HandleSubcontractingAfterPurchOrderLineInsert(PurchOrderLine, NextLineNo, RequisitionLine);
     end;
 
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Req. Wksh.-Make Order", OnInsertPurchOrderLineOnAfterTransferFromReqLineToPurchLine, '', false, false)]
+    local procedure OnInsertPurchOrderLineOnAfterTransferFromReqLineToPurchLine(var PurchOrderLine: Record "Purchase Line"; RequisitionLine: Record "Requisition Line")
+    var
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        if (RequisitionLine."Prod. Order No." = '') or (RequisitionLine."Operation No." = '') then
+            exit;
+
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchOrderLine);
+    end;
+
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Req. Wksh.-Make Order", OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader, '', false, false)]
     local procedure OnInsertPurchOrderLineOnAfterCheckInsertFinalizePurchaseOrderHeader(var RequisitionLine: Record "Requisition Line"; var PurchaseHeader: Record "Purchase Header"; var NextLineNo: Integer)
     var

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -33,7 +33,7 @@ codeunit 20516 "Subc. Req. Wksh. Make Ord."
     local procedure OnInsertPurchOrderLineOnAfterTransferFromReqLineToPurchLine(var PurchOrderLine: Record "Purchase Line"; RequisitionLine: Record "Requisition Line")
     var
         SubcPriceManagement: Codeunit "Subc. Price Management";
-        ReqLineDatePriceListCost: Decimal;
+        AutomaticReqLineCost: Decimal;
     begin
 #if not CLEAN29
 #pragma warning disable AL0432
@@ -44,11 +44,8 @@ codeunit 20516 "Subc. Req. Wksh. Make Ord."
         if (RequisitionLine."Prod. Order No." = '') or (RequisitionLine."Operation No." = '') then
             exit;
 
-        if not SubcPriceManagement.TryGetSubcPriceListCostForPurchLine(
-             PurchOrderLine, RequisitionLine."Order Date", ReqLineDatePriceListCost)
-        then
-            exit;
-        if PurchOrderLine."Direct Unit Cost" <> ReqLineDatePriceListCost then
+        AutomaticReqLineCost := SubcPriceManagement.GetAutomaticSubcCostForReqLine(RequisitionLine);
+        if RequisitionLine."Direct Unit Cost" <> AutomaticReqLineCost then
             exit;
 
         SubcPriceManagement.GetSubcPriceForPurchLine(PurchOrderLine);

--- a/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Manufacturing/SubcReqWkshMakeOrd.Codeunit.al
@@ -33,6 +33,7 @@ codeunit 20516 "Subc. Req. Wksh. Make Ord."
     local procedure OnInsertPurchOrderLineOnAfterTransferFromReqLineToPurchLine(var PurchOrderLine: Record "Purchase Line"; RequisitionLine: Record "Requisition Line")
     var
         SubcPriceManagement: Codeunit "Subc. Price Management";
+        ReqLineDatePriceListCost: Decimal;
     begin
 #if not CLEAN29
 #pragma warning disable AL0432
@@ -41,6 +42,13 @@ codeunit 20516 "Subc. Req. Wksh. Make Ord."
             exit;
 #endif
         if (RequisitionLine."Prod. Order No." = '') or (RequisitionLine."Operation No." = '') then
+            exit;
+
+        if not SubcPriceManagement.TryGetSubcPriceListCostForPurchLine(
+             PurchOrderLine, RequisitionLine."Order Date", ReqLineDatePriceListCost)
+        then
+            exit;
+        if PurchOrderLine."Direct Unit Cost" <> ReqLineDatePriceListCost then
             exit;
 
         SubcPriceManagement.GetSubcPriceForPurchLine(PurchOrderLine);

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -506,10 +506,8 @@ codeunit 20508 "Subc. Price Management"
     procedure GetSubcPriceForPurchLine(var PurchaseLine: Record "Purchase Line")
     var
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
-        SubcontractorPrice: Record "Subcontractor Price";
-        PriceListUOM: Code[10];
         OrderDate: Date;
-        DirectCost, PriceListCost, PriceListQty, PriceListQtyPerUOM : Decimal;
+        DirectCost: Decimal;
     begin
 #if not CLEAN29
 #pragma warning disable AL0432
@@ -521,36 +519,85 @@ codeunit 20508 "Subc. Price Management"
         if OrderDate = 0D then
             OrderDate := WorkDate();
 
+        if not TryGetSubcPriceListCostForPurchLine(PurchaseLine, OrderDate, DirectCost) then begin
+            GetProdOrderRtngLine(
+                PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.",
+                PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine);
+            ProdOrderRoutingLine.TestField(Type, "Capacity Type"::"Work Center");
+            DirectCost := GetNonPriceListDirectCost(ProdOrderRoutingLine);
+        end;
+
+        PurchaseLine."Direct Unit Cost" := DirectCost;
+        PurchaseLine.Validate("Line Discount %");
+    end;
+
+    internal procedure TryGetSubcPriceListCostForPurchLine(PurchaseLine: Record "Purchase Line"; OrderDate: Date; var DirectCost: Decimal): Boolean
+    var
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        SubcontractorPrice: Record "Subcontractor Price";
+        PriceListUOM: Code[10];
+        PriceListCost, PriceListQty, PriceListQtyPerUOM : Decimal;
+    begin
+        DirectCost := 0;
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit(false);
+#endif
+        if OrderDate = 0D then
+            OrderDate := WorkDate();
+
+        if not TryFindProdOrderRtngLine(
+                PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.",
+                PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine)
+        then
+            exit(false);
+
         SubcontractorPrice.SetRange("Vendor No.", PurchaseLine."Buy-from Vendor No.");
         SubcontractorPrice.SetRange("Work Center No.", PurchaseLine."Work Center No.");
         SubcontractorPrice.SetRange("Item No.", PurchaseLine."No.");
         SubcontractorPrice.SetFilter("Variant Code", '%1|%2', PurchaseLine."Variant Code", '');
         SubcontractorPrice.SetFilter("Unit of Measure Code", '%1|%2', PurchaseLine."Unit of Measure Code", '');
-
-        GetProdOrderRtngLine(PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.", PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine);
-
         SubcontractorPrice.SetFilter("Standard Task Code", '%1|%2', ProdOrderRoutingLine."Standard Task Code", '');
         SubcontractorPrice.SetFilter("Currency Code", '%1|%2', PurchaseLine."Currency Code", '');
         SubcontractorPrice.SetRange("Starting Date", 0D, OrderDate);
         SubcontractorPrice.SetFilter("Ending Date", '>=%1|%2', OrderDate, 0D);
 
-        if SubcontractorPrice.FindLast() then begin
-            if SubcontractorPrice."Unit of Measure Code" = PurchaseLine."Unit of Measure Code" then
-                PriceListUOM := SubcontractorPrice."Unit of Measure Code";
-            GetUOMPrice(PurchaseLine."No.", GetQuantityBase(PurchaseLine), SubcontractorPrice, PriceListUOM, PriceListQtyPerUOM, PriceListQty);
-            GetPriceByUOM(SubcontractorPrice, PriceListQty, PriceListCost);
-            if PriceListCost <> 0 then begin
-                ConvertPriceToUOM(PurchaseLine."Unit of Measure Code", PurchaseLine.GetQuantityPerUOM(), PriceListUOM, PriceListQtyPerUOM, PriceListCost, DirectCost);
-                ConvertPriceToCurrency(PurchaseLine."Currency Code", SubcontractorPrice."Currency Code", PriceListCost, DirectCost)
-            end;
-        end else begin
-            GetUOMPrice(PurchaseLine."No.", PurchaseLine.GetQuantityBase(), SubcontractorPrice, PriceListUOM, PriceListQtyPerUOM, PriceListQty);
-            ProdOrderRoutingLine.TestField(Type, "Capacity Type"::"Work Center");
-            DirectCost := ProdOrderRoutingLine."Direct Unit Cost";
-        end;
+        if not SubcontractorPrice.FindLast() then
+            exit(false);
 
-        PurchaseLine."Direct Unit Cost" := DirectCost;
-        PurchaseLine.Validate("Line Discount %");
+        if SubcontractorPrice."Unit of Measure Code" = PurchaseLine."Unit of Measure Code" then
+            PriceListUOM := SubcontractorPrice."Unit of Measure Code";
+        GetUOMPrice(PurchaseLine."No.", GetQuantityBase(PurchaseLine), SubcontractorPrice, PriceListUOM, PriceListQtyPerUOM, PriceListQty);
+        GetPriceByUOM(SubcontractorPrice, PriceListQty, PriceListCost);
+        if PriceListCost = 0 then
+            exit(true);
+
+        ConvertPriceToUOM(PurchaseLine."Unit of Measure Code", PurchaseLine.GetQuantityPerUOM(), PriceListUOM, PriceListQtyPerUOM, PriceListCost, DirectCost);
+        ConvertPriceToCurrency(PurchaseLine."Currency Code", SubcontractorPrice."Currency Code", PriceListCost, DirectCost);
+        exit(true);
+    end;
+
+    local procedure GetNonPriceListDirectCost(ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Decimal
+    var
+        GeneralLedgerSetup: Record "General Ledger Setup";
+        ProdOrderLine: Record "Prod. Order Line";
+    begin
+        GetLine(ProdOrderLine, ProdOrderRoutingLine);
+        GeneralLedgerSetup.Get();
+        if ProdOrderRoutingLine."Unit Cost Calculation" = ProdOrderRoutingLine."Unit Cost Calculation"::Units then
+            exit(
+                Round(
+                    ProdOrderRoutingLine."Direct Unit Cost" * ProdOrderLine."Qty. per Unit of Measure",
+                    GeneralLedgerSetup."Unit-Amount Rounding Precision"));
+
+        ProdOrderLine.CalcFields("Total Exp. Oper. Output (Qty.)");
+        exit(
+            Round(
+                (ProdOrderRoutingLine."Expected Operation Cost Amt." - ProdOrderRoutingLine."Expected Capacity Ovhd. Cost") /
+                ProdOrderLine."Total Exp. Oper. Output (Qty.)",
+                GeneralLedgerSetup."Unit-Amount Rounding Precision"));
     end;
 
     local procedure GetProdOrderRtngLine(ProdOrderNo: Code[20]; RtngRefNo: Integer; RoutingNo: Code[20]; OperationNo: Code[10]; var ProdOrderRoutingLine: Record "Prod. Order Routing Line")
@@ -562,6 +609,16 @@ codeunit 20508 "Subc. Price Management"
         ProdOrderRoutingLine.SetRange("Operation No.", OperationNo);
 
         ProdOrderRoutingLine.FindFirst();
+    end;
+
+    local procedure TryFindProdOrderRtngLine(ProdOrderNo: Code[20]; RtngRefNo: Integer; RoutingNo: Code[20]; OperationNo: Code[10]; var ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Boolean
+    begin
+        ProdOrderRoutingLine.SetFilter(Status, '%1|%2', ProdOrderRoutingLine.Status::Released, ProdOrderRoutingLine.Status::Finished);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProdOrderNo);
+        ProdOrderRoutingLine.SetRange("Routing Reference No.", RtngRefNo);
+        ProdOrderRoutingLine.SetRange("Routing No.", RoutingNo);
+        ProdOrderRoutingLine.SetRange("Operation No.", OperationNo);
+        exit(ProdOrderRoutingLine.FindFirst());
     end;
 
     local procedure SetSubcontractorPriceForPriceCalculation(var SubcontractorPrice: Record "Subcontractor Price"; VendorNo: Code[20]; ItemNo: Code[20]; VariantCode: Code[10]; StandardTaskCode: Code[10]; WorkCenterNo: Code[20]; UoM: Code[10]; StartingDate: Date)

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -485,7 +485,8 @@ codeunit 20508 "Subc. Price Management"
             end else
                 GetUOMPrice(RequisitionLine."No.", RequisitionLine.GetQuantityBase(), SubcontractorPrice, PriceListUOM, PriceListQtyPerUOM, PriceListQty);
 
-            GetPriceByUOM(SubcontractorPrice, PriceListQty, PriceListCost);
+            if not GetPriceByUOM(SubcontractorPrice, PriceListQty, PriceListCost) then
+                exit;
             if PriceListCost <> 0 then begin
                 ConvertPriceToUOM(RequisitionLine."Unit of Measure Code", RequisitionLine.GetQuantityForUOM(), PriceListUOM, PriceListQtyPerUOM, PriceListCost, DirectCost);
                 ConvertPriceToCurrency(RequisitionLine."Currency Code", SubcontractorPrice."Currency Code", PriceListCost, DirectCost);
@@ -505,6 +506,19 @@ codeunit 20508 "Subc. Price Management"
         end;
     end;
 
+    internal procedure GetAutomaticSubcCostForReqLine(RequisitionLine: Record "Requisition Line"): Decimal
+    var
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+    begin
+        GetProdOrderRtngLine(
+            RequisitionLine."Prod. Order No.", RequisitionLine."Routing Reference No.",
+            RequisitionLine."Routing No.", RequisitionLine."Operation No.", ProdOrderRoutingLine);
+        ProdOrderRoutingLine.TestField(Type, "Capacity Type"::"Work Center");
+        RequisitionLine."Direct Unit Cost" := GetNonPriceListDirectCost(ProdOrderRoutingLine);
+        GetSubcPriceForReqLine(RequisitionLine, '');
+        exit(RequisitionLine."Direct Unit Cost");
+    end;
+
     procedure GetSubcPriceForPurchLine(var PurchaseLine: Record "Purchase Line")
     var
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
@@ -521,10 +535,7 @@ codeunit 20508 "Subc. Price Management"
         if OrderDate = 0D then
             OrderDate := WorkDate();
 
-        if not TryGetSubcPriceListCostForPurchLine(PurchaseLine, OrderDate, DirectCost) then begin
-            GetProdOrderRtngLine(
-                PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.",
-                PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine);
+        if not TryGetSubcPriceListCostForPurchLine(PurchaseLine, OrderDate, DirectCost, ProdOrderRoutingLine) then begin
             ProdOrderRoutingLine.TestField(Type, "Capacity Type"::"Work Center");
             DirectCost := GetNonPriceListDirectCost(ProdOrderRoutingLine);
         end;
@@ -533,9 +544,8 @@ codeunit 20508 "Subc. Price Management"
         PurchaseLine.Validate("Line Discount %");
     end;
 
-    internal procedure TryGetSubcPriceListCostForPurchLine(PurchaseLine: Record "Purchase Line"; OrderDate: Date; var DirectCost: Decimal): Boolean
+    local procedure TryGetSubcPriceListCostForPurchLine(PurchaseLine: Record "Purchase Line"; OrderDate: Date; var DirectCost: Decimal; var ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Boolean
     var
-        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         SubcontractorPrice: Record "Subcontractor Price";
         PriceListUOM: Code[10];
         PriceListCost, PriceListQty, PriceListQtyPerUOM : Decimal;
@@ -551,11 +561,9 @@ codeunit 20508 "Subc. Price Management"
             OrderDate := WorkDate();
 
         ProdOrderRoutingLine.SetLoadFields("Standard Task Code");
-        if not TryFindProdOrderRtngLine(
-                PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.",
-                PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine)
-        then
-            exit(false);
+        GetProdOrderRtngLine(
+            PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.",
+            PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine);
 
         SubcontractorPrice.SetRange("Vendor No.", PurchaseLine."Buy-from Vendor No.");
         SubcontractorPrice.SetRange("Work Center No.", PurchaseLine."Work Center No.");
@@ -616,16 +624,6 @@ codeunit 20508 "Subc. Price Management"
         ProdOrderRoutingLine.SetRange("Operation No.", OperationNo);
 
         ProdOrderRoutingLine.FindFirst();
-    end;
-
-    local procedure TryFindProdOrderRtngLine(ProdOrderNo: Code[20]; RtngRefNo: Integer; RoutingNo: Code[20]; OperationNo: Code[10]; var ProdOrderRoutingLine: Record "Prod. Order Routing Line"): Boolean
-    begin
-        ProdOrderRoutingLine.SetFilter(Status, '%1|%2', ProdOrderRoutingLine.Status::Released, ProdOrderRoutingLine.Status::Finished);
-        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProdOrderNo);
-        ProdOrderRoutingLine.SetRange("Routing Reference No.", RtngRefNo);
-        ProdOrderRoutingLine.SetRange("Routing No.", RoutingNo);
-        ProdOrderRoutingLine.SetRange("Operation No.", OperationNo);
-        exit(ProdOrderRoutingLine.FindFirst());
     end;
 
     local procedure SetSubcontractorPriceForPriceCalculation(var SubcontractorPrice: Record "Subcontractor Price"; VendorNo: Code[20]; ItemNo: Code[20]; VariantCode: Code[10]; StandardTaskCode: Code[10]; WorkCenterNo: Code[20]; UoM: Code[10]; StartingDate: Date)

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -548,6 +548,7 @@ codeunit 20508 "Subc. Price Management"
         if OrderDate = 0D then
             OrderDate := WorkDate();
 
+        ProdOrderRoutingLine.SetLoadFields("Standard Task Code");
         if not TryFindProdOrderRtngLine(
                 PurchaseLine."Prod. Order No.", PurchaseLine."Routing Reference No.",
                 PurchaseLine."Routing No.", PurchaseLine."Operation No.", ProdOrderRoutingLine)
@@ -593,6 +594,9 @@ codeunit 20508 "Subc. Price Management"
                     GeneralLedgerSetup."Unit-Amount Rounding Precision"));
 
         ProdOrderLine.CalcFields("Total Exp. Oper. Output (Qty.)");
+        if ProdOrderLine."Total Exp. Oper. Output (Qty.)" = 0 then
+            exit(0);
+
         exit(
             Round(
                 (ProdOrderRoutingLine."Expected Operation Cost Amt." - ProdOrderRoutingLine."Expected Capacity Ovhd. Cost") /

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPriceManagement.Codeunit.al
@@ -365,16 +365,18 @@ codeunit 20508 "Subc. Price Management"
         PriceListQty := QtyBase / PriceListQtyPerUOM;
     end;
 
-    local procedure GetPriceByUOM(var SubcontractorPrice: Record "Subcontractor Price"; PriceListQty: Decimal; var PriceListCost: Decimal)
+    local procedure GetPriceByUOM(var SubcontractorPrice: Record "Subcontractor Price"; PriceListQty: Decimal; var PriceListCost: Decimal): Boolean
     begin
         SubcontractorPrice.SetRange("Minimum Quantity", 0, PriceListQty);
         SubcontractorPrice.SetRange("Unit of Measure Code", SubcontractorPrice."Unit of Measure Code");
-        if SubcontractorPrice.FindLast() then begin
-            PriceListCost := SubcontractorPrice."Direct Unit Cost";
-            if PriceListCost <> 0 then
-                if (PriceListCost * PriceListQty) < SubcontractorPrice."Minimum Amount" then
-                    PriceListCost := SubcontractorPrice."Minimum Amount" / PriceListQty;
-        end;
+        if not SubcontractorPrice.FindLast() then
+            exit(false);
+
+        PriceListCost := SubcontractorPrice."Direct Unit Cost";
+        if PriceListCost <> 0 then
+            if (PriceListCost * PriceListQty) < SubcontractorPrice."Minimum Amount" then
+                PriceListCost := SubcontractorPrice."Minimum Amount" / PriceListQty;
+        exit(true);
     end;
 
     procedure ConvertPriceToUOM(ProdUOM: Code[10]; ProdQtyPerUoM: Decimal; PriceListUOM: Code[10]; PriceListQtyPerUOM: Decimal; PriceListCost: Decimal; var DirectCost: Decimal)
@@ -571,7 +573,8 @@ codeunit 20508 "Subc. Price Management"
         if SubcontractorPrice."Unit of Measure Code" = PurchaseLine."Unit of Measure Code" then
             PriceListUOM := SubcontractorPrice."Unit of Measure Code";
         GetUOMPrice(PurchaseLine."No.", GetQuantityBase(PurchaseLine), SubcontractorPrice, PriceListUOM, PriceListQtyPerUOM, PriceListQty);
-        GetPriceByUOM(SubcontractorPrice, PriceListQty, PriceListCost);
+        if not GetPriceByUOM(SubcontractorPrice, PriceListQty, PriceListCost) then
+            exit(false);
         if PriceListCost = 0 then
             exit(true);
 

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -85,6 +85,48 @@ codeunit 20534 "Subc. Purchase Line Ext"
             SubcSynchronizeManagement.SynchronizeExpectedReceiptDate(Rec, xRec);
     end;
 
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnAfterValidateEvent, "Planned Receipt Date", false, false)]
+    local procedure OnAfterValidatePlannedReceiptDate(var Rec: Record "Purchase Line"; var xRec: Record "Purchase Line"; CurrFieldNo: Integer)
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        if Rec.IsTemporary() then
+            exit;
+
+        if GetExecutionContext() = ExecutionContext::Upgrade then
+            exit;
+
+        if Rec."Planned Receipt Date" = xRec."Planned Receipt Date" then
+            exit;
+
+        GetSubcontractingPrice(Rec);
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnAfterValidateEvent, "Order Date", false, false)]
+    local procedure OnAfterValidateOrderDate(var Rec: Record "Purchase Line"; var xRec: Record "Purchase Line"; CurrFieldNo: Integer)
+    begin
+#if not CLEAN29
+#pragma warning disable AL0432
+        if not SubcFeatureFlagHandler.IsSubcontractingEnabled() then
+#pragma warning restore AL0432
+            exit;
+#endif
+        if Rec.IsTemporary() then
+            exit;
+
+        if GetExecutionContext() = ExecutionContext::Upgrade then
+            exit;
+
+        if Rec."Order Date" = xRec."Order Date" then
+            exit;
+
+        GetSubcontractingPrice(Rec);
+    end;
+
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnAfterValidateEvent, Quantity, false, false)]
     local procedure OnAfterValidateQuantity(var Rec: Record "Purchase Line"; var xRec: Record "Purchase Line"; CurrFieldNo: Integer)
     begin

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -362,7 +362,9 @@ codeunit 20534 "Subc. Purchase Line Ext"
     var
         PurchaseHeader: Record "Purchase Header";
     begin
-        if PurchaseLine."Prod. Order No." = '' then
+        if (PurchaseLine.Type <> PurchaseLine.Type::Item) or (PurchaseLine."No." = '') or
+           (PurchaseLine."Prod. Order No." = '') or (PurchaseLine."Operation No." = '')
+        then
             exit;
 
         // Preserve released-order scheduling: repricing a subcontracting line after release

--- a/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/App/src/Purchase/SubcPurchaseLineExt.Codeunit.al
@@ -100,10 +100,14 @@ codeunit 20534 "Subc. Purchase Line Ext"
         if GetExecutionContext() = ExecutionContext::Upgrade then
             exit;
 
-        if Rec."Planned Receipt Date" = xRec."Planned Receipt Date" then
+        // Gate on the resulting Order Date rather than Planned Receipt Date so lead-time-only
+        // reschedules (for example changing Lead Time Calculation on an open line with nonblank
+        // Requested and Planned Receipt Dates) still trigger date-effective repricing when the
+        // planned-date validation reassigns Order Date without changing Planned Receipt Date.
+        if Rec."Order Date" = xRec."Order Date" then
             exit;
 
-        GetSubcontractingPrice(Rec);
+        RepriceSubcPurchLineOnScheduleChange(Rec);
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnAfterValidateEvent, "Order Date", false, false)]
@@ -124,7 +128,7 @@ codeunit 20534 "Subc. Purchase Line Ext"
         if Rec."Order Date" = xRec."Order Date" then
             exit;
 
-        GetSubcontractingPrice(Rec);
+        RepriceSubcPurchLineOnScheduleChange(Rec);
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnAfterValidateEvent, Quantity, false, false)]
@@ -352,6 +356,30 @@ codeunit 20534 "Subc. Purchase Line Ext"
     begin
         if (PurchaseLine.Type = PurchaseLine.Type::Item) and (PurchaseLine."No." <> '') and (PurchaseLine."Prod. Order No." <> '') and (PurchaseLine."Operation No." <> '') then
             SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+    end;
+
+    local procedure RepriceSubcPurchLineOnScheduleChange(var PurchaseLine: Record "Purchase Line")
+    var
+        PurchaseHeader: Record "Purchase Header";
+    begin
+        if PurchaseLine."Prod. Order No." = '' then
+            exit;
+
+        // Preserve released-order scheduling: repricing a subcontracting line after release
+        // would call Validate("Line Discount %") through GetSubcPriceForPurchLine, which in
+        // turn calls TestStatusOpen on the released header and fails the date edit. The base
+        // test suite explicitly permits Planned Receipt Date and Order Date edits on released
+        // purchase order lines (see ERMSalesPurchStatusError CanChangeOrderDateOnReleasedPurchOrderLine
+        // and CanChangePlannedReceiptDateOnReleasedPurchOrderLine). Bypass repricing entirely
+        // once the header is no longer Open so scheduling still works without silently
+        // changing released financial terms.
+        PurchaseHeader.SetLoadFields(Status);
+        if not PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.") then
+            exit;
+        if PurchaseHeader.Status <> PurchaseHeader.Status::Open then
+            exit;
+
+        GetSubcontractingPrice(PurchaseLine);
     end;
 
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", OnBeforeOpenItemTrackingLines, '', false, false)]

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -743,6 +743,225 @@ codeunit 139982 "Subc. Pricing Test"
         // Empty handler used to close the request page. We use default settings.
     end;
 
+    [Test]
+    procedure CreatedSubcPurchLineUsesPriceForBackwardScheduledOrderDate()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+    begin
+        // [SCENARIO 648535] A new subcontracting purchase line uses the price valid on its backward-scheduled order date
+        Initialize();
+
+        // [GIVEN] A subcontracting operation with adjacent prices before and from WorkDate
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+
+        // [WHEN] A purchase order is created for the subcontracting operation
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+
+        // [THEN] The purchase line uses the earlier price valid on its backward-scheduled order date
+        Assert.IsTrue(PurchaseLine."Order Date" < WorkDate(), 'The purchase line order date must be backward-scheduled before WorkDate.');
+        Assert.AreEqual(EarlierPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must use the subcontractor price valid on its order date.');
+    end;
+
+    [Test]
+    procedure ReqWkshCreatedSubcPurchLineUsesPriceForBackwardScheduledOrderDate()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+    begin
+        // [SCENARIO 648535] A worksheet-created subcontracting purchase line uses the price valid on its backward-scheduled order date
+        Initialize();
+
+        // [GIVEN] A subcontracting operation with adjacent prices before and from WorkDate
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+
+        // [WHEN] The worksheet action is carried out for the subcontracting operation
+        CarryOutSubcontractingAction(RequisitionLine);
+
+        // [THEN] The purchase line uses the earlier price valid on its backward-scheduled order date
+        FindSubcPurchLineForProdOrder(PurchaseLine, Item."No.", ProductionOrder."No.");
+        Assert.IsTrue(PurchaseLine."Order Date" < WorkDate(), 'The purchase line order date must be backward-scheduled before WorkDate.');
+        Assert.AreEqual(EarlierPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must use the subcontractor price valid on its order date.');
+    end;
+
+    [Test]
+    procedure ExpectedReceiptDateChangeRepricesBackwardScheduledSubcPurchLine()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+        NewExpectedReceiptDate: Date;
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+    begin
+        // [SCENARIO 648535] Rescheduling a subcontracting purchase line reapplies the date-effective price
+        Initialize();
+
+        // [GIVEN] A backward-scheduled subcontracting purchase line using the price valid before WorkDate
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+        Assert.AreEqual(EarlierPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must initially use the earlier subcontractor price.');
+        NewExpectedReceiptDate := CalcDate('<20D>', WorkDate());
+
+        // [WHEN] Expected Receipt Date is moved so Planned Receipt Date backward-schedules Order Date into the later price period
+        PurchaseLine.Validate("Expected Receipt Date", NewExpectedReceiptDate);
+
+        // [THEN] The purchase line uses the later price valid on its rescheduled order date
+        Assert.IsTrue(PurchaseLine."Order Date" >= WorkDate(), 'The rescheduled purchase line order date must be on or after WorkDate.');
+        Assert.AreEqual(LaterPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must use the subcontractor price valid on its rescheduled order date.');
+    end;
+
+    [Test]
+    procedure PlannedReceiptDateChangeRepricesSubcPurchLine()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+        NewPlannedReceiptDate: Date;
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+    begin
+        // [SCENARIO 648535] Changing Planned Receipt Date directly reapplies the price for the resulting order date
+        Initialize();
+
+        // [GIVEN] A backward-scheduled subcontracting purchase line using the price valid before WorkDate
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+        Assert.AreEqual(EarlierPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must initially use the earlier subcontractor price.');
+        NewPlannedReceiptDate := CalcDate('<20D>', WorkDate());
+
+        // [WHEN] Planned Receipt Date is changed directly
+        PurchaseLine.Validate("Planned Receipt Date", NewPlannedReceiptDate);
+
+        // [THEN] The purchase line uses the later price valid on the resulting order date
+        Assert.IsTrue(PurchaseLine."Order Date" >= WorkDate(), 'The resulting purchase line order date must be on or after WorkDate.');
+        Assert.AreEqual(LaterPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must use the subcontractor price valid on the resulting order date.');
+    end;
+
+    [Test]
+    procedure OrderDateChangeRepricesSubcPurchLine()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+    begin
+        // [SCENARIO 648535] Changing a subcontracting purchase line order date reapplies the date-effective price
+        Initialize();
+
+        // [GIVEN] A backward-scheduled subcontracting purchase line using the price valid before WorkDate
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+        Assert.AreEqual(EarlierPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must initially use the earlier subcontractor price.');
+
+        // [WHEN] Order Date is changed to WorkDate
+        PurchaseLine.Validate("Order Date", WorkDate());
+
+        // [THEN] The purchase line uses the later price valid from WorkDate
+        Assert.AreEqual(LaterPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must use the subcontractor price valid on its changed order date.');
+    end;
+
+    local procedure CreateDateEffectiveSubcontractingScenario(var Item: Record Item; var ProductionOrder: Record "Production Order"; var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var EarlierPrice: Decimal; var LaterPrice: Decimal)
+    var
+        SubcontractorPrice: Record "Subcontractor Price";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+    begin
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
+        Evaluate(Item."Lead Time Calculation", '<5D>');
+        Item.Modify(true);
+
+        EarlierPrice := 100;
+        LaterPrice := 200;
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '', CalcDate('<-1M>', WorkDate()), Item."Base Unit of Measure", 0, '');
+        SubcontractorPrice.Validate("Ending Date", CalcDate('<-1D>', WorkDate()));
+        SubcontractorPrice.Validate("Direct Unit Cost", EarlierPrice);
+        SubcontractorPrice.Modify(true);
+        Clear(SubcontractorPrice);
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '', WorkDate(), Item."Base Unit of Measure", 0, '');
+        SubcontractorPrice.Validate("Direct Unit Cost", LaterPrice);
+        SubcontractorPrice.Modify(true);
+
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, Item, '', '', 1, WorkDate());
+        ProdOrderRoutingLine.SetRange(Status, ProductionOrder.Status);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter."No.");
+        ProdOrderRoutingLine.FindFirst();
+    end;
+
+    local procedure CreateSubcontractingPurchaseLine(var PurchaseLine: Record "Purchase Line"; ProdOrderRoutingLine: Record "Prod. Order Routing Line"; ItemNo: Code[20]; ProdOrderNo: Code[20])
+    var
+        SubcPurchaseOrderCreator: Codeunit "Subc. Purchase Order Creator";
+    begin
+        SubcPurchaseOrderCreator.CreateSubcontractingPurchaseOrderFromRoutingLine(ProdOrderRoutingLine);
+        FindSubcPurchLineForProdOrder(PurchaseLine, ItemNo, ProdOrderNo);
+    end;
+
+
+    local procedure CalculateSubcontractsAndFindReqLine(RequisitionWkshName: Record "Requisition Wksh. Name"; ProdOrderNo: Code[20]; var RequisitionLine: Record "Requisition Line")
+    var
+        SubcCalculateSubContract: Report "Subc. Calculate Subcontracts";
+    begin
+        Clear(RequisitionLine);
+        RequisitionLine."Worksheet Template Name" := RequisitionWkshName."Worksheet Template Name";
+        RequisitionLine."Journal Batch Name" := RequisitionWkshName.Name;
+
+        SubcCalculateSubContract.SetWkShLine(RequisitionLine);
+        SubcCalculateSubContract.UseRequestPage(false);
+        SubcCalculateSubContract.RunModal();
+
+        RequisitionLine.SetRange("Worksheet Template Name", RequisitionWkshName."Worksheet Template Name");
+        RequisitionLine.SetRange("Journal Batch Name", RequisitionWkshName.Name);
+#pragma warning disable AA0210
+        RequisitionLine.SetRange("Prod. Order No.", ProdOrderNo);
+#pragma warning restore AA0210
+        RequisitionLine.FindFirst();
+    end;
+
+    local procedure CarryOutSubcontractingAction(var RequisitionLine: Record "Requisition Line")
+    var
+        CarryOutActionMsgReq: Report "Carry Out Action Msg. - Req.";
+    begin
+        CarryOutActionMsgReq.SetReqWkshLine(RequisitionLine);
+        CarryOutActionMsgReq.UseRequestPage(false);
+        CarryOutActionMsgReq.RunModal();
+    end;
+
+    local procedure FindSubcPurchLineForProdOrder(var PurchaseLine: Record "Purchase Line"; ItemNo: Code[20]; ProdOrderNo: Code[20])
+    begin
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange(Type, "Purchase Line Type"::Item);
+        PurchaseLine.SetRange("No.", ItemNo);
+        PurchaseLine.SetRange("Prod. Order No.", ProdOrderNo);
+        PurchaseLine.FindFirst();
+    end;
+
     var
         Assert: Codeunit Assert;
         LibraryERM: Codeunit "Library - ERM";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -943,6 +943,68 @@ codeunit 139982 "Subc. Pricing Test"
     end;
 
     [Test]
+    procedure NoMatchPriceListFallbackUsesCalculatedCostForUnitsAndTime()
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+        TimeDirectUnitCost: Decimal;
+        UnitsDirectUnitCost: Decimal;
+    begin
+        // [SCENARIO 648535] Direct purchase-line repricing without a matching price uses the
+        // standard subcontracting calculation for both unit- and time-based operations.
+        Initialize();
+
+        CreateNoPriceSubcontractingPurchaseLine(
+            PurchaseLine, ProdOrderLine, Enum::"Unit Cost Calculation Type"::Units);
+        UnitsDirectUnitCost := PurchaseLine."Direct Unit Cost";
+        Assert.AreNotEqual(0, UnitsDirectUnitCost, 'Test setup expects a nonzero Units Direct Unit Cost.');
+        PurchaseLine."Direct Unit Cost" := 0;
+
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+
+        Assert.AreEqual(
+            UnitsDirectUnitCost, PurchaseLine."Direct Unit Cost",
+            'The Units fallback must match the Direct Unit Cost calculated when the purchase line was created.');
+
+        CreateNoPriceSubcontractingPurchaseLine(
+            PurchaseLine, ProdOrderLine, Enum::"Unit Cost Calculation Type"::Time);
+        TimeDirectUnitCost := PurchaseLine."Direct Unit Cost";
+        Assert.AreNotEqual(0, TimeDirectUnitCost, 'Test setup expects a nonzero Time Direct Unit Cost.');
+        Assert.AreNotEqual(UnitsDirectUnitCost, TimeDirectUnitCost, 'Test setup expects Units and Time calculations to produce different costs.');
+        PurchaseLine."Direct Unit Cost" := 0;
+
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+
+        Assert.AreEqual(
+            TimeDirectUnitCost, PurchaseLine."Direct Unit Cost",
+            'The Time fallback must match the Direct Unit Cost calculated when the purchase line was created.');
+    end;
+
+    [Test]
+    procedure NoMatchPriceListFallbackHandlesZeroExpectedOutputQuantity()
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+    begin
+        // [SCENARIO 648535] Time-based fallback pricing returns zero instead of dividing by
+        // zero when the production order has no expected operation output quantity.
+        Initialize();
+
+        CreateNoPriceSubcontractingPurchaseLine(
+            PurchaseLine, ProdOrderLine, Enum::"Unit Cost Calculation Type"::Time);
+        ProdOrderLine.Quantity := 0;
+        ProdOrderLine.Modify();
+
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+
+        Assert.AreEqual(
+            0, PurchaseLine."Direct Unit Cost",
+            'The no-price fallback must be zero when expected operation output quantity is zero.');
+    end;
+
+    [Test]
     procedure ManualWorksheetDirectUnitCostOverridePreservedOnCarryOut()
     var
         Item: Record Item;
@@ -1087,6 +1149,53 @@ codeunit 139982 "Subc. Pricing Test"
     begin
         SubcPurchaseOrderCreator.CreateSubcontractingPurchaseOrderFromRoutingLine(ProdOrderRoutingLine);
         FindSubcPurchLineForProdOrder(PurchaseLine, ItemNo, ProdOrderNo);
+    end;
+
+    local procedure CreateNoPriceSubcontractingPurchaseLine(var PurchaseLine: Record "Purchase Line"; var ProdOrderLine: Record "Prod. Order Line"; UnitCostCalculation: Enum "Unit Cost Calculation Type")
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        SubcontractorPrice: Record "Subcontractor Price";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+    begin
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
+        WorkCenter.Validate("Direct Unit Cost", 10);
+        WorkCenter.Validate("Unit Cost Calculation", UnitCostCalculation);
+        WorkCenter.Modify(true);
+
+        RoutingHeader.Get(Item."Routing No.");
+        RoutingHeader.Validate(Status, RoutingHeader.Status::New);
+        RoutingHeader.Modify(true);
+        RoutingLine.SetRange("Routing No.", Item."Routing No.");
+        RoutingLine.FindFirst();
+        RoutingLine.Validate("Run Time", 5);
+        RoutingLine.Modify(true);
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        SubcontractorPrice.SetRange("Vendor No.", Vendor."No.");
+        SubcontractorPrice.SetRange("Work Center No.", WorkCenter."No.");
+        SubcontractorPrice.SetRange("Item No.", Item."No.");
+        Assert.IsTrue(SubcontractorPrice.IsEmpty(), 'Test setup expects no subcontractor prices for the operation.');
+
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, Item, '', '', 1, WorkDate());
+        ProdOrderRoutingLine.SetRange(Status, ProductionOrder.Status);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter."No.");
+        ProdOrderRoutingLine.FindFirst();
+
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+
+        ProdOrderLine.SetRange(Status, ProductionOrder.Status);
+        ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderLine.SetRange("Routing No.", ProdOrderRoutingLine."Routing No.");
+        ProdOrderLine.SetRange("Routing Reference No.", ProdOrderRoutingLine."Routing Reference No.");
+        ProdOrderLine.FindFirst();
     end;
 
 

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -982,6 +982,64 @@ codeunit 139982 "Subc. Pricing Test"
     end;
 
     [Test]
+    procedure NoApplicableMinimumQuantityPriceUsesCalculatedFallback()
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcontractorPrice: Record "Subcontractor Price";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+        CalculatedFallbackCost: Decimal;
+    begin
+        // [SCENARIO 648535] A date-compatible price with a minimum quantity above the purchase
+        // quantity is not an applicable price and must not replace the calculated fallback with zero.
+        Initialize();
+
+        CreateNoPriceSubcontractingPurchaseLine(
+            PurchaseLine, ProdOrderLine, Enum::"Unit Cost Calculation Type"::Time);
+        CalculatedFallbackCost := PurchaseLine."Direct Unit Cost";
+        Assert.AreNotEqual(0, CalculatedFallbackCost, 'Test setup expects a nonzero calculated fallback cost.');
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, PurchaseLine."Work Center No.", PurchaseLine."Buy-from Vendor No.",
+            PurchaseLine."No.", '', PurchaseLine."Variant Code", PurchaseLine."Order Date",
+            PurchaseLine."Unit of Measure Code", PurchaseLine.Quantity + 1, PurchaseLine."Currency Code");
+        SubcontractorPrice.Validate("Direct Unit Cost", CalculatedFallbackCost * 2);
+        SubcontractorPrice.Modify(true);
+        PurchaseLine."Direct Unit Cost" := 0;
+
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+
+        Assert.AreEqual(
+            CalculatedFallbackCost, PurchaseLine."Direct Unit Cost",
+            'A price above the purchase quantity threshold must not suppress the calculated fallback.');
+    end;
+
+    [Test]
+    procedure ApplicableZeroPriceIsNotReplacedByCalculatedFallback()
+    var
+        ProdOrderLine: Record "Prod. Order Line";
+        PurchaseLine: Record "Purchase Line";
+        SubcontractorPrice: Record "Subcontractor Price";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+    begin
+        // [SCENARIO 648535] A matched price tier can intentionally have a zero direct unit cost.
+        Initialize();
+
+        CreateNoPriceSubcontractingPurchaseLine(
+            PurchaseLine, ProdOrderLine, Enum::"Unit Cost Calculation Type"::Time);
+        Assert.AreNotEqual(0, PurchaseLine."Direct Unit Cost", 'Test setup expects a nonzero calculated fallback cost.');
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, PurchaseLine."Work Center No.", PurchaseLine."Buy-from Vendor No.",
+            PurchaseLine."No.", '', PurchaseLine."Variant Code", PurchaseLine."Order Date",
+            PurchaseLine."Unit of Measure Code", 0, PurchaseLine."Currency Code");
+
+        SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
+
+        Assert.AreEqual(
+            0, PurchaseLine."Direct Unit Cost",
+            'An applicable zero price must not be replaced by the calculated fallback.');
+    end;
+
+    [Test]
     procedure NoMatchPriceListFallbackHandlesZeroExpectedOutputQuantity()
     var
         ProdOrderLine: Record "Prod. Order Line";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -884,6 +884,172 @@ codeunit 139982 "Subc. Pricing Test"
         Assert.AreEqual(LaterPrice, PurchaseLine."Direct Unit Cost", 'The purchase line must use the subcontractor price valid on its changed order date.');
     end;
 
+    [Test]
+    procedure NoMatchPriceListPreservesCalculatedWorksheetCostForTimeBasedRouting()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        SubcontractorPrice: Record "Subcontractor Price";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        CalculatedWorksheetCost: Decimal;
+        RoutingRate: Decimal;
+    begin
+        // [SCENARIO 648535] Carry-out preserves the calculated time-based cost when no price matches
+        Initialize();
+
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
+        RoutingHeader.Get(Item."Routing No.");
+        RoutingHeader.Validate(Status, RoutingHeader.Status::New);
+        RoutingHeader.Modify(true);
+        RoutingLine.SetRange("Routing No.", Item."Routing No.");
+        RoutingLine.FindFirst();
+        RoutingLine.Validate("Run Time", 5);
+        RoutingLine.Modify(true);
+        RoutingHeader.Validate(Status, RoutingHeader.Status::Certified);
+        RoutingHeader.Modify(true);
+
+        SubcontractorPrice.SetRange("Vendor No.", Vendor."No.");
+        SubcontractorPrice.SetRange("Work Center No.", WorkCenter."No.");
+        SubcontractorPrice.SetRange("Item No.", Item."No.");
+        Assert.IsTrue(SubcontractorPrice.IsEmpty(), 'Test setup expects no subcontractor prices for the operation.');
+
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, Item, '', '', 1, WorkDate());
+        ProdOrderRoutingLine.SetRange(Status, ProductionOrder.Status);
+        ProdOrderRoutingLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderRoutingLine.SetRange("Work Center No.", WorkCenter."No.");
+        ProdOrderRoutingLine.FindFirst();
+        RoutingRate := ProdOrderRoutingLine."Direct Unit Cost";
+
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+        CalculatedWorksheetCost := RequisitionLine."Direct Unit Cost";
+        Assert.AreNotEqual(RoutingRate, CalculatedWorksheetCost, 'Test setup expects a time-based cost different from the routing rate.');
+
+        CarryOutSubcontractingAction(RequisitionLine);
+
+        FindSubcPurchLineForProdOrder(PurchaseLine, Item."No.", ProductionOrder."No.");
+        Assert.AreEqual(
+            CalculatedWorksheetCost, PurchaseLine."Direct Unit Cost",
+            'Carry-out must preserve the calculated worksheet cost when no subcontractor price matches.');
+    end;
+
+    [Test]
+    procedure ManualWorksheetDirectUnitCostOverridePreservedOnCarryOut()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+        ManualCost: Decimal;
+    begin
+        // [SCENARIO 648535] Carry-out preserves a manually overridden worksheet cost
+        Initialize();
+
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+        ManualCost := EarlierPrice + LaterPrice;
+        RequisitionLine.Validate("Direct Unit Cost", ManualCost);
+        RequisitionLine.Modify(true);
+
+        CarryOutSubcontractingAction(RequisitionLine);
+
+        FindSubcPurchLineForProdOrder(PurchaseLine, Item."No.", ProductionOrder."No.");
+        Assert.AreEqual(
+            ManualCost, PurchaseLine."Direct Unit Cost",
+            'Carry-out must preserve a manually overridden worksheet Direct Unit Cost.');
+    end;
+
+    [Test]
+    procedure DateEditsOnReleasedSubcPurchOrderLinePreserveFinancialTerms()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+        NewPlannedReceiptDate: Date;
+        OriginalDirectUnitCost: Decimal;
+        OriginalLineDiscount: Decimal;
+    begin
+        // [SCENARIO 648535] Scheduling edits remain allowed on a released subcontracting order
+        Initialize();
+
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+        OriginalDirectUnitCost := PurchaseLine."Direct Unit Cost";
+        OriginalLineDiscount := PurchaseLine."Line Discount %";
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+        PurchaseLine.Find();
+
+        NewPlannedReceiptDate := CalcDate('<20D>', WorkDate());
+        PurchaseLine.Validate("Planned Receipt Date", NewPlannedReceiptDate);
+
+        PurchaseLine.TestField("Planned Receipt Date", NewPlannedReceiptDate);
+        Assert.AreEqual(OriginalDirectUnitCost, PurchaseLine."Direct Unit Cost", 'A released line must retain its Direct Unit Cost.');
+        Assert.AreEqual(OriginalLineDiscount, PurchaseLine."Line Discount %", 'A released line must retain its Line Discount %.');
+
+        PurchaseLine.Validate("Order Date", WorkDate());
+
+        PurchaseLine.TestField("Order Date", WorkDate());
+        Assert.AreEqual(OriginalDirectUnitCost, PurchaseLine."Direct Unit Cost", 'A released line must retain its Direct Unit Cost.');
+        Assert.AreEqual(OriginalLineDiscount, PurchaseLine."Line Discount %", 'A released line must retain its Line Discount %.');
+    end;
+
+    [Test]
+    procedure LeadTimeCalculationOnlyOrderDateShiftRepricesSubcPurchLine()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ProdOrderRoutingLine: Record "Prod. Order Routing Line";
+        PurchaseLine: Record "Purchase Line";
+        EarlierPrice: Decimal;
+        LaterPrice: Decimal;
+        AlignedDate: Date;
+        NewLeadTime: DateFormula;
+        OriginalPlannedReceiptDate: Date;
+    begin
+        // [SCENARIO 648535] A lead-time-only Order Date change reapplies date-effective pricing
+        Initialize();
+
+        CreateDateEffectiveSubcontractingScenario(Item, ProductionOrder, ProdOrderRoutingLine, EarlierPrice, LaterPrice);
+        CreateSubcontractingPurchaseLine(PurchaseLine, ProdOrderRoutingLine, Item."No.", ProductionOrder."No.");
+        Assert.AreEqual(EarlierPrice, PurchaseLine."Direct Unit Cost", 'The line must initially use the earlier price.');
+
+        AlignedDate := CalcDate('<20D>', WorkDate());
+        PurchaseLine.Validate("Requested Receipt Date", AlignedDate);
+        PurchaseLine.Validate("Promised Receipt Date", 0D);
+        OriginalPlannedReceiptDate := PurchaseLine."Planned Receipt Date";
+
+        Evaluate(NewLeadTime, '<0D>');
+        PurchaseLine.Validate("Lead Time Calculation", NewLeadTime);
+
+        Assert.AreEqual(
+            OriginalPlannedReceiptDate, PurchaseLine."Planned Receipt Date",
+            'Planned Receipt Date must remain unchanged for a lead-time-only reschedule.');
+        Assert.IsTrue(PurchaseLine."Order Date" >= WorkDate(), 'Order Date must move into the later price period.');
+        Assert.AreEqual(
+            LaterPrice, PurchaseLine."Direct Unit Cost",
+            'The line must use the price valid on the resulting Order Date.');
+    end;
+
     local procedure CreateDateEffectiveSubcontractingScenario(var Item: Record Item; var ProductionOrder: Record "Production Order"; var ProdOrderRoutingLine: Record "Prod. Order Routing Line"; var EarlierPrice: Decimal; var LaterPrice: Decimal)
     var
         SubcontractorPrice: Record "Subcontractor Price";

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -906,6 +906,8 @@ codeunit 139982 "Subc. Pricing Test"
         Initialize();
 
         CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
+        WorkCenter.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        WorkCenter.Modify(true);
         RoutingHeader.Get(Item."Routing No.");
         RoutingHeader.Validate(Status, RoutingHeader.Status::New);
         RoutingHeader.Modify(true);
@@ -982,6 +984,95 @@ codeunit 139982 "Subc. Pricing Test"
     end;
 
     [Test]
+    procedure FinalPurchaseLineDateAppliesPriceWhenReqLineDateHasNoPrice()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        PurchaseLine: Record "Purchase Line";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        SubcontractorPrice: Record "Subcontractor Price";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        FinalDatePrice: Decimal;
+    begin
+        // [SCENARIO 648535] An automatically calculated worksheet fallback is repriced when
+        // the final purchase-line date has an applicable subcontractor price.
+        Initialize();
+
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
+        WorkCenter.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        WorkCenter.Modify(true);
+        Evaluate(Item."Lead Time Calculation", '<5D>');
+        Item.Modify(true);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, Item, '', '', 1, WorkDate());
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+        RequisitionLine.Validate("Order Date", WorkDate());
+        RequisitionLine.Modify(true);
+        FinalDatePrice := LibraryRandom.RandDecInRange(100, 200, 2);
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '',
+            CalcDate('<-1M>', WorkDate()), Item."Base Unit of Measure", 0, '');
+        SubcontractorPrice.Validate("Ending Date", CalcDate('<-1D>', WorkDate()));
+        SubcontractorPrice.Validate("Direct Unit Cost", FinalDatePrice);
+        SubcontractorPrice.Modify(true);
+
+        CarryOutSubcontractingAction(RequisitionLine);
+
+        FindSubcPurchLineForProdOrder(PurchaseLine, Item."No.", ProductionOrder."No.");
+        Assert.IsTrue(
+            PurchaseLine."Order Date" < WorkDate(),
+            'The final purchase-line Order Date must be in the price validity period.');
+        Assert.AreEqual(
+            FinalDatePrice, PurchaseLine."Direct Unit Cost",
+            'The price valid on the final purchase-line date must replace the automatic worksheet fallback.');
+    end;
+
+    [Test]
+    procedure ReqLinePriceAboveMinimumQuantityPreservesCalculatedFallback()
+    var
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        ReqWkshTemplate: Record "Req. Wksh. Template";
+        RequisitionLine: Record "Requisition Line";
+        RequisitionWkshName: Record "Requisition Wksh. Name";
+        SubcontractorPrice: Record "Subcontractor Price";
+        Vendor: Record Vendor;
+        WorkCenter: Record "Work Center";
+        SubcPriceManagement: Codeunit "Subc. Price Management";
+        CalculatedFallbackCost: Decimal;
+    begin
+        // [SCENARIO 648535] A requisition-line price whose minimum quantity is too high does
+        // not replace the standard calculated subcontracting cost with zero.
+        Initialize();
+
+        CreateSubcontractingItemWithSingleOperationRouting(Item, Vendor, WorkCenter, '');
+        WorkCenter.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        WorkCenter.Modify(true);
+        LibraryManufacturing.CreateProductionOrder(
+            ProductionOrder, "Production Order Status"::Released, Item, '', '', 1, WorkDate());
+        SubcontractingMgmtLibrary.CreateReqWkshTemplateAndName(ReqWkshTemplate, RequisitionWkshName);
+        CalculateSubcontractsAndFindReqLine(RequisitionWkshName, ProductionOrder."No.", RequisitionLine);
+        CalculatedFallbackCost := RequisitionLine."Direct Unit Cost";
+        Assert.AreNotEqual(0, CalculatedFallbackCost, 'Test setup expects a nonzero calculated fallback cost.');
+        SubcontractingMgmtLibrary.CreateSubContractingPrice(
+            SubcontractorPrice, WorkCenter."No.", Vendor."No.", Item."No.", '', '',
+            RequisitionLine."Order Date", RequisitionLine."Unit of Measure Code",
+            RequisitionLine.Quantity + 1, RequisitionLine."Currency Code");
+        SubcontractorPrice.Validate("Direct Unit Cost", CalculatedFallbackCost * 2);
+        SubcontractorPrice.Modify(true);
+
+        SubcPriceManagement.GetSubcPriceForReqLine(RequisitionLine, '');
+
+        Assert.AreEqual(
+            CalculatedFallbackCost, RequisitionLine."Direct Unit Cost",
+            'A requisition-line price above the quantity threshold must preserve the calculated fallback.');
+    end;
+
+    [Test]
     procedure NoApplicableMinimumQuantityPriceUsesCalculatedFallback()
     var
         ProdOrderLine: Record "Prod. Order Line";
@@ -1052,8 +1143,8 @@ codeunit 139982 "Subc. Pricing Test"
 
         CreateNoPriceSubcontractingPurchaseLine(
             PurchaseLine, ProdOrderLine, Enum::"Unit Cost Calculation Type"::Time);
-        ProdOrderLine.Quantity := 0;
-        ProdOrderLine.Modify();
+        ProdOrderLine.Validate(Quantity, 0);
+        ProdOrderLine.Modify(true);
 
         SubcPriceManagement.GetSubcPriceForPurchLine(PurchaseLine);
 
@@ -1117,7 +1208,7 @@ codeunit 139982 "Subc. Pricing Test"
         OriginalLineDiscount := PurchaseLine."Line Discount %";
         PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
         LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
-        PurchaseLine.Find();
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
 
         NewPlannedReceiptDate := CalcDate('<20D>', WorkDate());
         PurchaseLine.Validate("Planned Receipt Date", NewPlannedReceiptDate);

--- a/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
+++ b/src/Apps/W1/Subcontracting/Test/Tests/SubcPricingTest.Codeunit.al
@@ -1020,10 +1020,10 @@ codeunit 139982 "Subc. Pricing Test"
         ProductionOrder: Record "Production Order";
         ProdOrderRoutingLine: Record "Prod. Order Routing Line";
         PurchaseLine: Record "Purchase Line";
+        NewLeadTime: DateFormula;
         EarlierPrice: Decimal;
         LaterPrice: Decimal;
         AlignedDate: Date;
-        NewLeadTime: DateFormula;
         OriginalPlannedReceiptDate: Date;
     begin
         // [SCENARIO 648535] A lead-time-only Order Date change reapplies date-effective pricing


### PR DESCRIPTION
## Backport of #10917 to `releases/29.x`

Backports [#10917](https://github.com/microsoft/BCApps/pull/10917) — *Bug 648535: Reprice subcontracting lines after scheduling* — to the `releases/29.x` release branch.

### What & why
Subcontracting purchase lines were priced before backward scheduling had finalized the purchase-line Order Date and before routing context was transferred from the requisition line, so a subcontractor price valid for the purchase-header date could be selected instead of the price valid for the final purchase-line date.

The review follow-up also:
- preserves the worksheet's calculated Units/Time cost when no subcontractor price matches;
- preserves manually overridden worksheet costs during carry-out;
- keeps date scheduling editable on released purchase orders without changing financial terms;
- reprices lead-time-only changes when the resulting Order Date crosses a price boundary.

### Source
- Source PR: #10917
- Source squash-merge commit: `049258b463302e36649979d241a6f122c7eb87c0`
- Original backport commit: `6a3802a0a`
- Corrective follow-up commit: `02e7a0dba2`
- Main follow-up PR: #11292
- ADO: [AB#648535](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648535)

### Cherry-pick / conflict resolution
The product changes applied cleanly. The test file conflicted because the release branch predates the `Subc. Management Library` helper refactor. Only the relevant regression tests were applied, using equivalent local helper procedures already required by this backport. No unrelated `main` tests were introduced.

### Validation
- Static verification: no conflict markers or duplicate procedures; `git diff --check` passes.
- Four corrective regressions cover no-price fallback, manual worksheet overrides, released-order date edits, and lead-time-only Order Date changes.
- Full AL compile and test execution are deferred to the AL-Go PR build because local symbol packages are unavailable and sandbox policy blocks CoreXT package-state initialization.

⚠️ Do not merge until the AL-Go PR build passes. **Not** auto-merged.






