### PR TITLE
[MAIN]-Not enough inventory available at vendor location for this order

### DIFF
--- a/src/Apps/IN/INGST/app/GSTSubcontracting/src/Codeunit/SubcontractingPost.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTSubcontracting/src/Codeunit/SubcontractingPost.Codeunit.al
@@ -1623,7 +1623,6 @@ codeunit 18466 "Subcontracting Post"
         end else begin
             ItemLedgerEntry.Reset();
             ItemLedgerEntry.SetCurrentKey("Entry Type", "Location Code", "External Document No.", "Item No.");
-            ItemLedgerEntry.SetRange("Entry No.", AppDelChallan."Applies-to Entry");
             ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Transfer);
             ItemLedgerEntry.SetRange("Location Code", SubOrderCompVend."Vendor Location");
             ItemLedgerEntry.SetRange("External Document No.", AppDelChallan."Applied Delivery Challan No.");
@@ -1632,20 +1631,6 @@ codeunit 18466 "Subcontracting Post"
             ItemLedgerEntry.SetRange(Open, true);
             ItemLedgerEntry.SetRange(Positive, true);
             ItemLedgerEntry.SetFilter("Remaining Quantity", '>0');
-
-            // Fallback to re-resolve from the selected challan line when stored entry becomes stale.
-            if not ItemLedgerEntry.FindFirst() then begin
-                ItemLedgerEntry.Reset();
-                ItemLedgerEntry.SetCurrentKey("Entry Type", "Location Code", "External Document No.", "Item No.");
-                ItemLedgerEntry.SetRange("Entry Type", ItemLedgerEntry."Entry Type"::Transfer);
-                ItemLedgerEntry.SetRange("Location Code", SubOrderCompVend."Vendor Location");
-                ItemLedgerEntry.SetRange("External Document No.", AppDelChallan."Applied Delivery Challan No.");
-                ItemLedgerEntry.SetRange("Item No.", AppDelChallan."Item No.");
-                ItemLedgerEntry.SetRange("Variant Code", VariantCode);
-                ItemLedgerEntry.SetRange(Open, true);
-                ItemLedgerEntry.SetRange(Positive, true);
-                ItemLedgerEntry.SetFilter("Remaining Quantity", '>0');
-            end;
         end;
     end;
 


### PR DESCRIPTION
**Issue:**
Subcontracting receive/consume was failing with “Not enough inventory available at vendor location for this order”

**Cause:**
Failing due to Multiple ILE for larger quantity Flushing Method Backward and has

**Solution:**
Updated GetApplicationLines method by removing SetRange on "Entry No." so all ILE can be used during receiving.

