### PR TITLE
Fix duplicate retention continuations for Waiting jobs

### DIFF
--- a/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
@@ -58,36 +58,43 @@ codeunit 3997 "Retention Policy JQ"
             exit;
         end;
 
-        RetentionPolicyLog.LogInfo(RetentionPolicyLogCategory::"Retention Policy - Schedule", RescheduleOnLimitExceededLbl);
-
-        ScheduleContinuation();
+        if ScheduleContinuation() then
+            RetentionPolicyLog.LogInfo(RetentionPolicyLogCategory::"Retention Policy - Schedule", RescheduleOnLimitExceededLbl);
         Handled := true;
     end;
 
-    internal procedure ScheduleContinuation()
+    internal procedure ScheduleContinuation(): Boolean
     var
         JobQueueEntry: Record "Job Queue Entry";
     begin
         JobQueueEntry.ReadIsolation(IsolationLevel::ReadCommitted);
         JobQueueEntry.SetRange("Object ID to Run", Codeunit::"Retention Policy JQ");
         JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
-        JobQueueEntry.SetFilter(Status, '%1|%2|%3', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold", JobQueueEntry.Status::Waiting);
-        if JobQueueEntry.FindFirst() then begin
-            // The dispatcher activates Waiting entries when their category is available.
-            if JobQueueEntry.Status = JobQueueEntry.Status::Waiting then
-                exit;
+        // The dispatcher activates Waiting entries when their category is available.
+        JobQueueEntry.SetRange(Status, JobQueueEntry.Status::Waiting);
+        if JobQueueEntry.FindFirst() then
+            exit(false);
 
-            JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
-            if JobQueueEntry.FindFirst() then begin
-                if JobQueueEntry.Status <> JobQueueEntry.Status::Waiting then
-                    JobQueueEntry.Restart();
-                exit;
-            end;
+        JobQueueEntry.SetFilter(Status, '%1|%2', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold");
+        JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
+        if JobQueueEntry.FindFirst() then begin
+            if not (JobQueueEntry.Status in [JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold"]) then
+                exit(false);
+
+            JobQueueEntry.Restart();
+            exit(true);
         end;
 
-        // Clear any primary key retained from a match that disappeared before the locked re-read.
+        // A restartable entry may have become Waiting before the locked lookup.
+        JobQueueEntry.ReadIsolation(IsolationLevel::ReadCommitted);
+        JobQueueEntry.SetRange(Status, JobQueueEntry.Status::Waiting);
+        if JobQueueEntry.FindFirst() then
+            exit(false);
+
+        // Enqueue inserts only when no primary key is retained from a previous lookup.
         Clear(JobQueueEntry);
         JobQueueEntry.ScheduleJobQueueEntryForLater(Codeunit::"Retention Policy JQ", CurrentDateTime(), JobQueueCategoryTok, '');
+        exit(true);
     end;
 
     internal procedure SetSessionId(SessionId: Integer)

--- a/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
@@ -36,7 +36,6 @@ codeunit 3997 "Retention Policy JQ"
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Apply Retention Policy", 'OnApplyRetentionPolicyRecordLimitExceeded', '', true, true)]
     local procedure ScheduleJobQueueEntryOnApplyRetentionPolicyRecordLimitExceeded(ApplyAllRetentionPolicies: Boolean; UserInvokedRun: Boolean; var Handled: Boolean)
     var
-        JobQueueEntry: Record "Job Queue Entry";
         RetentionPolicyLog: Codeunit "Retention Policy Log";
     begin
         if Handled then begin
@@ -61,18 +60,27 @@ codeunit 3997 "Retention Policy JQ"
 
         RetentionPolicyLog.LogInfo(RetentionPolicyLogCategory::"Retention Policy - Schedule", RescheduleOnLimitExceededLbl);
 
+        ScheduleContinuation();
+        Handled := true;
+    end;
+
+    internal procedure ScheduleContinuation()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
         JobQueueEntry.ReadIsolation(IsolationLevel::ReadCommitted);
         JobQueueEntry.SetRange("Object ID to Run", Codeunit::"Retention Policy JQ");
         JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
-        JobQueueEntry.SetFilter(Status, '%1|%2', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold");
+        JobQueueEntry.SetFilter(Status, '%1|%2|%3', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold", JobQueueEntry.Status::Waiting);
         if JobQueueEntry.IsEmpty() then
             JobQueueEntry.ScheduleJobQueueEntryForLater(Codeunit::"Retention Policy JQ", CurrentDateTime(), JobQueueCategoryTok, '')
         else begin
             JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
             JobQueueEntry.FindFirst();
-            JobQueueEntry.Restart();
+            // The dispatcher activates Waiting entries when their category is available.
+            if JobQueueEntry.Status <> JobQueueEntry.Status::Waiting then
+                JobQueueEntry.Restart();
         end;
-        Handled := true;
     end;
 
     internal procedure SetSessionId(SessionId: Integer)

--- a/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
@@ -68,16 +68,26 @@ codeunit 3997 "Retention Policy JQ"
     var
         JobQueueEntry: Record "Job Queue Entry";
     begin
-        JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
+        JobQueueEntry.ReadIsolation(IsolationLevel::ReadCommitted);
         JobQueueEntry.SetRange("Object ID to Run", Codeunit::"Retention Policy JQ");
         JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
         JobQueueEntry.SetFilter(Status, '%1|%2|%3', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold", JobQueueEntry.Status::Waiting);
-        if not JobQueueEntry.FindFirst() then
-            JobQueueEntry.ScheduleJobQueueEntryForLater(Codeunit::"Retention Policy JQ", CurrentDateTime(), JobQueueCategoryTok, '')
-        else
+        if JobQueueEntry.FindFirst() then begin
             // The dispatcher activates Waiting entries when their category is available.
-            if JobQueueEntry.Status <> JobQueueEntry.Status::Waiting then
-                JobQueueEntry.Restart();
+            if JobQueueEntry.Status = JobQueueEntry.Status::Waiting then
+                exit;
+
+            JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
+            if JobQueueEntry.FindFirst() then begin
+                if JobQueueEntry.Status <> JobQueueEntry.Status::Waiting then
+                    JobQueueEntry.Restart();
+                exit;
+            end;
+        end;
+
+        // Clear any primary key retained from a match that disappeared before the locked re-read.
+        Clear(JobQueueEntry);
+        JobQueueEntry.ScheduleJobQueueEntryForLater(Codeunit::"Retention Policy JQ", CurrentDateTime(), JobQueueCategoryTok, '');
     end;
 
     internal procedure SetSessionId(SessionId: Integer)

--- a/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/RetentionPolicy/RetentionPolicyJQ.Codeunit.al
@@ -68,19 +68,16 @@ codeunit 3997 "Retention Policy JQ"
     var
         JobQueueEntry: Record "Job Queue Entry";
     begin
-        JobQueueEntry.ReadIsolation(IsolationLevel::ReadCommitted);
+        JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
         JobQueueEntry.SetRange("Object ID to Run", Codeunit::"Retention Policy JQ");
         JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
         JobQueueEntry.SetFilter(Status, '%1|%2|%3', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold", JobQueueEntry.Status::Waiting);
-        if JobQueueEntry.IsEmpty() then
+        if not JobQueueEntry.FindFirst() then
             JobQueueEntry.ScheduleJobQueueEntryForLater(Codeunit::"Retention Policy JQ", CurrentDateTime(), JobQueueCategoryTok, '')
-        else begin
-            JobQueueEntry.ReadIsolation(IsolationLevel::UpdLock);
-            JobQueueEntry.FindFirst();
+        else
             // The dispatcher activates Waiting entries when their category is available.
             if JobQueueEntry.Status <> JobQueueEntry.Status::Waiting then
                 JobQueueEntry.Restart();
-        end;
     end;
 
     internal procedure SetSessionId(SessionId: Integer)

--- a/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
@@ -766,8 +766,8 @@ codeunit 139018 "Job Queue Entry Tests"
         ExpectedJobQueueEntry := WaitingJobQueueEntry;
 
         BindSubscription(this);
-        RetentionPolicyJQ.ScheduleContinuation();
-        RetentionPolicyJQ.ScheduleContinuation();
+        Assert.IsFalse(RetentionPolicyJQ.ScheduleContinuation(), 'Preserving a Waiting job must not report scheduling.');
+        Assert.IsFalse(RetentionPolicyJQ.ScheduleContinuation(), 'Preserving a Waiting job must not report scheduling.');
         UnbindSubscription(this);
 
         Assert.AreEqual(2, JobQueueEntry.Count(), 'A Waiting continuation must prevent duplicate retention jobs.');
@@ -778,6 +778,28 @@ codeunit 139018 "Job Queue Entry Tests"
         WaitingJobQueueEntry.TestField("No. of Attempts to Run", ExpectedJobQueueEntry."No. of Attempts to Run");
         RunningJobQueueEntry.Get(RunningJobQueueEntry.ID);
         RunningJobQueueEntry.TestField(Status, RunningJobQueueEntry.Status::"In Process");
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
+    procedure RetentionContinuationPrefersWaitingOverReadyJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        // [SCENARIO 649571] A Waiting continuation takes priority over a Ready job that sorts before it.
+        VerifyRetentionContinuationPrefersWaitingJob(JobQueueEntry.Status::Ready);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
+    procedure RetentionContinuationPrefersWaitingOverOnHoldJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        // [SCENARIO 649571] A Waiting continuation takes priority over an On Hold job that sorts before it.
+        VerifyRetentionContinuationPrefersWaitingJob(JobQueueEntry.Status::"On Hold");
     end;
 
     [Test]
@@ -820,7 +842,7 @@ codeunit 139018 "Job Queue Entry Tests"
         UnrelatedWaitingJobQueueEntry.Modify();
 
         BindSubscription(this);
-        RetentionPolicyJQ.ScheduleContinuation();
+        Assert.IsTrue(RetentionPolicyJQ.ScheduleContinuation(), 'Creating a retention continuation must report scheduling.');
         UnbindSubscription(this);
 
         Assert.AreEqual(2, JobQueueEntry.Count(), 'A continuation must be created when no retention job is pending.');
@@ -857,6 +879,58 @@ codeunit 139018 "Job Queue Entry Tests"
         JobQueueEntry.Get(JobQueueEntry.ID);
     end;
 
+    local procedure VerifyRetentionContinuationPrefersWaitingJob(InitialStatus: Option)
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+        RestartableJobQueueEntry: Record "Job Queue Entry";
+        WaitingJobQueueEntry: Record "Job Queue Entry";
+        ExpectedRestartableJobQueueEntry: Record "Job Queue Entry";
+        ExpectedWaitingJobQueueEntry: Record "Job Queue Entry";
+        RetentionPolicyJQ: Codeunit "Retention Policy JQ";
+    begin
+        InitializeRetentionPolicyJobQueue(JobQueueEntry);
+        CreateRetentionPolicyJobQueueEntry(RestartableJobQueueEntry, InitialStatus);
+        CreateRetentionPolicyJobQueueEntry(WaitingJobQueueEntry, InitialStatus);
+
+        // Assign Waiting to the last persisted ID so the original mixed-status lookup finds the restartable job first.
+        JobQueueEntry.SetCurrentKey(ID);
+        JobQueueEntry.FindLast();
+        WaitingJobQueueEntry := JobQueueEntry;
+        WaitingJobQueueEntry.Status := WaitingJobQueueEntry.Status::Waiting;
+        WaitingJobQueueEntry.Modify();
+        WaitingJobQueueEntry.Get(WaitingJobQueueEntry.ID);
+        ExpectedWaitingJobQueueEntry := WaitingJobQueueEntry;
+
+        JobQueueEntry.SetFilter(Status, '%1|%2|%3', JobQueueEntry.Status::Ready, JobQueueEntry.Status::"On Hold", JobQueueEntry.Status::Waiting);
+        JobQueueEntry.FindFirst();
+        Assert.IsTrue(JobQueueEntry.Status = InitialStatus, 'The mixed-status lookup must return the restartable job first.');
+        RestartableJobQueueEntry := JobQueueEntry;
+        ExpectedRestartableJobQueueEntry := RestartableJobQueueEntry;
+        JobQueueEntry.SetRange(Status);
+        Assert.AreEqual(2, JobQueueEntry.Count(), 'The fixture must contain both pending retention jobs.');
+        WaitingJobQueueEntry.TestField("System Task ID");
+        RestartableJobQueueEntry.TestField("System Task ID");
+        WaitingJobQueueEntry.TestField("No. of Attempts to Run");
+        RestartableJobQueueEntry.TestField("No. of Attempts to Run");
+
+        BindSubscription(this);
+        Assert.IsFalse(RetentionPolicyJQ.ScheduleContinuation(), 'A Waiting job must prevent scheduling a restartable job.');
+        Assert.IsFalse(RetentionPolicyJQ.ScheduleContinuation(), 'A Waiting job must prevent scheduling a restartable job.');
+        UnbindSubscription(this);
+
+        Assert.AreEqual(2, JobQueueEntry.Count(), 'Both pending retention jobs must be preserved without duplicates.');
+        WaitingJobQueueEntry.Get(ExpectedWaitingJobQueueEntry.ID);
+        WaitingJobQueueEntry.TestField(Status, ExpectedWaitingJobQueueEntry.Status);
+        WaitingJobQueueEntry.TestField("System Task ID", ExpectedWaitingJobQueueEntry."System Task ID");
+        WaitingJobQueueEntry.TestField("Earliest Start Date/Time", ExpectedWaitingJobQueueEntry."Earliest Start Date/Time");
+        WaitingJobQueueEntry.TestField("No. of Attempts to Run", ExpectedWaitingJobQueueEntry."No. of Attempts to Run");
+        RestartableJobQueueEntry.Get(ExpectedRestartableJobQueueEntry.ID);
+        RestartableJobQueueEntry.TestField(Status, ExpectedRestartableJobQueueEntry.Status);
+        RestartableJobQueueEntry.TestField("System Task ID", ExpectedRestartableJobQueueEntry."System Task ID");
+        RestartableJobQueueEntry.TestField("Earliest Start Date/Time", ExpectedRestartableJobQueueEntry."Earliest Start Date/Time");
+        RestartableJobQueueEntry.TestField("No. of Attempts to Run", ExpectedRestartableJobQueueEntry."No. of Attempts to Run");
+    end;
+
     local procedure VerifyRetentionContinuationRestartsJob(InitialStatus: Option)
     var
         JobQueueEntry: Record "Job Queue Entry";
@@ -869,7 +943,7 @@ codeunit 139018 "Job Queue Entry Tests"
         SystemTaskId := ExistingJobQueueEntry."System Task ID";
 
         BindSubscription(this);
-        RetentionPolicyJQ.ScheduleContinuation();
+        Assert.IsTrue(RetentionPolicyJQ.ScheduleContinuation(), 'Restarting an existing retention job must report scheduling.');
         UnbindSubscription(this);
 
         Assert.AreEqual(1, JobQueueEntry.Count(), 'The existing retention job must be reused.');

--- a/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
@@ -1,3 +1,5 @@
+using System.DataAdministration;
+
 codeunit 139018 "Job Queue Entry Tests"
 {
     Subtype = Test;
@@ -746,6 +748,134 @@ codeunit 139018 "Job Queue Entry Tests"
         JobQueueLogEntry.Get(EntryNo);
         JobQueueLogEntry.TestField(Status, JobQueueLogEntry.Status::Success);
         Assert.AreNotEqual(0DT, JobQueueLogEntry."End Date/Time", 'End Date/Time should be set after finalization');
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
+    procedure RetentionContinuationPreservesWaitingJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+        RunningJobQueueEntry: Record "Job Queue Entry";
+        WaitingJobQueueEntry: Record "Job Queue Entry";
+        ExpectedJobQueueEntry: Record "Job Queue Entry";
+        RetentionPolicyJQ: Codeunit "Retention Policy JQ";
+    begin
+        // [SCENARIO 649571] Repeated continuation requests preserve an existing Waiting job and its scheduled task.
+        InitializeRetentionPolicyJobQueue(JobQueueEntry);
+        CreateRetentionPolicyJobQueueEntry(RunningJobQueueEntry, RunningJobQueueEntry.Status::"In Process");
+        CreateRetentionPolicyJobQueueEntry(WaitingJobQueueEntry, WaitingJobQueueEntry.Status::Waiting);
+        ExpectedJobQueueEntry := WaitingJobQueueEntry;
+
+        BindSubscription(this);
+        RetentionPolicyJQ.ScheduleContinuation();
+        RetentionPolicyJQ.ScheduleContinuation();
+        UnbindSubscription(this);
+
+        Assert.AreEqual(2, JobQueueEntry.Count(), 'A Waiting continuation must prevent duplicate retention jobs.');
+        WaitingJobQueueEntry.Get(ExpectedJobQueueEntry.ID);
+        WaitingJobQueueEntry.TestField(Status, WaitingJobQueueEntry.Status::Waiting);
+        WaitingJobQueueEntry.TestField("System Task ID", ExpectedJobQueueEntry."System Task ID");
+        WaitingJobQueueEntry.TestField("Earliest Start Date/Time", ExpectedJobQueueEntry."Earliest Start Date/Time");
+        WaitingJobQueueEntry.TestField("No. of Attempts to Run", ExpectedJobQueueEntry."No. of Attempts to Run");
+        RunningJobQueueEntry.Get(RunningJobQueueEntry.ID);
+        RunningJobQueueEntry.TestField(Status, RunningJobQueueEntry.Status::"In Process");
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
+    procedure RetentionContinuationRestartsReadyJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        // [SCENARIO 649571] A Ready retention job is still restarted rather than duplicated.
+        VerifyRetentionContinuationRestartsJob(JobQueueEntry.Status::Ready);
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
+    procedure RetentionContinuationRestartsOnHoldJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+    begin
+        // [SCENARIO 649571] An On Hold retention job is still restarted rather than duplicated.
+        VerifyRetentionContinuationRestartsJob(JobQueueEntry.Status::"On Hold");
+    end;
+
+    [Test]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    [Scope('OnPrem')]
+    procedure RetentionContinuationCreatedWithoutPendingJob()
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+        RunningJobQueueEntry: Record "Job Queue Entry";
+        UnrelatedWaitingJobQueueEntry: Record "Job Queue Entry";
+        RetentionPolicyJQ: Codeunit "Retention Policy JQ";
+    begin
+        // [SCENARIO 649571] Running retention jobs and Waiting jobs for another object do not prevent a continuation.
+        InitializeRetentionPolicyJobQueue(JobQueueEntry);
+        CreateRetentionPolicyJobQueueEntry(RunningJobQueueEntry, RunningJobQueueEntry.Status::"In Process");
+        CreateRetentionPolicyJobQueueEntry(UnrelatedWaitingJobQueueEntry, UnrelatedWaitingJobQueueEntry.Status::Waiting);
+        UnrelatedWaitingJobQueueEntry."Object ID to Run" := Codeunit::"Job Queue - Enqueue";
+        UnrelatedWaitingJobQueueEntry.Modify();
+
+        BindSubscription(this);
+        RetentionPolicyJQ.ScheduleContinuation();
+        UnbindSubscription(this);
+
+        Assert.AreEqual(2, JobQueueEntry.Count(), 'A continuation must be created when no retention job is pending.');
+        JobQueueEntry.SetRange(Status, JobQueueEntry.Status::Ready);
+        JobQueueEntry.FindFirst();
+        JobQueueEntry.TestField("Job Queue Category Code", 'RETENTION');
+        JobQueueEntry.TestField("Recurring Job", false);
+        JobQueueEntry.TestField("System Task ID");
+        RunningJobQueueEntry.Get(RunningJobQueueEntry.ID);
+        RunningJobQueueEntry.TestField(Status, RunningJobQueueEntry.Status::"In Process");
+        UnrelatedWaitingJobQueueEntry.Get(UnrelatedWaitingJobQueueEntry.ID);
+        UnrelatedWaitingJobQueueEntry.TestField(Status, UnrelatedWaitingJobQueueEntry.Status::Waiting);
+    end;
+
+    local procedure InitializeRetentionPolicyJobQueue(var JobQueueEntry: Record "Job Queue Entry")
+    begin
+        JobQueueEntry.SetRange("Object Type to Run", JobQueueEntry."Object Type to Run"::Codeunit);
+        JobQueueEntry.SetRange("Object ID to Run", Codeunit::"Retention Policy JQ");
+        JobQueueEntry.DeleteAll();
+    end;
+
+    local procedure CreateRetentionPolicyJobQueueEntry(var JobQueueEntry: Record "Job Queue Entry"; InitialStatus: Option)
+    begin
+        Clear(JobQueueEntry);
+        CreateJobQueueEntry(JobQueueEntry, InitialStatus);
+        JobQueueEntry."Object Type to Run" := JobQueueEntry."Object Type to Run"::Codeunit;
+        JobQueueEntry."Object ID to Run" := Codeunit::"Retention Policy JQ";
+        JobQueueEntry."Job Queue Category Code" := 'RETENTION';
+        JobQueueEntry."System Task ID" := CreateGuid();
+        JobQueueEntry."Earliest Start Date/Time" := CurrentDateTime() + 60000;
+        JobQueueEntry.Modify();
+    end;
+
+    local procedure VerifyRetentionContinuationRestartsJob(InitialStatus: Option)
+    var
+        JobQueueEntry: Record "Job Queue Entry";
+        ExistingJobQueueEntry: Record "Job Queue Entry";
+        RetentionPolicyJQ: Codeunit "Retention Policy JQ";
+        SystemTaskId: Guid;
+    begin
+        InitializeRetentionPolicyJobQueue(JobQueueEntry);
+        CreateRetentionPolicyJobQueueEntry(ExistingJobQueueEntry, InitialStatus);
+        SystemTaskId := ExistingJobQueueEntry."System Task ID";
+
+        BindSubscription(this);
+        RetentionPolicyJQ.ScheduleContinuation();
+        UnbindSubscription(this);
+
+        Assert.AreEqual(1, JobQueueEntry.Count(), 'The existing retention job must be reused.');
+        ExistingJobQueueEntry.Get(ExistingJobQueueEntry.ID);
+        ExistingJobQueueEntry.TestField(Status, ExistingJobQueueEntry.Status::Ready);
+        ExistingJobQueueEntry.TestField("No. of Attempts to Run", 0);
+        Assert.AreNotEqual(SystemTaskId, ExistingJobQueueEntry."System Task ID", 'The existing retention job must be restarted.');
     end;
 
     local procedure CreateJobQueueEntry(var JobQueueEntry: Record "Job Queue Entry"; InitialStatus: Option)

--- a/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
@@ -1,5 +1,3 @@
-using System.DataAdministration;
-
 codeunit 139018 "Job Queue Entry Tests"
 {
     Subtype = Test;
@@ -848,6 +846,7 @@ codeunit 139018 "Job Queue Entry Tests"
     begin
         Clear(JobQueueEntry);
         CreateJobQueueEntry(JobQueueEntry, InitialStatus);
+        JobQueueEntry."No. of Attempts to Run" := 3;
         JobQueueEntry."Object Type to Run" := JobQueueEntry."Object Type to Run"::Codeunit;
         JobQueueEntry."Object ID to Run" := Codeunit::"Retention Policy JQ";
         JobQueueEntry."Job Queue Category Code" := 'RETENTION';

--- a/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JobQueueEntryTests.Codeunit.al
@@ -853,6 +853,8 @@ codeunit 139018 "Job Queue Entry Tests"
         JobQueueEntry."System Task ID" := CreateGuid();
         JobQueueEntry."Earliest Start Date/Time" := CurrentDateTime() + 60000;
         JobQueueEntry.Modify();
+        // Capture the persisted DateTime precision before checking that scheduling preserves it.
+        JobQueueEntry.Get(JobQueueEntry.ID);
     end;
 
     local procedure VerifyRetentionContinuationRestartsJob(InitialStatus: Option)


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Retention continuation scheduling previously recognized only Ready and On Hold jobs. Once the dispatcher moved an existing continuation to Waiting, another limit-exceeded notification could create a duplicate.

Check for Waiting continuations with a dedicated read-only existence check before selecting any Ready or On Hold job to restart. The Waiting probes use `IsEmpty()` to avoid materializing unused records; the restart path retains its guarded, update-locked `FindFirst()`. Waiting work takes priority even when restartable entries sort first, and both entries remain untouched in that case. The internal scheduling helper enables deterministic coverage without depending on the overnight scheduling window and reports whether an actual create or restart occurred, so scheduling-success telemetry is emitted only after that action succeeds.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

[AB#649571](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649571)

[Azure DevOps Bug 649571](https://dev.azure.com/dynamicssmb2/Dynamics%20SMB/_workitems/edit/649571)

An approved GitHub issue has not been provided.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

**Local Docker validation passed on 2026-09-17 for commit `8369aa7e5e55bcca06a23e7f79bb049ba9ac8a49`.**

- **Environment:** isolated Windows Docker container `bc-ret11257`, Business Central sandbox/base artifact `30.0.54235.0`, BcContainerHelper `6.1.18`, and AL compiler `18.0.41.7630`. Tests ran in `CRONUS International Ltd.` with the task scheduler disabled.
- **Build and publication:** compiled all 14 application/dependency packages inside Docker using `Compile-AppInBcContainer`, including Base Application and Tests-Misc. Published them using `Publish-BcContainerApp` after the repository's `Setup-ContainerForDevelopment` setup, and verified all 14 were installed at version `30.0.0.0`. Compilation succeeded with warnings and no errors.
- **Tests:** ran codeunit `139018` (`Job Queue Entry Tests`) from the source-built Tests-Misc app using `Run-TestsInBcContainer`. **32 passed, 0 failed, 2 skipped.** All six new retention regression cases passed: repeated requests preserve Waiting work; Waiting takes priority over Ready or On Hold entries; Ready and On Hold jobs restart when no Waiting continuation exists; and running retention jobs or unrelated Waiting jobs do not suppress a new continuation. The mixed-state cases put restartable jobs first in persisted key order and verify both records remain unchanged. The new tests use the existing task-scheduler mock and automatic rollback, and assert the reported scheduling outcome.
- **Existing skips:** `RunJQWithinStartOfDayAndEndTime` and `RunJQWithinStartTimeAndEndOfDay` were skipped according to `src\DisabledTests\Tests-Misc\Tests-Misc.DisabledTest.json`. None of the new regression cases was skipped.
- **Evidence:** build/publication logs, package hashes, the test summary, and `job-queue-tests.xunit.xml` are retained locally under `artifacts\bc-ret11257\`. The worktree remained clean; no source changes were needed for validation. These are local Docker results, not a claim that all CI checks or the full Tests-Misc suite passed.
- The repository's `Test-ObjectIDsAreValid` check passed for both modified codeunits, and `git diff --check` passed, including after the existence-check optimization in `1673a42dff`.

**Analyzer caveat:** the Docker build succeeded, but code analyzers and a warning-baseline comparison were not run. The combined "built locally with no new analyzer warnings" checkbox remains unchecked for that reason.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

No schema, permission, category, or scheduling-window changes. Waiting-first behavior is explicit for mixed pending states, and scheduling-success telemetry is suppressed for no-op reuse. Existing Ready and On Hold restart behavior is unchanged when no Waiting continuation is pending. This does not clean up existing duplicate entries or introduce a new cross-session uniqueness guarantee. The scheduling helper remains internal.

