### PR TITLE
[29.0] - Bug 649738: [Expense Agent] Unwanted caption in expense report FactBox

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/ExpenseReportFactBox.Page.al
@@ -8,7 +8,7 @@ page 7098 "Expense Report FactBox"
 {
     PageType = CardPart;
     SourceTable = "Expense Report Header";
-    Caption = 'Expense Report FactBox';
+    Caption = 'Expense Report';
 
     layout
     {

--- a/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReportFactBox.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/ExpenseReport/Pages/PostedExpenseReportFactBox.Page.al
@@ -8,7 +8,7 @@ page 7094 "Posted Expense Report FactBox"
 {
     PageType = CardPart;
     SourceTable = "Posted Expense Report Header";
-    Caption = 'Posted Expense Report FactBox';
+    Caption = 'Posted Expense Report';
     Editable = false;
 
     layout


### PR DESCRIPTION
Fixes [AB#649738](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649738)

### Problem

Expense Report and Posted Expense Report FactBoxes displayed unwanted technical captions instead of user-facing captions.

### Changes

- Set the Expense Report FactBox caption to Expense Report.
- Set the Posted Expense Report FactBox caption to Posted Expense Report.

### Backport

Backport of #10438 to releases/29.0.

Cherry-picked commit(s):

- 17a9dfbffb17166e90fef66e5fafaf9de8f2865b

Applied cleanly with no conflicts or hand edits.

### Validation

The source PR validation completed successfully.



