### PR TITLE
[master] - Subscription Contract Price Update applies the lowest sales price across all Unit of Measure codes instead of respecting Unit-Specific Price List entries in Subscription Billing.

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/App/Base/Codeunits/SubContractsItemManagement.Codeunit.al
@@ -138,7 +138,7 @@ codeunit 8055 "Sub. Contracts Item Management"
         if (SellToCustomerNo = '') or (ItemNo = '') then
             exit;
         CreateTempSalesHeader(TempSalesHeader, TempSalesHeader."Document Type"::Order, SellToCustomerNo, SellToCustomerNo, 0D, CurrencyCode);
-        CreateTempSalesLine(TempSalesLine, TempSalesHeader, "Service Object Type"::Item, ItemNo, Quantity, 0D, '');
+        CreateTempSalesLine(TempSalesLine, TempSalesHeader, "Service Object Type"::Item, ItemNo, Quantity, 0D, '', '');
         UnitPrice := CalculateUnitPrice(TempSalesHeader, TempSalesLine);
     end;
 
@@ -159,10 +159,10 @@ codeunit 8055 "Sub. Contracts Item Management"
 
     internal procedure CreateTempSalesLine(var TempSalesLine: Record "Sales Line" temporary; var TempSalesHeader: Record "Sales Header" temporary; ServiceObject: Record "Subscription Header"; OrderDate: Date)
     begin
-        CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate, ServiceObject."Variant Code");
+        CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate, ServiceObject."Variant Code", ServiceObject."Unit of Measure");
     end;
 
-    internal procedure CreateTempSalesLine(var TempSalesLine: Record "Sales Line" temporary; var TempSalesHeader: Record "Sales Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10])
+    internal procedure CreateTempSalesLine(var TempSalesLine: Record "Sales Line" temporary; var TempSalesHeader: Record "Sales Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10]; UnitOfMeasureCode: Code[10])
     begin
         TempSalesLine.Init();
         TempSalesLine.SetHideValidationDialog(true);
@@ -183,9 +183,24 @@ codeunit 8055 "Sub. Contracts Item Management"
         TempSalesLine.Quantity := Quantity;
         TempSalesLine."Currency Code" := TempSalesHeader."Currency Code";
         TempSalesLine."Variant Code" := VariantCode;
+        TempSalesLine."Unit of Measure Code" := UnitOfMeasureCode;
+        TempSalesLine."Qty. per Unit of Measure" := GetQtyPerUnitOfMeasure(ServiceObjectType, SourceNo, UnitOfMeasureCode);
 
         if OrderDate <> 0D then
             TempSalesLine."Posting Date" := OrderDate; //Field is empty in the temp table and affects whether the correct sales price will be picked. Field has to be forced either it will use WorkDate
+    end;
+
+    local procedure GetQtyPerUnitOfMeasure(ServiceObjectType: Enum "Service Object Type"; SourceNo: Code[20]; UnitOfMeasureCode: Code[10]): Decimal
+    var
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+    begin
+        if (ServiceObjectType <> ServiceObjectType::Item) or (UnitOfMeasureCode = '') then
+            exit(1);
+        if not ItemUnitOfMeasure.Get(SourceNo, UnitOfMeasureCode) then
+            exit(1);
+        if ItemUnitOfMeasure."Qty. per Unit of Measure" = 0 then
+            exit(1);
+        exit(ItemUnitOfMeasure."Qty. per Unit of Measure");
     end;
 
     procedure CalculateUnitPrice(var TempSalesHeader: Record "Sales Header" temporary; var TempSalesLine: Record "Sales Line" temporary): Decimal
@@ -223,10 +238,10 @@ codeunit 8055 "Sub. Contracts Item Management"
 
     internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObject: Record "Subscription Header"; OrderDate: Date)
     begin
-        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate, ServiceObject."Variant Code");
+        CreateTempPurchaseLine(TempPurchaseLine, TempPurchaseHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, OrderDate, ServiceObject."Variant Code", ServiceObject."Unit of Measure");
     end;
 
-    internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10])
+    internal procedure CreateTempPurchaseLine(var TempPurchaseLine: Record "Purchase Line" temporary; var TempPurchaseHeader: Record "Purchase Header" temporary; ServiceObjectType: enum "Service Object Type"; SourceNo: Code[20]; Quantity: Decimal; OrderDate: Date; VariantCode: Code[10]; UnitOfMeasureCode: Code[10])
     begin
         TempPurchaseLine.Init();
         TempPurchaseLine.SuspendStatusCheck(true);
@@ -245,6 +260,8 @@ codeunit 8055 "Sub. Contracts Item Management"
         TempPurchaseLine.Quantity := Quantity;
         TempPurchaseLine."Currency Code" := TempPurchaseHeader."Currency Code";
         TempPurchaseLine."Variant Code" := VariantCode;
+        TempPurchaseLine."Unit of Measure Code" := UnitOfMeasureCode;
+        TempPurchaseLine."Qty. per Unit of Measure" := GetQtyPerUnitOfMeasure(ServiceObjectType, SourceNo, UnitOfMeasureCode);
         if OrderDate <> 0D then
             TempPurchaseLine."Expected Receipt Date" := OrderDate;
     end;

--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -1626,7 +1626,7 @@ table 8059 "Subscription Line"
             "Service Partner"::Customer:
                 begin
                     ContractsItemManagement.CreateTempSalesHeader(TempSalesHeader, TempSalesHeader."Document Type"::Order, ServiceObject."End-User Customer No.", ServiceObject."Bill-to Customer No.", Rec."Subscription Line Start Date", Rec."Currency Code");
-                    ContractsItemManagement.CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObject.Type, ServiceObject."Source No.", ServiceObject.Quantity, Rec."Subscription Line Start Date", ServiceObject."Variant Code");
+                    ContractsItemManagement.CreateTempSalesLine(TempSalesLine, TempSalesHeader, ServiceObject, Rec."Subscription Line Start Date");
                     Rec."Calculation Base Amount" := ContractsItemManagement.CalculateUnitPrice(TempSalesHeader, TempSalesLine);
                 end;
             "Service Partner"::Vendor:

--- a/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
+++ b/src/Apps/W1/Subscription Billing/Test/Contract Price Update/ContractPriceProposalTest.Codeunit.al
@@ -44,6 +44,7 @@ codeunit 139690 "Contract Price Proposal Test"
         Assert: Codeunit Assert;
         ContractTestLibrary: Codeunit "Contract Test Library";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
+        LibraryInventory: Codeunit "Library - Inventory";
         LibraryPriceCalculation: Codeunit "Library - Price Calculation";
         LibraryPurchase: Codeunit "Library - Purchase";
         LibraryRandom: Codeunit "Library - Random";
@@ -703,6 +704,54 @@ codeunit 139690 "Contract Price Proposal Test"
         Assert.RecordIsNotEmpty(ContractPriceUpdateLine);
         ContractPriceUpdateLine.FindFirst();
         Assert.AreEqual(PriceListLine."Direct Unit Cost", ContractPriceUpdateLine."New Calculation Base", 'New Calculation Base must equal the purchase price of the G/L Account');
+    end;
+
+    [Test]
+    [HandlerFunctions('ExchangeRateSelectionModalPageHandler,MessageHandler,ConfirmHandlerYes')]
+    procedure CreateCustomerPriceUpdateProposalUsesPriceOfSubscriptionUnitOfMeasure()
+    var
+        CustomerContract: Record "Customer Subscription Contract";
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+        PriceListHeader: Record "Price List Header";
+        PriceListLineForBaseUnitOfMeasure: Record "Price List Line";
+        PriceListLineForSubscriptionUnitOfMeasure: Record "Price List Line";
+    begin
+        // [SCENARIO 648553] The price update proposal must use the price of the Subscription unit of measure instead of the lowest price of all units of measure.
+        Initialize();
+
+        // [GIVEN] A customer contract with a Subscription that uses a unit of measure other than the base unit of measure
+        ContractTestLibrary.CreateCustomerContractAndCreateContractLinesForItems(CustomerContract, ServiceObject, '', false);
+        Item.Get(ServiceObject."Source No.");
+        LibraryInventory.CreateItemUnitOfMeasureCode(ItemUnitOfMeasure, Item."No.", 1);
+        ServiceObject.Validate("Unit of Measure", ItemUnitOfMeasure.Code);
+        ServiceObject.Modify(true);
+
+        // [GIVEN] An active sales price list with a lower price for the base unit of measure and a higher price for the Subscription unit of measure
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Sale, "Price Source Type"::"All Customers", '');
+        LibraryPriceCalculation.CreateSalesPriceLine(PriceListLineForBaseUnitOfMeasure, PriceListHeader.Code, "Price Source Type"::"All Customers", '', "Price Asset Type"::Item, Item."No.");
+        PriceListLineForBaseUnitOfMeasure.Validate("Unit of Measure Code", Item."Base Unit of Measure");
+        PriceListLineForBaseUnitOfMeasure.Validate("Unit Price", 10);
+        PriceListLineForBaseUnitOfMeasure.Modify(true);
+
+        LibraryPriceCalculation.CreateSalesPriceLine(PriceListLineForSubscriptionUnitOfMeasure, PriceListHeader.Code, "Price Source Type"::"All Customers", '', "Price Asset Type"::Item, Item."No.");
+        PriceListLineForSubscriptionUnitOfMeasure.Validate("Unit of Measure Code", ItemUnitOfMeasure.Code);
+        PriceListLineForSubscriptionUnitOfMeasure.Validate("Unit Price", 100);
+        PriceListLineForSubscriptionUnitOfMeasure.Modify(true);
+
+        PriceListHeader.Validate(Status, PriceListHeader.Status::Active);
+        PriceListHeader.Modify(true);
+
+        // [WHEN] Create a price update proposal with the Recent Item Prices method
+        ContractTestLibrary.CreatePriceUpdateTemplate(PriceUpdateTemplateCustomer, "Service Partner"::Customer, "Price Update Method"::"Recent Item Prices", 0, '<12M>', '<12M>', '<12M>');
+        PriceUpdateManagement.CreatePriceUpdateProposal(PriceUpdateTemplateCustomer.Code, CalcDate(PriceUpdateTemplateCustomer.InclContrLinesUpToDateFormula, WorkDate()), WorkDate());
+
+        // [THEN] The new calculation base is taken from the price list line of the Subscription unit of measure
+        ContractPriceUpdateLine.SetRange("Price Update Template Code", PriceUpdateTemplateCustomer.Code);
+        Assert.RecordIsNotEmpty(ContractPriceUpdateLine);
+        ContractPriceUpdateLine.FindSet();
+        repeat
+            Assert.AreEqual(PriceListLineForSubscriptionUnitOfMeasure."Unit Price", ContractPriceUpdateLine."New Calculation Base", 'New Calculation Base must equal the sales price of the Subscription unit of measure');
+        until ContractPriceUpdateLine.Next() = 0;
     end;
 
     #endregion Tests


### PR DESCRIPTION
[Bug 649438](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649438): [master] [All-e]Subscription Contract Price Update applies the lowest sales price across all Unit of Measure codes instead of respecting Unit-Specific Price List entries in Subscription Billing.

[AB#649438](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649438)

**Issue**: When the "Subscription Contract Price Update" is run with the "Recent Item Prices" method, the system incorrectly applies the lowest sales price across all Unit of Measure codes for an item, instead of respecting unit-specific price list entries in Subscription Billing. This results in all contract lines receiving the same, typically lowest, price, disregarding the specific Unit of Measure configured for each subscription.

**Cause**: The CreateTempSalesLine and CreateTempPurchaseLine procedures in SubContractsItemManagement.Codeunit.al were not populating the "Unit of Measure Code" on the temporary sales/purchase lines used for price calculation. Because the price calculation filtering logic in PriceCalculationBufferMgt.Codeunit.al only applies the Unit of Measure filter when the code is explicitly set, all price list lines for the item were considered, leading to the selection of the lowest price regardless of the subscription's Unit of Measure.

**Solution**: The CreateTempSalesLine and CreateTempPurchaseLine procedures in SubContractsItemManagement.Codeunit.al were updated to include a UnitOfMeasureCode parameter. This parameter is now passed to set the "Unit of Measure Code" and "Qty. per Unit of Measure" fields on the temporary sales/purchase lines. Additionally, calls to these procedures in SubscriptionLine.Table.al were updated to pass the ServiceObject."Unit of Measure", ensuring that the price calculation correctly filters by the subscription's specific unit of measure. A new test case was added in ContractPriceProposalTest.Codeunit.al to validate this fix.

