### PR TITLE
Postcode Configuration Page: display the stored provider selection on open

### DIFF
--- a/src/Layers/GB/BaseApp/Local/Foundation/Address/PostcodeConfigurationPage.Page.al
+++ b/src/Layers/GB/BaseApp/Local/Foundation/Address/PostcodeConfigurationPage.Page.al
@@ -86,7 +86,8 @@ page 10501 "Postcode Configuration Page"
             Rec.SaveServiceKey(DisabledTok);
         end;
 
-        PrevValue := Rec.GetServiceKey();
+        ServiceKeyText := Rec.GetServiceKey();
+        PrevValue := ServiceKeyText;
     end;
 
     trigger OnQueryClosePage(CloseAction: Action): Boolean

--- a/src/Layers/W1/BaseApp/Foundation/Address/PostcodeConfigurationPageW1.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Address/PostcodeConfigurationPageW1.Page.al
@@ -82,7 +82,8 @@ page 9143 "Postcode Configuration Page W1"
             Rec.SaveServiceKey(DisabledTok);
         end;
 
-        PrevValue := Rec.GetServiceKey();
+        ServiceKeyText := Rec.GetServiceKey();
+        PrevValue := ServiceKeyText;
     end;
 
     trigger OnQueryClosePage(CloseAction: Action): Boolean


### PR DESCRIPTION
Fixes #11255

`OnOpenPage` of page 9143 "Postcode Configuration Page W1" and page 10501 "Postcode Configuration Page" (GB) sets the `ServiceKeyText` display variable only in the record-missing / not-configured branches, so with a configured provider the *Address Provider* field renders empty (an underscore in the web client). The stored key was already read into `PrevValue` — it was just never displayed.

One-line fix in each page: load the stored service key into `ServiceKeyText` and keep `PrevValue` for cancel-restore. Together with #11254, the field then reads `IdealPostcodes` for that provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
