### PR TITLE
[29.x] - Bug 649740: [Expense Agent] BC Approval Workflow - Improve error message when Approval User Setup is missing

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -21,8 +21,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
         NoExpenseReportLinesToProcessErr: Label 'There are no Expense Report Lines to process in %1 action.', Comment = '%1 = Action';
         NotAuthorizedToOpenExpReportErr: Label 'You are not authorized to open expense reports. Please configure your %1 in the %2.', Comment = '%1 = Field Caption,%2 = Table Caption';
         NotAuthorizedToRecallExpReportErr: Label 'Only the original submitter or a user with %1 can recall a submitted expense report.', Comment = '%1 = User Setup field caption';
-        MissingUserSetupErr: Label 'Please configure your user ''%1'' on the User Setup page, as the approval workflow for expenses is enabled.', Comment = '%1 = current user ID';
-        OpenApprovalUserSetupLbl: Label 'Open the Approval User Setup page';
+        MissingUserSetupErr: Label 'Please configure your user ''%1'' on the User Setup, as the approval workflow for expenses is enabled.', Comment = '%1 = current user ID';
+        OpenApprovalUserSetupLbl: Label 'Open the Approval User Setup';
         ApproverMustBeEnabledInExpenseUserErr: Label '%1 must be enabled to approve or reject expense reports in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
         UserIdForApprovalMustNotBeBlankInExpenseUserErr: Label '%1 must not be blank in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
         InterimApproverAgentRequiredErr: Label 'An interim approver can only be assigned when the agent is enabled in %1.', Comment = '%1 = Expense Agent Setup table caption';

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.ExpenseAgent;
+using System.Automation;
 using System.Security.User;
 
 codeunit 6901 "Expense Report Approval Mgmt"
@@ -20,6 +21,8 @@ codeunit 6901 "Expense Report Approval Mgmt"
         NoExpenseReportLinesToProcessErr: Label 'There are no Expense Report Lines to process in %1 action.', Comment = '%1 = Action';
         NotAuthorizedToOpenExpReportErr: Label 'You are not authorized to open expense reports. Please configure your %1 in the %2.', Comment = '%1 = Field Caption,%2 = Table Caption';
         NotAuthorizedToRecallExpReportErr: Label 'Only the original submitter or a user with %1 can recall a submitted expense report.', Comment = '%1 = User Setup field caption';
+        MissingUserSetupErr: Label 'Please configure your user ''%1'' on the User Setup page, as the approval workflow for expenses is enabled.', Comment = '%1 = current user ID';
+        OpenApprovalUserSetupLbl: Label 'Open the Approval User Setup page';
         ApproverMustBeEnabledInExpenseUserErr: Label '%1 must be enabled to approve or reject expense reports in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
         UserIdForApprovalMustNotBeBlankInExpenseUserErr: Label '%1 must not be blank in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
         InterimApproverAgentRequiredErr: Label 'An interim approver can only be assigned when the agent is enabled in %1.', Comment = '%1 = Expense Agent Setup table caption';
@@ -510,6 +513,27 @@ codeunit 6901 "Expense Report Approval Mgmt"
             exit(Enum::"Expense Activity Actor Role"::Administrator);
 
         Error(NotAuthorizedToRecallExpReportErr, UserSetup.FieldCaption("Unlimited Expense Approval"));
+    end;
+
+    internal procedure GetCurrentUserSetupForApproval(var UserSetup: Record "User Setup")
+    begin
+        if not UserSetup.Get(UserId()) then
+            Error(CreateMissingUserSetupErrorInfo());
+    end;
+
+    local procedure CreateMissingUserSetupErrorInfo(): ErrorInfo
+    var
+        UserSetup: Record "User Setup";
+        MissingUserSetupErrorInfo: ErrorInfo;
+    begin
+        MissingUserSetupErrorInfo.Message := StrSubstNo(MissingUserSetupErr, UserId());
+        MissingUserSetupErrorInfo.DataClassification := DataClassification::CustomerContent;
+        MissingUserSetupErrorInfo.ErrorType := ErrorType::Client;
+        if UserSetup.ReadPermission() then begin
+            MissingUserSetupErrorInfo.PageNo := Page::"Approval User Setup";
+            MissingUserSetupErrorInfo.AddNavigationAction(OpenApprovalUserSetupLbl);
+        end;
+        exit(MissingUserSetupErrorInfo);
     end;
 
     internal procedure NoExpenseLinesToProcess(ExpenseApprovalAction: Enum "Expense Approval Action")

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Codeunits/ExpenseReportApprovalMgmt.Codeunit.al
@@ -22,6 +22,9 @@ codeunit 6901 "Expense Report Approval Mgmt"
         NotAuthorizedToOpenExpReportErr: Label 'You are not authorized to open expense reports. Please configure your %1 in the %2.', Comment = '%1 = Field Caption,%2 = Table Caption';
         NotAuthorizedToRecallExpReportErr: Label 'Only the original submitter or a user with %1 can recall a submitted expense report.', Comment = '%1 = User Setup field caption';
         MissingUserSetupErr: Label 'Please configure your user ''%1'' on the User Setup, as the approval workflow for expenses is enabled.', Comment = '%1 = current user ID';
+        MissingUserSetupWithoutPermissionErr: Label 'Your user is not configured for expense approval. Please contact your administrator to configure your user on the User Setup page.';
+        MissingUserSetupTitleTxt: Label 'User Setup is missing';
+        MissingUserSetupDetailedMessageTxt: Label 'The approval workflow for expenses is enabled, but no User Setup record exists for the current user.';
         OpenApprovalUserSetupLbl: Label 'Open the Approval User Setup';
         ApproverMustBeEnabledInExpenseUserErr: Label '%1 must be enabled to approve or reject expense reports in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
         UserIdForApprovalMustNotBeBlankInExpenseUserErr: Label '%1 must not be blank in %2.', Comment = '%1 = Field Caption, %2 = Table Caption';
@@ -517,6 +520,7 @@ codeunit 6901 "Expense Report Approval Mgmt"
 
     internal procedure GetCurrentUserSetupForApproval(var UserSetup: Record "User Setup")
     begin
+        UserSetup.SetLoadFields("Unlimited Expense Approval");
         if not UserSetup.Get(UserId()) then
             Error(CreateMissingUserSetupErrorInfo());
     end;
@@ -526,13 +530,16 @@ codeunit 6901 "Expense Report Approval Mgmt"
         UserSetup: Record "User Setup";
         MissingUserSetupErrorInfo: ErrorInfo;
     begin
-        MissingUserSetupErrorInfo.Message := StrSubstNo(MissingUserSetupErr, UserId());
-        MissingUserSetupErrorInfo.DataClassification := DataClassification::CustomerContent;
+        MissingUserSetupErrorInfo.Title := MissingUserSetupTitleTxt;
+        MissingUserSetupErrorInfo.DetailedMessage := MissingUserSetupDetailedMessageTxt;
         MissingUserSetupErrorInfo.ErrorType := ErrorType::Client;
         if UserSetup.ReadPermission() then begin
+            MissingUserSetupErrorInfo.Message := StrSubstNo(MissingUserSetupErr, UserId());
+            MissingUserSetupErrorInfo.DataClassification := DataClassification::EndUserIdentifiableInformation;
             MissingUserSetupErrorInfo.PageNo := Page::"Approval User Setup";
             MissingUserSetupErrorInfo.AddNavigationAction(OpenApprovalUserSetupLbl);
-        end;
+        end else
+            MissingUserSetupErrorInfo.Message := MissingUserSetupWithoutPermissionErr;
         exit(MissingUserSetupErrorInfo);
     end;
 

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReport.Page.al
@@ -503,7 +503,7 @@ page 6980 "Manager Expense Report"
         ExpenseAgentSetup.GetRecordOnce();
 
         if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
+            ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
             if not UserSetup."Unlimited Expense Approval" then begin
                 CheckSetDefaultOwnerFilter();
                 ExpenseUserNo := ExpenseReportApprovalMgmt.GetExpenseUserNo();

--- a/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReports.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Approval/Pages/ManagerExpenseReports.Page.al
@@ -197,7 +197,7 @@ page 6981 "Manager Expense Reports"
         ExpenseAgentSetup.GetRecordOnce();
 
         if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
+            ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
             if not UserSetup."Unlimited Expense Approval" then
                 ExpenseReportApprovalMgmt.FilterExpenseReports(Rec, Rec.FieldNo("Approver Expense User ID"))
         end;

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReport.Page.al
@@ -681,7 +681,7 @@ page 6910 "Expense Report"
         ExpenseAgentSetup.GetRecordOnce();
 
         if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
+            ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
             if not UserSetup."Unlimited Expense Approval" then begin
                 CheckSetDefaultOwnerFilter();
                 ExpenseUserNo := ExpenseReportApprovalMgmt.GetExpenseUserNo();

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportList.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportList.Page.al
@@ -157,7 +157,7 @@ page 6979 "Expense Report List"
         ExpenseAgentSetup.GetRecordOnce();
 
         if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
+            ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
             if not UserSetup."Unlimited Expense Approval" then
                 ExpenseReportApprovalMgmt.FilterExpenseReports(Rec, Rec.FieldNo("Created By"));
         end;

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReports.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReports.Page.al
@@ -305,7 +305,7 @@ page 6997 "Expense Reports"
         ExpenseAgentSetup.GetRecordOnce();
 
         if ExpenseAgentSetup."Enable Approval Workflow" then begin
-            UserSetup.Get(UserId());
+            ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
             if not UserSetup."Unlimited Expense Approval" then
                 ExpenseReportApprovalMgmt.FilterExpenseReports(Rec, Rec.FieldNo("Created By"));
         end;

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Tables/ExpenseReportHeader.Table.al
@@ -1277,13 +1277,14 @@ table 6906 "Expense Report Header"
     var
         UserSetup: Record "User Setup";
         ExpenseUser: Record "Expense User";
+        ExpenseReportApprovalMgmt: Codeunit "Expense Report Approval Mgmt";
     begin
         ExpenseAgentSetup.GetRecordOnce();
         if not ExpenseAgentSetup."Enable Approval Workflow" then
             exit;
 
         UserSetup.SetLoadFields("Unlimited Expense Approval");
-        UserSetup.Get(UserId);
+        ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
         if UserSetup."Unlimited Expense Approval" then
             exit;
 

--- a/src/Apps/W1/ExpenseAgent/test/src/WFDemoExpReportApprovals.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/WFDemoExpReportApprovals.Codeunit.al
@@ -48,6 +48,7 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         ApproveActionMustBeVisibleErr: Label 'Approve action must be visible for the assigned approver.';
         RejectActionMustBeVisibleErr: Label 'Reject action must be visible for the assigned approver.';
         ApproveActionMustNotBeVisibleErr: Label 'Approve action must not be visible when the user is not the assigned approver.';
+        MissingUserSetupErr: Label 'Please configure your user ''%1'' on the User Setup, as the approval workflow for expenses is enabled.', Comment = '%1 = current user ID';
 
     [Test]
     [HandlerFunctions('ExpensesModalPageHandler,ConfirmHandler')]
@@ -965,6 +966,66 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         Assert.IsFalse(
             ExpenseAgentSetup."Enable Approval Workflow",
             StrSubstNo(ValueMustBeEqualErr, ExpenseAgentSetup.FieldCaption("Enable Approval Workflow"), false, ExpenseAgentSetup.TableCaption()));
+    end;
+
+    [Test]
+    procedure MissingUserSetupThrowsActionableErrorForApproval()
+    var
+        UserSetup: Record "User Setup";
+    begin
+        // [SCENARIO 645040] Resolving the current user's setup for approval raises an actionable error when the user is not on the User Setup page.
+        Initialize();
+
+        // [GIVEN] Approval workflow is enabled.
+        LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(true);
+
+        // [WHEN] Resolving the current user's setup for approval.
+        asserterror ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
+
+        // [THEN] The actionable missing-User-Setup error is raised for the current user.
+        Assert.ExpectedError(StrSubstNo(MissingUserSetupErr, UserId()));
+    end;
+
+    [Test]
+    procedure CurrentUserSetupIsReturnedWhenPresentForApproval()
+    var
+        UserSetup: Record "User Setup";
+    begin
+        // [SCENARIO 645040] Resolving the current user's setup for approval returns the record when the user is on the User Setup page.
+        Initialize();
+
+        // [GIVEN] Approval workflow is enabled.
+        LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(true);
+
+        // [GIVEN] The current user has a User Setup record.
+        UserSetup.Init();
+        UserSetup."User ID" := CopyStr(UserId(), 1, MaxStrLen(UserSetup."User ID"));
+        UserSetup.Insert();
+        Clear(UserSetup);
+
+        // [WHEN] Resolving the current user's setup for approval.
+        ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
+
+        // [THEN] The current user's User Setup record is returned without error.
+        UserSetup.TestField("User ID", CopyStr(UserId(), 1, MaxStrLen(UserSetup."User ID")));
+    end;
+
+    [Test]
+    procedure ManagerExpenseReportSurfacesMissingUserSetupError()
+    var
+        ManagerExpenseReportPage: TestPage "Manager Expense Report";
+    begin
+        // [SCENARIO 645040] Opening Manager Expense Report raises the actionable error when approval workflow is enabled and the current user is not on the User Setup page.
+        Initialize();
+
+        // [GIVEN] Approval workflow is enabled.
+        LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(true);
+
+        // [WHEN] Opening the Manager Expense Report page.
+        asserterror ManagerExpenseReportPage.OpenView();
+
+        // [THEN] The actionable missing-User-Setup error is raised for the current user.
+        Assert.ExpectedError(StrSubstNo(MissingUserSetupErr, UserId()));
     end;
 
     // [Test] // Disabled - will be re-enabled in work item 629484

--- a/src/Apps/W1/ExpenseAgent/test/src/WFDemoExpReportApprovals.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/WFDemoExpReportApprovals.Codeunit.al
@@ -1196,6 +1196,7 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         LibraryExpense.SetupNumberSeriesInExpenseMgmt();
         LibraryExpense.InitializeExpenseSourceCode();
         LibraryExpense.UpdateUseRulesInAgentSetup(true);
+        ResetApprovalAndAgentSetup();
         LibraryExpense.CleanUpBeforeTesting();
         LibraryExpense.CleanTransactionalData();
         LibraryWorkflow.DisableAllWorkflows();
@@ -1363,6 +1364,16 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         ExpenseAgentSetup.GetRecordOnce();
         ExpenseAgentSetup."Enable Agent" := Enable;
         ExpenseAgentSetup.Modify(true);
+    end;
+
+    local procedure ResetApprovalAndAgentSetup()
+    var
+        ExpenseAgentSetup: Record "Expense Agent Setup";
+    begin
+        ExpenseAgentSetup.GetRecordOnce();
+        ExpenseAgentSetup."Enable Approval Workflow" := false;
+        ExpenseAgentSetup."Enable Agent" := false;
+        ExpenseAgentSetup.Modify();
     end;
 
     local procedure CreateAndUpdateUserWithEmail(UserName: Code[50]; UserEmail: Text[80])

--- a/src/Apps/W1/ExpenseAgent/test/src/WFDemoExpReportApprovals.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/WFDemoExpReportApprovals.Codeunit.al
@@ -48,7 +48,7 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         ApproveActionMustBeVisibleErr: Label 'Approve action must be visible for the assigned approver.';
         RejectActionMustBeVisibleErr: Label 'Reject action must be visible for the assigned approver.';
         ApproveActionMustNotBeVisibleErr: Label 'Approve action must not be visible when the user is not the assigned approver.';
-        MissingUserSetupErr: Label 'Please configure your user ''%1'' on the User Setup, as the approval workflow for expenses is enabled.', Comment = '%1 = current user ID';
+        MissingUserSetupMessagePartTxt: Label 'Please configure your user';
 
     [Test]
     [HandlerFunctions('ExpensesModalPageHandler,ConfirmHandler')]
@@ -983,7 +983,7 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         asserterror ExpenseReportApprovalMgmt.GetCurrentUserSetupForApproval(UserSetup);
 
         // [THEN] The actionable missing-User-Setup error is raised for the current user.
-        Assert.ExpectedError(StrSubstNo(MissingUserSetupErr, UserId()));
+        Assert.ExpectedError(MissingUserSetupMessagePartTxt);
     end;
 
     [Test]
@@ -998,9 +998,7 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         LibraryExpense.UpdateEnableApprovalWorkflowInAgentSetup(true);
 
         // [GIVEN] The current user has a User Setup record.
-        UserSetup.Init();
-        UserSetup."User ID" := CopyStr(UserId(), 1, MaxStrLen(UserSetup."User ID"));
-        UserSetup.Insert();
+        LibraryDocumentApprovals.CreateOrFindUserSetup(UserSetup, CopyStr(UserId(), 1, 50));
         Clear(UserSetup);
 
         // [WHEN] Resolving the current user's setup for approval.
@@ -1025,7 +1023,7 @@ codeunit 148304 "WF Demo Exp. Report Approvals"
         asserterror ManagerExpenseReportPage.OpenView();
 
         // [THEN] The actionable missing-User-Setup error is raised for the current user.
-        Assert.ExpectedError(StrSubstNo(MissingUserSetupErr, UserId()));
+        Assert.ExpectedError(MissingUserSetupMessagePartTxt);
     end;
 
     // [Test] // Disabled - will be re-enabled in work item 629484


### PR DESCRIPTION
Fixes [AB#649740](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649740)

### Problem

When the BC approval workflow is enabled and the current user has no User Setup record, opening an expense report shows a generic and non-actionable platform error.

### Changes

- Added actionable guidance to configure the current user on User Setup.
- Added navigation to the Approval User Setup page when the user has permission.
- Routed approval-workflow User Setup lookups through the helper.
- Added and updated approval workflow tests.

### Backport

Backport of #10890 to releases/29.x.

The existing fork branch contains the 29.x backport commits.

### Validation

The PR includes the approval workflow test updates.
