### PR TITLE
Chat v2 privacy notice behavior changed to not auto agree for Eval companies

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -232,7 +232,7 @@ codeunit 7774 "Copilot Capability Impl"
 
         // check privacy notices
         foreach RequiredPrivacyNotice in RequiredPrivacyNotices do
-            if (PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, true) <> Enum::"Privacy Notice Approval State"::Agreed) then
+            if (PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, false) <> Enum::"Privacy Notice Approval State"::Agreed) then
                 exit(false);
 
         exit(true);

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -220,6 +220,7 @@ codeunit 7774 "Copilot Capability Impl"
         SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
         RequiredPrivacyNotices: List of [Code[50]];
         RequiredPrivacyNotice: Code[50];
+        SkipCheckInEval: Boolean;
     begin
         CopilotSettings.ReadIsolation(IsolationLevel::ReadCommitted);
         CopilotSettings.SetLoadFields(Status);
@@ -233,12 +234,9 @@ codeunit 7774 "Copilot Capability Impl"
 
         // check privacy notices
         foreach RequiredPrivacyNotice in RequiredPrivacyNotices do begin
-            if RequiredPrivacyNotice = SystemPrivacyNoticeReg.GetMicrosoftCopilotID() then begin
-                if PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, false) <> Enum::"Privacy Notice Approval State"::Agreed then
-                    exit(false);
-            end else
-                if PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice) <> Enum::"Privacy Notice Approval State"::Agreed then
-                    exit(false);
+            SkipCheckInEval := RequiredPrivacyNotice <> SystemPrivacyNoticeReg.GetMicrosoftCopilotID();
+            if PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, SkipCheckInEval) <> Enum::"Privacy Notice Approval State"::Agreed then
+                exit(false);
         end;
 
         exit(true);

--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -217,6 +217,7 @@ codeunit 7774 "Copilot Capability Impl"
     var
         CopilotCapabilityCU: Codeunit "Copilot Capability";
         PrivacyNotice: Codeunit "Privacy Notice";
+        SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
         RequiredPrivacyNotices: List of [Code[50]];
         RequiredPrivacyNotice: Code[50];
     begin
@@ -231,9 +232,14 @@ codeunit 7774 "Copilot Capability Impl"
             exit(CopilotSettings.Status = Enum::"Copilot Status"::Active);
 
         // check privacy notices
-        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do
-            if (PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, false) <> Enum::"Privacy Notice Approval State"::Agreed) then
-                exit(false);
+        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do begin
+            if RequiredPrivacyNotice = SystemPrivacyNoticeReg.GetMicrosoftCopilotID() then begin
+                if PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, false) <> Enum::"Privacy Notice Approval State"::Agreed then
+                    exit(false);
+            end else
+                if PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice) <> Enum::"Privacy Notice Approval State"::Agreed then
+                    exit(false);
+        end;
 
         exit(true);
     end;

--- a/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
@@ -104,6 +104,7 @@ table 7775 "Copilot Settings"
         SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
         RequiredPrivacyNotices: List of [Code[50]];
         RequiredPrivacyNotice: Code[50];
+        SkipCheckInEval: Boolean;
     begin
         CopilotCapability.OnGetRequiredPrivacyNotices(Rec.Capability, Rec."App Id", RequiredPrivacyNotices);
 
@@ -111,12 +112,9 @@ table 7775 "Copilot Settings"
             exit(true);
 
         foreach RequiredPrivacyNotice in RequiredPrivacyNotices do begin
-            if RequiredPrivacyNotice = SystemPrivacyNoticeReg.GetMicrosoftCopilotID() then begin
-                if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, false) then
-                    exit(false);
-            end else
-                if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice) then
-                    exit(false);
+            SkipCheckInEval := RequiredPrivacyNotice <> SystemPrivacyNoticeReg.GetMicrosoftCopilotID();
+            if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, SkipCheckInEval) then
+                exit(false);
         end;
 
         exit(true);

--- a/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
@@ -110,7 +110,7 @@ table 7775 "Copilot Settings"
             exit(true);
 
         foreach RequiredPrivacyNotice in RequiredPrivacyNotices do
-            if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, true) then
+            if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, false) then
                 exit(false);
 
         exit(true);

--- a/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
@@ -101,6 +101,7 @@ table 7775 "Copilot Settings"
     var
         CopilotCapability: Codeunit "Copilot Capability";
         PrivacyNotice: Codeunit "Privacy Notice";
+        SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
         RequiredPrivacyNotices: List of [Code[50]];
         RequiredPrivacyNotice: Code[50];
     begin
@@ -109,9 +110,14 @@ table 7775 "Copilot Settings"
         if RequiredPrivacyNotices.Count() <= 0 then
             exit(true);
 
-        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do
-            if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, false) then
-                exit(false);
+        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do begin
+            if RequiredPrivacyNotice = SystemPrivacyNoticeReg.GetMicrosoftCopilotID() then begin
+                if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, false) then
+                    exit(false);
+            end else
+                if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice) then
+                    exit(false);
+        end;
 
         exit(true);
     end;


### PR DESCRIPTION
Fixes: [AB#649164](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649164)

Description: Turning the skip the check for eval companies to false for copilot chat privacy notice essentially changing the default behavior of Eval company to the current behavior of non-Eval company.  




