### PR TITLE
Fix 647571: remove superseded VATVIESDeclarationTaxAuthReport test fr…

### DIFF
--- a/src/DisabledTests/Tests-Local/Tests-Local.DisabledTest.json
+++ b/src/DisabledTests/Tests-Local/Tests-Local.DisabledTest.json
@@ -7045,11 +7045,6 @@
     "method": "VATStatementTotal"
   },
   {
-    "codeunitId": 144010,
-    "codeunitName": "Company Field Report Test",
-    "method": "VATVIESDeclarationTaxAuthReport"
-  },
-  {
     "codeunitId": 144011,
     "codeunitName": "SEPADD08 IntegrationTest - BE",
     "method": "CreateGenJnlErrBalAccNo"

--- a/src/Layers/FI/Tests/Local/CompanyFieldReportTest.Codeunit.al
+++ b/src/Layers/FI/Tests/Local/CompanyFieldReportTest.Codeunit.al
@@ -177,11 +177,6 @@ codeunit 144010 "Company Field Report Test"
                         LibraryReportDataset.GetElementValueInCurrentRow('CompanyInfoBusinessIdCode', CompanyInfoBusinessIdCode);
                         LibraryReportDataset.GetElementValueInCurrentRow('CompanyInfoegHomeCity', CompanyInfoRegHomeCity);
                     end;
-                3:
-                    begin
-                        LibraryReportDataset.GetElementValueInCurrentRow('CompanyInfoBusinessIdentityCode', CompanyInfoBusinessIdCode);
-                        LibraryReportDataset.GetElementValueInCurrentRow('CompanyInfoRegisteredHomeCity', CompanyInfoRegHomeCity);
-                    end;
                 4:
                     begin
                         LibraryReportDataset.GetElementValueInCurrentRow('CompanyInfoBusinessIDCode', CompanyInfoBusinessIdCode);
@@ -199,29 +194,6 @@ codeunit 144010 "Company Field Report Test"
     begin
         Reply := false;
     end;
-
-    [RequestPageHandler]
-    [Scope('OnPrem')]
-    procedure VATVIESDeclarationTaxAuthReportHandler(var VATVIESDeclarationTaxAuthReport: TestRequestPage "VAT- VIES Declaration Tax Auth")
-    begin
-        VATVIESDeclarationTaxAuthReport.SaveAsXml(LibraryReportDataset.GetParametersFileName(), LibraryReportDataset.GetFileName());
-    end;
-
-    [Test]
-    [HandlerFunctions('VATVIESDeclarationTaxAuthReportHandler')]
-    [Scope('OnPrem')]
-    procedure VATVIESDeclarationTaxAuthReport()
-    var
-        VATVIESDeclarationTaxAuthReport: Report "VAT- VIES Declaration Tax Auth";
-    begin
-        Initialize();
-
-        VATVIESDeclarationTaxAuthReport.UseRequestPage(true);
-        VATVIESDeclarationTaxAuthReport.InitializeRequest(true, WorkDate(), WorkDate() + 365, '');
-        VATVIESDeclarationTaxAuthReport.Run();
-        TestBusinessIdentityandHomeCity(3);
-    end;
-
 
     [RequestPageHandler]
     [Scope('OnPrem')]


### PR DESCRIPTION
## What & why

During the BCApps uptake the VAT VIES Declaration Tax Auth report was changed so the Finnish company fields (Business Identity Code, Registered Home City) are only emitted when the FI Core VIES declaration feature is enabled. Codeunit 144010 is obsolete (ObsoleteState Pending, reason "Moved to the FI Core app", wrapped in `#if not CLEAN29`) and its old test never enables that feature, so the report now returns an empty Business Identity Code and the assertion fails. This is a stale test versus intentional new behaviour, not a product regression.

The scenario is already fully covered in the new FI Core app codeunit 148150 by two tests: CompanyFieldsInVATVIESDeclaration (feature enabled, fields present) and CompanyFieldsNotInVATVIESDeclarationWhenFeatureDisabled (feature disabled, fields empty). Patching the obsolete copy would be wasted effort on code already scheduled for removal, so the stale test is removed instead.

The change deletes the obsolete VATVIESDeclarationTaxAuthReport test and its VATVIESDeclarationTaxAuthReportHandler, removes the now unused case 3 branch in TestBusinessIdentityandHomeCity, and drops the matching entry from Tests-Local.DisabledTest.json. No remaining references, so it compiles cleanly.

## Linked work

Fixes [AB#647571](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647571)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

## Risk & compatibility

Test only. Removes a stale, obsolete test; no product code, schema, permissions, telemetry or upgrade impact.

