### PR TITLE
[28.5] Classify restored E-Document table sensitivities

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -491,6 +491,8 @@ codeunit 6103 "E-Document Subscribers"
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Service Data Exch. Def.");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Message");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. External Reference");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Payment Occurrence");
 #if not CLEAN28
 #pragma warning disable AL0432
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Documents Setup");


### PR DESCRIPTION
## Why

The restored E-Document lifecycle tables are not registered when demo data sensitivity evaluation runs. As a result, `TestDataSensitivities` fails because fields in table 6433 remain unclassified, starting with the Amount field.

## Summary

- **Classified** E-Document Message fields as normal sensitivity data.
- **Classified** E-Doc. External Reference and E-Doc. Payment Occurrence fields as normal sensitivity data.
- **Prevented** the W1 demo data sensitivity test from leaving restored E-Document tables unclassified.

Fixes
[AB#648771](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648771)






