### PR TITLE
[Probe] Census nine disabled analyzer rules

### DIFF
--- a/src/rulesets/base.ruleset.json
+++ b/src/rulesets/base.ruleset.json
@@ -11,7 +11,7 @@
   "rules": [
     {
       "id": "PTE0020",
-      "action": "None",
+      "action": "Warning",
       "justification": "The application app shouldn't point at itself."
     },
     {
@@ -21,7 +21,7 @@
     },
     {
       "id": "AL0432",
-      "action": "None",
+      "action": "Warning",
       "justification": "Use pragma to remove obsolete warning."
     },
     {
@@ -30,7 +30,7 @@
     },
     {
       "id": "AL0605",
-      "action": "None",
+      "action": "Warning",
       "justification": "Use of implicit 'with' will be removed in the future. Qualify with 'Rec'."
     },
     {
@@ -40,7 +40,7 @@
     },
     {
       "id": "AL0684",
-      "action": "None",
+      "action": "Warning",
       "justification": "The permissionset contains permissionsets or permission for objects from other module. Permissions on objects from other modules will be ignored."
     },
     {
@@ -59,7 +59,7 @@
     },
     {
       "id": "AS0112",
-      "action": "None",
+      "action": "Warning",
       "justification": "Permission set extensions that include permission sets covering objects from another application. Needs a permission set redesign to fix."
     },
     {
@@ -198,7 +198,7 @@
     },
     {
       "id": "AA0219",
-      "action": "Hidden",
+      "action": "Warning",
       "justification": "TBD Bug: fails for actions. The Tooltip property of Fields must start with 'Specifies'. Set to None because setting it to warning will fail RunCodeCopBaseApplication_XX"
     },
     {
@@ -257,7 +257,7 @@
     },
     {
       "id": "AA0473",
-      "action": "None",
+      "action": "Warning",
       "justification": "AutoformatType should be defined for decimal fields in Table objects to ensure proper formatting behavior."
     },
     {
@@ -277,7 +277,7 @@
     },
     {
       "id": "PTE0002",
-      "action": "None",
+      "action": "Warning",
       "justification": "Field ID must be within the range '[50000..99999]'."
     },
     {
@@ -338,7 +338,7 @@
     },
     {
       "id": "AA0241",
-      "action": "None"
+      "action": "Warning"
     }
   ]
 }


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE.** This is a temporary diagnostic probe and must be closed after its results are captured.

Links [AB#640773](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/640773).

This probe changes only the nine disabled analyzer-rule actions in `src/rulesets/base.ruleset.json` to `Warning`. It intentionally surfaces current-compiler diagnostics in the `Pull Request Build` BuildOutput for both **Clean** and **Default** build modes.

The newly surfaced warnings may cause `failOn: newWarning` checks or build-matrix legs to fail. Those failures are expected diagnostic output, not a production regression.

No AL, app, manifest, pragma, test, or other production source behavior changes are included. The probe will remain draft, will not use auto-merge, and will be closed after the census results are captured.