### PR TITLE
Fix retention policy deletion-limit stop propagation

### DIFF
--- a/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
+++ b/src/System Application/App/Retention Policy/src/Apply Retention Policy/ApplyRetentionPolicyImpl.Codeunit.al
@@ -79,6 +79,7 @@ codeunit 3904 "Apply Retention Policy Impl."
             TotalNumberOfRecordsDeleted := Rec."Number Of Records Deleted";
             ApplyRetentionPolicy(RetentionPolicySetup, false, false);
             Rec."Number Of Records Deleted" := TotalNumberOfRecordsDeleted;
+            Rec."End Current Run" := EndCurrentRun;
         end;
     end;
 
@@ -192,6 +193,7 @@ codeunit 3904 "Apply Retention Policy Impl."
             exit
         end;
         TotalNumberOfRecordsDeleted := TempRetentionPolicySetup."Number Of Records Deleted";
+        EndCurrentRun := TempRetentionPolicySetup."End Current Run";
     end;
 
     local procedure CanApplyRetentionPolicy(var RetentionPolicySetup: Record "Retention Policy Setup"; Manual: Boolean): Boolean

--- a/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
+++ b/src/System Application/App/Retention Policy/src/Retention Policy Setup/RetentionPolicySetup.Table.al
@@ -154,6 +154,12 @@ table 3901 "Retention Policy Setup"
             Access = Internal;
             Editable = false;
         }
+        field(101; "End Current Run"; Boolean)
+        {
+            DataClassification = SystemMetadata;
+            Access = Internal;
+            Editable = false;
+        }
     }
 
     keys

--- a/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
+++ b/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
@@ -1485,13 +1485,15 @@ codeunit 138702 "Retention Policy Test"
         RetentionPolicyTestData3: Record "Retention Policy Test Data 3";
         ApplyRetentionPolicy: Codeunit "Apply Retention Policy";
     begin
-        PermissionsMock.Set('Retention Pol. Admin');
         // Setup
+        // Enabled policy setup can schedule Base Application job queue entries.
+        PermissionsMock.Set('SUPER');
         RetentionPolicyTestLibrary.RaiseOnRefreshAllowedTables();
         ClearTestData();
         InsertOneMonthRetentionPeriod(RetentionPeriod);
         InsertEnabledRetentionPolicySetupForAllRecords(RetentionPolicySetup, RetentionPeriod, 0);
         InsertRetentionPolicySetupTable3(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData3.FieldNo("Datetime Field"));
+        PermissionsMock.Set('Retention Pol. Admin');
         InsertRetentionPolicyTestData('<-2M>');
         InsertRetentionPolicyTestData3('<-2M>');
 
@@ -1682,13 +1684,15 @@ codeunit 138702 "Retention Policy Test"
         RetentionPolicyTestLibrarySubs: Codeunit "Retention Policy Test Library";
         i: Integer;
     begin
-        PermissionsMock.Set('Retention Pol. Admin');
         // Setup
+        // Enabled policy setup can schedule Base Application job queue entries.
+        PermissionsMock.Set('SUPER');
         RetentionPolicyTestLibrary.RaiseOnRefreshAllowedTables();
         ClearTestData();
         InsertOneMonthRetentionPeriod(RetentionPeriod);
         InsertEnabledRetentionPolicySetupForAllRecords(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData.FieldNo("Date Field"));
         InsertRetentionPolicySetupTable3(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData3.FieldNo("Datetime Field"));
+        PermissionsMock.Set('Retention Pol. Admin');
         for i := 1 to RecordsTableOne do
             InsertRetentionPolicyTestData('<-2M>');
         InsertRetentionPolicyTestData3('<-2M>');

--- a/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
+++ b/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
@@ -1487,6 +1487,7 @@ codeunit 138702 "Retention Policy Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         // Setup
+        RetentionPolicyTestLibrary.RaiseOnRefreshAllowedTables();
         ClearTestData();
         InsertOneMonthRetentionPeriod(RetentionPeriod);
         InsertEnabledRetentionPolicySetupForAllRecords(RetentionPolicySetup, RetentionPeriod, 0);
@@ -1683,6 +1684,7 @@ codeunit 138702 "Retention Policy Test"
     begin
         PermissionsMock.Set('Retention Pol. Admin');
         // Setup
+        RetentionPolicyTestLibrary.RaiseOnRefreshAllowedTables();
         ClearTestData();
         InsertOneMonthRetentionPeriod(RetentionPeriod);
         InsertEnabledRetentionPolicySetupForAllRecords(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData.FieldNo("Date Field"));

--- a/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
+++ b/src/System Application/Test/Retention Policy/src/RetentionPolicyTest.Codeunit.al
@@ -1456,6 +1456,53 @@ codeunit 138702 "Retention Policy Test"
     end;
 
     [Test]
+    procedure TestApplyRetentionPolicyStopsAtLimitAcrossTables()
+    begin
+        VerifyApplyRetentionPolicyRecordLimit(RetentionPolicyTestLibrary.MaxNumberOfRecordsToDelete(), 0, true);
+    end;
+
+    [Test]
+    procedure TestApplyRetentionPolicyStopsWithRecordsRemainingAcrossTables()
+    var
+        RemainingRecords: Integer;
+    begin
+        RemainingRecords := RetentionPolicyTestLibrary.MaxNumberOfRecordsToDeleteBuffer() + 1;
+        VerifyApplyRetentionPolicyRecordLimit(RetentionPolicyTestLibrary.MaxNumberOfRecordsToDelete() + RemainingRecords, RemainingRecords, true);
+    end;
+
+    [Test]
+    procedure TestApplyRetentionPolicyContinuesBelowLimitAcrossTables()
+    begin
+        VerifyApplyRetentionPolicyRecordLimit(RetentionPolicyTestLibrary.MaxNumberOfRecordsToDelete() - 2, 0, false);
+    end;
+
+    [Test]
+    procedure TestApplyRetentionPolicyContinuesAfterPolicyError()
+    var
+        RetentionPeriod: Record "Retention Period";
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        RetentionPolicyTestData: Record "Retention Policy Test Data";
+        RetentionPolicyTestData3: Record "Retention Policy Test Data 3";
+        ApplyRetentionPolicy: Codeunit "Apply Retention Policy";
+    begin
+        PermissionsMock.Set('Retention Pol. Admin');
+        // Setup
+        ClearTestData();
+        InsertOneMonthRetentionPeriod(RetentionPeriod);
+        InsertEnabledRetentionPolicySetupForAllRecords(RetentionPolicySetup, RetentionPeriod, 0);
+        InsertRetentionPolicySetupTable3(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData3.FieldNo("Datetime Field"));
+        InsertRetentionPolicyTestData('<-2M>');
+        InsertRetentionPolicyTestData3('<-2M>');
+
+        // Exercise
+        ApplyRetentionPolicy.ApplyRetentionPolicy(false);
+
+        // Verify
+        Assert.AreEqual(1, RetentionPolicyTestData.Count(), 'Records for the invalid policy must not be deleted.');
+        Assert.RecordIsEmpty(RetentionPolicyTestData3);
+    end;
+
+    [Test]
     procedure TestApplyRetentionPolicyTooManyLinesToDeleteOneTableAndReschedule()
     var
         RetentionPeriod: Record "Retention Period";
@@ -1622,6 +1669,50 @@ codeunit 138702 "Retention Policy Test"
         RetentionPolicySetup.DeleteAll(true);
         RetentionPolicySetupLine.DeleteAll(true);
         RetentionPeriod.DeleteAll(true);
+    end;
+
+    local procedure VerifyApplyRetentionPolicyRecordLimit(RecordsTableOne: Integer; RemainingRecordsTableOne: Integer; LimitReached: Boolean)
+    var
+        RetentionPeriod: Record "Retention Period";
+        RetentionPolicySetup: Record "Retention Policy Setup";
+        RetentionPolicyTestData: Record "Retention Policy Test Data";
+        RetentionPolicyTestData3: Record "Retention Policy Test Data 3";
+        ApplyRetentionPolicy: Codeunit "Apply Retention Policy";
+        RetentionPolicyTestLibrarySubs: Codeunit "Retention Policy Test Library";
+        i: Integer;
+    begin
+        PermissionsMock.Set('Retention Pol. Admin');
+        // Setup
+        ClearTestData();
+        InsertOneMonthRetentionPeriod(RetentionPeriod);
+        InsertEnabledRetentionPolicySetupForAllRecords(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData.FieldNo("Date Field"));
+        InsertRetentionPolicySetupTable3(RetentionPolicySetup, RetentionPeriod, RetentionPolicyTestData3.FieldNo("Datetime Field"));
+        for i := 1 to RecordsTableOne do
+            InsertRetentionPolicyTestData('<-2M>');
+        InsertRetentionPolicyTestData3('<-2M>');
+
+        Assert.AreEqual(RecordsTableOne, RetentionPolicyTestData.Count(), 'Incorrect number of records before applying retention policy.');
+        Assert.AreEqual(1, RetentionPolicyTestData3.Count(), 'Incorrect number of records before applying retention policy.');
+
+        // Exercise
+        BindSubscription(RetentionPolicyTestLibrarySubs);
+        ApplyRetentionPolicy.ApplyRetentionPolicy(false);
+        UnbindSubscription(RetentionPolicyTestLibrarySubs);
+
+        // Verify
+        Assert.AreEqual(RemainingRecordsTableOne, RetentionPolicyTestData.Count(), 'Incorrect number of records after applying retention policy.');
+        if LimitReached then begin
+            Assert.AreEqual(1, RetentionPolicyTestData3.Count(), 'Later policies must not be processed after the record limit is reached.');
+            Assert.AreEqual(1, RetentionPolicyTestLibrarySubs.GetRecordLimitExceededSubscriberCount(), 'The record limit event must be raised only once per run.');
+        end else begin
+            Assert.RecordIsEmpty(RetentionPolicyTestData3);
+            Assert.AreEqual(0, RetentionPolicyTestLibrarySubs.GetRecordLimitExceededSubscriberCount(), 'The record limit event must not be raised below the limit.');
+        end;
+
+        // A new background run must process the remaining records.
+        ApplyRetentionPolicy.Run();
+        Assert.RecordIsEmpty(RetentionPolicyTestData);
+        Assert.RecordIsEmpty(RetentionPolicyTestData3);
     end;
 
     local procedure InsertOneWeekRetentionPeriod(var RetentionPeriod: Record "Retention Period")


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

Background retention runs execute each policy in an isolated `Codeunit.Run` call. The child returns the cumulative deletion count but loses `EndCurrentRun`, so the outer loop continues processing later policies and can raise additional limit events after the batch should have stopped.

Return the stop flag through the temporary retention policy setup record alongside the deletion count, and import it only after successful child execution. This preserves per-policy error isolation while allowing the existing outer-loop stop condition to take effect.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

[AB#649569](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649569)

[Azure DevOps Bug 649569: Retention policies continue past the deletion limit because EndCurrentRun is not propagated](https://dev.azure.com/dynamicssmb2/Dynamics%20SMB/_workitems/edit/649569)

Approved GitHub issue: not provided; the source work item is in Azure DevOps.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required - be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

- `git diff --check` passed.
- Added AL regression cases for reaching the exact limit, stopping with records remaining, continuing below the limit, and continuing after a policy error. The limit cases also assert that the limit event is raised only once, and explicitly start a subsequent run to process remaining records.
- AL compilation and runtime execution are pending: Docker is unavailable, and no usable local AL compiler or module symbol cache was available. The subsequent-run assertions do not establish automatic job-queue scheduling. This PR is a draft pending Business Central execution.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

- Adds internal Boolean field 101, `End Current Run`, to `Retention Policy Setup` for temporary result transport, following the existing deletion-count field pattern. Existing setup records are not rewritten by the execution path.
- Leaves the configured deletion allowance, per-policy transaction/error handling, event signature, and continuation scheduler unchanged. The existing limit event is raised before the stop flag returns to the outer loop.
- `ApplyAllRetentionPolicies` context propagation is a separate follow-up and is not included here. This change does not redesign scheduling/fairness or guarantee a hard cap for custom or indirect-permission deletion implementations.




