### PR TITLE
Fix 647572: add ContractTemplateConfirmHandler to FI Company Field Report Test

### DIFF
--- a/src/Apps/FI/FICore/test/src/FICompanyFieldReportTest.Codeunit.al
+++ b/src/Apps/FI/FICore/test/src/FICompanyFieldReportTest.Codeunit.al
@@ -342,10 +342,12 @@ codeunit 148150 "FI Company Field Report Test"
     var
         ServiceContractHeader: Record "Service Contract Header";
         ServiceContractLine: Record "Service Contract Line";
+        ServiceContractTemplate: Record "Service Contract Template";
         Customer: Record Customer;
         ServiceItem: Record "Service Item";
         DocumentNumber: Variant;
     begin
+        ServiceContractTemplate.DeleteAll();
         LibrarySales.CreateCustomer(Customer);
         LibraryService.CreateServiceContractHeader(ServiceContractHeader, ServiceContractType, Customer."No.");
         LibraryService.CreateServiceItem(ServiceItem, Customer."No.");


### PR DESCRIPTION
## What & why
The two service contract tests in codeunit 148150 fail on and off with an unhandled confirm, "Do you want to create the contract using a contract template?". Table 5965 Service Contract Header raises that confirm on insert only when a Service Contract Template record exists. Both tests create a contract through the shared helper CreateServiceContract but the codeunit does not handle the confirm, so whenever a template is left in the shared test database the dialog has nowhere to go. That is why it fails intermittently. This is a test isolation gap, not a product bug.

##Fix

Clear the Service Contract Template table at the start of CreateServiceContract so the confirm never fires. No template is applied, the tests behave as they did when green, and the assertions are unchanged. Both tests use this one helper, so the single change covers both.

Fixes [AB#647572](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647572)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior or explained below why none are needed.

## Risk & compatibility

Test-only, FI Core test app. No product code, schema, permissions or upgrade impact as nothing ships to customers.





