### PR TITLE
[main] Bug 649189: Update E-Document vendor invoice caption

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocReadablePurchaseDoc.Page.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocReadablePurchaseDoc.Page.al
@@ -133,8 +133,8 @@ page 6182 "E-Doc. Readable Purchase Doc."
                 }
                 field("Vendor Invoice No."; Rec."Vendor Invoice No.")
                 {
-                    Caption = 'Vendor Invoice No.';
-                    ToolTip = 'Specifies the vendor invoice number.';
+                    Caption = 'Applies-to Ext. Invoice No.';
+                    ToolTip = 'Specifies the external invoice number that the document applies to.';
                 }
                 field("Invoice Date"; Rec."Invoice Date")
                 {

--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Purchase/EDocumentPurchaseHeader.Table.al
@@ -234,7 +234,7 @@ table 6100 "E-Document Purchase Header"
 #pragma warning disable AS0005
         field(40; "Vendor Invoice No."; Text[100])
         {
-            Caption = 'Vendor Invoice No.';
+            Caption = 'Applies-to Ext. Invoice No.';
             DataClassification = CustomerContent;
         }
 #pragma warning restore AS0005


### PR DESCRIPTION
## What & why

The E-Document purchase header field used to resolve the invoice referenced by an imported purchase credit memo was labeled as a vendor invoice number. This was misleading because the value is the external invoice number that the document applies to.

Update the table field caption and the readable purchase document page caption and tooltip to use the applies-to terminology.

## Linked work

Fixes 
[AB#649189](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649189)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Ran `git diff --check`; it completed successfully.
- Verified the table field and page control use the exact caption `Applies-to Ext. Invoice No.` and that the tooltip describes the applies-to behavior.
- No automated tests were added because this change only updates display metadata and does not alter application behavior.
- The local container build and UI validation were not run because Docker is unavailable in this environment.

## Risk & compatibility

None. The field ID, name, type, and behavior are unchanged; only the displayed caption and tooltip are updated.
