### PR TITLE
[29.0] - Bug 649737: [Expense Agent] Confirm before closing Expense User Card without mandatory Employee No.

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
@@ -260,7 +260,7 @@ page 6949 "Expense User"
     var
         NoFieldVisible: Boolean;
         IsCreateEmployeeVisible: Boolean;
-        CloseWithoutEmployeeNoQst: Label '%1 is blank. Do you want to close the card without linking an %1?', Comment = '%1 = Employee No. field caption';
+        CloseWithoutEmployeeNoQst: Label '%1 is blank. The expense user will not be linked to an employee.\\Are you sure you want to exit?', Comment = '%1 = Employee No. field caption';
 
     local procedure SetCodeFieldVisible()
     var

--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/ExpenseUser.Page.al
@@ -5,6 +5,7 @@
 namespace Microsoft.ExpenseAgent;
 
 using Microsoft.Projects.Resources.Resource;
+using System.Utilities;
 
 page 6949 "Expense User"
 {
@@ -236,6 +237,15 @@ page 6949 "Expense User"
         exit(Rec.ConfirmApproverReassignment());
     end;
 
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    var
+        ConfirmManagement: Codeunit "Confirm Management";
+    begin
+        if Rec."Employee No." = '' then
+            if not ConfirmManagement.GetResponseOrDefault(StrSubstNo(CloseWithoutEmployeeNoQst, Rec.FieldCaption("Employee No.")), true) then
+                exit(false);
+    end;
+
     trigger OnOpenPage()
     begin
         SetCodeFieldVisible();
@@ -250,6 +260,7 @@ page 6949 "Expense User"
     var
         NoFieldVisible: Boolean;
         IsCreateEmployeeVisible: Boolean;
+        CloseWithoutEmployeeNoQst: Label '%1 is blank. Do you want to close the card without linking an %1?', Comment = '%1 = Employee No. field caption';
 
     local procedure SetCodeFieldVisible()
     var

--- a/src/Apps/W1/ExpenseAgent/test/src/ExpenseTestII.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/ExpenseTestII.Codeunit.al
@@ -2534,6 +2534,7 @@ codeunit 148309 "Expense Test II"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
     procedure EmployeeIsNotCreatedFromExpenseUserWhenNameIsEmpty()
     var
         ExpenseUser: Record "Expense User";
@@ -2563,6 +2564,7 @@ codeunit 148309 "Expense Test II"
     end;
 
     [Test]
+    [HandlerFunctions('ConfirmHandlerYes')]
     procedure EmployeeIsNotCreatedFromExpenseUserWhenEmailIsEmpty()
     var
         ExpenseUser: Record "Expense User";


### PR DESCRIPTION
Fixes [AB#649737](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649737)

### Problem

The Expense User Card could be closed with a blank mandatory Employee No., silently creating an unlinked expense user.

### Changes

- Added a close confirmation when Employee No. is blank.
- Keeps the card open when the user declines.
- Updated affected tests with the confirmation handler.

### Backport

Backport of #10638 to releases/29.0.

Cherry-picked commit(s):

- 6713e9cafe9e8ddb56dcc5e04f3250b90b5fd9a0
- 4a26b0df2326b7ec0fc571fe19b2b1812d42e7aa
- 74abc2112849fdc962a1f7643ae20d7ddd0c418d

Applied cleanly with no conflicts or hand edits.

### Validation

The source Expense Agent tests were included in the cherry-picked commits.




