### PR TITLE
[28.x] Classify restored E-Document table sensitivities

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocumentSubscribers.Codeunit.al
@@ -490,6 +490,9 @@ codeunit 6103 "E-Document Subscribers"
     begin
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Service Data Exch. Def.");
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Document Message");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. External Reference");
+        DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Doc. Payment Occurrence");
 #if not CLEAN28
 #pragma warning disable AL0432
         DataClassificationEvalData.SetTableFieldsToNormal(Database::"E-Documents Setup");


### PR DESCRIPTION
## Why

The restored E-Document message infrastructure introduces tables whose runtime data sensitivity remains unclassified. This causes `Data Classs Demo Data Tests.TestDataSensitivities` to fail across localization test buckets.

This backports the classifications from #11170 and #11276 to `releases/28.x`.

## Summary

- **Classified** E-Document Message fields as normal sensitivity data.
- **Classified** E-Doc. External Reference and E-Doc. Payment Occurrence fields as normal sensitivity data.

Fixes
[AB#648705](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648705)
[AB#648955](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648955)



