### PR TITLE
[Master]-Validation of the "No." field on the sales order additionally re-validates the Unit of Measure Code

### DIFF
--- a/src/Layers/APAC/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Sales/Document/SalesLine.Table.al
@@ -510,7 +510,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -758,7 +766,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -10150,13 +10159,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11777,6 +11790,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/BE/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/BE/BaseApp/Sales/Document/SalesLine.Table.al
@@ -506,7 +506,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -754,7 +762,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9649,13 +9658,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11220,6 +11233,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/CH/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/CH/BaseApp/Sales/Document/SalesLine.Table.al
@@ -515,7 +515,15 @@ table 37 "Sales Line"
                     if Type in [Type::"G/L Account", Type::Item, Type::Resource, Type::"Fixed Asset", Type::"Charge (Item)"] then
                         Validate("VAT Prod. Posting Group");
 
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -766,7 +774,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9824,13 +9833,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11395,6 +11408,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/ES/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/ES/BaseApp/Sales/Document/SalesLine.Table.al
@@ -506,7 +506,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -754,7 +762,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9663,13 +9672,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11239,6 +11252,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/FI/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/FI/BaseApp/Sales/Document/SalesLine.Table.al
@@ -507,7 +507,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -755,7 +763,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9637,13 +9646,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11208,6 +11221,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/GB/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/GB/BaseApp/Sales/Document/SalesLine.Table.al
@@ -510,7 +510,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -758,7 +766,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9718,13 +9727,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11303,6 +11316,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/IT/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/IT/BaseApp/Sales/Document/SalesLine.Table.al
@@ -521,7 +521,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -769,7 +777,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9756,13 +9765,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11354,6 +11367,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/NA/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/NA/BaseApp/Sales/Document/SalesLine.Table.al
@@ -508,7 +508,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -758,7 +766,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9793,13 +9802,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11396,6 +11409,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/NO/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/NO/BaseApp/Sales/Document/SalesLine.Table.al
@@ -507,7 +507,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -755,7 +763,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9674,13 +9683,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11248,6 +11261,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/RU/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/RU/BaseApp/Sales/Document/SalesLine.Table.al
@@ -507,7 +507,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -755,7 +763,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -10062,13 +10071,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11597,6 +11610,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/SE/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/SE/BaseApp/Sales/Document/SalesLine.Table.al
@@ -507,7 +507,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -755,7 +763,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9637,13 +9646,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11208,6 +11221,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/W1/BaseApp/Manufacturing/Document/CheckProdOrderStatus.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Document/CheckProdOrderStatus.Codeunit.al
@@ -59,6 +59,9 @@ codeunit 99000777 "Check Prod. Order Status"
         if IsHandled then
             exit;
 
+        if SalesLine.GetSuspendedStatusCheck() then
+            exit;
+
         if SalesLine."Document Type" <> SalesLine."Document Type"::Order then
             exit;
 

--- a/src/Layers/W1/BaseApp/Sales/Document/SalesLine.Table.al
+++ b/src/Layers/W1/BaseApp/Sales/Document/SalesLine.Table.al
@@ -506,7 +506,15 @@ table 37 "Sales Line"
 
                 TestStatusOpen();
                 SalesWarehouseMgt.SalesLineVerifyChange(Rec, xRec);
-                DoCheckReceiptOrderStatus := CurrFieldNo <> 0;
+                DoCheckReceiptOrderStatus :=
+                    (CurrFieldNo in [
+                        FieldNo("Planned Shipment Date"),
+                        FieldNo("Planned Delivery Date"),
+                        FieldNo("Shipment Date"),
+                        FieldNo("Shipping Time"),
+                        FieldNo("Outbound Whse. Handling Time"),
+                        FieldNo("Requested Delivery Date"),
+                        FieldNo("Promised Delivery Date")]) and not StatusCheckSuspended;
                 OnValidateShipmentDateOnAfterSalesLineVerifyChange(Rec, CurrFieldNo, DoCheckReceiptOrderStatus, HasBeenShown);
                 if DoCheckReceiptOrderStatus then
                     CheckReceiptOrderStatus();
@@ -754,7 +762,8 @@ table 37 "Sales Line"
                 IsHandled := false;
                 OnValidateQuantityOnBeforeCheckReceiptOrderStatus(Rec, StatusCheckSuspended, IsHandled);
                 if not IsHandled then
-                    CheckReceiptOrderStatus();
+                    if not StatusCheckSuspended then
+                        CheckReceiptOrderStatus();
 
                 InitQty();
 
@@ -9625,13 +9634,17 @@ table 37 "Sales Line"
     local procedure ValidateUnitOfMeasureCodeFromNo()
     var
         IsHandled: Boolean;
+        OldStatusCheckSuspended: Boolean;
     begin
         IsHandled := false;
         OnBeforeValidateUnitOfMeasureCodeFromNo(Rec, xRec, IsHandled, CurrFieldNo);
         if IsHandled then
             exit;
 
+        OldStatusCheckSuspended := StatusCheckSuspended;
+        StatusCheckSuspended := true;
         Validate("Unit of Measure Code");
+        StatusCheckSuspended := OldStatusCheckSuspended;
     end;
 
     local procedure NotifyOnMissingSetup(FieldNumber: Integer)
@@ -11196,6 +11209,9 @@ table 37 "Sales Line"
 
     local procedure CheckReceiptOrderStatus()
     begin
+        if StatusCheckSuspended then
+            exit;
+
         OnCheckReceiptOrderStatus(Rec);
     end;
 

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMPlanningAndManufacturing.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMPlanningAndManufacturing.Codeunit.al
@@ -89,6 +89,8 @@ codeunit 137080 "SCM Planning And Manufacturing"
         ImpactMissingTransferLineErr: Label 'Impact list does not contain Transfer Order %1 line %2.', Comment = '%1 = Transfer Order No., %2 = Line No.';
         ImpactUnexpectedSalesLineErr: Label 'Impact list unexpectedly contains Sales Order %1 line %2.', Comment = '%1 = Sales Order No., %2 = Line No.';
         CannotFindImpactedDocumentsErr: Label 'Cannot find impacted documents. Please make sure the document line you are simulating on has reservations and try again.';
+        ExpectedCheckProdOrderStatusWarningErr: Label 'Expected Check Prod. Order Status warning to be displayed once.';
+        CheckProdOrderStatusWarningCount: Integer;
 
     [Test]
     [Scope('OnPrem')]
@@ -3316,9 +3318,144 @@ codeunit 137080 "SCM Planning And Manufacturing"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [HandlerFunctions('SimpleMessageHandler,SalesOrderPlanningPageHandler,CreateReleasedOrderFromSalesModalPageHandler,CheckProdOrderStatusModalPageHandlerCount')]
+    procedure RevalidateItemNoOnSalesLineWithLinkedProdOrderDoesNotThrowWriteTransactionError()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+        ProdOrder: Record "Production Order";
+    begin
+        // [SCENARIO] Re-entering the same manufactured item into Sales Line "No." when a Released Prod. Order is linked does not throw write transaction error.
+        Initialize();
+
+        // [GIVEN] A manufactured item and a sales order with 1 line
+        CreateManufacturedItem(Item);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, LibrarySales.CreateCustomerNo());
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+
+        // [GIVEN] A Released Production Order linked to the Sales Line demand
+        CreateReleasedProdOrderForSalesLine(ProdOrder, SalesLine);
+        Commit();
+
+        // [WHEN] Clearing the Sales Line "No." and re-validating the same Item "No."
+        CheckProdOrderStatusWarningCount := 0;
+        LibraryVariableStorage.Enqueue(true);
+        asserterror SalesLine.Validate("No.", '');
+        SalesLine.Reset();
+        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        LibraryVariableStorage.Enqueue(true);
+        SalesLine.Validate("No.", SalesLine."No.");
+
+        // [THEN] The sales line is successfully updated without any transaction errors
+        SalesLine.TestField("No.", Item."No.");
+        SalesLine.TestField(Quantity, 1);
+        SalesLine.TestField("Quantity (Base)", 1);
+        Assert.AreEqual(1, CheckProdOrderStatusWarningCount, ExpectedCheckProdOrderStatusWarningErr);
+    end;
+
+    [Test]
+    procedure QuantityRecalculationOccursCorrectlyWhenValidatingNoWithExistingQuantity()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+        ItemUnitOfMeasure: Record "Item Unit of Measure";
+    begin
+        // [SCENARIO] Validating "No." on a line with existing quantity recalculates Quantity (Base) and unit of measure relations.
+        Initialize();
+
+        // [GIVEN] An item with an alternate UOM (Qty. per UOM = 5)
+        CreateManufacturedItem(Item);
+        LibraryInventory.CreateItemUnitOfMeasureCode(ItemUnitOfMeasure, Item."No.", 5);
+        Item.Validate("Sales Unit of Measure", ItemUnitOfMeasure.Code);
+        Item.Modify(true);
+
+        // [GIVEN] A sales line with Quantity = 3
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, LibrarySales.CreateCustomerNo());
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 3);
+
+        // [WHEN] Re-validating "No."
+        SalesLine.Validate("No.", Item."No.");
+
+        // [THEN] Quantity (Base) is recalculated as 3 * 5 = 15
+        SalesLine.TestField(Quantity, 3);
+        SalesLine.TestField("Unit of Measure Code", ItemUnitOfMeasure.Code);
+        SalesLine.TestField("Qty. per Unit of Measure", 5);
+        SalesLine.TestField("Quantity (Base)", 15);
+    end;
+
+    [Test]
+    [HandlerFunctions('SimpleMessageHandler,SalesOrderPlanningPageHandler,CreateReleasedOrderFromSalesModalPageHandler,CheckProdOrderStatusModalPageHandlerCount')]
+    procedure ProdOrderStatusWarningExecutesOnDirectQuantityValidationOnSalesLine()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+        ProdOrder: Record "Production Order";
+    begin
+        // [SCENARIO] Modifying Quantity directly on a Sales Line linked to a Released Prod. Order triggers the status check warning.
+        Initialize();
+
+        // [GIVEN] Sales Line linked to a Released Production Order
+        CreateManufacturedItem(Item);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, LibrarySales.CreateCustomerNo());
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+        CreateReleasedProdOrderForSalesLine(ProdOrder, SalesLine);
+        Commit();
+
+        // [WHEN] Directly validating Quantity
+        CheckProdOrderStatusWarningCount := 0;
+        LibraryVariableStorage.Enqueue(true);
+        SalesLine.Validate(Quantity, 2);
+
+        // [THEN] Warning handler was invoked and quantity was updated
+        SalesLine.TestField(Quantity, 2);
+        Assert.AreEqual(1, CheckProdOrderStatusWarningCount, ExpectedCheckProdOrderStatusWarningErr);
+    end;
+
+    [Test]
+    [HandlerFunctions('SimpleMessageHandler,SalesOrderPlanningPageHandler,CreateReleasedOrderFromSalesModalPageHandler,CheckProdOrderStatusModalPageHandlerCount')]
+    procedure Regression_ClearAndReenterManufacturedItemOnSalesLineWithReleasedProdOrder()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+        ProdOrder: Record "Production Order";
+    begin
+        // [SCENARIO] Full end-to-end repro of BC 28.4 bug report
+        Initialize();
+
+        // Step 1-4: Create Sales Order and line with manufactured item
+        CreateManufacturedItem(Item);
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, LibrarySales.CreateCustomerNo());
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+
+        // Step 5: Create Released Production Order from demand
+        CreateReleasedProdOrderForSalesLine(ProdOrder, SalesLine);
+        Commit();
+
+        // Step 6-10: Clear "No." and enter same item number again
+        CheckProdOrderStatusWarningCount := 0;
+        LibraryVariableStorage.Enqueue(true);
+        asserterror SalesLine.Validate("No.", '');
+        SalesLine.Reset();
+        SalesLine.Get(SalesLine."Document Type", SalesLine."Document No.", SalesLine."Line No.");
+        LibraryVariableStorage.Enqueue(true);
+        SalesLine.Validate("No.", Item."No.");
+
+        // Validation succeeds and fields are intact
+        SalesLine.TestField("No.", Item."No.");
+        SalesLine.TestField(Quantity, 1);
+        SalesLine.TestField("Outstanding Quantity", 1);
+        Assert.AreEqual(1, CheckProdOrderStatusWarningCount, ExpectedCheckProdOrderStatusWarningErr);
+    end;
+
     local procedure Initialize()
     var
         PlanningErrorLog: Record "Planning Error Log";
+        ManufacturingSetup: Record "Manufacturing Setup";
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
     begin
         LibraryTestInitialize.OnTestInitialize(CODEUNIT::"SCM Planning And Manufacturing");
@@ -3328,6 +3465,11 @@ codeunit 137080 "SCM Planning And Manufacturing"
         LibraryApplicationArea.EnablePremiumSetup();
 
         PlanningErrorLog.DeleteAll();
+        ManufacturingSetup.Get();
+        ManufacturingSetup.Validate("Planning Warning", true);
+        ManufacturingSetup.Modify(true);
+
+        CheckProdOrderStatusWarningCount := 0;
 
         // Lazy Setup.
         if isInitialized then
@@ -4961,6 +5103,31 @@ codeunit 137080 "SCM Planning And Manufacturing"
         Assert.AreEqual(ExpectedStatus, ProdOrderLine.Status, 'Wrong status is set on production order.');
     end;
 
+    local procedure CreateManufacturedItem(var Item: Record Item)
+    begin
+        LibraryInventory.CreateItem(Item);
+        Item.Validate("Replenishment System", Item."Replenishment System"::"Prod. Order");
+        Item.Validate("Manufacturing Policy", Item."Manufacturing Policy"::"Make-to-Order");
+        Item.Modify(true);
+    end;
+
+    local procedure CreateReleasedProdOrderForSalesLine(var ProdOrder: Record "Production Order"; var SalesLine: Record "Sales Line")
+    var
+        SalesHeader: Record "Sales Header";
+        SalesOrder: TestPage "Sales Order";
+    begin
+        SalesHeader.Get(SalesLine."Document Type", SalesLine."Document No.");
+        SalesOrder.OpenEdit();
+        SalesOrder.GotoRecord(SalesHeader);
+        SalesOrder."Pla&nning".Invoke();
+        SalesOrder.Close();
+
+        ProdOrder.SetRange("Source Type", ProdOrder."Source Type"::Item);
+        ProdOrder.SetRange("Source No.", SalesLine."No.");
+        ProdOrder.SetRange(Status, ProdOrder.Status::Released);
+        ProdOrder.FindLast();
+    end;
+
     [ConfirmHandler]
     [Scope('OnPrem')]
     procedure ConfirmHandler(ConfirmMessage: Text[1024]; var Reply: Boolean)
@@ -5038,6 +5205,36 @@ codeunit 137080 "SCM Planning And Manufacturing"
     procedure CheckProdOrderStatusModalPageHandler(var CheckProdOrderStatus: TestPage "Check Prod. Order Status")
     begin
         CheckProdOrderStatus.Yes().Invoke();
+    end;
+
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure CheckProdOrderStatusModalPageHandlerCount(var CheckProdOrderStatus: TestPage "Check Prod. Order Status")
+    var
+        UserResponse: Boolean;
+    begin
+        CheckProdOrderStatusWarningCount += 1;
+        UserResponse := LibraryVariableStorage.DequeueBoolean();
+        if UserResponse then
+            CheckProdOrderStatus.Yes().Invoke()
+        else
+            CheckProdOrderStatus.No().Invoke();
+    end;
+
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure SalesOrderPlanningPageHandler(var SalesOrderPlanning: TestPage "Sales Order Planning")
+    begin
+        SalesOrderPlanning."&Create Prod. Order".Invoke();
+    end;
+
+    [ModalPageHandler]
+    [Scope('OnPrem')]
+    procedure CreateReleasedOrderFromSalesModalPageHandler(var CreateOrderFromSales: TestPage "Create Order From Sales")
+    begin
+        CreateOrderFromSales.Status.SetValue(Enum::"Production Order Status"::Released);
+        CreateOrderFromSales.OrderType.SetValue(0);
+        CreateOrderFromSales.Yes().Invoke();
     end;
 
     [ReportHandler]


### PR DESCRIPTION
[Bug 649961](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649961): [master] [ALL-E] Validation of the "No." field on the sales order additionally re-validates the Unit of Measure Code

[AB#649961](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649961)

**Issue**: When re-validating the "No." field on a Sales Line linked to a Released Production Order (with Planning Warning enabled), the production order status warning is prompted multiple times and can fail with the error "Form.RunModal is not allowed in write transactions".

**Cause**: During "No." validation, nested internal validations for "Shipment Date" (via UpdateDates()) and "Quantity" (via ValidateUnitOfMeasureCodeFromNo() → UpdateQuantityFromUOMCode()) re-triggered CheckReceiptOrderStatus(). Because these subsequent calls occurred after write operations had already started, the modal check page was invoked repeatedly and violated write-transaction safety.

**Solution**: Wrapped Validate("Unit of Measure Code") inside ValidateUnitOfMeasureCodeFromNo() with StatusCheckSuspended to suppress nested status checks, checked StatusCheckSuspended before calling CheckReceiptOrderStatus() in Quantity and Shipment Date validations, and added a suspended check in CheckProdOrderStatus.Codeunit.al to ensure the warning executes only once at the safe initiation of "No." validation.


