### PR TITLE
[GB] IdealPostcodes: fix provider selection and address retrieval through the Postcode Service Manager framework

### DIFF
--- a/src/Apps/GB/IdealPostcodes/app/src/IPCManagement.Codeunit.al
+++ b/src/Apps/GB/IdealPostcodes/app/src/IPCManagement.Codeunit.al
@@ -57,40 +57,6 @@ codeunit 9400 "IPC Management"
         exit(false);
     end;
 
-    [NonDebuggable]
-    procedure GetAddressDetails(AddressId: Text; var TempIPCAddressLookup: Record "IPC Address Lookup" temporary; var ReasonCode: Integer; var ReasonPhrase: Text)
-    var
-        Config: Record "IPC Config";
-        TypeHelper: Codeunit "Type Helper";
-        FeatureTelemetry: Codeunit "Feature Telemetry";
-        AuditLog: Codeunit "Audit Log";
-        HttpClient: HttpClient;
-        HttpResponse: HttpResponseMessage;
-        ResponseText: Text;
-        RequestUrl: Text;
-    begin
-        if not GetConfiguration(Config) then
-            Error(ConfigNotSetupErr);
-
-        if not Config.Enabled then
-            exit;
-
-        FeatureTelemetry.LogUptake('0000RFF', 'IdealPostcodes', Enum::"Feature Uptake Status"::Used);
-        RequestUrl := Config.APIEndpoint() + '/' + TypeHelper.UriEscapeDataString(AddressId);
-        HttpClient.DefaultRequestHeaders().Add('Authorization', SecretStrSubstNo('IDEALPOSTCODES api_key="%1"', Config.GetAPIPasswordAsSecret(Config."API Key")));
-
-        if HttpClient.Get(RequestUrl, HttpResponse) then begin
-            ReasonCode := HttpResponse.HttpStatusCode();
-            ReasonPhrase := HttpResponse.ReasonPhrase();
-            if HttpResponse.IsSuccessStatusCode then begin
-                HttpResponse.Content.ReadAs(ResponseText);
-                ParseAddressDetail(ResponseText, TempIPCAddressLookup);
-            end else
-                if ReasonCode in [401, 403] then
-                    AuditLog.LogAuditMessage(StrSubstNo(SecurityAuditAuthFailedTxt, ReasonCode, ReasonPhrase), SecurityOperationResult::Failure, AuditCategory::Authentication, 4, 0);
-        end;
-    end;
-
     procedure LookupAddress(var Address: Text[100]; var Address2: Text[50]; var City: Text[30]; var PostCode: Code[20]; var County: Text[30]; var CountryCode: Code[10])
     var
         TempIPCAddressLookup: Record "IPC Address Lookup" temporary;
@@ -198,28 +164,6 @@ codeunit 9400 "IPC Management"
         TempIPCAddressLookup."Display Text" := CopyStr(DisplayText, 1, MaxStrLen(TempIPCAddressLookup."Display Text"));
 
         TempIPCAddressLookup.Insert();
-    end;
-
-    local procedure ParseAddressDetail(ResponseText: Text; var TempIPCAddressLookup: Record "IPC Address Lookup")
-    var
-        JsonObject: JsonObject;
-    begin
-        if JsonObject.ReadFrom(ResponseText) then begin
-            TempIPCAddressLookup.Init();
-            TempIPCAddressLookup.Address := CopyStr(GetJsonValue(JsonObject, 'address'), 1, MaxStrLen(TempIPCAddressLookup.Address));
-            TempIPCAddressLookup."Address 2" := CopyStr(GetJsonValue(JsonObject, 'address2'), 1, MaxStrLen(TempIPCAddressLookup."Address 2"));
-            TempIPCAddressLookup.City := CopyStr(GetJsonValue(JsonObject, 'city'), 1, MaxStrLen(TempIPCAddressLookup.City));
-            TempIPCAddressLookup."Post Code" := CopyStr(GetJsonValue(JsonObject, 'postcode'), 1, MaxStrLen(TempIPCAddressLookup."Post Code"));
-            TempIPCAddressLookup.County := CopyStr(GetJsonValue(JsonObject, 'county'), 1, MaxStrLen(TempIPCAddressLookup.County));
-            TempIPCAddressLookup."Country/Region Code" := CopyStr(GetJsonValue(JsonObject, 'country_code'), 1, MaxStrLen(TempIPCAddressLookup."Country/Region Code"));
-        end;
-
-        // Create display text
-        TempIPCAddressLookup."Display Text" := TempIPCAddressLookup.Address;
-        if TempIPCAddressLookup.City <> '' then
-            TempIPCAddressLookup."Display Text" += ', ' + TempIPCAddressLookup.City;
-        if TempIPCAddressLookup."Post Code" <> '' then
-            TempIPCAddressLookup."Display Text" += ' ' + TempIPCAddressLookup."Post Code";
     end;
 
     local procedure GetJsonValue(JsonObject: JsonObject; KeyName: Text): Text

--- a/src/Apps/GB/IdealPostcodes/app/src/IPCProvider.Codeunit.al
+++ b/src/Apps/GB/IdealPostcodes/app/src/IPCProvider.Codeunit.al
@@ -11,7 +11,7 @@ codeunit 9403 "IPC Provider"
 
     var
         MyServiceKeyTok: Label 'IDEAL_POSTCODE_POSTCODE_SERVICE', Locked = true;
-        MyServiceNameLbl: Label 'IdealPostcodes';
+        MyServiceNameLbl: Label 'IdealPostcodes', Locked = true; // product name; also accepted as service key - see IsMyServiceKey
         ServiceConnectionNameLbl: Label 'Postcode Service';
         RetrieveAddressDetailsErr: Label 'Failed to retrieve address details.';
 
@@ -33,7 +33,7 @@ codeunit 9403 "IPC Provider"
         if IsConfigured then
             exit;
 
-        if ServiceKey <> MyServiceKeyTok then
+        if not IsMyServiceKey(ServiceKey) then
             exit;
 
         if not IdealPostcodesConfig.Get() then begin
@@ -65,7 +65,7 @@ codeunit 9403 "IPC Provider"
         IPCConfig: Record "IPC Config";
         IPCConfigPage: Page "IPC Config";
     begin
-        if ServiceKey <> MyServiceKeyTok then
+        if not IsMyServiceKey(ServiceKey) then
             exit;
 
         Successful := IPCConfigPage.RunModal() = ACTION::OK;
@@ -81,7 +81,7 @@ codeunit 9403 "IPC Provider"
         SearchText, ReasonPhrase : Text;
         LastId, StatusCode : Integer;
     begin
-        if ServiceKey <> MyServiceKeyTok then
+        if not IsMyServiceKey(ServiceKey) then
             exit;
 
         LastId := 0;
@@ -118,14 +118,29 @@ codeunit 9403 "IPC Provider"
     var
         TempIPCAddressLookup: Record "IPC Address Lookup" temporary;
         IPCManagement: Codeunit "IPC Management";
+        SearchText, ReasonPhrase : Text;
         StatusCode: Integer;
-        ReasonPhrase: Text;
     begin
-        if ServiceKey <> MyServiceKeyTok then
+        if not IsMyServiceKey(ServiceKey) then
             exit;
 
-        IPCManagement.GetAddressDetails(TempSelectedAddressNameValueBuffer.Name, TempIPCAddressLookup, StatusCode, ReasonPhrase);
-        IsSuccessful := TempIPCAddressLookup."Display Text" <> '';
+        // The API has no address-by-id endpoint. Search again for what the user entered and take the
+        // entry that was selected; this also delivers the address with the "Remove Organisation Name"
+        // setting applied, exactly as it was shown in the selection list.
+        if TempEnteredAutocompleteAddress.Postcode <> '' then
+            SearchText := TempEnteredAutocompleteAddress.Postcode
+        else
+            SearchText := TempEnteredAutocompleteAddress.City;
+
+        IsSuccessful := (SearchText <> '') and IPCManagement.SearchAddress(SearchText, TempIPCAddressLookup, StatusCode, ReasonPhrase);
+        if IsSuccessful then begin
+            if TempSelectedAddressNameValueBuffer.Name <> '' then
+                TempIPCAddressLookup.SetRange("Address ID", CopyStr(TempSelectedAddressNameValueBuffer.Name, 1, MaxStrLen(TempIPCAddressLookup."Address ID")))
+            else
+                TempIPCAddressLookup.SetRange("Display Text", TempSelectedAddressNameValueBuffer.Value);
+            IsSuccessful := TempIPCAddressLookup.FindFirst();
+        end;
+
         if not IsSuccessful then begin
             ErrorMsg := RetrieveAddressDetailsErr;
             exit;
@@ -167,5 +182,12 @@ codeunit 9403 "IPC Provider"
     procedure GetServiceKey(): Text
     begin
         exit(MyServiceKeyTok);
+    end;
+
+    local procedure IsMyServiceKey(ServiceKey: Text): Boolean
+    begin
+        // The Postcode Configuration Page W1 stores the selected row's Name - our display name - as
+        // the service key, while internal callers pass the token from GetServiceKey(). Accept both.
+        exit(ServiceKey in [MyServiceKeyTok, MyServiceNameLbl]);
     end;
 }

--- a/src/Apps/GB/IdealPostcodes/test/src/TestNegativeOutcomes.Codeunit.al
+++ b/src/Apps/GB/IdealPostcodes/test/src/TestNegativeOutcomes.Codeunit.al
@@ -5,6 +5,7 @@
 namespace Microsoft.Foundation.Address.IdealPostcodes.Test;
 
 using Microsoft.Foundation.Address;
+using Microsoft.Utilities;
 using Microsoft.Foundation.Address.IdealPostcodes;
 using System.TestLibraries.Utilities;
 
@@ -123,6 +124,43 @@ codeunit 148119 "Test Negative Outcomes"
         IPCConfig.OK().INVOKE();
 
         // [THEN] Message dialog should appear.
+    end;
+
+    [Test]
+    procedure TestIsConfiguredWithKeySavedByConfigurationPage()
+    var
+        IPCConfig: Record "IPC Config";
+        PostcodeServiceConfig: Record "Postcode Service Config";
+        TempServiceListNameValueBuffer: Record "Name/Value Buffer" temporary;
+        ApiKeyGuid: Guid;
+    begin
+        // [SCENARIO] Page 9143 "Postcode Configuration Page W1" stores the selected row's Name as the
+        // service key. The provider must accept that key too; otherwise IsConfigured() is false and the
+        // page resets the stored selection to Disabled every time it opens.
+
+        // [GIVEN] An enabled configuration with an API key
+        LibraryLowerPermissions.SetO365BusFull();
+        Initialize();
+        IPCConfig.FindFirst();
+        IPCConfig.Enabled := true;
+        ApiKeyGuid := CreateGuid();
+        IPCConfig.SaveAPIKeyAsSecret(ApiKeyGuid, SecretStrSubstNo('apikey'));
+        IPCConfig."API Key" := ApiKeyGuid;
+        IPCConfig.Modify();
+
+        // [GIVEN] The service key stored the way the configuration page stores it: the discovered row's Name
+        PostcodeServiceManager.DiscoverPostcodeServices(TempServiceListNameValueBuffer);
+        TempServiceListNameValueBuffer.SetRange(Value, MyServiceKeyTok);
+        TempServiceListNameValueBuffer.FindFirst();
+        PostcodeServiceConfig.FindFirst();
+        PostcodeServiceConfig.SaveServiceKey(TempServiceListNameValueBuffer.Name);
+
+        // [WHEN] [THEN] The framework reports the stored selection as configured
+        Assert.IsTrue(PostcodeServiceManager.IsConfigured(), 'Provider must accept the service key saved by the configuration page (the discovered row''s Name).');
+
+        // Cleanup
+        Clear(IPCConfig."API Key");
+        IPCConfig.Modify();
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
Fixes #11254

A BC partner integrating with IdealPostcodes as a postcode provider through the Postcode Service Manager framework reported the lookup never becoming available. Two defects:

1. `OnDiscoverPostcodeServices` registers the display name in `Name` and the key in `Value`, while page 9143 saves the selected row's `Name` as the service key — every subscriber guard rejects the stored key, `IsConfigured()` stays false, and page 9143 resets the selection to `Disabled` on each open.
2. `OnRetrieveAddress` re-fetches the picked address from `https://api.ideal-postcodes.co.uk/v1/<id>` — a route the API does not have (we are the API vendor) — with a parser expecting fields the API never returns, so every framework lookup fails.

Changes:
- `IPCProvider`: new `IsMyServiceKey()` accepts both the token and the display name (label now `Locked` — it acts as a key); `OnRetrieveAddress` re-runs the search and returns the entry matching the selected `Address ID` (fallback: `Display Text`), which also makes the *Remove Organisation Name* setting apply to the written-back address.
- `IPCManagement`: removed dead `GetAddressDetails`/`ParseAddressDetail`.
- Tests: `TestIsConfiguredWithKeySavedByConfigurationPage` stores the key exactly the way page 9143 does and asserts `IsConfigured()`.

Verified live on a BC 28.2 sandbox against the production Ideal Postcodes API (postcode SW1A 2AE), deployed as a per-tenant copy of the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
