### PR TITLE
[Main]-Re-enable BC tests disabled due to BCApps submodule migration-IT

### DIFF
--- a/src/Layers/IT/Tests/Local/FatturaPATest.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/FatturaPATest.Codeunit.al
@@ -63,6 +63,7 @@ codeunit 144200 "FatturaPA Test"
         SignatureXSDRelativePathTxt: Label '\GDL\IT\App\Test\XMLSchemas\xmldsig-core-schema.xsd', Locked = true;
         XSDRelativePathTxt: Label '\GDL\IT\App\Test\XMLSchemas\FatturaPA_1_2.xsd', Locked = true;
         InetRootRelativePathTxt: Label '..\', Locked = true;
+        BCAppsRelativePathTxt: Label '\App\BCApps\src', Locked = true;
         DescriptionTxt: Label 'Description Text';
 
     [Test]
@@ -2913,7 +2914,7 @@ codeunit 144200 "FatturaPA Test"
         XsdPath: Text;
         InetRoot: Text;
     BEGIN
-        InetRoot := LibraryUtilityOnPrem.GetInetRoot() + InetRootRelativePathTxt;
+        InetRoot := LibraryUtilityOnPrem.GetInetRoot() + InetRootRelativePathTxt + BCAppsRelativePathTxt;
         SignatureXsdPath := InetRoot + SignatureXSDRelativePathTxt;
         XsdPath := InetRoot + XSDRelativePathTxt;
         LibraryVerifyXMLSchema.SetAdditionalSchemaPath(SignatureXsdPath);

--- a/src/Layers/IT/Tests/Local/ITVATReportingExport.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/ITVATReportingExport.Codeunit.al
@@ -41,6 +41,10 @@ codeunit 144012 "IT - VAT Reporting - Export"
         StandardDatifatturaXmlnsDsAttrTxt: Label 'http://www.w3.org/2000/09/xmldsig#', Locked = true;
         StandardDatifatturaXmlnsNs2AttrTxt: Label 'http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v2.0', Locked = true;
         DatiFatturaForOneDocumentWithMultipleLinesErr: Label 'DatiFattura Report has wrong number of elements for document with multiple lines.';
+        XPathQueryLbl: Label '//*[local-name()="%1"]', Locked = true, Comment = '%1 = element name used to build an XPath expression';
+        IncorrectNodeCountErr: Label 'Incorrect %1 count', Comment = '%1 = node name';
+        AttributeMissingErr: Label 'Attribute %1 is missing', Comment = '%1 = attribute name';
+        IncorrectAttributeValueErr: Label 'Incorrect %1 attribute value', Comment = '%1 = attribute name';
 
     [Test]
     [HandlerFunctions('MessageHandler')]
@@ -2437,6 +2441,17 @@ codeunit 144012 "IT - VAT Reporting - Export"
         exit(ApplicationPath + '\..\..\..\');
     end;
 
+    local procedure ResolveTestAssetPath(RelativePath: Text): Text
+    var
+        FileManagement: Codeunit "File Management";
+        BCAppsAssetPath: Text;
+    begin
+        BCAppsAssetPath := GetInetRoot() + '\App\BCApps\src' + RelativePath;
+        if FileManagement.ServerFileExists(BCAppsAssetPath) then
+            exit(BCAppsAssetPath);
+        exit(GetInetRoot() + RelativePath);
+    end;
+
     local procedure GenerateReportLine(var VATReportHeader: Record "VAT Report Header"; var VATReportLine: Record "VAT Report Line"; IndividualPerson: Boolean; Resident: Option; DocumentType: Enum "Gen. Journal Document Type"; GenPostingType: Enum "General Posting Type"; VATReportType: Option; ContractPaymentType: Option)
     var
         VATPostingSetup: Record "VAT Posting Setup";
@@ -2508,9 +2523,9 @@ codeunit 144012 "IT - VAT Reporting - Export"
         XMLDoc.Save(XmlStream);
         XmlFile.Close();
 
-        SignatureXsdPath := GetInetRoot() + '\GDL\IT\App\Test\XMLSchemas\xmldsig-core-schema.xsd';
+        SignatureXsdPath := ResolveTestAssetPath('\GDL\IT\App\Test\XMLSchemas\xmldsig-core-schema.xsd');
         LibraryVerifyXMLSchema.SetAdditionalSchemaPath(SignatureXsdPath);
-        XsdPath := GetInetRoot() + '\GDL\IT\App\Test\XMLSchemas\fornituraIvp_2018_v1.xsd';
+        XsdPath := ResolveTestAssetPath('\GDL\IT\App\Test\XMLSchemas\fornituraIvp_2018_v1.xsd');
         Assert.IsTrue(LibraryVerifyXMLSchema.VerifyXMLAgainstSchema(XmlPath, XsdPath, Message), Message);
     end;
 
@@ -2615,27 +2630,61 @@ codeunit 144012 "IT - VAT Reporting - Export"
 
     local procedure VerifyDatiFatturaAttributes(FileName: Text)
     var
-        XMLDoc: DotNet XmlDocument;
+        XmlDocument: XmlDocument;
+        XmlRootElement: XmlElement;
     begin
-        XMLDoc := XMLDoc.XmlDocument();
-        XMLDoc.Load(FileName);
-        ValidateXmlAgainstXsdSchema(XMLDoc);
-        LibraryXMLRead.Initialize(FileName);
-        LibraryXMLRead.VerifyAttributeValue('ns2:DatiFattura', 'xmlns:xs', StandardDatifatturaXmlnsXsAttrTxt);
-        LibraryXMLRead.VerifyAttributeValue('ns2:DatiFattura', 'xmlns:ds', StandardDatifatturaXmlnsDsAttrTxt);
-        LibraryXMLRead.VerifyAttributeValue('ns2:DatiFattura', 'versione', 'DAT20');
-        LibraryXMLRead.VerifyAttributeValue('ns2:DatiFattura', 'xmlns:ns2', StandardDatifatturaXmlnsNs2AttrTxt);
+        LoadXmlDocument(FileName, XmlDocument);
+        XmlDocument.GetRoot(XmlRootElement);
+        VerifyXmlAttribute(XmlRootElement, 'xs', 'http://www.w3.org/2000/xmlns/', StandardDatifatturaXmlnsXsAttrTxt);
+        VerifyXmlAttribute(XmlRootElement, 'ds', 'http://www.w3.org/2000/xmlns/', StandardDatifatturaXmlnsDsAttrTxt);
+        VerifyXmlAttribute(XmlRootElement, 'versione', '', 'DAT20');
+        VerifyXmlAttribute(XmlRootElement, 'ns2', 'http://www.w3.org/2000/xmlns/', StandardDatifatturaXmlnsNs2AttrTxt);
     end;
 
     local procedure VerifyDatiFatturaInvoiceNoAndDate(FileName: Text; PostingDate: Date; Numero: Text)
+    var
+        XmlDocument: XmlDocument;
+        ActualNumero: Text;
     begin
-        LibraryXMLRead.Initialize(FileName);
-        Assert.AreEqual(1, LibraryXMLRead.GetNodesCount('Numero'), 'Incorrect Numero count');
-        Assert.AreEqual(GetAlphanumeric(Numero), LibraryXMLRead.GetNodeValueAtIndex('Numero', 0), 'Incorrect Numero value');
-        AssertIsAlphanumeric(LibraryXMLRead.GetNodeValueAtIndex('Numero', 0));
-        Assert.AreEqual(1, LibraryXMLRead.GetNodesCount('Data'), 'Incorrect Data count');
+        LoadXmlDocument(FileName, XmlDocument);
+        ActualNumero := GetSingleXmlNodeValue(XmlDocument, 'Numero');
+        Assert.AreEqual(GetAlphanumeric(Numero), ActualNumero, 'Incorrect Numero value');
+        AssertIsAlphanumeric(ActualNumero);
         Assert.AreEqual(
-          Format(PostingDate, 0, '<Year4>-<Month,2>-<Day,2>'), LibraryXMLRead.GetNodeValueAtIndex('Data', 0), 'Incorrect Data value');
+            Format(PostingDate, 0, '<Year4>-<Month,2>-<Day,2>'), GetSingleXmlNodeValue(XmlDocument, 'Data'), 'Incorrect Data value');
+    end;
+
+    local procedure LoadXmlDocument(FileName: Text; var LoadedXmlDocument: XmlDocument)
+    var
+      XmlFile: File;
+      XmlInStream: InStream;
+    begin
+      XmlFile.Open(FileName);
+      XmlFile.CreateInStream(XmlInStream);
+      XmlDocument.ReadFrom(XmlInStream, LoadedXmlDocument);
+      XmlFile.Close();
+    end;
+
+    local procedure GetSingleXmlNodeValue(XmlDocument: XmlDocument; NodeName: Text): Text
+    var
+      XmlNode: XmlNode;
+      XmlNodeList: XmlNodeList;
+    begin
+        XmlDocument.SelectNodes(StrSubstNo(XPathQueryLbl, NodeName), XmlNodeList);
+        Assert.AreEqual(1, XmlNodeList.Count(), StrSubstNo(IncorrectNodeCountErr, NodeName));
+        XmlNodeList.Get(1, XmlNode);
+        exit(XmlNode.AsXmlElement().InnerText());
+    end;
+
+    local procedure VerifyXmlAttribute(XmlElement: XmlElement; AttributeName: Text; NamespaceUri: Text; ExpectedValue: Text)
+    var
+      XmlAttribute: XmlAttribute;
+      XmlAttributes: XmlAttributeCollection;
+    begin
+        XmlAttributes := XmlElement.Attributes();
+        Assert.IsTrue(
+            XmlAttributes.Get(AttributeName, NamespaceUri, XmlAttribute), StrSubstNo(AttributeMissingErr, AttributeName));
+        Assert.AreEqual(ExpectedValue, XmlAttribute.Value(), StrSubstNo(IncorrectAttributeValueErr, AttributeName));
     end;
 
     local procedure VerifyDatiFatturaFileForScenarioWithOneFile(NodeName: Text; SuggestedFileName: Text)

--- a/src/Layers/IT/Tests/Local/PeriodicVATPmtCommTests.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/PeriodicVATPmtCommTests.Codeunit.al
@@ -30,6 +30,7 @@ codeunit 144150 "Periodic VAT Pmt. Comm. Tests"
         SpecifyMethodOfCalcAdvancedAmountErr: Label 'You must select a calculation method for advanced amounts.';
         ModuleNumberBlankErr: Label 'You must enter a module number.';
         WrongCaptionErr: Label 'Wrong caption.';
+        BCAppsRelativePathTxt: Label '\App\BCApps\src', Locked = true;
 
     [Test]
     [Scope('OnPrem')]
@@ -251,9 +252,9 @@ codeunit 144150 "Periodic VAT Pmt. Comm. Tests"
         VATPaymentCommunication.Run();
 
         // [THEN] XML generated conforms to the XSD
-        SignatureSchemaPath := GetInetRoot() + '\GDL\IT\App\Test\XMLSchemas\xmldsig-core-schema.xsd';
+        SignatureSchemaPath := ResolveTestAssetPath('\GDL\IT\App\Test\XMLSchemas\xmldsig-core-schema.xsd');
         LibraryVerifyXMLSchema.SetAdditionalSchemaPath(SignatureSchemaPath);
-        SchemaPath := GetInetRoot() + '\GDL\IT\App\Test\XMLSchemas\fornituraIvp_2018_v1.xsd';
+        SchemaPath := ResolveTestAssetPath('\GDL\IT\App\Test\XMLSchemas\fornituraIvp_2018_v1.xsd');
         Assert.IsTrue(LibraryVerifyXMLSchema.VerifyXMLAgainstSchema(DestinationPath, SchemaPath, Message), Message);
         UnbindSubscription(PeriodicVATPmtCommTests);
     end;
@@ -1200,6 +1201,11 @@ codeunit 144150 "Periodic VAT Pmt. Comm. Tests"
     local procedure GetInetRoot(): Text
     begin
         exit(ApplicationPath + '\..\..\..\');
+    end;
+
+    local procedure ResolveTestAssetPath(RelativePath: Text): Text
+    begin
+        exit(GetInetRoot() + BCAppsRelativePathTxt + RelativePath);
     end;
 
     local procedure PopulateVATEntryTable(StartDate: Date; var TotalSales: Decimal; var TotalPurchases: Decimal; var TotalSalesTax: Decimal; var TotalPurchaseTax: Decimal)


### PR DESCRIPTION
Workitem [Bug 641038](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641038): [all-e]Re-enable BC tests disabled due to BCApps submodule migration (hardcoded GDL/DemoTool paths)

Fixes [AB#641038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641038)


