### PR TITLE
Make AL test fixtures compatible with ClientService connections

### DIFF
--- a/src/Layers/BE/Tests/Dimension/ERMChangeGlobalDimensions.Codeunit.al
+++ b/src/Layers/BE/Tests/Dimension/ERMChangeGlobalDimensions.Codeunit.al
@@ -485,6 +485,12 @@ codeunit 134483 "ERM Change Global Dimensions"
         Initialize();
         // [GIVEN] There is another active session
         ActiveSessionNo := MockActiveSessions(1);
+        // [GIVEN] The current session is a web client shown in the session list.
+        ActiveSession.SetRange("Server Instance ID", ServiceInstanceId());
+        ActiveSession.SetRange("Session ID", SessionId());
+        ActiveSession.FindFirst();
+        ActiveSession."Client Type" := ActiveSession."Client Type"::"Web Client";
+        ActiveSession.Modify();
         // [GIVEN] Open page "Change Global Dimensions"
         ApplicationAreaMgmtFacade.SaveExperienceTierCurrentCompany(ExperienceTierSetup.FieldCaption(Essential));
         OpenPageForParalllelProcessing(ChangeGlobalDimensionsPage);
@@ -4447,4 +4453,3 @@ codeunit 134483 "ERM Change Global Dimensions"
             end;
     end;
 }
-

--- a/src/Layers/ES/Tests/Report/TestCustomReports.Codeunit.al
+++ b/src/Layers/ES/Tests/Report/TestCustomReports.Codeunit.al
@@ -299,9 +299,12 @@ codeunit 134761 "Test Custom Reports"
     var
         CustomLayoutReporting: Codeunit "Custom Layout Reporting";
         FileManagement: Codeunit "File Management";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         OutputPath: Text;
     begin
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         OutputPath := GetOutputFolder();
 
         RunStatementReport(CustomerFullMod, CustomLayoutReporting, OutputPath, false, true);
@@ -317,9 +320,12 @@ codeunit 134761 "Test Custom Reports"
     var
         CustomLayoutReporting: Codeunit "Custom Layout Reporting";
         FileManagement: Codeunit "File Management";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         OutputPath: Text;
     begin
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         OutputPath := GetOutputFolder();
 
         RunStatementReport(CustomerFullMod, CustomLayoutReporting, OutputPath, false, true);

--- a/src/Layers/IT/Tests/Local/ITVATReportingExport.Codeunit.al
+++ b/src/Layers/IT/Tests/Local/ITVATReportingExport.Codeunit.al
@@ -2372,9 +2372,12 @@ codeunit 144012 "IT - VAT Reporting - Export"
     local procedure ExportFile_Datifattura(VATReportHeader: Record "VAT Report Header")
     var
         DatifatturaExport: Codeunit "Datifattura Export";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         VATReportReleaseReopen: Codeunit "VAT Report Release/Reopen";
         ITVATReportingExport: Codeunit "IT - VAT Reporting - Export";
     begin
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         VATReportReleaseReopen.Release(VATReportHeader);
         VATReportHeader.SetFilter("No.", VATReportHeader."No.");
         BindSubscription(ITVATReportingExport);
@@ -3910,4 +3913,3 @@ codeunit 144012 "IT - VAT Reporting - Export"
         LibraryVariableStorage.Enqueue(ErrorMessages.Description.Value);
     end;
 }
-

--- a/src/Layers/IT/Tests/TestLibraries/LibraryITDatifattura.Codeunit.al
+++ b/src/Layers/IT/Tests/TestLibraries/LibraryITDatifattura.Codeunit.al
@@ -18,8 +18,11 @@ codeunit 143005 "Library - IT Datifattura"
         NameValueBuffer: Record "Name/Value Buffer";
         LibraryITDatifattura: Codeunit "Library - IT Datifattura";
         DatifatturaExport: Codeunit "Datifattura Export";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         VATReportReleaseReopen: Codeunit "VAT Report Release/Reopen";
     begin
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         BindSubscription(LibraryITDatifattura);
         VATReportHeader.SetRecFilter();
         VATReportReleaseReopen.Release(VATReportHeader);
@@ -126,4 +129,3 @@ codeunit 143005 "Library - IT Datifattura"
             Error('%1: <%2> in %3', Rec."Message Type", Rec.Message, Rec."Context Record ID");
     end;
 }
-

--- a/src/Layers/NA/Tests/Report/TestCustomReports.Codeunit.al
+++ b/src/Layers/NA/Tests/Report/TestCustomReports.Codeunit.al
@@ -299,9 +299,12 @@ codeunit 134761 "Test Custom Reports"
     var
         CustomLayoutReporting: Codeunit "Custom Layout Reporting";
         FileManagement: Codeunit "File Management";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         OutputPath: Text;
     begin
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         OutputPath := GetOutputFolder();
 
         RunStatementReport(CustomerFullMod, CustomLayoutReporting, OutputPath, false, true);
@@ -317,9 +320,12 @@ codeunit 134761 "Test Custom Reports"
     var
         CustomLayoutReporting: Codeunit "Custom Layout Reporting";
         FileManagement: Codeunit "File Management";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         OutputPath: Text;
     begin
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         OutputPath := GetOutputFolder();
 
         RunStatementReport(CustomerFullMod, CustomLayoutReporting, OutputPath, false, true);

--- a/src/Layers/RU/Tests/Dimension/ERMChangeGlobalDimensions.Codeunit.al
+++ b/src/Layers/RU/Tests/Dimension/ERMChangeGlobalDimensions.Codeunit.al
@@ -485,6 +485,12 @@ codeunit 134483 "ERM Change Global Dimensions"
         Initialize();
         // [GIVEN] There is another active session
         ActiveSessionNo := MockActiveSessions(1);
+        // [GIVEN] The current session is a web client shown in the session list.
+        ActiveSession.SetRange("Server Instance ID", ServiceInstanceId());
+        ActiveSession.SetRange("Session ID", SessionId());
+        ActiveSession.FindFirst();
+        ActiveSession."Client Type" := ActiveSession."Client Type"::"Web Client";
+        ActiveSession.Modify();
         // [GIVEN] Open page "Change Global Dimensions"
         ApplicationAreaMgmtFacade.SaveExperienceTierCurrentCompany(ExperienceTierSetup.FieldCaption(Essential));
         OpenPageForParalllelProcessing(ChangeGlobalDimensionsPage);
@@ -4445,4 +4451,3 @@ codeunit 134483 "ERM Change Global Dimensions"
             end;
     end;
 }
-

--- a/src/Layers/W1/Tests/Dimension/ERMChangeGlobalDimensions.Codeunit.al
+++ b/src/Layers/W1/Tests/Dimension/ERMChangeGlobalDimensions.Codeunit.al
@@ -485,6 +485,12 @@ codeunit 134483 "ERM Change Global Dimensions"
         Initialize();
         // [GIVEN] There is another active session
         ActiveSessionNo := MockActiveSessions(1);
+        // [GIVEN] The current session is a web client shown in the session list.
+        ActiveSession.SetRange("Server Instance ID", ServiceInstanceId());
+        ActiveSession.SetRange("Session ID", SessionId());
+        ActiveSession.FindFirst();
+        ActiveSession."Client Type" := ActiveSession."Client Type"::"Web Client";
+        ActiveSession.Modify();
         // [GIVEN] Open page "Change Global Dimensions"
         ApplicationAreaMgmtFacade.SaveExperienceTierCurrentCompany(ExperienceTierSetup.FieldCaption(Essential));
         OpenPageForParalllelProcessing(ChangeGlobalDimensionsPage);
@@ -4446,4 +4452,3 @@ codeunit 134483 "ERM Change Global Dimensions"
             end;
     end;
 }
-

--- a/src/Layers/W1/Tests/Integration/TestEmailLoggingonExchange.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration/TestEmailLoggingonExchange.Codeunit.al
@@ -16,7 +16,11 @@ codeunit 139025 "Test Email Logging on Exchange"
         Assert: Codeunit Assert;
 
     local procedure TryInitializeEWS(var ExchangeWebServicesClient: Codeunit "Exchange Web Services Client"): Boolean
+    var
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
     begin
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         // This function returns TRUE, only if the current test environment allows for successful EWS autodetection with the email address below
         exit(ExchangeWebServicesClient.InitializeOnClient('vlabtest@microsoft.com', 'https://outlook.office365.com/EWS/Exchange.asmx'));
     end;
@@ -104,4 +108,3 @@ codeunit 139025 "Test Email Logging on Exchange"
         Assert.ExpectedError('Connection to the Exchange server failed.');
     end;
 }
-

--- a/src/Layers/W1/Tests/Report/TestCustomReports.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/TestCustomReports.Codeunit.al
@@ -299,9 +299,12 @@ codeunit 134761 "Test Custom Reports"
     var
         CustomLayoutReporting: Codeunit "Custom Layout Reporting";
         FileManagement: Codeunit "File Management";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         OutputPath: Text;
     begin
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         OutputPath := GetOutputFolder();
 
         RunStatementReport(CustomerFullMod, CustomLayoutReporting, OutputPath, false, true);
@@ -317,9 +320,12 @@ codeunit 134761 "Test Custom Reports"
     var
         CustomLayoutReporting: Codeunit "Custom Layout Reporting";
         FileManagement: Codeunit "File Management";
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         OutputPath: Text;
     begin
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         OutputPath := GetOutputFolder();
 
         RunStatementReport(CustomerFullMod, CustomLayoutReporting, OutputPath, false, true);

--- a/src/Layers/W1/Tests/Report/WordRDLCReportSelections.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/WordRDLCReportSelections.Codeunit.al
@@ -263,12 +263,15 @@ codeunit 134775 "Word & RDLC Report Selections"
     procedure OneCustomer_TwoSelections_RDLC_Ok_WORD_Ok()
     var
         Customer: Record Customer;
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         WordRDLCReportSelections: Codeunit "Word & RDLC Report Selections";
     begin
         // [FEATURE] [RDLC] [Word]
         // [SCENARIO 228763] Print customer statement report (SaveAs PDF) in case of one customer with entries,
         // [SCENARIO 228763] two report selections (1 - RDLC, 2 - WORD)
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         BindSubscription(WordRDLCReportSelections);
 
         // [GIVEN] Report Selections setup:
@@ -498,12 +501,15 @@ codeunit 134775 "Word & RDLC Report Selections"
     procedure OneCustomer_TwoSelections_WORD_Ok_RDLC_Ok()
     var
         Customer: Record Customer;
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         WordRDLCReportSelections: Codeunit "Word & RDLC Report Selections";
     begin
         // [FEATURE] [RDLC] [Word]
         // [SCENARIO 228763] Print customer statement report (SaveAs PDF) in case of one customer with entries,
         // [SCENARIO 228763] two report selections (1 - WORD, 2 - RDLC)
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         BindSubscription(WordRDLCReportSelections);
 
         // [GIVEN] Report Selections setup:
@@ -733,11 +739,14 @@ codeunit 134775 "Word & RDLC Report Selections"
     procedure TwoCustomers_OneSelection_RDLC_Ok()
     var
         Customer: array[2] of Record Customer;
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         WordRDLCReportSelections: Codeunit "Word & RDLC Report Selections";
     begin
         // [FEATURE] [RDLC]
         // [SCENARIO 228763] Print customer statement report (SaveAs PDF) in case of two customers with entries, one RDLC report selections
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         BindSubscription(WordRDLCReportSelections);
 
         // [GIVEN] Report Selections setup:
@@ -880,11 +889,14 @@ codeunit 134775 "Word & RDLC Report Selections"
     procedure TwoCustomers_OneSelection_WORD_Ok()
     var
         Customer: array[2] of Record Customer;
+        TestClientTypeSubscriber: Codeunit "Test Client Type Subscriber";
         WordRDLCReportSelections: Codeunit "Word & RDLC Report Selections";
     begin
         // [FEATURE] [Word]
         // [SCENARIO 228763] Print customer statement report (SaveAs PDF) in case of two customers with entries, one WORD report selections
         Initialize();
+        TestClientTypeSubscriber.SetClientType(CLIENTTYPE::Windows);
+        BindSubscription(TestClientTypeSubscriber);
         BindSubscription(WordRDLCReportSelections);
 
         // [GIVEN] Report Selections setup:
@@ -1317,4 +1329,3 @@ codeunit 134775 "Word & RDLC Report Selections"
         Statement.OK().Invoke();
     end;
 }
-


### PR DESCRIPTION
## What & why

[AB#625894](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/625894)

Update client-dependent test fixtures for the ALTest runner identifying itself as `ClientService`, which AL exposes as the Web client type. Previously, the unspecified client identity fell back to the server's Windows default.

- Use the existing `Test Client Type Subscriber` to explicitly select Windows behavior for server-file report output, Exchange initialization, and Italian Datifattura XML export fixtures.
- Model the current session as a visible Web Client in the concurrent-session-list fixture.
- Apply the shared fixes to the W1 fixtures and the BE, ES, NA, and RU overrides. NA also supplies the affected fixtures for MX, US, and CA.

Existing assertions are preserved. This PR contains only test and test-library fixture changes; the currency-formatting feature and upgrade changes from #10717 are not included.

## Linked work

Fixes #11240

Related investigation: #10717.

## How I validated this

- Reproduced the report-output, session-list, and Exchange failures with the `ClientService` runner on an unmodified server runtime.
- A combined local run of 157 selected AL regressions passed after the fixture fixes. Exchange tests improved from 3/6 to 6/6 passing.
- The seven relevant report/session-list failures were resolved in the 180-test local run; two pre-existing local setup-notification failures remained and were not changed by this PR.
- Built the affected localized test projects against their matching country application symbols, including IT, ES, MX, RU, and BE, with zero compilation errors.
- Targeted automated runs covering the affected scenarios passed, including the final ES/MX/RU/BE runs.

These results were obtained on the original repair branch. This PR extracts its two fixture commits onto current `main`; the patches are unchanged, and validation of the new branch will run through this PR's CI.

## Risk & compatibility

No production application behavior, schema, permissions, or runtime changes. The explicit fixtures remove reliance on the runner's implicit client identity without relaxing assertions. The runner identity and download-directory changes themselves are outside the scope of BCApps.



