### PR TITLE
[28.x] Restore PEPPOL validation and legacy export events

### DIFF
--- a/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/DataExchange/EDocDataExchangeImpl.Codeunit.al
@@ -26,34 +26,40 @@ codeunit 6152 "E-Doc. Data Exchange Impl." implements "E-Document"
         SalesCrMemoHeader: Record "Sales Cr.Memo Header";
         ServiceInvoiceHeader: Record "Service Invoice Header";
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
-        PEPPOLValidation: Codeunit "PEPPOL30 Sales Validation";
-        PEPPOLServiceValidation: Codeunit "PEPPOL30 Service Validation";
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+        SalesValidation: Interface "PEPPOL30 Validation";
+        ServiceValidation: Interface "PEPPOL30 Validation";
     begin
+        PeppolSetup.GetSetup();
+        SalesValidation := PeppolSetup."PEPPOL 3.0 Sales Format";
+        ServiceValidation := PeppolSetup."PEPPOL 3.0 Service Format";
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesHeader);
-                    PEPPOLValidation.Run(SalesHeader);
+                    SalesValidation.ValidateDocument(SalesHeader);
+                    SalesValidation.ValidateDocumentLines(SalesHeader);
                 end;
             Database::"Sales Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesInvoiceHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesInvoiceHeader);
+                    SalesValidation.ValidatePostedDocument(SalesInvoiceHeader);
                 end;
             Database::"Sales Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesCrMemoHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesCrMemoHeader);
+                    SalesValidation.ValidatePostedDocument(SalesCrMemoHeader);
                 end;
             Database::"Service Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceInvoiceHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
                 end;
             Database::"Service Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceCrMemoHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
                 end;
         end;
     end;

--- a/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Format/EDocPEPPOLBIS30.Codeunit.al
@@ -8,6 +8,7 @@ using Microsoft.Purchases.Document;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.FinanceCharge;
 using Microsoft.Sales.History;
+using Microsoft.Sales.Peppol;
 using Microsoft.Sales.Reminder;
 using Microsoft.Service.Document;
 using Microsoft.Service.History;
@@ -25,35 +26,39 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
         ServiceCrMemoHeader: Record "Service Cr.Memo Header";
         ReminderHeader: Record "Reminder Header";
         FinChargeMemoHeader: Record "Finance Charge Memo Header";
-        PEPPOLValidation: Codeunit "PEPPOL30 Sales Validation";
-        PEPPOLServiceValidation: Codeunit "PEPPOL30 Service Validation";
         EDocPEPPOLValidation: Codeunit "E-Doc. PEPPOL Validation";
+        SalesValidation: Interface "PEPPOL30 Validation";
+        ServiceValidation: Interface "PEPPOL30 Validation";
     begin
+        SalesValidation := GetSalesFormat();
+        ServiceValidation := GetServiceFormat();
+
         case SourceDocumentHeader.Number of
             Database::"Sales Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesHeader);
-                    PEPPOLValidation.Run(SalesHeader);
+                    SalesValidation.ValidateDocument(SalesHeader);
+                    SalesValidation.ValidateDocumentLines(SalesHeader);
                 end;
             Database::"Sales Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesInvoiceHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesInvoiceHeader);
+                    SalesValidation.ValidatePostedDocument(SalesInvoiceHeader);
                 end;
             Database::"Sales Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(SalesCrMemoHeader);
-                    PEPPOLValidation.ValidatePostedDocument(SalesCrMemoHeader);
+                    SalesValidation.ValidatePostedDocument(SalesCrMemoHeader);
                 end;
             Database::"Service Invoice Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceInvoiceHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceInvoiceHeader);
                 end;
             Database::"Service Cr.Memo Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceCrMemoHeader);
-                    PEPPOLServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
+                    ServiceValidation.ValidatePostedDocument(ServiceCrMemoHeader);
                 end;
             Database::"Reminder Header":
                 begin
@@ -68,7 +73,8 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
             Database::"Service Header":
                 begin
                     SourceDocumentHeader.SetTable(ServiceHeader);
-                    PEPPOLServiceValidation.Run(ServiceHeader);
+                    ServiceValidation.ValidateDocument(ServiceHeader);
+                    ServiceValidation.ValidateDocumentLines(ServiceHeader);
                 end;
         end;
     end;
@@ -121,24 +127,38 @@ codeunit 6165 "EDoc PEPPOL BIS 3.0" implements "E-Document"
 
     local procedure GenerateInvoiceXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
     var
-        SalesInvoicePEPPOL30: XMLport "Sales Invoice - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
+        SalesInvoicePEPPOLBIS30: XMLport "Sales Invoice - PEPPOL BIS 3.0";
     begin
-        SalesInvoicePEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
-        SalesInvoicePEPPOL30.SetGeneratePDF(GeneratePDF);
-        SalesInvoicePEPPOL30.SetDestination(OutStr);
-        SalesInvoicePEPPOL30.Export();
+        SalesInvoicePEPPOLBIS30.Initialize(VariantRec);
+        SalesInvoicePEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+        SalesInvoicePEPPOLBIS30.SetDestination(OutStr);
+        SalesInvoicePEPPOLBIS30.Export();
     end;
 
     local procedure GenerateCrMemoXMLFile(VariantRec: Variant; var OutStr: OutStream; GeneratePDF: Boolean)
     var
-        SalesCrMemoPEPPOL30: XMLport "Sales Cr.Memo - PEPPOL30";
-        PEPPOLFormat: Enum "PEPPOL 3.0 Format";
+        SalesCrMemoPEPPOLBIS30: XMLport "Sales Cr.Memo - PEPPOL BIS 3.0";
     begin
-        SalesCrMemoPEPPOL30.Initialize(VariantRec, PEPPOLFormat::"PEPPOL 3.0 - Sales");
-        SalesCrMemoPEPPOL30.SetGeneratePDF(GeneratePDF);
-        SalesCrMemoPEPPOL30.SetDestination(OutStr);
-        SalesCrMemoPEPPOL30.Export();
+        SalesCrMemoPEPPOLBIS30.Initialize(VariantRec);
+        SalesCrMemoPEPPOLBIS30.SetGeneratePDF(GeneratePDF);
+        SalesCrMemoPEPPOLBIS30.SetDestination(OutStr);
+        SalesCrMemoPEPPOLBIS30.Export();
+    end;
+
+    local procedure GetSalesFormat(): Enum "PEPPOL 3.0 Format"
+    var
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+    begin
+        PeppolSetup.GetSetup();
+        exit(PeppolSetup."PEPPOL 3.0 Sales Format");
+    end;
+
+    local procedure GetServiceFormat(): Enum "PEPPOL 3.0 Format"
+    var
+        PeppolSetup: Record "PEPPOL 3.0 Setup";
+    begin
+        PeppolSetup.GetSetup();
+        exit(PeppolSetup."PEPPOL 3.0 Service Format");
     end;
 
     local procedure GenerateFinancialResultsXMLFile(VariantRec: Variant; var OutStr: OutStream)


### PR DESCRIPTION
Backports #11250. Restores localization-selected PEPPOL 3.0 validation and legacy PEPPOL BIS 3.0 invoice/credit-memo XMLport events while preserving EDI receive/order-response behavior.

Fixes
[AB#649649](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649649)





