### PR TITLE
Fix sample invoice email when the agent setup is not saved yet

### DIFF
--- a/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Codeunit.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Codeunit.al
@@ -35,10 +35,11 @@ codeunit 3309 "PA Demo Guide"
     /// <summary>
     /// Opens the demo guide page.
     /// </summary>
-    procedure OpenGuidePage()
+    procedure OpenGuidePage(PASetupConfiguration: Codeunit "PA Setup Configuration")
     var
         PADemoGuidePage: Page "PA Demo Guide";
     begin
+        PADemoGuidePage.SetSetupConfiguration(PASetupConfiguration);
         PADemoGuidePage.Run();
     end;
 
@@ -53,28 +54,16 @@ codeunit 3309 "PA Demo Guide"
 #endif
 
     /// <summary>
-    /// Sends a demo email using the active PA setup configuration.
-    /// </summary>
-    /// <returns>True if the demo email was sent.</returns>
-    procedure SendDemoEmail(): Boolean
-    var
-        PayablesAgentSetup: Codeunit "Payables Agent Setup";
-        PASetupConfiguration: Codeunit "PA Setup Configuration";
-    begin
-        PayablesAgentSetup.LoadSetupConfiguration(PASetupConfiguration);
-        exit(SendDemoEmail(PASetupConfiguration));
-    end;
-
-    /// <summary>
     /// Sends the sample invoices by email if the agent is active, otherwise flags them to be sent at activation.
     /// </summary>
+    /// <param name="PASetupConfiguration">The setup configuration to send with.</param>
     /// <returns>True if the sample invoices were sent.</returns>
-    procedure SendDemoInvoicesByEmail(): Boolean
+    procedure SendDemoInvoicesByEmail(PASetupConfiguration: Codeunit "PA Setup Configuration"): Boolean
     var
         EDocSamplePurchInvFile: Record "E-Doc Sample Purch. Inv File";
     begin
         EDocSamplePurchInvFile.ModifyAll("Send By Email", true);
-        exit(SendDemoEmail());
+        exit(SendDemoEmail(PASetupConfiguration));
     end;
 
     /// <summary>
@@ -97,7 +86,9 @@ codeunit 3309 "PA Demo Guide"
     begin
         if not DemoExperienceAvailable() then
             exit(false);
-        if not CanSendDemoEmail(PASetupConfiguration) then
+        if not IsEmailConfiguredForDemoEmail(PASetupConfiguration) then
+            exit(false);
+        if PASetupConfiguration.GetAgentSetupBuffer().State = PASetupConfiguration.GetAgentSetupBuffer().State::Disabled then
             exit(false);
         EDocSamplePurchInvFile.SetRange("Send By Email", true);
         if EDocSamplePurchInvFile.IsEmpty() then
@@ -125,13 +116,10 @@ codeunit 3309 "PA Demo Guide"
     /// <summary>
     /// Returns True if an email account is configured so that demo invoices can be sent by email.
     /// </summary>
+    /// <param name="PASetupConfiguration">The setup configuration to evaluate. It does not have to be persisted yet.</param>
     /// <returns>True if an email account is configured and email monitoring is enabled.</returns>
-    procedure IsEmailConfiguredForDemoEmail(): Boolean
-    var
-        PayablesAgentSetup: Codeunit "Payables Agent Setup";
-        PASetupConfiguration: Codeunit "PA Setup Configuration";
+    procedure IsEmailConfiguredForDemoEmail(PASetupConfiguration: Codeunit "PA Setup Configuration"): Boolean
     begin
-        PayablesAgentSetup.LoadSetupConfiguration(PASetupConfiguration);
         if not PASetupConfiguration.GetPayablesAgentSetup()."Monitor Outlook" then
             exit(false);
         if IsNullGuid(PASetupConfiguration.GetEmailAccount()."Account Id") then
@@ -170,15 +158,4 @@ codeunit 3309 "PA Demo Guide"
     end;
 #pragma warning restore AL0432
 #endif
-
-    local procedure CanSendDemoEmail(PASetupConfiguration: Codeunit "PA Setup Configuration"): Boolean
-    begin
-        if PASetupConfiguration.GetAgentSetupBuffer().State = PASetupConfiguration.GetAgentSetupBuffer().State::Disabled then
-            exit(false);
-        if not PASetupConfiguration.GetPayablesAgentSetup()."Monitor Outlook" then
-            exit(false);
-        if IsNullGuid(PASetupConfiguration.GetEmailAccount()."Account Id") then
-            exit(false);
-        exit(true);
-    end;
 }

--- a/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PADemoGuide.Page.al
@@ -181,19 +181,28 @@ page 3307 "PA Demo Guide"
         MediaResourcesFinished: Record "Media Resources";
         MediaResourcesStd: Record "Media Resources";
         PADemoGuide: Codeunit "PA Demo Guide";
+        PASetupConfiguration: Codeunit "PA Setup Configuration";
         DemoOption: Option " ","Send Demo Email","Download Demo PDFs";
         Step: Option Start,ChooseDemoOption,ShowDemoFilesToDownload,Finish;
         BackActionEnabled, FinishActionEnabled, NextActionEnabled, WelcomeStepVisible, ChooseDemoOption, ShowDemoFilesToDownloadVisible, TopBannerVisible : Boolean;
+        SetupConfigurationProvided, DemoInvoicesHandled, DemoEmailSent : Boolean;
         DemoFilesToDownloadText, FinalStepHeadline, FinalStepText : Text;
         PayablesAgentTelemetryTok: Label 'Payables Agent', Locked = true;
         DemoInvoicesSentTok: Label 'Sent demo sample invoices by email', Locked = true;
         DemoInvoicesPreparedTok: Label 'Prepared demo sample invoices to send on agent activation', Locked = true;
+        NoSetupConfigurationProvidedTok: Label 'Demo guide opened without a setup configuration, falling back to the saved setup', Locked = true;
         DemoFilesToDownloadLbl: Label 'Click here to select and download sample invoices (%1 file(s) available)', Comment = '%1 = number of files';
         FinalStepHeadlineEmailLbl: Label 'Sample invoices sent!';
         FinalStepTextEmailLbl: Label 'We have prepared the sample invoices and will send them when the agent is activated. If this is the first time you configure the agent, the agent is activated when you select "Update" on the configuration page. When the agent is activated you should see them appear as tasks on the agent''s avatar in the top right corner of the home screen';
+        FinalStepTextEmailSentLbl: Label 'We sent the sample invoices to %1. You should see them appear as tasks on the agent''s avatar in the top right corner of the home screen.', Comment = '%1 = the email address the sample invoices were sent to';
         FinalStepHeadlineDownloadLbl: Label 'Sample invoices downloaded!';
         FinalStepTextDownloadLbl: Label 'You have chosen to download sample invoice(s). Now, send the invoice(s) to the configured email so the agent will pick them up.';
 
+    internal procedure SetSetupConfiguration(NewPASetupConfiguration: Codeunit "PA Setup Configuration")
+    begin
+        PASetupConfiguration := NewPASetupConfiguration;
+        SetupConfigurationProvided := true;
+    end;
 
     trigger OnInit();
     begin
@@ -201,9 +210,16 @@ page 3307 "PA Demo Guide"
     end;
 
     trigger OnOpenPage();
+    var
+        PayablesAgentSetup: Codeunit "Payables Agent Setup";
     begin
         Session.LogMessage('0000PJU', 'Running demo guide for payables agent', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
         Commit();
+
+        if not SetupConfigurationProvided then begin
+            Session.LogMessage('0000VDH', NoSetupConfigurationProvidedTok, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
+            PayablesAgentSetup.LoadSetupConfiguration(PASetupConfiguration);
+        end;
 
         Step := Step::Start;
         EnableControls();
@@ -230,11 +246,6 @@ page 3307 "PA Demo Guide"
     var
         GuidedExperience: Codeunit "Guided Experience";
     begin
-        if DemoOption = DemoOption::"Send Demo Email" then
-            if PADemoGuide.SendDemoInvoicesByEmail() then
-                Session.LogMessage('0000V8C', DemoInvoicesSentTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok)
-            else
-                Session.LogMessage('0000V8D', DemoInvoicesPreparedTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
         Session.LogMessage('0000PJV', 'Ran demo guide for payables agent', Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
         GuidedExperience.CompleteAssistedSetup(ObjectType::Page, Page::"PA Demo Guide");
         CurrPage.Close();
@@ -321,24 +332,42 @@ page 3307 "PA Demo Guide"
 
     local procedure RunDemoOption();
     var
-        NoOptionChosenChosenErr: Label 'No option chosen. Please select one of the options to continue.', Locked = true;
-        EmailNotConfiguredErr: Label 'No email account is configured for the agent. To send sample invoices by email, set up email monitoring on the Payables Agent setup page first, or choose to download the sample invoices and send them manually.';
+        NoOptionChosenErr: Label 'No option chosen. Please select one of the options to continue.';
     begin
         case DemoOption of
             DemoOption::"Send Demo Email":
-                begin
-                    if not PADemoGuide.IsEmailConfiguredForDemoEmail() then
-                        Error(EmailNotConfiguredErr);
-                    FinalStepHeadline := FinalStepHeadlineEmailLbl;
-                    FinalStepText := FinalStepTextEmailLbl;
-                end;
+                SendDemoInvoices();
             DemoOption::"Download Demo PDFs":
                 begin
                     FinalStepHeadline := FinalStepHeadlineDownloadLbl;
                     FinalStepText := FinalStepTextDownloadLbl;
                 end;
             else
-                error(NoOptionChosenChosenErr);
+                Error(NoOptionChosenErr);
         end;
+    end;
+
+    local procedure SendDemoInvoices()
+    var
+        EmailNotConfiguredErr: Label 'No email account is configured for the agent. To send sample invoices by email, set up email monitoring on the Payables Agent setup page first, or choose to download the sample invoices and send them manually.';
+    begin
+        if not PADemoGuide.IsEmailConfiguredForDemoEmail(PASetupConfiguration) then
+            Error(EmailNotConfiguredErr);
+
+        if not DemoInvoicesHandled then begin
+            DemoEmailSent := PADemoGuide.SendDemoInvoicesByEmail(PASetupConfiguration);
+            DemoInvoicesHandled := true;
+
+            if DemoEmailSent then
+                Session.LogMessage('0000V8C', DemoInvoicesSentTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok)
+            else
+                Session.LogMessage('0000V8D', DemoInvoicesPreparedTok, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', PayablesAgentTelemetryTok);
+        end;
+
+        FinalStepHeadline := FinalStepHeadlineEmailLbl;
+        if DemoEmailSent then
+            FinalStepText := StrSubstNo(FinalStepTextEmailSentLbl, PASetupConfiguration.GetEmailAccount()."Email Address")
+        else
+            FinalStepText := FinalStepTextEmailLbl;
     end;
 }

--- a/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Page.al
+++ b/src/Apps/W1/PayablesAgent/app/Setup/PayablesAgentSetup.Page.al
@@ -96,7 +96,7 @@ page 3304 "Payables Agent Setup"
 
                             trigger OnDrillDown()
                             begin
-                                PADemoGuide.OpenGuidePage();
+                                OpenDemoGuide();
                             end;
                         }
                     }
@@ -139,7 +139,7 @@ page 3304 "Payables Agent Setup"
 
                             trigger OnDrillDown()
                             begin
-                                PADemoGuide.OpenGuidePage();
+                                OpenDemoGuide();
                             end;
                         }
                     }
@@ -306,7 +306,7 @@ page 3304 "Payables Agent Setup"
 
                         trigger OnDrillDown()
                         begin
-                            PADemoGuide.OpenGuidePage();
+                            OpenDemoGuide();
                         end;
                     }
                 }
@@ -499,12 +499,23 @@ page 3304 "Payables Agent Setup"
 
     local procedure ApplySetup()
     begin
+        BuildSetupConfiguration();
+        PayablesAgentSetup.ApplyPayablesAgentSetup(PASetupConfiguration);
+    end;
+
+    local procedure BuildSetupConfiguration()
+    begin
         CurrPage.AgentSetupPart.Page.GetAgentSetupBuffer(TempAgentSetupBuffer);
         PASetupConfiguration.SetAgentSetupBuffer(TempAgentSetupBuffer);
         PASetupConfiguration.SetPayablesAgentSetup(Rec);
         PASetupConfiguration.SetEDocumentService(TempEDocumentService);
         PASetupConfiguration.SetOutlookSetup(TempOutlookSetup);
-        PayablesAgentSetup.ApplyPayablesAgentSetup(PASetupConfiguration);
+    end;
+
+    local procedure OpenDemoGuide()
+    begin
+        BuildSetupConfiguration();
+        PADemoGuide.OpenGuidePage(PASetupConfiguration);
     end;
 
     local procedure CalcOpenAgentDemoGuideVisible()


### PR DESCRIPTION
## What & why

The sample invoice guide read the payables agent setup from the database, but the setup page is a configuration dialog that keeps everything in memory until you press Update. So if you picked a email account and went straight to "Try sample invoice", the guide looked at an empty database and told you no email account was configured, even though you had just chosen one.

The setup page now hands its current buffer to the guide instead of letting the guide go and fetch a saved copy. The email also goes out when you press Next, so you get told there and then that the invoices were sent and where to.

Fixes [AB#648897](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648897)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

## Risk & compatibility

No breaking changes and no data or upgrade impact. Nothing new is written to the database.

Three procedures on codeunit "PA Demo Guide" now take the setup configuration as a parameter instead of loading it themselves, and the redundant parameterless SendDemoEmail overload is gone.







