### PR TITLE
Bug 649654: [29.0][NAV] Track Translation update (AUTODETECTED)

### DIFF
--- a/src/Layers/APAC/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/APAC/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/AU/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/AU/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/CA/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/CA/DemoTool/CreateCurrency.Codeunit.al
@@ -222,7 +222,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/CH/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/CH/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/CZ/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/CZ/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/DE/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/DE/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/DK/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/DK/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/ES/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/ES/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/FR/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/FR/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/GB/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/GB/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/NL/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/NL/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
     

--- a/src/Layers/NO/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/NO/DemoTool/CreateCurrency.Codeunit.al
@@ -222,7 +222,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/NZ/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/NZ/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/RU/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/RU/DemoTool/CreateCurrency.Codeunit.al
@@ -234,7 +234,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Validate("RU Bank Code", Currency.Code);
         Currency.Insert(true);
     end;

--- a/src/Layers/US/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/US/DemoTool/CreateCurrency.Codeunit.al
@@ -223,7 +223,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 

--- a/src/Layers/W1/DemoTool/CreateCurrency.Codeunit.al
+++ b/src/Layers/W1/DemoTool/CreateCurrency.Codeunit.al
@@ -218,7 +218,6 @@ codeunit 101004 "Create Currency"
         Currency.Validate("EMU Currency", CurrencyData."EMU Currency");
         Currency.Validate("Amount Decimal Places", CurrencyData."Amount Decimal Places");
         Currency.Validate("Unit-Amount Decimal Places", CurrencyData."Unit-Amount Decimal Places");
-        Currency.Validate(Symbol, Currency.ResolveCurrencySymbol(Currency.Code));
         Currency.Insert(true);
     end;
 


### PR DESCRIPTION
Remove validation that causes failures if GLSetup isn't inserted yet. (translation builds)

Fixes [AB#649654](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649654)





