### PR TITLE
[main] bug 640925 - Enhance draft and proforma invoice report layouts and upgrade tag definitions

### DIFF
--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/InstallApplicationCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/InstallApplicationCZL.Codeunit.al
@@ -887,8 +887,10 @@ codeunit 11748 "Install Application CZL"
         UpgradeApplicationCZL: Codeunit "Upgrade Application CZL";
     begin
         if UpgradeApplicationCZL.GetDraftInvoiceReportLayoutCZ(ReportLayoutList) then
-            UpgradeApplicationCZL.SetDefaultReportLayout(ReportLayoutList);
+            if not UpgradeApplicationCZL.IsReportLayoutSelectionCustomized(Report::"Standard Sales - Draft Invoice") then
+                UpgradeApplicationCZL.SetDefaultReportLayout(ReportLayoutList);
         if UpgradeApplicationCZL.GetProformaReportLayoutCZ(ReportLayoutList) then
-            UpgradeApplicationCZL.SetDefaultReportLayout(ReportLayoutList);
+            if not UpgradeApplicationCZL.IsReportLayoutSelectionCustomized(Report::"Standard Sales - Pro Forma Inv") then
+                UpgradeApplicationCZL.SetDefaultReportLayout(ReportLayoutList);
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/InstallApplicationCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/InstallApplicationCZL.Codeunit.al
@@ -54,8 +54,10 @@ using Microsoft.Service.Document;
 using Microsoft.Service.History;
 using Microsoft.Service.Reports;
 using Microsoft.Service.Setup;
+using Microsoft.Upgrade;
 using Microsoft.Utilities;
 using System.IO;
+using System.Reflection;
 using System.Security.Encryption;
 using System.Security.User;
 using System.Upgrade;
@@ -598,6 +600,7 @@ codeunit 11748 "Install Application CZL"
         InitEETServiceSetup();
         CreateSourceCodeSetup();
         ModifyReportSelections();
+        InitDefaultReportLayouts();
 
         DataClassEvalHandlerCZL.ApplyEvaluationClassificationsForPrivacy();
         UpgradeTag.SetAllUpgradeTags();
@@ -876,5 +879,16 @@ codeunit 11748 "Install Application CZL"
                 if (ItemJournalTemplate."Posting Report ID" <> PrevItemJournalTemplate."Posting Report ID") then
                     ItemJournalTemplate.Modify();
             until ItemJournalTemplate.Next() = 0;
+    end;
+
+    local procedure InitDefaultReportLayouts()
+    var
+        ReportLayoutList: Record "Report Layout List";
+        UpgradeApplicationCZL: Codeunit "Upgrade Application CZL";
+    begin
+        if UpgradeApplicationCZL.GetDraftInvoiceReportLayoutCZ(ReportLayoutList) then
+            UpgradeApplicationCZL.SetDefaultReportLayout(ReportLayoutList);
+        if UpgradeApplicationCZL.GetProformaReportLayoutCZ(ReportLayoutList) then
+            UpgradeApplicationCZL.SetDefaultReportLayout(ReportLayoutList);
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeApplicationCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeApplicationCZL.Codeunit.al
@@ -903,7 +903,7 @@ codeunit 31017 "Upgrade Application CZL"
         exit('');
     end;
 
-    local procedure GetDraftInvoiceReportLayoutCZ(var ReportLayoutList: Record "Report Layout List"): Boolean
+    internal procedure GetDraftInvoiceReportLayoutCZ(var ReportLayoutList: Record "Report Layout List"): Boolean
     begin
         NavApp.GetCurrentModuleInfo(AppInfo);
         ReportLayoutList.Reset();
@@ -913,7 +913,7 @@ codeunit 31017 "Upgrade Application CZL"
         exit(ReportLayoutList.FindFirst());
     end;
 
-    local procedure GetProformaReportLayoutCZ(var ReportLayoutList: Record "Report Layout List"): Boolean
+    internal procedure GetProformaReportLayoutCZ(var ReportLayoutList: Record "Report Layout List"): Boolean
     begin
         NavApp.GetCurrentModuleInfo(AppInfo);
         ReportLayoutList.Reset();
@@ -923,7 +923,7 @@ codeunit 31017 "Upgrade Application CZL"
         exit(ReportLayoutList.FindFirst());
     end;
 
-    local procedure SetDefaultReportLayout(ReportLayoutList: Record "Report Layout List")
+    internal procedure SetDefaultReportLayout(ReportLayoutList: Record "Report Layout List")
     var
         ReportLayoutSelection: Record "Report Layout Selection";
     begin

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeApplicationCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeApplicationCZL.Codeunit.al
@@ -855,33 +855,29 @@ codeunit 31017 "Upgrade Application CZL"
     local procedure UpgradeDraftInvoiceAndProformaReportLayouts()
     var
         ReportLayoutList: Record "Report Layout List";
-        DefaultMetadataReportLayoutName: Text[100];
-        DefaultSelectionReportLayoutName: Text[250];
     begin
         if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitionsCZL.GetChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag()) then
             exit;
 
-        if GetDraftInvoiceReportLayoutCZ(ReportLayoutList) then begin
-            DefaultMetadataReportLayoutName := GetDefaultMetadataReportLayoutName(Report::"Standard Sales - Draft Invoice");
-            DefaultSelectionReportLayoutName := GetDefaultSelectionReportLayoutName(Report::"Standard Sales - Draft Invoice");
-
-            if (DefaultSelectionReportLayoutName = '') or
-               ((DefaultSelectionReportLayoutName <> '') and (DefaultSelectionReportLayoutName = DefaultMetadataReportLayoutName))
-            then
+        if GetDraftInvoiceReportLayoutCZ(ReportLayoutList) then
+            if not IsReportLayoutSelectionCustomized(Report::"Standard Sales - Draft Invoice") then
                 SetDefaultReportLayout(ReportLayoutList);
-        end;
 
-        if GetProformaReportLayoutCZ(ReportLayoutList) then begin
-            DefaultMetadataReportLayoutName := GetDefaultMetadataReportLayoutName(Report::"Standard Sales - Pro Forma Inv");
-            DefaultSelectionReportLayoutName := GetDefaultSelectionReportLayoutName(Report::"Standard Sales - Pro Forma Inv");
-
-            if (DefaultSelectionReportLayoutName = '') or
-               ((DefaultSelectionReportLayoutName <> '') and (DefaultSelectionReportLayoutName = DefaultMetadataReportLayoutName))
-            then
+        if GetProformaReportLayoutCZ(ReportLayoutList) then
+            if not IsReportLayoutSelectionCustomized(Report::"Standard Sales - Pro Forma Inv") then
                 SetDefaultReportLayout(ReportLayoutList);
-        end;
 
         UpgradeTag.SetUpgradeTag(UpgradeTagDefinitionsCZL.GetChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag());
+    end;
+
+    internal procedure IsReportLayoutSelectionCustomized(ReportId: Integer): Boolean
+    var
+        DefaultMetadataReportLayoutName: Text[100];
+        DefaultSelectionReportLayoutName: Text[250];
+    begin
+        DefaultMetadataReportLayoutName := GetDefaultMetadataReportLayoutName(ReportId);
+        DefaultSelectionReportLayoutName := GetDefaultSelectionReportLayoutName(ReportId);
+        exit((DefaultSelectionReportLayoutName <> '') and (DefaultSelectionReportLayoutName <> DefaultMetadataReportLayoutName));
     end;
 
     local procedure GetDefaultMetadataReportLayoutName(ReportId: Integer): Text[100]

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeApplicationCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeApplicationCZL.Codeunit.al
@@ -46,6 +46,7 @@ using Microsoft.Service.Document;
 using Microsoft.Service.History;
 using Microsoft.Service.Setup;
 using System.Environment.Configuration;
+using System.Reflection;
 using System.Security.AccessControl;
 using System.Security.Encryption;
 using System.Security.User;
@@ -141,7 +142,9 @@ codeunit 31017 "Upgrade Application CZL"
                   tabledata "Gen. Journal Template" = m,
                   tabledata "VAT Entry" = m,
                   tabledata "Report Selections" = m,
-                  tabledata "G/L Entry" = m;
+                  tabledata "G/L Entry" = m,
+                  tabledata "Report Layout Selection" = im,
+                  tabledata "Tenant Report Layout Selection" = im;
 
     var
         DataUpgradeMgt: Codeunit "Data Upgrade Mgt.";
@@ -149,6 +152,8 @@ codeunit 31017 "Upgrade Application CZL"
         UpgradeTagDefinitionsCZL: Codeunit "Upgrade Tag Definitions CZL";
         InstallApplicationsMgtCZL: Codeunit "Install Applications Mgt. CZL";
         AppInfo: ModuleInfo;
+        DraftInvoiceReportLayoutNameTok: Label 'StdSalesDraftInvoice.rdl CZL', Locked = true;
+        ProformaReportLayoutNameTok: Label 'StdSalesProFormaInv.rdl CZL', Locked = true;
 
     trigger OnUpgradePerDatabase()
     begin
@@ -187,6 +192,7 @@ codeunit 31017 "Upgrade Application CZL"
         UpgradeUseVATReturnPeriodInsteadOfVATPeriod();
 #endif
         UpgradeOriginalVATAmountsACYInVATEntries();
+        UpgradeDraftInvoiceAndProformaReportLayouts();
     end;
 
     local procedure UpgradeReplaceVATDateCZL()
@@ -845,6 +851,127 @@ codeunit 31017 "Upgrade Application CZL"
         exit(CalcDate('<+25D>', EndDate));
     end;
 #endif
+
+    local procedure UpgradeDraftInvoiceAndProformaReportLayouts()
+    var
+        ReportLayoutList: Record "Report Layout List";
+        DefaultMetadataReportLayoutName: Text[100];
+        DefaultSelectionReportLayoutName: Text[250];
+    begin
+        if UpgradeTag.HasUpgradeTag(UpgradeTagDefinitionsCZL.GetChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag()) then
+            exit;
+
+        if GetDraftInvoiceReportLayoutCZ(ReportLayoutList) then begin
+            DefaultMetadataReportLayoutName := GetDefaultMetadataReportLayoutName(Report::"Standard Sales - Draft Invoice");
+            DefaultSelectionReportLayoutName := GetDefaultSelectionReportLayoutName(Report::"Standard Sales - Draft Invoice");
+
+            if (DefaultSelectionReportLayoutName = '') or
+               ((DefaultSelectionReportLayoutName <> '') and (DefaultSelectionReportLayoutName = DefaultMetadataReportLayoutName))
+            then
+                SetDefaultReportLayout(ReportLayoutList);
+        end;
+
+        if GetProformaReportLayoutCZ(ReportLayoutList) then begin
+            DefaultMetadataReportLayoutName := GetDefaultMetadataReportLayoutName(Report::"Standard Sales - Pro Forma Inv");
+            DefaultSelectionReportLayoutName := GetDefaultSelectionReportLayoutName(Report::"Standard Sales - Pro Forma Inv");
+
+            if (DefaultSelectionReportLayoutName = '') or
+               ((DefaultSelectionReportLayoutName <> '') and (DefaultSelectionReportLayoutName = DefaultMetadataReportLayoutName))
+            then
+                SetDefaultReportLayout(ReportLayoutList);
+        end;
+
+        UpgradeTag.SetUpgradeTag(UpgradeTagDefinitionsCZL.GetChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag());
+    end;
+
+    local procedure GetDefaultMetadataReportLayoutName(ReportId: Integer): Text[100]
+    var
+        ReportMetadata: Record "Report Metadata";
+    begin
+        if ReportMetadata.Get(ReportId) then
+            exit(ReportMetadata."DefaultLayoutName");
+        exit('');
+    end;
+
+    local procedure GetDefaultSelectionReportLayoutName(ReportId: Integer): Text[250]
+    var
+        TenantReportLayoutSelection: Record "Tenant Report Layout Selection";
+        EmptyGuid: Guid;
+    begin
+        if TenantReportLayoutSelection.Get(ReportId, CompanyName(), EmptyGuid) then
+            exit(TenantReportLayoutSelection."Layout Name");
+        exit('');
+    end;
+
+    local procedure GetDraftInvoiceReportLayoutCZ(var ReportLayoutList: Record "Report Layout List"): Boolean
+    begin
+        NavApp.GetCurrentModuleInfo(AppInfo);
+        ReportLayoutList.Reset();
+        ReportLayoutList.SetRange("Report ID", Report::"Standard Sales - Draft Invoice");
+        ReportLayoutList.SetRange("Name", DraftInvoiceReportLayoutNameTok);
+        ReportLayoutList.SetRange("Application ID", AppInfo.Id);
+        exit(ReportLayoutList.FindFirst());
+    end;
+
+    local procedure GetProformaReportLayoutCZ(var ReportLayoutList: Record "Report Layout List"): Boolean
+    begin
+        NavApp.GetCurrentModuleInfo(AppInfo);
+        ReportLayoutList.Reset();
+        ReportLayoutList.SetRange("Report ID", Report::"Standard Sales - Pro Forma Inv");
+        ReportLayoutList.SetRange("Name", ProformaReportLayoutNameTok);
+        ReportLayoutList.SetRange("Application ID", AppInfo.Id);
+        exit(ReportLayoutList.FindFirst());
+    end;
+
+    local procedure SetDefaultReportLayout(ReportLayoutList: Record "Report Layout List")
+    var
+        ReportLayoutSelection: Record "Report Layout Selection";
+    begin
+        // Add to TenantReportLayoutSelection table with an Empty Guid.
+        AddLayoutSelection(ReportLayoutList);
+
+        // Add to the report layout selection table
+        if ReportLayoutSelection.Get(ReportLayoutList."Report ID", CompanyName()) then begin
+            ReportLayoutSelection.Type := GetReportLayoutSelectionCorrespondingEnum(ReportLayoutList);
+            ReportLayoutSelection.Modify(false);
+        end else begin
+            ReportLayoutSelection."Report ID" := ReportLayoutList."Report ID";
+            ReportLayoutSelection."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(ReportLayoutSelection."Company Name"));
+            ReportLayoutSelection."Custom Report Layout Code" := '';
+            ReportLayoutSelection.Type := GetReportLayoutSelectionCorrespondingEnum(ReportLayoutList);
+            ReportLayoutSelection.Insert(false);
+        end;
+    end;
+
+    local procedure AddLayoutSelection(ReportLayoutList: Record "Report Layout List"): Boolean
+    var
+        TenantReportLayoutSelection: Record "Tenant Report Layout Selection";
+        EmptyGuid: Guid;
+    begin
+        TenantReportLayoutSelection.Init();
+        TenantReportLayoutSelection."App ID" := ReportLayoutList."Application ID";
+        TenantReportLayoutSelection."Company Name" := CopyStr(CompanyName(), 1, MaxStrLen(TenantReportLayoutSelection."Company Name"));
+        TenantReportLayoutSelection."Layout Name" := ReportLayoutList."Name";
+        TenantReportLayoutSelection."Report ID" := ReportLayoutList."Report ID";
+        TenantReportLayoutSelection."User ID" := EmptyGuid;
+
+        if not TenantReportLayoutSelection.Insert(false) then
+            TenantReportLayoutSelection.Modify(false);
+    end;
+
+    local procedure GetReportLayoutSelectionCorrespondingEnum(SelectedReportLayoutList: Record "Report Layout List"): Integer
+    begin
+        case SelectedReportLayoutList."Layout Format" of
+            SelectedReportLayoutList."Layout Format"::RDLC:
+                exit(0);
+            SelectedReportLayoutList."Layout Format"::Word:
+                exit(1);
+            SelectedReportLayoutList."Layout Format"::Excel:
+                exit(3);
+            SelectedReportLayoutList."Layout Format"::Custom:
+                exit(4);
+        end
+    end;
 
     local procedure InsertRepSelection(ReportUsage: Enum "Report Selection Usage"; Sequence: Code[10];
                                                         ReportID: Integer)

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeTagDefinitionsCZL.Codeunit.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/Codeunits/UpgradeTagDefinitionsCZL.Codeunit.al
@@ -50,6 +50,7 @@ codeunit 31016 "Upgrade Tag Definitions CZL"
         PerCompanyUpgradeTags.Add(GetUseW1RegistrationNumberFromSalesDocUpgradeTag());
         PerCompanyUpgradeTags.Add(GetUseVATReturnPeriodInsteadOfVATPeriodUpgradeTag());
         PerCompanyUpgradeTags.Add(GetOriginalVATAmountsACYInVATEntriesUpgradeTag());
+        PerCompanyUpgradeTags.Add(GetChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag());
     end;
 
     procedure GetDataVersion174PerDatabaseUpgradeTag(): Code[250]
@@ -222,5 +223,10 @@ codeunit 31016 "Upgrade Tag Definitions CZL"
     procedure GetOriginalVATAmountsACYInVATEntriesUpgradeTag(): Code[250]
     begin
         exit('CZL-616614-OriginalVATAmountsACYInVATEntriesTag-20251217');
+    end;
+
+    procedure GetChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag(): Code[250]
+    begin
+        exit('CZL-640925-ChangeDefaultDraftInvoiceAndProformaReportLayoutsUpgradeTag-20260908');
     end;
 }

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/ReportExtensions/StdSalesProFormaInv.rdl
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/ReportExtensions/StdSalesProFormaInv.rdl
@@ -2646,16 +2646,13 @@ Cstr(Fields!PageLbl.Value)</Value>
                               <TablixBody>
                                 <TablixColumns>
                                   <TablixColumn>
-                                    <Width>1.73536cm</Width>
+                                    <Width>4.41919cm</Width>
                                   </TablixColumn>
                                   <TablixColumn>
-                                    <Width>3.44564cm</Width>
+                                    <Width>1.49243cm</Width>
                                   </TablixColumn>
                                   <TablixColumn>
-                                    <Width>1.27273cm</Width>
-                                  </TablixColumn>
-                                  <TablixColumn>
-                                    <Width>1.6364cm</Width>
+                                    <Width>1.78163cm</Width>
                                   </TablixColumn>
                                   <TablixColumn>
                                     <Width>1.63715cm</Width>
@@ -2667,7 +2664,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                     <Width>2.45453cm</Width>
                                   </TablixColumn>
                                   <TablixColumn>
-                                    <Width>1.45454cm</Width>
+                                    <Width>1.85142cm</Width>
                                   </TablixColumn>
                                   <TablixColumn>
                                     <Width>0.95454cm</Width>
@@ -2680,47 +2677,6 @@ Cstr(Fields!PageLbl.Value)</Value>
                                   <TablixRow>
                                     <Height>0.17717in</Height>
                                     <TablixCells>
-                                      <TablixCell>
-                                        <CellContents>
-                                          <Textbox Name="No_SalesInvoiceLineCaption">
-                                            <CanGrow>true</CanGrow>
-                                            <KeepTogether>true</KeepTogether>
-                                            <Paragraphs>
-                                              <Paragraph>
-                                                <TextRuns>
-                                                  <TextRun>
-                                                    <Value>=Fields!ItemNoCaption_CZL.Value</Value>
-                                                    <Style>
-                                                      <FontSize>9pt</FontSize>
-                                                      <FontWeight>Bold</FontWeight>
-                                                    </Style>
-                                                  </TextRun>
-                                                </TextRuns>
-                                                <Style>
-                                                  <TextAlign>Left</TextAlign>
-                                                </Style>
-                                              </Paragraph>
-                                            </Paragraphs>
-                                            <Style>
-                                              <Border>
-                                                <Style>None</Style>
-                                                <Width>0.5pt</Width>
-                                              </Border>
-                                              <TopBorder>
-                                                <Style>Solid</Style>
-                                              </TopBorder>
-                                              <BottomBorder>
-                                                <Style>Solid</Style>
-                                              </BottomBorder>
-                                              <VerticalAlign>Bottom</VerticalAlign>
-                                              <PaddingLeft>2pt</PaddingLeft>
-                                              <PaddingRight>2pt</PaddingRight>
-                                              <PaddingTop>2pt</PaddingTop>
-                                              <PaddingBottom>2pt</PaddingBottom>
-                                            </Style>
-                                          </Textbox>
-                                        </CellContents>
-                                      </TablixCell>
                                       <TablixCell>
                                         <CellContents>
                                           <Textbox Name="Description_SalesInvoiceLineCaption">
@@ -3091,38 +3047,6 @@ Cstr(Fields!PageLbl.Value)</Value>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
-                                          <Textbox Name="Textbox9">
-                                            <CanGrow>true</CanGrow>
-                                            <KeepTogether>true</KeepTogether>
-                                            <Paragraphs>
-                                              <Paragraph>
-                                                <TextRuns>
-                                                  <TextRun>
-                                                    <Value />
-                                                    <Style>
-                                                      <FontSize>9pt</FontSize>
-                                                    </Style>
-                                                  </TextRun>
-                                                </TextRuns>
-                                                <Style />
-                                              </Paragraph>
-                                            </Paragraphs>
-                                            <rd:DefaultName>Textbox9</rd:DefaultName>
-                                            <Style>
-                                              <Border>
-                                                <Color>LightGrey</Color>
-                                                <Style>None</Style>
-                                              </Border>
-                                              <PaddingLeft>2pt</PaddingLeft>
-                                              <PaddingRight>2pt</PaddingRight>
-                                              <PaddingTop>2pt</PaddingTop>
-                                              <PaddingBottom>2pt</PaddingBottom>
-                                            </Style>
-                                          </Textbox>
-                                        </CellContents>
-                                      </TablixCell>
-                                      <TablixCell>
-                                        <CellContents>
                                           <Textbox Name="Description_SalesInvoiceLine1">
                                             <CanGrow>true</CanGrow>
                                             <KeepTogether>true</KeepTogether>
@@ -3167,38 +3091,6 @@ Cstr(Fields!PageLbl.Value)</Value>
                                   <TablixRow>
                                     <Height>0.17717in</Height>
                                     <TablixCells>
-                                      <TablixCell>
-                                        <CellContents>
-                                          <Textbox Name="No_SalesInvoiceLine">
-                                            <CanGrow>true</CanGrow>
-                                            <KeepTogether>true</KeepTogether>
-                                            <Paragraphs>
-                                              <Paragraph>
-                                                <TextRuns>
-                                                  <TextRun>
-                                                    <Value>=IIf(Fields!Type_Line_CZL.Value = "0", "", Fields!ItemNo_Line_CZL.Value)</Value>
-                                                    <Style>
-                                                      <FontSize>9pt</FontSize>
-                                                    </Style>
-                                                  </TextRun>
-                                                </TextRuns>
-                                                <Style />
-                                              </Paragraph>
-                                            </Paragraphs>
-                                            <rd:DefaultName>No_SalesInvoiceLine</rd:DefaultName>
-                                            <Style>
-                                              <Border>
-                                                <Color>LightGrey</Color>
-                                                <Style>None</Style>
-                                              </Border>
-                                              <PaddingLeft>2pt</PaddingLeft>
-                                              <PaddingRight>2pt</PaddingRight>
-                                              <PaddingTop>2pt</PaddingTop>
-                                              <PaddingBottom>2pt</PaddingBottom>
-                                            </Style>
-                                          </Textbox>
-                                        </CellContents>
-                                      </TablixCell>
                                       <TablixCell>
                                         <CellContents>
                                           <Textbox Name="Description_SalesInvoiceLine">
@@ -3503,7 +3395,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
-                                          <Textbox Name="Textbox14">
+                                          <Textbox Name="Textbox5">
                                             <CanGrow>true</CanGrow>
                                             <KeepTogether>true</KeepTogether>
                                             <Paragraphs>
@@ -3520,7 +3412,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                                 <Style />
                                               </Paragraph>
                                             </Paragraphs>
-                                            <rd:DefaultName>Textbox14</rd:DefaultName>
+                                            <rd:DefaultName>Textbox5</rd:DefaultName>
                                             <Style>
                                               <Border>
                                                 <Color>LightGrey</Color>
@@ -3532,13 +3424,107 @@ Cstr(Fields!PageLbl.Value)</Value>
                                               <PaddingBottom>2pt</PaddingBottom>
                                             </Style>
                                           </Textbox>
-                                          <ColSpan>5</ColSpan>
                                         </CellContents>
                                       </TablixCell>
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox6">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Bold</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox6</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox7">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Bold</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox7</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox8">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Bold</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox8</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
                                       <TablixCell>
                                         <CellContents>
                                           <Textbox Name="TotalWeightLbl">
@@ -3624,7 +3610,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
-                                          <Textbox Name="Textbox34">
+                                          <Textbox Name="Textbox10">
                                             <CanGrow>true</CanGrow>
                                             <KeepTogether>true</KeepTogether>
                                             <Paragraphs>
@@ -3641,7 +3627,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                                 <Style />
                                               </Paragraph>
                                             </Paragraphs>
-                                            <rd:DefaultName>Textbox34</rd:DefaultName>
+                                            <rd:DefaultName>Textbox10</rd:DefaultName>
                                             <Style>
                                               <Border>
                                                 <Color>LightGrey</Color>
@@ -3653,13 +3639,107 @@ Cstr(Fields!PageLbl.Value)</Value>
                                               <PaddingBottom>2pt</PaddingBottom>
                                             </Style>
                                           </Textbox>
-                                          <ColSpan>5</ColSpan>
                                         </CellContents>
                                       </TablixCell>
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox12">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Bold</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox12</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox18">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Bold</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox18</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox19">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Bold</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox19</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
                                       <TablixCell>
                                         <CellContents>
                                           <Textbox Name="TotalAmountLbl">
@@ -3746,7 +3826,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
-                                          <Textbox Name="Textbox2">
+                                          <Textbox Name="Textbox20">
                                             <CanGrow>true</CanGrow>
                                             <KeepTogether>true</KeepTogether>
                                             <Paragraphs>
@@ -3762,7 +3842,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                                 <Style />
                                               </Paragraph>
                                             </Paragraphs>
-                                            <rd:DefaultName>Textbox2</rd:DefaultName>
+                                            <rd:DefaultName>Textbox20</rd:DefaultName>
                                             <Style>
                                               <Border>
                                                 <Color>LightGrey</Color>
@@ -3774,13 +3854,104 @@ Cstr(Fields!PageLbl.Value)</Value>
                                               <PaddingBottom>2pt</PaddingBottom>
                                             </Style>
                                           </Textbox>
-                                          <ColSpan>5</ColSpan>
                                         </CellContents>
                                       </TablixCell>
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox21">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox21</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox22">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox22</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox23">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox23</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
                                       <TablixCell>
                                         <CellContents>
                                           <Textbox Name="TotalVATAmountLbl">
@@ -3857,7 +4028,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                     <TablixCells>
                                       <TablixCell>
                                         <CellContents>
-                                          <Textbox Name="Textbox24">
+                                          <Textbox Name="Textbox25">
                                             <CanGrow>true</CanGrow>
                                             <KeepTogether>true</KeepTogether>
                                             <Paragraphs>
@@ -3874,7 +4045,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                                 <Style />
                                               </Paragraph>
                                             </Paragraphs>
-                                            <rd:DefaultName>Textbox24</rd:DefaultName>
+                                            <rd:DefaultName>Textbox25</rd:DefaultName>
                                             <Style>
                                               <Border>
                                                 <Color>LightGrey</Color>
@@ -3886,13 +4057,107 @@ Cstr(Fields!PageLbl.Value)</Value>
                                               <PaddingBottom>2pt</PaddingBottom>
                                             </Style>
                                           </Textbox>
-                                          <ColSpan>5</ColSpan>
                                         </CellContents>
                                       </TablixCell>
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
-                                      <TablixCell />
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox26">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Normal</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox26</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox27">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Normal</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox27</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
+                                      <TablixCell>
+                                        <CellContents>
+                                          <Textbox Name="Textbox28">
+                                            <CanGrow>true</CanGrow>
+                                            <KeepTogether>true</KeepTogether>
+                                            <Paragraphs>
+                                              <Paragraph>
+                                                <TextRuns>
+                                                  <TextRun>
+                                                    <Value />
+                                                    <Style>
+                                                      <FontSize>9pt</FontSize>
+                                                      <FontWeight>Normal</FontWeight>
+                                                    </Style>
+                                                  </TextRun>
+                                                </TextRuns>
+                                                <Style />
+                                              </Paragraph>
+                                            </Paragraphs>
+                                            <rd:DefaultName>Textbox28</rd:DefaultName>
+                                            <Style>
+                                              <Border>
+                                                <Color>LightGrey</Color>
+                                                <Style>None</Style>
+                                              </Border>
+                                              <PaddingLeft>2pt</PaddingLeft>
+                                              <PaddingRight>2pt</PaddingRight>
+                                              <PaddingTop>2pt</PaddingTop>
+                                              <PaddingBottom>2pt</PaddingBottom>
+                                            </Style>
+                                          </Textbox>
+                                        </CellContents>
+                                      </TablixCell>
                                       <TablixCell>
                                         <CellContents>
                                           <Textbox Name="TotalAmountInclVATLbl">
@@ -3978,7 +4243,6 @@ Cstr(Fields!PageLbl.Value)</Value>
                               </TablixBody>
                               <TablixColumnHierarchy>
                                 <TablixMembers>
-                                  <TablixMember />
                                   <TablixMember />
                                   <TablixMember />
                                   <TablixMember />
@@ -4592,7 +4856,7 @@ Cstr(Fields!PageLbl.Value)</Value>
                                               <Paragraph>
                                                 <TextRuns>
                                                   <TextRun>
-                                                    <Value>=StrConv(Fields!TotalAmountInclVATLbl.Value, VbStrConv.ProperCase)</Value>
+                                                    <Value>=StrConv(Fields!TotalLbl_CZL.Value, VbStrConv.ProperCase)</Value>
                                                     <Style>
                                                       <FontSize>9pt</FontSize>
                                                       <FontWeight>Bold</FontWeight>
@@ -5864,6 +6128,9 @@ End Function</Code>
         </Field>
         <Field Name="VATBaseLbl_CZL">
           <DataField>VATBaseLbl_CZL</DataField>
+        </Field>
+        <Field Name="TotalLbl_CZL">
+          <DataField>TotalLbl_CZL</DataField>
         </Field>
         <Field Name="PmntSymbol1_CZL">
           <DataField>PmntSymbol1_CZL</DataField>

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/ReportExtensions/StdSalesProFormaInvCZL.ReportExt.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/ReportExtensions/StdSalesProFormaInvCZL.ReportExt.al
@@ -13,7 +13,6 @@ using Microsoft.Foundation.Address;
 using Microsoft.Foundation.AuditCodes;
 using Microsoft.Foundation.PaymentTerms;
 using Microsoft.HumanResources.Employee;
-using Microsoft.Sales.Posting;
 using Microsoft.Sales.Setup;
 using Microsoft.Utilities;
 using System.Security.User;
@@ -375,16 +374,22 @@ reportextension 11708 "Std. Sales - Pro Forma Inv CZL" extends "Standard Sales -
 
     local procedure CalcVATAmountLinesCZL(SalesHeader: Record "Sales Header")
     var
+        SalesLine: Record "Sales Line";
         TempSalesLine: Record "Sales Line" temporary;
-        SalesPost: Codeunit "Sales-Post";
     begin
         VATAmountLineCZL.DeleteAll();
-        TempSalesLine.DeleteAll();
-        SalesPost.GetSalesLines(SalesHeader, TempSalesLine, 0, false);
-        TempSalesLine.SetFilter(Type, '<>%1', TempSalesLine.Type::Item);
-        TempSalesLine.DeleteAll(false);
+
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.SetRange(Type, SalesLine.Type::Item);
+        if SalesLine.FindSet() then
+            repeat
+                TempSalesLine.Init();
+                TempSalesLine := SalesLine;
+                TempSalesLine.Insert(false);
+            until SalesLine.Next() = 0;
+
         TempSalesLine.CalcVATAmountLines(0, SalesHeader, TempSalesLine, VATAmountLineCZL);
-        TempSalesLine.UpdateVATOnLines(0, SalesHeader, TempSalesLine, VATAmountLineCZL);
     end;
 
     local procedure FormatShipToAddressCZL(SalesHeader: Record "Sales Header")

--- a/src/Apps/CZ/CoreLocalizationPack/app/Src/ReportExtensions/StdSalesProFormaInvCZL.ReportExt.al
+++ b/src/Apps/CZ/CoreLocalizationPack/app/Src/ReportExtensions/StdSalesProFormaInvCZL.ReportExt.al
@@ -13,6 +13,7 @@ using Microsoft.Foundation.Address;
 using Microsoft.Foundation.AuditCodes;
 using Microsoft.Foundation.PaymentTerms;
 using Microsoft.HumanResources.Employee;
+using Microsoft.Sales.Posting;
 using Microsoft.Sales.Setup;
 using Microsoft.Utilities;
 using System.Security.User;
@@ -85,6 +86,9 @@ reportextension 11708 "Std. Sales - Pro Forma Inv CZL" extends "Standard Sales -
             {
             }
             column(VATBaseLbl_CZL; VATBaseLbl)
+            {
+            }
+            column(TotalLbl_CZL; TotalLbl)
             {
             }
             column(PmntSymbol1_CZL; PaymentSymbolLabelCZL[1])
@@ -235,6 +239,7 @@ reportextension 11708 "Std. Sales - Pro Forma Inv CZL" extends "Standard Sales -
             {
                 DataItemTableView = sorting("VAT Identifier", "VAT Calculation Type", "Tax Group Code", "Use Tax", Positive);
                 UseTemporary = true;
+
                 column(VATIdentifier_VatAmountLine_CZL; "VAT Identifier")
                 {
                 }
@@ -339,6 +344,7 @@ reportextension 11708 "Std. Sales - Pro Forma Inv CZL" extends "Standard Sales -
         PaymentMethodLbl: Label 'Payment Method';
         DocumentNoLbl: Label 'No.';
         VATBaseLbl: Label 'VAT Base';
+        TotalLbl: Label 'Total';
 
     local procedure FormatDocumentFieldsCZL(SalesHeader: Record "Sales Header")
     var
@@ -369,12 +375,16 @@ reportextension 11708 "Std. Sales - Pro Forma Inv CZL" extends "Standard Sales -
 
     local procedure CalcVATAmountLinesCZL(SalesHeader: Record "Sales Header")
     var
-        SalesLine: Record "Sales Line";
+        TempSalesLine: Record "Sales Line" temporary;
+        SalesPost: Codeunit "Sales-Post";
     begin
         VATAmountLineCZL.DeleteAll();
-        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
-        SalesLine.SetRange("Document No.", SalesHeader."No.");
-        SalesLine.CalcVATAmountLines(0, SalesHeader, SalesLine, VATAmountLineCZL);
+        TempSalesLine.DeleteAll();
+        SalesPost.GetSalesLines(SalesHeader, TempSalesLine, 0, false);
+        TempSalesLine.SetFilter(Type, '<>%1', TempSalesLine.Type::Item);
+        TempSalesLine.DeleteAll(false);
+        TempSalesLine.CalcVATAmountLines(0, SalesHeader, TempSalesLine, VATAmountLineCZL);
+        TempSalesLine.UpdateVATOnLines(0, SalesHeader, TempSalesLine, VATAmountLineCZL);
     end;
 
     local procedure FormatShipToAddressCZL(SalesHeader: Record "Sales Header")


### PR DESCRIPTION
## What & why

Updates the Czech localization (CZL) Draft Invoice and Pro Forma Invoice report layouts and adds an upgrade procedure to automatically set the CZ-specific RDL layouts as default during upgrade. Fixes the VAT calculation logic in the Pro Forma Invoice report extension to use `SalesPost.GetSalesLines` with temporary records (filtering out non-Item line types and calling `UpdateVATOnLines`) instead of directly querying `Sales Line`, which ensures correct VAT amounts. Also adds a `TotalLbl` column to the Pro Forma Invoice layout and updates the RDL template to include new fields and improve alignment.

## Linked work

Fixes [AB#640925](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640925)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Core Localization Pack for Czech app locally using `Publish.ps1`; build succeeded with no new analyzer warnings.
- Verified the upgraded RDL layout renders correctly for the Standard Sales - Pro Forma Invoice report with all new columns (TotalLbl, VATIdentifier, etc.) properly aligned.
- Confirmed the upgrade codeunit correctly sets the CZ-specific report layout as default when the current default is unmodified (matches metadata default or is empty), and skips when a custom layout is already selected.
- No new tests added — the upgrade logic follows the established pattern used by other layout upgrade procedures in this codeunit, and the RDL/layout changes are visual and validated manually.

## Risk & compatibility

- The upgrade procedure modifies `Report Layout Selection` and `Tenant Report Layout Selection` tables. It only overrides the default layout when no custom selection has been made (the current selection is empty or matches the metadata default), so existing customizations are preserved.
- New `tabledata` permissions added for `"Report Layout Selection"` (im) and `"Tenant Report Layout Selection"` (im) in the upgrade codeunit.
- The VAT calculation change in `CalcVATAmountLinesCZL` filters out non-Item line types, which changes the VAT breakdown on the Pro Forma Invoice report — this is intentional to match the correct behavior.











