### PR TITLE
[29.0] - Bug 649778: [Expense Agent] Add mileage setup to Expense Agent wizard

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/MileageRateSetup.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/MasterData/Pages/MileageRateSetup.Page.al
@@ -42,4 +42,17 @@ page 7128 "Mileage Rate Setup"
             }
         }
     }
+
+    trigger OnQueryClosePage(CloseAction: Action): Boolean
+    var
+        MileageRateSetup: Record "Mileage Rate Setup";
+    begin
+        if not MileageRateSetup.IsEmpty() then
+            exit(true);
+
+        exit(Confirm(MissingMileageRateSetupQst, true));
+    end;
+
+    var
+        MissingMileageRateSetupQst: Label 'No mileage rates have been configured. The standard mileage rate will be used. Do you want to continue?';
 }

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Pages/ExpenseAgentSetupWizard.Page.al
@@ -738,6 +738,19 @@ page 6991 "Expense Agent Setup Wizard"
                         ConfigUpdated();
                     end;
                 }
+                field(MileageRateSetupLink; MileageRateSetupLinkTxt)
+                {
+                    ShowCaption = false;
+                    Editable = false;
+                    ToolTip = 'Specifies where to configure mileage rates by vehicle type.';
+
+                    trigger OnDrillDown()
+                    var
+                        MileageRateSetup: Page "Mileage Rate Setup";
+                    begin
+                        MileageRateSetup.RunModal();
+                    end;
+                }
             }
             group(ProjectGroup)
             {
@@ -973,6 +986,7 @@ page 6991 "Expense Agent Setup Wizard"
         ExpensePoliciesLinkTxt: Label 'View expense policies';
         NoSeriesLinkTxt: Label 'Preview the default number series that will be added';
         NoSeriesAppliedLinkTxt: Label 'View number series including new defaults';
+        MileageRateSetupLinkTxt: Label 'Configure mileage rates by vehicle type';
         ExpenseDashboardLinkTxt: Label 'Go to Expense app (opens in new window)';
         ExpenseDashboardUrlOnPremTxt: Label 'http://localhost:5173/', Locked = true;
         ExpenseDashboardUrlProdTxt: Label 'https://go.microsoft.com/fwlink/?LinkId=2365219', Locked = true;


### PR DESCRIPTION
Fixes [AB#649778](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649778)

### Problem

The Expense Agent setup wizard does not provide mileage configuration, and closing Mileage Rate Setup without configuring mileage rates does not warn the user.

### Changes

- Added the mileage configuration link to the Expense Agent setup wizard.
- Added the empty-configuration confirmation on Mileage Rate Setup.

### Backport

Backport of #11027 to releases/29.0.

Cherry-picked commit(s):

- 09d1d4758478d686baed9a82e22e4b3f3464b40a

Applied cleanly with no conflicts or hand edits.

### Validation

The source PR AL build completed successfully.

