### PR TITLE
[Main]- Production order can be deleted with registered unconsumed warehouse picks

### DIFF
--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
@@ -766,7 +766,7 @@ table 5405 "Production Order"
         end;
 
         if Status = Status::Released then
-            ConfirmDeletion();
+            CheckPickedQtyBeforeDeletion();
 
         if Status = Status::Finished then
             DeleteFinishedProdOrderRelations()
@@ -868,7 +868,7 @@ table 5405 "Production Order"
         Text010: Label 'You may have changed a dimension.\\Do you want to update the lines?';
         Text011: Label 'You cannot change Finished Production Order dimensions.';
 #pragma warning restore AA0074
-        ConfirmDeleteQst: Label 'The items have been picked. If you delete the Production Order, then the items will remain in the operation area until you put them away.\Related item tracking information that is defined during the pick will be deleted.\Are you sure that you want to delete the Production Order?';
+        CannotDeleteWithPickedQtyErr: Label 'You cannot delete the production order because one or more components have a picked quantity that has not been consumed. Consume or return the picked quantity before deleting the production order.';
 
     protected var
         HideValidationDialog: Boolean;
@@ -1647,20 +1647,17 @@ table 5405 "Production Order"
         RemQtyBaseInvtItemProdOrdComp.Close();
     end;
 
-    local procedure ConfirmDeletion()
+    local procedure CheckPickedQtyBeforeDeletion()
     var
         ProdOrderComponent: Record "Prod. Order Component";
-        Confirmed: Boolean;
     begin
+        ProdOrderComponent.SetRange(Status, Rec.Status);
         ProdOrderComponent.SetRange("Prod. Order No.", "No.");
         if ProdOrderComponent.FindSet() then
             repeat
-                if (ProdOrderComponent."Expected Quantity" - ProdOrderComponent."Remaining Quantity") < ProdOrderComponent."Qty. Picked" then begin
-                    if not Confirm(ConfirmDeleteQst) then
-                        Error('');
-                    Confirmed := true;
-                end;
-            until (ProdOrderComponent.Next() = 0) or Confirmed;
+                if (ProdOrderComponent."Expected Qty. (Base)" - ProdOrderComponent."Remaining Qty. (Base)") < ProdOrderComponent."Qty. Picked (Base)" then
+                    Error(CannotDeleteWithPickedQtyErr);
+            until ProdOrderComponent.Next() = 0;
     end;
 
     local procedure ValidateWarehousePutAwayLocation(ProductionOrder: Record "Production Order")

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
@@ -1653,6 +1653,7 @@ table 5405 "Production Order"
     begin
         ProdOrderComponent.SetRange(Status, Rec.Status);
         ProdOrderComponent.SetRange("Prod. Order No.", "No.");
+        ProdOrderComponent.SetLoadFields("Expected Qty. (Base)", "Remaining Qty. (Base)", "Qty. Picked (Base)");
         if ProdOrderComponent.FindSet() then
             repeat
                 if ((ProdOrderComponent."Expected Qty. (Base)" - ProdOrderComponent."Remaining Qty. (Base)") < ProdOrderComponent."Qty. Picked (Base)") and
@@ -1674,9 +1675,34 @@ table 5405 "Production Order"
             ProdOrderComponent."Item No.", ProdOrderComponent."Variant Code", ProdOrderComponent."Unit of Measure Code")
         then
             exit(false);
-
         BinContent.CalcFields("Quantity (Base)");
-        exit(BinContent."Quantity (Base)" > 0);
+        exit(BinContent."Quantity (Base)" > CalcOtherComponentsUnconsumedPickedQty(ProdOrderComponent));
+    end;
+
+    local procedure CalcOtherComponentsUnconsumedPickedQty(ProdOrderComponent: Record "Prod. Order Component") TotalUnconsumedPickedQtyBase: Decimal
+    var
+        OtherProdOrderComponent: Record "Prod. Order Component";
+        OtherUnconsumedPickedQtyBase: Decimal;
+    begin
+        OtherProdOrderComponent.SetFilter(Status, '%1|%2', OtherProdOrderComponent.Status::Released, OtherProdOrderComponent.Status::Finished);
+        OtherProdOrderComponent.SetRange("Item No.", ProdOrderComponent."Item No.");
+        OtherProdOrderComponent.SetRange("Variant Code", ProdOrderComponent."Variant Code");
+        OtherProdOrderComponent.SetRange("Location Code", ProdOrderComponent."Location Code");
+        OtherProdOrderComponent.SetRange("Bin Code", ProdOrderComponent."Bin Code");
+        OtherProdOrderComponent.SetFilter("Qty. Picked (Base)", '<>%1', 0);
+        if OtherProdOrderComponent.FindSet() then
+            repeat
+                if (OtherProdOrderComponent.Status <> ProdOrderComponent.Status) or
+                   (OtherProdOrderComponent."Prod. Order No." <> ProdOrderComponent."Prod. Order No.") or
+                   (OtherProdOrderComponent."Prod. Order Line No." <> ProdOrderComponent."Prod. Order Line No.") or
+                   (OtherProdOrderComponent."Line No." <> ProdOrderComponent."Line No.")
+                then begin
+                    OtherUnconsumedPickedQtyBase :=
+                        OtherProdOrderComponent."Qty. Picked (Base)" - (OtherProdOrderComponent."Expected Qty. (Base)" - OtherProdOrderComponent."Remaining Qty. (Base)");
+                    if OtherUnconsumedPickedQtyBase > 0 then
+                        TotalUnconsumedPickedQtyBase += OtherUnconsumedPickedQtyBase;
+                end;
+            until OtherProdOrderComponent.Next() = 0;
     end;
 
     local procedure ValidateWarehousePutAwayLocation(ProductionOrder: Record "Production Order")

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/ProductionOrder.Table.al
@@ -1655,9 +1655,28 @@ table 5405 "Production Order"
         ProdOrderComponent.SetRange("Prod. Order No.", "No.");
         if ProdOrderComponent.FindSet() then
             repeat
-                if (ProdOrderComponent."Expected Qty. (Base)" - ProdOrderComponent."Remaining Qty. (Base)") < ProdOrderComponent."Qty. Picked (Base)" then
+                if ((ProdOrderComponent."Expected Qty. (Base)" - ProdOrderComponent."Remaining Qty. (Base)") < ProdOrderComponent."Qty. Picked (Base)") and
+                   IsPickedQtyStillInOperationArea(ProdOrderComponent)
+                then
                     Error(CannotDeleteWithPickedQtyErr);
             until ProdOrderComponent.Next() = 0;
+    end;
+
+    local procedure IsPickedQtyStillInOperationArea(ProdOrderComponent: Record "Prod. Order Component"): Boolean
+    var
+        BinContent: Record "Bin Content";
+    begin
+        if ProdOrderComponent."Bin Code" = '' then
+            exit(true);
+
+        if not BinContent.Get(
+            ProdOrderComponent."Location Code", ProdOrderComponent."Bin Code",
+            ProdOrderComponent."Item No.", ProdOrderComponent."Variant Code", ProdOrderComponent."Unit of Measure Code")
+        then
+            exit(false);
+
+        BinContent.CalcFields("Quantity (Base)");
+        exit(BinContent."Quantity (Base)" > 0);
     end;
 
     local procedure ValidateWarehousePutAwayLocation(ProductionOrder: Record "Production Order")

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
@@ -61,6 +61,7 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         QtyPickedBaseShouldBePositiveErr: Label 'Qty. Picked (Base) should be positive after registering pick.';
         ActConsumptionQtyShouldBeZeroErr: Label 'Act. Consumption (Qty) should be zero.';
         ProdOrderShouldExistErr: Label 'Production Order should still exist after blocked deletion.';
+        ProdOrderShouldNotExistErr: Label 'Production Order should not exist after deletion succeeds.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1706,12 +1707,12 @@ codeunit 137298 "SCM Prod. Whse. Handling"
     [Test]
     procedure DeleteReleasedProdOrderBlockedWhenComponentHasPickedQty()
     var
-        ParentItem: Record Item;
         CompItem1: Record Item;
         CompItem2: Record Item;
         Location: Record Location;
-        ProductionOrder: Record "Production Order";
+        ParentItem: Record Item;
         ProdOrderComponent: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
         RegisteredWhseActivityLine: Record "Registered Whse. Activity Line";
         WarehouseActivityHeader: Record "Warehouse Activity Header";
         WarehouseActivityLine: Record "Warehouse Activity Line";
@@ -1730,8 +1731,8 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         ProductionOrder.SetHideValidationDialog(true);
         ProductionOrder.CreatePick(CopyStr(UserId(), 1, 50), 0, false, false, false);
         FindWarehouseActivityLine(
-          WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
-          Location.Code, WarehouseActivityLine."Action Type"::Take);
+            WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
+            Location.Code, WarehouseActivityLine."Action Type"::Take);
         WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
         LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
         LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
@@ -1769,6 +1770,63 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
         ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
         Assert.RecordIsNotEmpty(ProdOrderComponent);
+    end;
+
+    [Test]
+    procedure DeleteReleasedProdOrderAllowedAfterPickedQtyReturnedFromOperationArea()
+    var
+        BinContent: Record "Bin Content";
+        CompItem1: Record Item;
+        CompItem2: Record Item;
+        Location: Record Location;
+        ParentItem: Record Item;
+        ProdOrderComponent: Record "Prod. Order Component";
+        ProductionOrder: Record "Production Order";
+        WarehouseActivityHeader: Record "Warehouse Activity Header";
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647854] Deleting a Released Production Order is allowed once the picked, unconsumed component quantity has been returned from the operation area bin.
+        Initialize();
+
+        // [GIVEN] Location with bins and "Warehouse Pick (mandatory)" for production consumption, released production order "PO" with two components stocked in bins.
+        CreateProductionOrderWithLocationBinsAndTwoComponents(ProductionOrder, Location, ParentItem, CompItem1, CompItem2);
+        Location."Prod. Consump. Whse. Handling" := "Prod. Consump. Whse. Handling"::"Warehouse Pick (mandatory)";
+        Location.Modify(true);
+        LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, true, true, true, false);
+
+        // [GIVEN] Warehouse pick is created and fully registered for "PO".
+        ProductionOrder.SetHideValidationDialog(true);
+        ProductionOrder.CreatePick(CopyStr(UserId(), 1, 50), 0, false, false, false);
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
+            Location.Code, WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
+        LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
+        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
+
+        // [GIVEN] Component has positive Qty. Picked (Base) that has not been consumed.
+        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderComponent.FindSet();
+        repeat
+            Assert.IsTrue(ProdOrderComponent."Qty. Picked (Base)" > 0, QtyPickedBaseShouldBePositiveErr);
+
+            // [GIVEN] The picked quantity is returned from the operation area bin, e.g. by posting a movement out of it.
+            BinContent.Get(
+                ProdOrderComponent."Location Code", ProdOrderComponent."Bin Code",
+                ProdOrderComponent."Item No.", ProdOrderComponent."Variant Code", ProdOrderComponent."Unit of Measure Code");
+            BinContent.CalcFields("Quantity (Base)");
+            CreateAndPostItemJournalLine(
+                ProdOrderComponent."Item No.", "Item Ledger Entry Type"::"Negative Adjmt.", BinContent."Quantity (Base)",
+                ProdOrderComponent."Location Code", ProdOrderComponent."Bin Code", '');
+        until ProdOrderComponent.Next() = 0;
+
+        // [WHEN] Delete the production order.
+        ProductionOrder.Delete(true);
+
+        // [THEN] No error is raised and the production order no longer exists.
+        Assert.IsFalse(ProductionOrder.Get(ProductionOrder.Status, ProductionOrder."No."), ProdOrderShouldNotExistErr);
     end;
 
     local procedure Initialize()

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
@@ -62,6 +62,7 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         ActConsumptionQtyShouldBeZeroErr: Label 'Act. Consumption (Qty) should be zero.';
         ProdOrderShouldExistErr: Label 'Production Order should still exist after blocked deletion.';
         ProdOrderShouldNotExistErr: Label 'Production Order should not exist after deletion succeeds.';
+        SharedOperationBinErr: Label 'Both production orders should pick the component into the same operation area bin.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1714,7 +1715,6 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         ProdOrderComponent: Record "Prod. Order Component";
         ProductionOrder: Record "Production Order";
         RegisteredWhseActivityLine: Record "Registered Whse. Activity Line";
-        WarehouseActivityHeader: Record "Warehouse Activity Header";
         WarehouseActivityLine: Record "Warehouse Activity Line";
     begin
         // [FEATURE] [AI test 0.4]
@@ -1728,17 +1728,9 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, true, true, true, false);
 
         // [GIVEN] Warehouse pick is created and fully registered for "PO".
-        ProductionOrder.SetHideValidationDialog(true);
-        ProductionOrder.CreatePick(CopyStr(UserId(), 1, 50), 0, false, false, false);
-        FindWarehouseActivityLine(
-            WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
-            Location.Code, WarehouseActivityLine."Action Type"::Take);
-        WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
-        LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
-        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
+        CreateAndRegisterFullPick(ProductionOrder, Location.Code);
 
         // [GIVEN] No active warehouse pick lines remain for "PO".
-        WarehouseActivityLine.Reset();
         WarehouseActivityLine.SetRange("Source No.", ProductionOrder."No.");
         WarehouseActivityLine.SetRange("Activity Type", WarehouseActivityLine."Activity Type"::Pick);
         Assert.RecordIsEmpty(WarehouseActivityLine);
@@ -1749,9 +1741,7 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         Assert.RecordIsNotEmpty(RegisteredWhseActivityLine);
 
         // [GIVEN] Component has positive Qty. Picked (Base) and zero Act. Consumption (Qty.).
-        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
-        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
-        ProdOrderComponent.FindFirst();
+        FindFirstProdOrderComponent(ProdOrderComponent, ProductionOrder);
         ProdOrderComponent.CalcFields("Act. Consumption (Qty)");
         Assert.IsTrue(ProdOrderComponent."Qty. Picked (Base)" > 0, QtyPickedBaseShouldBePositiveErr);
         Assert.AreEqual(0, ProdOrderComponent."Act. Consumption (Qty)", ActConsumptionQtyShouldBeZeroErr);
@@ -1773,60 +1763,58 @@ codeunit 137298 "SCM Prod. Whse. Handling"
     end;
 
     [Test]
-    procedure DeleteReleasedProdOrderAllowedAfterPickedQtyReturnedFromOperationArea()
+    procedure DeleteReleasedProdOrderAllowedAfterPickedQtyReturnedWithSharedOperationBin()
     var
-        BinContent: Record "Bin Content";
         CompItem1: Record Item;
         CompItem2: Record Item;
         Location: Record Location;
         ParentItem: Record Item;
-        ProdOrderComponent: Record "Prod. Order Component";
-        ProductionOrder: Record "Production Order";
-        WarehouseActivityHeader: Record "Warehouse Activity Header";
-        WarehouseActivityLine: Record "Warehouse Activity Line";
+        ProdOrderComponentA: Record "Prod. Order Component";
+        ProdOrderComponentB: Record "Prod. Order Component";
+        ProductionOrderA: Record "Production Order";
+        ProductionOrderB: Record "Production Order";
     begin
         // [FEATURE] [AI test 0.4]
-        // [SCENARIO 647854] Deleting a Released Production Order is allowed once the picked, unconsumed component quantity has been returned from the operation area bin.
+        // [SCENARIO 647854] Deleting a Released Production Order is allowed once its own picked, unconsumed quantity has been returned from a shared operation area bin, even though another order's picked quantity for the same component remains in that bin.
         Initialize();
 
-        // [GIVEN] Location with bins and "Warehouse Pick (mandatory)" for production consumption, released production order "PO" with two components stocked in bins.
-        CreateProductionOrderWithLocationBinsAndTwoComponents(ProductionOrder, Location, ParentItem, CompItem1, CompItem2);
+        // [GIVEN] Location with bins and "Warehouse Pick (mandatory)" for production consumption, and two released production orders "POA" and "POB" for the same item, both picking the same components into the same operation area bins.
+        CreateProductionOrderWithLocationBinsAndTwoComponents(ProductionOrderA, Location, ParentItem, CompItem1, CompItem2);
         Location."Prod. Consump. Whse. Handling" := "Prod. Consump. Whse. Handling"::"Warehouse Pick (mandatory)";
         Location.Modify(true);
-        LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, true, true, true, false);
+        LibraryManufacturing.RefreshProdOrder(ProductionOrderA, false, true, true, true, false);
+        CreateAndRefreshProductionOrder(ProductionOrderB, "Production Order Status"::Released, "Prod. Order Source Type"::Item, ParentItem."No.", 1, Location.Code);
 
-        // [GIVEN] Warehouse pick is created and fully registered for "PO".
-        ProductionOrder.SetHideValidationDialog(true);
-        ProductionOrder.CreatePick(CopyStr(UserId(), 1, 50), 0, false, false, false);
-        FindWarehouseActivityLine(
-            WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
-            Location.Code, WarehouseActivityLine."Action Type"::Take);
-        WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
-        LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
-        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
+        // [GIVEN] Warehouse pick is created and fully registered for "POA" and "POB".
+        CreateAndRegisterFullPick(ProductionOrderA, Location.Code);
+        CreateAndRegisterFullPick(ProductionOrderB, Location.Code);
 
-        // [GIVEN] Component has positive Qty. Picked (Base) that has not been consumed.
-        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
-        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
-        ProdOrderComponent.FindSet();
+        // [GIVEN] Every one of "POA"'s picked, unconsumed components is returned from its shared operation area bin, using the supported Internal Movement warehouse document, leaving behind only what "POB" still claims.
+        ProdOrderComponentA.SetRange(Status, ProductionOrderA.Status);
+        ProdOrderComponentA.SetRange("Prod. Order No.", ProductionOrderA."No.");
+        ProdOrderComponentA.FindSet();
         repeat
-            Assert.IsTrue(ProdOrderComponent."Qty. Picked (Base)" > 0, QtyPickedBaseShouldBePositiveErr);
+            Assert.IsTrue(ProdOrderComponentA."Qty. Picked (Base)" > 0, QtyPickedBaseShouldBePositiveErr);
 
-            // [GIVEN] The picked quantity is returned from the operation area bin, e.g. by posting a movement out of it.
-            BinContent.Get(
-                ProdOrderComponent."Location Code", ProdOrderComponent."Bin Code",
-                ProdOrderComponent."Item No.", ProdOrderComponent."Variant Code", ProdOrderComponent."Unit of Measure Code");
-            BinContent.CalcFields("Quantity (Base)");
-            CreateAndPostItemJournalLine(
-                ProdOrderComponent."Item No.", "Item Ledger Entry Type"::"Negative Adjmt.", BinContent."Quantity (Base)",
-                ProdOrderComponent."Location Code", ProdOrderComponent."Bin Code", '');
-        until ProdOrderComponent.Next() = 0;
+            ProdOrderComponentB.SetRange(Status, ProductionOrderB.Status);
+            ProdOrderComponentB.SetRange("Prod. Order No.", ProductionOrderB."No.");
+            ProdOrderComponentB.SetRange("Item No.", ProdOrderComponentA."Item No.");
+            ProdOrderComponentB.FindFirst();
+            Assert.IsTrue(ProdOrderComponentB."Qty. Picked (Base)" > 0, QtyPickedBaseShouldBePositiveErr);
+            Assert.AreEqual(ProdOrderComponentA."Bin Code", ProdOrderComponentB."Bin Code", SharedOperationBinErr);
 
-        // [WHEN] Delete the production order.
-        ProductionOrder.Delete(true);
+            ReturnExcessBinQtyBeyondOtherClaim(Location.Code, ProdOrderComponentA, ProdOrderComponentB."Qty. Picked (Base)");
+        until ProdOrderComponentA.Next() = 0;
 
-        // [THEN] No error is raised and the production order no longer exists.
-        Assert.IsFalse(ProductionOrder.Get(ProductionOrder.Status, ProductionOrder."No."), ProdOrderShouldNotExistErr);
+        // [WHEN] Delete "POA".
+        ProductionOrderA.Delete(true);
+
+        // [THEN] No error is raised and "POA" no longer exists, even though "POB" still has picked quantity in the same bins.
+        Assert.IsFalse(ProductionOrderA.Get(ProductionOrderA.Status, ProductionOrderA."No."), ProdOrderShouldNotExistErr);
+
+        // [THEN] "POB" is still blocked from deletion, since its own picked quantity is still in the shared bins.
+        asserterror ProductionOrderB.Delete(true);
+        Assert.ExpectedError(CannotDeleteWithPickedQtyErr);
     end;
 
     local procedure Initialize()
@@ -1986,6 +1974,69 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         ProdOrderLine.SetRange(Status, ProductionOrder.Status);
         ProdOrderLine.SetRange("Prod. Order No.", ProductionOrder."No.");
         ProdOrderLine.FindFirst();
+    end;
+
+    local procedure FindFirstProdOrderComponent(var ProdOrderComponent: Record "Prod. Order Component"; ProductionOrder: Record "Production Order")
+    begin
+        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderComponent.FindFirst();
+    end;
+
+    local procedure CreateAndRegisterFullPick(var ProductionOrder: Record "Production Order"; LocationCode: Code[10])
+    var
+        WarehouseActivityHeader: Record "Warehouse Activity Header";
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+    begin
+        ProductionOrder.SetHideValidationDialog(true);
+        ProductionOrder.CreatePick(CopyStr(UserId(), 1, 50), 0, false, false, false);
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
+            LocationCode, WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
+        LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
+        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
+    end;
+
+    local procedure ReturnExcessBinQtyBeyondOtherClaim(LocationCode: Code[10]; ProdOrderComponent: Record "Prod. Order Component"; OtherClaimQtyBase: Decimal)
+    var
+        Bin: Record Bin;
+        ToBin: Record Bin;
+        BinContent: Record "Bin Content";
+        InternalMovementHeader: Record "Internal Movement Header";
+        InternalMovementLine: Record "Internal Movement Line";
+        CreateInventoryPickMovement: Codeunit "Create Inventory Pick/Movement";
+        WarehouseActivityHeader: Record "Warehouse Activity Header";
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+        QtyToReturnBase: Decimal;
+    begin
+        Bin.Get(LocationCode, ProdOrderComponent."Bin Code");
+        ToBin.SetRange("Location Code", LocationCode);
+        ToBin.SetFilter(Code, '<>%1', Bin.Code);
+        ToBin.FindFirst();
+
+        BinContent.Get(
+            LocationCode, ProdOrderComponent."Bin Code", ProdOrderComponent."Item No.",
+            ProdOrderComponent."Variant Code", ProdOrderComponent."Unit of Measure Code");
+        BinContent.CalcFields("Quantity (Base)");
+        QtyToReturnBase := BinContent."Quantity (Base)" - OtherClaimQtyBase;
+        if QtyToReturnBase <= 0 then
+            exit;
+
+        LibraryWarehouse.CreateInternalMovementHeader(InternalMovementHeader, LocationCode, ToBin.Code);
+        LibraryWarehouse.CreateInternalMovementLine(
+            InternalMovementHeader, InternalMovementLine, ProdOrderComponent."Item No.",
+            ProdOrderComponent."Bin Code", ToBin.Code, QtyToReturnBase);
+
+        CreateInventoryPickMovement.SetHideDialog(true);
+        CreateInventoryPickMovement.CreateInvtMvntWithoutSource(InternalMovementHeader);
+
+        FindWarehouseActivityLine(
+            WarehouseActivityLine, '', WarehouseActivityLine."Activity Type"::"Invt. Movement",
+            LocationCode, WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
+        LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
+        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
     end;
 
     local procedure FindWarehouseActivityLine(var WarehouseActivityLine: Record "Warehouse Activity Line"; SourceNo: Code[20]; ActivityType: Enum "Warehouse Activity Type"; LocationCode: Code[10]; ActionType: Enum "Warehouse Action Type")

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMProdWhseHandling.Codeunit.al
@@ -18,6 +18,7 @@ using Microsoft.Manufacturing.Routing;
 using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.Warehouse.Activity;
+using Microsoft.Warehouse.Activity.History;
 using Microsoft.Warehouse.InternalDocument;
 using Microsoft.Warehouse.Request;
 using Microsoft.Warehouse.Setup;
@@ -56,6 +57,10 @@ codeunit 137298 "SCM Prod. Whse. Handling"
         PickActivitiesCreatedMsg: Label 'Number of Invt. Pick activities created';
         BinPickQtyIsWrongErr: Label 'Bin pick quantity is wrong.';
         ShortageLineQtyIsWrongErr: Label 'Shortage line quantity is wrong.';
+        CannotDeleteWithPickedQtyErr: Label 'You cannot delete the production order because one or more components have a picked quantity that has not been consumed. Consume or return the picked quantity before deleting the production order.';
+        QtyPickedBaseShouldBePositiveErr: Label 'Qty. Picked (Base) should be positive after registering pick.';
+        ActConsumptionQtyShouldBeZeroErr: Label 'Act. Consumption (Qty) should be zero.';
+        ProdOrderShouldExistErr: Label 'Production Order should still exist after blocked deletion.';
 
     [Test]
     [Scope('OnPrem')]
@@ -1696,6 +1701,74 @@ codeunit 137298 "SCM Prod. Whse. Handling"
 
         Assert.ExpectedMessage(PickActivitiesCreatedMsg, LibraryVariableStorage.DequeueText());
         LibraryVariableStorage.AssertEmpty();
+    end;
+
+    [Test]
+    procedure DeleteReleasedProdOrderBlockedWhenComponentHasPickedQty()
+    var
+        ParentItem: Record Item;
+        CompItem1: Record Item;
+        CompItem2: Record Item;
+        Location: Record Location;
+        ProductionOrder: Record "Production Order";
+        ProdOrderComponent: Record "Prod. Order Component";
+        RegisteredWhseActivityLine: Record "Registered Whse. Activity Line";
+        WarehouseActivityHeader: Record "Warehouse Activity Header";
+        WarehouseActivityLine: Record "Warehouse Activity Line";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647854] Deleting a Released Production Order is blocked when a component has picked quantity not yet consumed.
+        Initialize();
+
+        // [GIVEN] Location with bins and "Warehouse Pick (mandatory)" for production consumption, released production order "PO" with two components stocked in bins.
+        CreateProductionOrderWithLocationBinsAndTwoComponents(ProductionOrder, Location, ParentItem, CompItem1, CompItem2);
+        Location."Prod. Consump. Whse. Handling" := "Prod. Consump. Whse. Handling"::"Warehouse Pick (mandatory)";
+        Location.Modify(true);
+        LibraryManufacturing.RefreshProdOrder(ProductionOrder, false, true, true, true, false);
+
+        // [GIVEN] Warehouse pick is created and fully registered for "PO".
+        ProductionOrder.SetHideValidationDialog(true);
+        ProductionOrder.CreatePick(CopyStr(UserId(), 1, 50), 0, false, false, false);
+        FindWarehouseActivityLine(
+          WarehouseActivityLine, ProductionOrder."No.", WarehouseActivityLine."Activity Type"::Pick,
+          Location.Code, WarehouseActivityLine."Action Type"::Take);
+        WarehouseActivityHeader.Get(WarehouseActivityLine."Activity Type", WarehouseActivityLine."No.");
+        LibraryWarehouse.AutoFillQtyHandleWhseActivity(WarehouseActivityHeader);
+        LibraryWarehouse.RegisterWhseActivity(WarehouseActivityHeader);
+
+        // [GIVEN] No active warehouse pick lines remain for "PO".
+        WarehouseActivityLine.Reset();
+        WarehouseActivityLine.SetRange("Source No.", ProductionOrder."No.");
+        WarehouseActivityLine.SetRange("Activity Type", WarehouseActivityLine."Activity Type"::Pick);
+        Assert.RecordIsEmpty(WarehouseActivityLine);
+
+        // [GIVEN] Registered warehouse pick lines remain for "PO".
+        RegisteredWhseActivityLine.SetRange("Source No.", ProductionOrder."No.");
+        RegisteredWhseActivityLine.SetRange("Activity Type", RegisteredWhseActivityLine."Activity Type"::Pick);
+        Assert.RecordIsNotEmpty(RegisteredWhseActivityLine);
+
+        // [GIVEN] Component has positive Qty. Picked (Base) and zero Act. Consumption (Qty.).
+        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
+        ProdOrderComponent.FindFirst();
+        ProdOrderComponent.CalcFields("Act. Consumption (Qty)");
+        Assert.IsTrue(ProdOrderComponent."Qty. Picked (Base)" > 0, QtyPickedBaseShouldBePositiveErr);
+        Assert.AreEqual(0, ProdOrderComponent."Act. Consumption (Qty)", ActConsumptionQtyShouldBeZeroErr);
+        Commit();
+
+        // [WHEN] Delete the production order.
+        asserterror ProductionOrder.Delete(true);
+
+        // [THEN] Error is raised because picked quantity has not been consumed.
+        Assert.ExpectedError(CannotDeleteWithPickedQtyErr);
+        Assert.ExpectedErrorCode('Dialog');
+
+        // [THEN] Production order and its components still exist.
+        Assert.IsTrue(ProductionOrder.Get(ProductionOrder.Status, ProductionOrder."No."), ProdOrderShouldExistErr);
+        ProdOrderComponent.Reset();
+        ProdOrderComponent.SetRange(Status, ProductionOrder.Status);
+        ProdOrderComponent.SetRange("Prod. Order No.", ProductionOrder."No.");
+        Assert.RecordIsNotEmpty(ProdOrderComponent);
     end;
 
     local procedure Initialize()


### PR DESCRIPTION
Workitem [Bug 647854](https://dev.azure.com/dynamicssmb2/Dynamics%20SMB/_workitems/edit/647854): [All-E] [Repair Item] Production order can be deleted with registered unconsumed warehouse picks

Fixes [AB#647854](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647854)




