### PR TITLE
[29.x] Bug 649734 Validation missing for Deferral Code field on Released Purchase documents.

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2656,6 +2656,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2632,6 +2632,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/CH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2634,6 +2634,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/DACH/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2630,6 +2630,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2634,6 +2634,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/FI/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2631,6 +2631,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/GB/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2647,6 +2647,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2685,6 +2685,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/IT/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2568,6 +2568,41 @@
         PurchaseInvoice.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeferralCodeCannotBeChangedOnReleasedPurchaseInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Deferral Code cannot be changed on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        asserterror PurchaseLine2.Validate("Deferral Code", DeferralTemplateCode);
+
+        // [THEN] The change is rejected because the Purchase Invoice is not open
+        Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2726,6 +2726,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/NA/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/NA/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2545,6 +2545,41 @@ codeunit 134804 "RED Test Unit for Purch Doc"
         PurchaseInvoice.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeferralCodeCannotBeChangedOnReleasedPurchaseInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Deferral Code cannot be changed on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        asserterror PurchaseLine2.Validate("Deferral Code", DeferralTemplateCode);
+
+        // [THEN] The change is rejected because the Purchase Invoice is not open
+        Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2630,6 +2630,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/NO/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2634,6 +2634,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2635,6 +2635,11 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                if "Deferral Code" = xRec."Deferral Code" then begin
+                    if PurchHeader.Status = PurchHeader.Status::Released then
+                        exit;
+                end else
+                    PurchHeader.TestField(Status, PurchHeader.Status::Open);
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
@@ -32,6 +32,7 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         FieldErrorErr: Label 'Calc. Method must not be 4 in Deferral Template Deferral Code';
         AmountLCYNotFilledErr: Label 'Amount (LCY) should be filled before posting.';
         AmountLCYSumErr: Label 'The sum of the deferral line Amount (LCY) values must equal the header Amount to Defer (LCY).';
+        DeferralCodeChangedErr: Label 'Deferral Code cannot be changed on a line with a deferral schedule.';
 
     [Test]
     [Scope('OnPrem')]

--- a/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM-Sales/REDTestUnitforSalesPurDoc2.Codeunit.al
@@ -1184,6 +1184,38 @@ codeunit 134806 "RED Test Unit for SalesPurDoc2"
         Assert.AreEqual(DeferralHeader."Amount to Defer (LCY)", TotalLineAmountLCY, AmountLCYSumErr);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReleasedPurchLineDeferralCodeSameValueDoesNotRecalculateRU()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Unchanged Deferral Code remains the same on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", LibraryERM.CreateGLAccountWithPurchSetup(), WorkDate());
+        DeferralTemplateCode := LibraryERM.CreateDeferralTemplateCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        PurchaseLine2.Validate("Deferral Code", PurchaseLine2."Deferral Code");
+
+        // [THEN] No Error is thrown and the Deferral Code remains the same
+        Assert.AreEqual(PurchaseLine2."Deferral Code", PurchaseLine2."Deferral Code", DeferralCodeChangedErr);
+    end;
+
     local procedure Initialize()
     var
         AccountingPeriod: Record "Accounting Period";

--- a/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/SE/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2631,6 +2631,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchaseLine.Table.al
@@ -2630,6 +2630,7 @@ table 39 "Purchase Line"
                 DeferralPostDate: Date;
             begin
                 GetPurchHeader();
+                TestStatusOpen();
                 DeferralPostDate := GetDeferralPostDate(PurchHeader);
 
                 DeferralUtilities.DeferralCodeOnValidate(

--- a/src/Layers/W1/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM-Purchase/REDTestUnitforPurchDoc.Codeunit.al
@@ -2545,6 +2545,41 @@ codeunit 134804 "RED Test Unit for Purch Doc"
         PurchaseInvoice.Close();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure DeferralCodeCannotBeChangedOnReleasedPurchaseInvoice()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLine2: Record "Purchase Line";
+        GLAccount: Record "G/L Account";
+        DeferralTemplateCode: Code[10];
+    begin
+        // [FEATURE] [Deferral Code]
+        // [SCENARIO 649204] Deferral Code cannot be changed on a released Purchase Invoice
+        Initialize();
+
+        // [GIVEN] A Purchase Invoice with a deferral code on a G/L Account line
+        CreateGLAccount(GLAccount);
+        CreatePurchDocWithLine(
+          PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Invoice,
+          PurchaseLine.Type::"G/L Account", GLAccount."No.", WorkDate());
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 1);
+        PurchaseLine.Validate("Deferral Code", DeferralTemplateCode);
+        PurchaseLine.Modify(true);
+
+        // [GIVEN] The Purchase Invoice is released
+        LibraryPurchase.ReleasePurchaseDocument(PurchaseHeader);
+
+        // [WHEN] Changing the Deferral Code on the Purchase Line
+        DeferralTemplateCode := CreateDeferralCode(CalcMethod::"Straight-Line", StartDate::"Posting Date", 3);
+        PurchaseLine2.Get(PurchaseLine."Document Type", PurchaseLine."Document No.", PurchaseLine."Line No.");
+        asserterror PurchaseLine2.Validate("Deferral Code", DeferralTemplateCode);
+
+        // [THEN] The change is rejected because the Purchase Invoice is not open
+        Assert.ExpectedTestFieldError(PurchaseHeader.FieldCaption(Status), Format(PurchaseHeader.Status::Open));
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";


### PR DESCRIPTION
[Bug 649734](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649734): [29.x][All-e]"Status must be equal to 'Open' in Purchase Header" validation missing for Deferral Code field on Released Purchase documents.

Fixes [AB#649734](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649734)

Issue
"Status must be equal to 'Open' in Purchase Header" validation missing for Deferral Code field on Released Purchase documents.

Root Cause
TestStatusOpen(); missing for Field Deferral Code.

Solution
Added the function and related test automation


