### PR TITLE
[Master]-Purchase invoice lines of type G/L Account where enabling 'Prices Including VAT' and changing the VAT Prod. Posting Group causes recalculation of the Direct Unit Cost Incl. VAT and Line Amount - Related to Bug  632380

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1594,7 +1594,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1585,7 +1585,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1589,7 +1589,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1585,7 +1585,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1589,7 +1589,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/ES/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
@@ -997,14 +997,12 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         GLAccountNo := LibraryERM.CreateGLAccountWithVATPostingSetup(VATPostingSetup, "General Posting Type"::Purchase);
         LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, LibraryPurchase.CreateVendorNo());
         PurchaseHeader.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        PurchaseHeader.Validate("Prices Including VAT", true);
         PurchaseHeader.Modify(true);
         LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccountNo, 1);
         PurchaseLine.Validate("Direct Unit Cost", 1000);
         PurchaseLine.Modify(true);
 
-        // [GIVEN] Prices Including VAT is enabled without updating Direct Unit Cost
-        PurchaseHeader."Prices Including VAT" := true;
-        PurchaseHeader.Modify(true);
         PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
         DirectUnitCost := PurchaseLine."Direct Unit Cost";
         LineAmount := PurchaseLine."Line Amount";

--- a/src/Layers/ES/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
@@ -973,7 +973,6 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerNo')]
     procedure DirectUnitCostInclVATDoesNotUpdateWhenVATProdPostGrpChangedForGLAccount()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -1004,7 +1003,7 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         PurchaseLine.Modify(true);
 
         // [GIVEN] Prices Including VAT is enabled without updating Direct Unit Cost
-        PurchaseHeader.Validate("Prices Including VAT", true);
+        PurchaseHeader."Prices Including VAT" := true;
         PurchaseHeader.Modify(true);
         PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
         DirectUnitCost := PurchaseLine."Direct Unit Cost";
@@ -1598,13 +1597,7 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         LibraryVariableStorage.Dequeue(Balance);
         ApplyVendorEntries.ControlBalance.AssertEquals(Balance);
     end;
-
-    [ConfirmHandler]
-    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
-    begin
-        Reply := false;
-    end;
-
+    
     [IntegrationEvent(false, false)]
     local procedure OnAfterCreateSingleLinePurchaseDoc(var PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
     begin

--- a/src/Layers/ES/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
+++ b/src/Layers/ES/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
@@ -973,8 +973,8 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     end;
 
     [Test]
-    [Scope('OnPrem')]
-    procedure DirectUnitCostInclVATUpdatesWhenVATProdPostGrpChangedForGLAccount()
+    [HandlerFunctions('ConfirmHandlerNo')]
+    procedure DirectUnitCostInclVATDoesNotUpdateWhenVATProdPostGrpChangedForGLAccount()
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
@@ -982,41 +982,40 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         NewVATPostingSetup: Record "VAT Posting Setup";
         GLAccountNo: Code[20];
         DirectUnitCost: Decimal;
-        ExpectedDirectUnitCost: Decimal;
+        LineAmount: Decimal;
     begin
         // [FEATURE] [AI test 0.4]
-        // [SCENARIO] Direct Unit Cost Incl. VAT is recalculated when VAT Prod. Posting Group is changed on a G/L Account line with Prices Including VAT enabled
+        // [SCENARIO 648146] Direct Unit Cost Incl. VAT is preserved when VAT Prod. Posting Group is changed on a G/L Account line
 
         Initialize();
 
-        // [GIVEN] VAT Posting Setup "VS1" with VAT % = 21
+        // [GIVEN] Two VAT Posting Setups with VAT rates 21% and 0%
         LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", 21);
-
-        // [GIVEN] A second VAT Posting Setup "VS2" with same VAT Bus. Posting Group and VAT % = 0
         LibraryERM.CreateVATPostingSetupWithAccounts(NewVATPostingSetup, NewVATPostingSetup."VAT Calculation Type"::"Normal VAT", 0);
         NewVATPostingSetup.Rename(VATPostingSetup."VAT Bus. Posting Group", NewVATPostingSetup."VAT Prod. Posting Group");
 
-        // [GIVEN] G/L Account "G" with VAT Prod. Posting Group from "VS1"
+        // [GIVEN] A purchase invoice with a G/L Account line and Direct Unit Cost 1000
         GLAccountNo := LibraryERM.CreateGLAccountWithVATPostingSetup(VATPostingSetup, "General Posting Type"::Purchase);
-
-        // [GIVEN] Purchase Invoice with Prices Including VAT enabled
         LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, LibraryPurchase.CreateVendorNo());
         PurchaseHeader.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
-        PurchaseHeader.Validate("Prices Including VAT", true);
         PurchaseHeader.Modify(true);
-
-        // [GIVEN] Purchase line with Type = G/L Account, Direct Unit Cost = 1000 (incl. VAT at 21%)
         LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccountNo, 1);
         PurchaseLine.Validate("Direct Unit Cost", 1000);
         PurchaseLine.Modify(true);
-        DirectUnitCost := PurchaseLine."Direct Unit Cost";
 
-        // [WHEN] VAT Prod. Posting Group is changed to "VS2" (0% VAT)
+        // [GIVEN] Prices Including VAT is enabled without updating Direct Unit Cost
+        PurchaseHeader.Validate("Prices Including VAT", true);
+        PurchaseHeader.Modify(true);
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        DirectUnitCost := PurchaseLine."Direct Unit Cost";
+        LineAmount := PurchaseLine."Line Amount";
+
+        // [WHEN] VAT Prod. Posting Group is changed to the setup with 0% VAT
         PurchaseLine.Validate("VAT Prod. Posting Group", NewVATPostingSetup."VAT Prod. Posting Group");
 
-        // [THEN] Direct Unit Cost is recalculated: 1000 * (100 + 0) / (100 + 21) = 826.45 (approx)
-        ExpectedDirectUnitCost := Round(DirectUnitCost * (100 + NewVATPostingSetup."VAT %") / (100 + VATPostingSetup."VAT %"), LibraryERM.GetUnitAmountRoundingPrecision());
-        Assert.AreEqual(ExpectedDirectUnitCost, PurchaseLine."Direct Unit Cost", 'Direct Unit Cost should be recalculated when VAT Prod. Posting Group changes on G/L Account line');
+        // [THEN] Direct Unit Cost Incl. VAT and Line Amount are preserved
+        PurchaseLine.TestField("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.TestField("Line Amount", LineAmount);
     end;
 
     local procedure Initialize()
@@ -1598,6 +1597,12 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     begin
         LibraryVariableStorage.Dequeue(Balance);
         ApplyVendorEntries.ControlBalance.AssertEquals(Balance);
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := false;
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1586,7 +1586,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1602,7 +1602,7 @@ table 39 "Purchase Line"
                         FieldError("VAT Bus. Posting Group", StrSubstNo(Text1041003, "VAT Bus. Posting Group"));
 #endif
 
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1634,7 +1634,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1681,7 +1681,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1585,7 +1585,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1587,7 +1587,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1590,7 +1590,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1586,7 +1586,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -1585,7 +1585,7 @@ table 39 "Purchase Line"
                                     TestField("No.", VATPostingSetup.GetPurchAccount(false));
                                 end;
                         end;
-                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::"G/L Account", Rec.Type::Item, Rec.Type::Resource]);
+                    ShouldUpdateUnitCost := PurchHeader."Prices Including VAT" and (Rec.Type in [Rec.Type::Item, Rec.Type::Resource]);
                     OnValidateVATProdPostingGroupOnAfterCalcShouldUpdateUnitCost(Rec, VATPostingSetup, ShouldUpdateUnitCost);
                     if ShouldUpdateUnitCost then
                         Validate("Direct Unit Cost",

--- a/src/Layers/W1/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
@@ -973,7 +973,6 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     end;
 
     [Test]
-    [HandlerFunctions('ConfirmHandlerNo')]
     procedure DirectUnitCostInclVATDoesNotUpdateWhenVATProdPostGrpChangedForGLAccount()
     var
         PurchaseHeader: Record "Purchase Header";
@@ -1004,7 +1003,7 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         PurchaseLine.Modify(true);
 
         // [GIVEN] Prices Including VAT is enabled without updating Direct Unit Cost
-        PurchaseHeader.Validate("Prices Including VAT", true);
+        PurchaseHeader."Prices Including VAT" := true;
         PurchaseHeader.Modify(true);
         PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
         DirectUnitCost := PurchaseLine."Direct Unit Cost";
@@ -1597,12 +1596,6 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     begin
         LibraryVariableStorage.Dequeue(Balance);
         ApplyVendorEntries.ControlBalance.AssertEquals(Balance);
-    end;
-
-    [ConfirmHandler]
-    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
-    begin
-        Reply := false;
     end;
 
     [IntegrationEvent(false, false)]

--- a/src/Layers/W1/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
@@ -997,14 +997,12 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         GLAccountNo := LibraryERM.CreateGLAccountWithVATPostingSetup(VATPostingSetup, "General Posting Type"::Purchase);
         LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, LibraryPurchase.CreateVendorNo());
         PurchaseHeader.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
+        PurchaseHeader.Validate("Prices Including VAT", true);
         PurchaseHeader.Modify(true);
         LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccountNo, 1);
         PurchaseLine.Validate("Direct Unit Cost", 1000);
         PurchaseLine.Modify(true);
 
-        // [GIVEN] Prices Including VAT is enabled without updating Direct Unit Cost
-        PurchaseHeader."Prices Including VAT" := true;
-        PurchaseHeader.Modify(true);
         PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
         DirectUnitCost := PurchaseLine."Direct Unit Cost";
         LineAmount := PurchaseLine."Line Amount";

--- a/src/Layers/W1/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMPricesInclVATDoc.Codeunit.al
@@ -973,8 +973,8 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     end;
 
     [Test]
-    [Scope('OnPrem')]
-    procedure DirectUnitCostInclVATUpdatesWhenVATProdPostGrpChangedForGLAccount()
+    [HandlerFunctions('ConfirmHandlerNo')]
+    procedure DirectUnitCostInclVATDoesNotUpdateWhenVATProdPostGrpChangedForGLAccount()
     var
         PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
@@ -982,41 +982,40 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
         NewVATPostingSetup: Record "VAT Posting Setup";
         GLAccountNo: Code[20];
         DirectUnitCost: Decimal;
-        ExpectedDirectUnitCost: Decimal;
+        LineAmount: Decimal;
     begin
         // [FEATURE] [AI test 0.4]
-        // [SCENARIO] Direct Unit Cost Incl. VAT is recalculated when VAT Prod. Posting Group is changed on a G/L Account line with Prices Including VAT enabled
+        // [SCENARIO 648146] Direct Unit Cost Incl. VAT is preserved when VAT Prod. Posting Group is changed on a G/L Account line
 
         Initialize();
 
-        // [GIVEN] VAT Posting Setup "VS1" with VAT % = 21
+        // [GIVEN] Two VAT Posting Setups with VAT rates 21% and 0%
         LibraryERM.CreateVATPostingSetupWithAccounts(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT", 21);
-
-        // [GIVEN] A second VAT Posting Setup "VS2" with same VAT Bus. Posting Group and VAT % = 0
         LibraryERM.CreateVATPostingSetupWithAccounts(NewVATPostingSetup, NewVATPostingSetup."VAT Calculation Type"::"Normal VAT", 0);
         NewVATPostingSetup.Rename(VATPostingSetup."VAT Bus. Posting Group", NewVATPostingSetup."VAT Prod. Posting Group");
 
-        // [GIVEN] G/L Account "G" with VAT Prod. Posting Group from "VS1"
+        // [GIVEN] A purchase invoice with a G/L Account line and Direct Unit Cost 1000
         GLAccountNo := LibraryERM.CreateGLAccountWithVATPostingSetup(VATPostingSetup, "General Posting Type"::Purchase);
-
-        // [GIVEN] Purchase Invoice with Prices Including VAT enabled
         LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Invoice, LibraryPurchase.CreateVendorNo());
         PurchaseHeader.Validate("VAT Bus. Posting Group", VATPostingSetup."VAT Bus. Posting Group");
-        PurchaseHeader.Validate("Prices Including VAT", true);
         PurchaseHeader.Modify(true);
-
-        // [GIVEN] Purchase line with Type = G/L Account, Direct Unit Cost = 1000 (incl. VAT at 21%)
         LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::"G/L Account", GLAccountNo, 1);
         PurchaseLine.Validate("Direct Unit Cost", 1000);
         PurchaseLine.Modify(true);
-        DirectUnitCost := PurchaseLine."Direct Unit Cost";
 
-        // [WHEN] VAT Prod. Posting Group is changed to "VS2" (0% VAT)
+        // [GIVEN] Prices Including VAT is enabled without updating Direct Unit Cost
+        PurchaseHeader.Validate("Prices Including VAT", true);
+        PurchaseHeader.Modify(true);
+        PurchaseLine.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        DirectUnitCost := PurchaseLine."Direct Unit Cost";
+        LineAmount := PurchaseLine."Line Amount";
+
+        // [WHEN] VAT Prod. Posting Group is changed to the setup with 0% VAT
         PurchaseLine.Validate("VAT Prod. Posting Group", NewVATPostingSetup."VAT Prod. Posting Group");
 
-        // [THEN] Direct Unit Cost is recalculated: 1000 * (100 + 0) / (100 + 21) = 826.45 (approx)
-        ExpectedDirectUnitCost := Round(DirectUnitCost * (100 + NewVATPostingSetup."VAT %") / (100 + VATPostingSetup."VAT %"), LibraryERM.GetUnitAmountRoundingPrecision());
-        Assert.AreEqual(ExpectedDirectUnitCost, PurchaseLine."Direct Unit Cost", 'Direct Unit Cost should be recalculated when VAT Prod. Posting Group changes on G/L Account line');
+        // [THEN] Direct Unit Cost Incl. VAT and Line Amount are preserved
+        PurchaseLine.TestField("Direct Unit Cost", DirectUnitCost);
+        PurchaseLine.TestField("Line Amount", LineAmount);
     end;
 
     local procedure Initialize()
@@ -1598,6 +1597,12 @@ codeunit 134046 "ERM Prices Incl VAT Doc"
     begin
         LibraryVariableStorage.Dequeue(Balance);
         ApplyVendorEntries.ControlBalance.AssertEquals(Balance);
+    end;
+
+    [ConfirmHandler]
+    procedure ConfirmHandlerNo(Question: Text[1024]; var Reply: Boolean)
+    begin
+        Reply := false;
     end;
 
     [IntegrationEvent(false, false)]


### PR DESCRIPTION
Fixes [AB#649414](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649414)



