### PR TITLE
[29.0] Backport Chat v2 privacy notice behavior changed to not auto agree for Eval companies

### DIFF
--- a/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotCapabilityImpl.Codeunit.al
@@ -217,8 +217,10 @@ codeunit 7774 "Copilot Capability Impl"
     var
         CopilotCapabilityCU: Codeunit "Copilot Capability";
         PrivacyNotice: Codeunit "Privacy Notice";
+        SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
         RequiredPrivacyNotices: List of [Code[50]];
         RequiredPrivacyNotice: Code[50];
+        SkipCheckInEval: Boolean;
     begin
         CopilotSettings.ReadIsolation(IsolationLevel::ReadCommitted);
         CopilotSettings.SetLoadFields(Status);
@@ -231,9 +233,11 @@ codeunit 7774 "Copilot Capability Impl"
             exit(CopilotSettings.Status = Enum::"Copilot Status"::Active);
 
         // check privacy notices
-        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do
-            if (PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, true) <> Enum::"Privacy Notice Approval State"::Agreed) then
+        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do begin
+            SkipCheckInEval := RequiredPrivacyNotice <> SystemPrivacyNoticeReg.GetMicrosoftCopilotID();
+            if PrivacyNotice.GetPrivacyNoticeApprovalState(RequiredPrivacyNotice, SkipCheckInEval) <> Enum::"Privacy Notice Approval State"::Agreed then
                 exit(false);
+        end;
 
         exit(true);
     end;

--- a/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
+++ b/src/System Application/App/AI/src/Copilot/CopilotSettings.Table.al
@@ -101,17 +101,21 @@ table 7775 "Copilot Settings"
     var
         CopilotCapability: Codeunit "Copilot Capability";
         PrivacyNotice: Codeunit "Privacy Notice";
+        SystemPrivacyNoticeReg: Codeunit "System Privacy Notice Reg.";
         RequiredPrivacyNotices: List of [Code[50]];
         RequiredPrivacyNotice: Code[50];
+        SkipCheckInEval: Boolean;
     begin
         CopilotCapability.OnGetRequiredPrivacyNotices(Rec.Capability, Rec."App Id", RequiredPrivacyNotices);
 
         if RequiredPrivacyNotices.Count() <= 0 then
             exit(true);
 
-        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do
-            if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, true) then
+        foreach RequiredPrivacyNotice in RequiredPrivacyNotices do begin
+            SkipCheckInEval := RequiredPrivacyNotice <> SystemPrivacyNoticeReg.GetMicrosoftCopilotID();
+            if not PrivacyNotice.ConfirmPrivacyNoticeApproval(RequiredPrivacyNotice, SkipCheckInEval) then
                 exit(false);
+        end;
 
         exit(true);
     end;


### PR DESCRIPTION
Fixes: [AB#649639](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649639) 
Backport commit: d5ea8cced9ffecb2a69a3d530842211b9f52ca6b

Backports new behavior for chat v2 privacy policy to treat Eval companies as non-Eval companies




