### PR TITLE
Move review ownership to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,45 +1,16 @@
-# Each line is a file pattern followed by one or more owners.
-# Order is important; the last matching pattern takes the most precedence.
-# CODEOWNERS paths are case sensitive, because GitHub uses a case sensitive file system
-
-# ---------------------------------------------------------------------------
-# Application team ownership (GENERATED - do not hand-edit)
+# CODEOWNERS is case sensitive and uses the last matching rule.
+# There is no repository-wide default: unmatched AL files fall back to the full
+# Business Central team, while later application and specialist rules override
+# that fallback. Ownerless rules release non-AL content from broader mappings.
 #
-# One fallback for AL files, followed by one line per thing a team owns: each
-# app, each Base Application area, the System Application and Business
-# Foundation. Nothing else.
-#
-# There is deliberately no repository-wide `*` default. Instead, unmatched AL
-# files fall back to the full Business Central team. This keeps AL changes
-# covered without requesting the 123-member team for unrelated files. The
-# specific application ownership rules below take precedence over the fallback.
-#
-# Tests, demo data, the demo tool and localization layers use a specific
-# application owner where one exists, and otherwise use the AL fallback. Non-AL
-# files in explicitly released folders remain unclaimed. The triage agent still
-# labels issues and pull requests with a team so the work stays visible on that
-# team's backlog.
-#
-# The rules are generated from the routing data the BCApps triage agent uses to
-# classify issues and pull requests:
+# The application map is generated from the BCApps triage routing data:
 #   microsoft/BCAppsTriage
 #     plugins/triage/skills/triage/scripts/ownership/ownership-rules.js
 #     plugins/triage/skills/triage/scripts/ownership/ownership-resolver.js
-# which are themselves seeded from the Business Central Ownership Matrix.
-#
-# To change ownership, edit ownership-rules.js in BCAppsTriage and regenerate.
-# Do not hand-edit the block below; hand edits will be lost and will silently
-# diverge from issue and pull request triage.
-# Apps with dedicated reviewer teams are intentionally omitted from this block
-# and listed once in the dedicated application reviewers section below.
-#
-# The specialized cross-cutting rules at the bottom of this file (App Security,
-# App Permissions, app.json, AL-Go and build files, Developer Experience, Code
-# Review Tools) still take precedence over everything here.
-# ---------------------------------------------------------------------------
+# Change generated ownership in BCAppsTriage, then regenerate this file.
+# Dedicated and cross-cutting ownership rules are listed after the generated map.
 
-# AL fallback. Keep this before every more specific ownership rule because
-# CODEOWNERS uses the last matching pattern.
+# AL fallback
 *.al @microsoft/dynamics-365-business-central
 
 # Platform. Integration owns these end to end; the sub-sections other
@@ -198,16 +169,10 @@
 /src/Apps/W1/VATGroupManagement/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/WithholdingTax/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/WorldPayPaymentsStandard/ @microsoft/d365-bc-finance-1
-# PowerBIReports hosts per-area report folders, which split across teams.
-/src/Apps/W1/PowerBIReports/App/.resources/ @microsoft/d365-bc-finance-1
-/src/Apps/W1/PowerBIReports/App/Core/ @microsoft/d365-bc-finance-1
-/src/Apps/W1/PowerBIReports/App/Finance/ @microsoft/d365-bc-finance-1
+# PowerBIReports defaults to Finance; SCM owns these area-specific folders.
 /src/Apps/W1/PowerBIReports/App/Inventory/ @microsoft/d365-bc-scm
 /src/Apps/W1/PowerBIReports/App/Manufacturing/ @microsoft/d365-bc-scm
-/src/Apps/W1/PowerBIReports/App/Projects/ @microsoft/d365-bc-finance-1
-/src/Apps/W1/PowerBIReports/App/Purchasing/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/PowerBIReports/App/Sales/ @microsoft/d365-bc-scm
-/src/Apps/W1/PowerBIReports/App/_Obsolete/ @microsoft/d365-bc-finance-1
 
 # Localization apps that are not Finance.
 /src/Apps/BE/ShopifyBE/ @microsoft/d365-bc-integrations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -196,9 +196,6 @@
 Upgrade/ @microsoft/d365-bc-app-upgrade
 /src/GDL/ @microsoft/d365-bc-integrations
 
-# App Rulesets
-/src/rulesets/ @microsoft/d365-bc-app-rulesets
-
 # Developer Experience
 /src/System\ Application/App/AI @microsoft/d365-bc-copilot-toolkit @microsoft/dynamics-smb-developertools
 /src/System\ Application/Test/AI @microsoft/dynamics-smb-developertools
@@ -219,13 +216,13 @@ dotnet*.al @microsoft/d365-bc-app-security
 # app.json files are owned by the BC app team to control the metadata
 app.json @microsoft/d365-bc-app-required
 
-# AL-Go files and build scripts are owned by Engineering Systems
-.AL-Go/ @microsoft/d365-bc-engineering-systems
-*.ps1 @microsoft/d365-bc-engineering-systems
-/.azuredevops @microsoft/d365-bc-engineering-systems
-/.github @microsoft/d365-bc-engineering-systems
-/build @microsoft/d365-bc-engineering-systems
-/CODEOWNERS @microsoft/d365-bc-engineering-systems
-
-# Code Review Tools
-/tools/Code\ Review @microsoft/d365-bc-code-review-agent
+# Special paths are governed by required-reviewer repository rules. These
+# ownerless entries keep the repository fallback from requesting a second team.
+/src/rulesets/
+/tools/Code\ Review
+.AL-Go/
+*.ps1
+/.azuredevops
+/.github
+/build
+/CODEOWNERS

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,6 @@
 # CODEOWNERS is case sensitive and uses the last matching rule.
-# There is no repository-wide default: unmatched AL files fall back to the full
-# Business Central team, while later application and specialist rules override
-# that fallback. Ownerless rules release non-AL content from broader mappings.
+# Unmatched files fall back to the full Business Central team, while later
+# application and specialist rules override that fallback.
 #
 # The application map is generated from the BCApps triage routing data:
 #   microsoft/BCAppsTriage
@@ -10,8 +9,8 @@
 # Change generated ownership in BCAppsTriage, then regenerate this file.
 # Dedicated and cross-cutting ownership rules are listed after the generated map.
 
-# AL fallback
-*.al @microsoft/dynamics-365-business-central
+# Repository fallback
+* @microsoft/dynamics-365-business-central
 
 # Platform. Integration owns these end to end; the sub-sections other
 # teams own are listed further down, after this block.
@@ -64,10 +63,9 @@
 # (GST, TDS, Intrastat, IRS forms, e-invoicing), so Finance owns them by
 # default. Exceptions are listed at the end of this block.
 /src/Apps/*/ @microsoft/d365-bc-finance-1
-# W1 is a layer name, not a country code, so release it from that wildcard.
-# Restore the AL fallback before the individual app rules override it.
-/src/Apps/W1/
-/src/Apps/W1/**/*.al @microsoft/dynamics-365-business-central
+# W1 is a layer name, not a country code, so restore the repository fallback
+# before the individual app rules override it.
+/src/Apps/W1/ @microsoft/dynamics-365-business-central
 
 # W1 apps - one line each (100). These also override the wildcard
 # above, since W1 is a layer name rather than a country code.
@@ -178,14 +176,13 @@
 /src/Apps/BE/ShopifyBE/ @microsoft/d365-bc-integrations
 /src/Apps/IT/SubcontractingMigrationIT/ @microsoft/d365-bc-scm
 
-# Demo data. Every team contributes demo data for its own area, so these lines
-# release non-AL content from broader ownership rules. Integrations owns the AL
-# files that were previously covered by the Official Branches ruleset.
-/src/Apps/*/*ContosoCoffeeDemoDataset*/
+# Demo data. Every team contributes demo data for its own area, so non-AL
+# content uses the repository fallback. Integrations owns the AL files that
+# were previously covered by the Official Branches ruleset.
+/src/Apps/*/*ContosoCoffeeDemoDataset*/ @microsoft/dynamics-365-business-central
 /src/Apps/*/*ContosoCoffeeDemoDataset*/**/*.al @microsoft/d365-bc-integrations
-/src/DemoTool/*/
-/src/DemoTool/**/*.al @microsoft/dynamics-365-business-central
-/src/Layers/*/DemoTool/*/
+/src/DemoTool/*/ @microsoft/dynamics-365-business-central
+/src/Layers/*/DemoTool/*/ @microsoft/dynamics-365-business-central
 /src/Layers/*/DemoTool/**/*.al @microsoft/d365-bc-integrations
 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,21 +5,20 @@
 # ---------------------------------------------------------------------------
 # Application team ownership (GENERATED - do not hand-edit)
 #
-# One line per thing a team owns: each app, each Base Application area, the
-# System Application and Business Foundation. Nothing else.
+# One fallback for AL files, followed by one line per thing a team owns: each
+# app, each Base Application area, the System Application and Business
+# Foundation. Nothing else.
 #
-# There is deliberately no `* @microsoft/dynamics-365-business-central` default.
-# A catch-all default makes the 123-member org team a reviewer on every pull
-# request that touches any unclaimed file, which is the noise this file exists
-# to remove. A path no team claims simply has no code owner.
+# There is deliberately no repository-wide `*` default. Instead, unmatched AL
+# files fall back to the full Business Central team. This keeps AL changes
+# covered without requesting the 123-member team for unrelated files. The
+# specific application ownership rules below take precedence over the fallback.
 #
-# Tests, demo data, the demo tool and the localization layers are deliberately
-# unclaimed. Every team writes tests and ships demo data, so naming one team
-# there requests a review nobody needs. The triage agent still labels those
-# issues and pull requests with a team, so the work stays visible on that team's
-# backlog - it just does not pull in a specific reviewer. In short: CODEOWNERS
-# decides who is asked to review, triage decides whose backlog it lands on.
-# Those two answers are allowed to differ.
+# Tests, demo data, the demo tool and localization layers use a specific
+# application owner where one exists, and otherwise use the AL fallback. Non-AL
+# files in explicitly released folders remain unclaimed. The triage agent still
+# labels issues and pull requests with a team so the work stays visible on that
+# team's backlog.
 #
 # The rules are generated from the routing data the BCApps triage agent uses to
 # classify issues and pull requests:
@@ -38,6 +37,10 @@
 # App Permissions, app.json, AL-Go and build files, Developer Experience, Code
 # Review Tools) still take precedence over everything here.
 # ---------------------------------------------------------------------------
+
+# AL fallback. Keep this before every more specific ownership rule because
+# CODEOWNERS uses the last matching pattern.
+*.al @microsoft/dynamics-365-business-central
 
 # Platform. Integration owns these end to end; the sub-sections other
 # teams own are listed further down, after this block.
@@ -91,8 +94,9 @@
 # default. Exceptions are listed at the end of this block.
 /src/Apps/*/ @microsoft/d365-bc-finance-1
 # W1 is a layer name, not a country code, so release it from that wildcard.
-# Its apps are listed individually below and override this line.
+# Restore the AL fallback before the individual app rules override it.
 /src/Apps/W1/
+/src/Apps/W1/**/*.al @microsoft/dynamics-365-business-central
 
 # W1 apps - one line each (100). These also override the wildcard
 # above, since W1 is a layer name rather than a country code.
@@ -209,12 +213,14 @@
 /src/Apps/BE/ShopifyBE/ @microsoft/d365-bc-integrations
 /src/Apps/IT/SubcontractingMigrationIT/ @microsoft/d365-bc-scm
 
-# Demo data. Every team contributes demo data for its own area, so it has no
-# single owner. This line has no owner on purpose: it releases demo data
-# from the localization wildcard above without naming anyone.
+# Demo data. Every team contributes demo data for its own area, so these lines
+# release non-AL content from broader ownership rules. AL files use the fallback.
 /src/Apps/*/*ContosoCoffeeDemoDataset*/
+/src/Apps/*/*ContosoCoffeeDemoDataset*/**/*.al @microsoft/dynamics-365-business-central
 /src/DemoTool/*/
+/src/DemoTool/**/*.al @microsoft/dynamics-365-business-central
 /src/Layers/*/DemoTool/*/
+/src/Layers/*/DemoTool/**/*.al @microsoft/dynamics-365-business-central
 
 
 # Expense Agent application family. These review routes intentionally differ

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -105,8 +105,8 @@
 /src/Apps/W1/AIDevelopmentToolkitEvaluation/ @microsoft/d365-bc-integrations
 /src/Apps/W1/AMCBanking365Fundamentals/ @microsoft/d365-bc-finance-1
 /src/Apps/W1/APIReportsFinance/ @microsoft/d365-bc-finance-1
-/src/Apps/W1/APIV1/ @microsoft/d365-bc-integrations
-/src/Apps/W1/APIV2/ @microsoft/d365-bc-integrations
+/src/Apps/W1/APIV1/ @microsoft/d365-bc-app-api
+/src/Apps/W1/APIV2/ @microsoft/d365-bc-app-api
 /src/Apps/W1/AgentDesignExperience/ @microsoft/d365-bc-integrations
 /src/Apps/W1/AgentSamples/ @microsoft/d365-bc-integrations
 /src/Apps/W1/AuditFileExport/ @microsoft/d365-bc-finance-1
@@ -214,19 +214,25 @@
 /src/Apps/IT/SubcontractingMigrationIT/ @microsoft/d365-bc-scm
 
 # Demo data. Every team contributes demo data for its own area, so these lines
-# release non-AL content from broader ownership rules. AL files use the fallback.
+# release non-AL content from broader ownership rules. Integrations owns the AL
+# files that were previously covered by the Official Branches ruleset.
 /src/Apps/*/*ContosoCoffeeDemoDataset*/
-/src/Apps/*/*ContosoCoffeeDemoDataset*/**/*.al @microsoft/dynamics-365-business-central
+/src/Apps/*/*ContosoCoffeeDemoDataset*/**/*.al @microsoft/d365-bc-integrations
 /src/DemoTool/*/
 /src/DemoTool/**/*.al @microsoft/dynamics-365-business-central
 /src/Layers/*/DemoTool/*/
-/src/Layers/*/DemoTool/**/*.al @microsoft/dynamics-365-business-central
+/src/Layers/*/DemoTool/**/*.al @microsoft/d365-bc-integrations
 
 
 # Expense Agent application family. These review routes intentionally differ
 # from the Finance functional ownership labels used by triage.
 /src/Apps/*/ExpenseAgent*/ @microsoft/d365-bc-app-expense-agent
 /src/Apps/*/ExpenseWithholdingTax*/ @microsoft/d365-bc-app-expense-agent
+
+# AL ownership migrated from the Official Branches ruleset
+/src/DisabledTests/ @microsoft/d365-bc-app-tests
+Upgrade/ @microsoft/d365-bc-app-upgrade
+/src/GDL/ @microsoft/d365-bc-integrations
 
 # App Rulesets
 /src/rulesets/ @microsoft/d365-bc-app-rulesets
@@ -242,7 +248,7 @@
 /src/System\ Application/Test/Extension\ Management @microsoft/dynamics-smb-developertools
 
 # App Security
-dotnet.al @microsoft/d365-bc-app-security
+dotnet*.al @microsoft/d365-bc-app-security
 
 # App Permissions
 *.Entitlement.al @microsoft/d365-bc-integrations

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -193,6 +193,7 @@
 
 # AL ownership migrated from the Official Branches ruleset
 /src/DisabledTests/ @microsoft/d365-bc-app-tests
+# Unanchored intentionally to preserve ownership of every Upgrade folder.
 Upgrade/ @microsoft/d365-bc-app-upgrade
 /src/GDL/ @microsoft/d365-bc-integrations
 


### PR DESCRIPTION
## Summary

- add `@microsoft/dynamics-365-business-central` as the repository fallback when no more specific CODEOWNER exists
- move AL review routes from the **Official Branches** ruleset into CODEOWNERS, including API, disabled tests, upgrade, GDL, demo-tool/data, and `dotnet*.al` ownership
- keep existing Power BI, AI/developer-experience, e-document, modules, entitlement, SCM, Integrations, Finance, and specialist mappings authoritative through CODEOWNERS' last-match-wins ordering
- make ruleset-controlled special paths explicitly ownerless in CODEOWNERS so they do not request both the fallback team and the ruleset reviewer
- remove redundant Power BI rules and condense the guidance

## Ruleset coordination

Update the **Official Branches** ruleset (ID `17834252`) as follows:

- enable `require_code_owner_review`
- remove the blanket `*` required reviewer
- remove the AL file/folder-specific required reviewers after migrating their ownership to CODEOWNERS
- retain only these special-path required reviewers:
  - App Rulesets: `/src/rulesets/`
  - Code Review Tools: `/tools/Code Review`
  - Engineering Systems: `.AL-Go/`, `*.ps1`, `/.azuredevops`, `/.github`, `/build`, `/CODEOWNERS`

Unlike the ruleset's additive `*` required-reviewer entry, the CODEOWNERS fallback is replaced by any later matching rule. The 539 tracked files covered by the retained special-path rules are explicitly ownerless in CODEOWNERS; every other tracked file resolves to a CODEOWNER.

Fixes [AB#647781](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647781).

