### PR TITLE
[CH] When posting with FCY, VAT G/L Entry stores VAT base amount in Source Currency Amount instead of VAT amount

### DIFF
--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -2311,9 +2311,11 @@ codeunit 12 "Gen. Jnl.-Post Line"
                 GLEntry."Source Currency Amount" := AmountSrcCurr;
         end;
 
+        // Net-of-VAT source amount applies only to the account's own line, not to system-created VAT split entries (which already carry their correct source amount).
         if not (GLAcc."Source Currency Code" in ['', GLSetup."LCY Code"]) and
             not (GenJnlLine."Currency Code" in ['', GLSetup."LCY Code"]) and
             not (GenJnlLine."Additional-Currency Posting" = GenJnlLine."Additional-Currency Posting"::"Additional-Currency Amount Only") and
+            not SystemCreatedEntry and
             not IsVendorPayableAccount(GLAcc."No.")
         then
             GLEntry."Source Currency Amount" := GenJnlLine.Amount / (1 + GenJnlLine."VAT %" / 100);

--- a/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
+++ b/src/Layers/CH/BaseApp/Finance/GeneralLedger/Posting/GenJnlPostLine.Codeunit.al
@@ -2315,10 +2315,10 @@ codeunit 12 "Gen. Jnl.-Post Line"
         if not (GLAcc."Source Currency Code" in ['', GLSetup."LCY Code"]) and
             not (GenJnlLine."Currency Code" in ['', GLSetup."LCY Code"]) and
             not (GenJnlLine."Additional-Currency Posting" = GenJnlLine."Additional-Currency Posting"::"Additional-Currency Amount Only") and
-            not SystemCreatedEntry and
-            not IsVendorPayableAccount(GLAcc."No.")
+            not SystemCreatedEntry
         then
-            GLEntry."Source Currency Amount" := GenJnlLine.Amount / (1 + GenJnlLine."VAT %" / 100);
+            if not IsVendorPayableAccount(GLAcc."No.") then
+                GLEntry."Source Currency Amount" := GenJnlLine.Amount / (1 + GenJnlLine."VAT %" / 100);
 
         OnAfterInitGLEntry(GLEntry, GenJnlLine, Amount, AmountAddCurr, UseAmountAddCurr, CurrencyFactor, GLReg);
     end;

--- a/src/Layers/CH/Tests/Local/TestSRGLEntriesForeignC.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/TestSRGLEntriesForeignC.Codeunit.al
@@ -16,6 +16,7 @@ codeunit 144026 "Test SR G/L Entries Foreign C."
         LibraryERM: Codeunit "Library - ERM";
         LibraryCostAccounting: Codeunit "Library - Cost Accounting";
         Assert: Codeunit Assert;
+        IncorrectSourceCurrencyAmountErr: Label 'Source Currency Amount on G/L entry for account %1 is incorrect.', Comment = '%1 = G/L Account No.';
 
     [Test]
     [HandlerFunctions('ReportRequestPageHandler,GLAccountCreationMessageHandler')]
@@ -172,7 +173,7 @@ codeunit 144026 "Test SR G/L Entries Foreign C."
         GLEntry.FindFirst();
         Assert.AreEqual(
             ExpectedSrcCurrAmount, GLEntry."Source Currency Amount",
-            StrSubstNo('Source Currency Amount on G/L entry for account %1 is incorrect.', GLAccountNo));
+            StrSubstNo(IncorrectSourceCurrencyAmountErr, GLAccountNo));
     end;
 
     [Normal]

--- a/src/Layers/CH/Tests/Local/TestSRGLEntriesForeignC.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/TestSRGLEntriesForeignC.Codeunit.al
@@ -89,6 +89,7 @@ codeunit 144026 "Test SR G/L Entries Foreign C."
     end;
 
     [Test]
+    [TransactionModel(TransactionModel::AutoCommit)]
     [Scope('OnPrem')]
     procedure VerifySourceCurrencyVATAmountOnForeignPurchaseVATEntry()
     var

--- a/src/Layers/CH/Tests/Local/TestSRGLEntriesForeignC.Codeunit.al
+++ b/src/Layers/CH/Tests/Local/TestSRGLEntriesForeignC.Codeunit.al
@@ -15,6 +15,7 @@ codeunit 144026 "Test SR G/L Entries Foreign C."
         LibraryCH: Codeunit "Library - CH";
         LibraryERM: Codeunit "Library - ERM";
         LibraryCostAccounting: Codeunit "Library - Cost Accounting";
+        Assert: Codeunit Assert;
 
     [Test]
     [HandlerFunctions('ReportRequestPageHandler,GLAccountCreationMessageHandler')]
@@ -86,9 +87,92 @@ codeunit 144026 "Test SR G/L Entries Foreign C."
         VerifyReportData(GenJournalLine, GLAccountNo);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure VerifySourceCurrencyVATAmountOnForeignPurchaseVATEntry()
+    var
+        GenJournalLine: Record "Gen. Journal Line";
+        VATPostingSetup: Record "VAT Posting Setup";
+        GeneralPostingSetup: Record "General Posting Setup";
+        Currency: Record Currency;
+        CurrencyCode: Code[10];
+        ExpenseAccountNo: Code[20];
+        VATPct: Decimal;
+        GrossAmount: Decimal;
+        ExpectedNet: Decimal;
+        ExpectedVAT: Decimal;
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647818] Source-currency VAT G/L entry of a foreign-currency purchase must carry the VAT amount, not the net amount.
+        Initialize();
+
+        // [GIVEN] A foreign currency (1:1 rate) and source-currency posting on both the expense and the purchase VAT account
+        VATPct := 25;
+        GrossAmount := 1000;
+        CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate() - 1, 1, 1);
+        Currency.Get(CurrencyCode);
+        LibraryERMCountryData.UpdateGeneralLedgerSetup();
+        LibraryCH.CreateGeneralPostingSetup(GeneralPostingSetup);
+        LibraryCH.CreateVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", '', '');
+        VATPostingSetup.Validate("VAT %", VATPct);
+        VATPostingSetup.Modify(true);
+        ExpenseAccountNo := CreateGLAccount(GeneralPostingSetup, VATPostingSetup, CurrencyCode);
+        SetSourceCurrencyPosting(VATPostingSetup."Purchase VAT Account", CurrencyCode);
+
+        // [GIVEN] A purchase general journal line in the foreign currency for a VAT-inclusive amount
+        CreatePurchaseJnlLineFCY(GenJournalLine, ExpenseAccountNo, CurrencyCode, VATPostingSetup, GrossAmount);
+
+        // [WHEN] The journal line is posted
+        LibraryERM.PostGeneralJnlLine(GenJournalLine);
+
+        // [THEN] The expense G/L entry keeps the net amount and the VAT G/L entry keeps the VAT amount, both in source currency
+        ExpectedNet := Round(GrossAmount / (1 + VATPct / 100), Currency."Amount Rounding Precision");
+        ExpectedVAT := GrossAmount - ExpectedNet;
+        VerifySourceCurrencyAmount(GenJournalLine."Document No.", ExpenseAccountNo, ExpectedNet);
+        VerifySourceCurrencyAmount(GenJournalLine."Document No.", VATPostingSetup."Purchase VAT Account", ExpectedVAT);
+    end;
+
     local procedure Initialize()
     begin
         LibraryVariableStorage.Clear();
+    end;
+
+    local procedure SetSourceCurrencyPosting(GLAccountNo: Code[20]; CurrencyCode: Code[10])
+    var
+        GLAccount: Record "G/L Account";
+    begin
+        GLAccount.Get(GLAccountNo);
+        GLAccount.Validate("Income/Balance", GLAccount."Income/Balance"::"Balance Sheet");
+        GLAccount.Validate("Source Currency Posting", GLAccount."Source Currency Posting"::"Same Currency");
+        GLAccount.Validate("Source Currency Code", CurrencyCode);
+        GLAccount.Modify(true);
+    end;
+
+    local procedure CreatePurchaseJnlLineFCY(var GenJournalLine: Record "Gen. Journal Line"; ExpenseAccountNo: Code[20]; CurrencyCode: Code[10]; VATPostingSetup: Record "VAT Posting Setup"; GrossAmount: Decimal)
+    var
+        GenJournalBatch: Record "Gen. Journal Batch";
+    begin
+        LibraryCostAccounting.SetupGeneralJnlBatch(GenJournalBatch);
+        LibraryERM.CreateGeneralJnlLine(
+            GenJournalLine, GenJournalBatch."Journal Template Name", GenJournalBatch.Name,
+            GenJournalLine."Document Type"::Invoice, GenJournalLine."Account Type"::"G/L Account", ExpenseAccountNo, GrossAmount);
+        GenJournalLine.Validate("Currency Code", CurrencyCode);
+        GenJournalLine.Validate("Gen. Posting Type", GenJournalLine."Gen. Posting Type"::Purchase);
+        GenJournalLine.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        GenJournalLine.Validate("VAT Prod. Posting Group", VATPostingSetup."VAT Prod. Posting Group");
+        GenJournalLine.Modify(true);
+    end;
+
+    local procedure VerifySourceCurrencyAmount(DocumentNo: Code[20]; GLAccountNo: Code[20]; ExpectedSrcCurrAmount: Decimal)
+    var
+        GLEntry: Record "G/L Entry";
+    begin
+        GLEntry.SetRange("Document No.", DocumentNo);
+        GLEntry.SetRange("G/L Account No.", GLAccountNo);
+        GLEntry.FindFirst();
+        Assert.AreEqual(
+            ExpectedSrcCurrAmount, GLEntry."Source Currency Amount",
+            StrSubstNo('Source Currency Amount on G/L entry for account %1 is incorrect.', GLAccountNo));
     end;
 
     [Normal]


### PR DESCRIPTION
When posting with FCY, VAT G/L Entry stores VAT base amount in Source Currency Amount instead of VAT amount

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why
During initialization of a system-generated G/L Entry, not recalculating source currency amounts, as it already carries the correct source currency amount.
<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#649413](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649413)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->
Added an automated test that covers the repro steps.

## Risk & compatibility
Low
<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->



