### PR TITLE
[MCP] Allow setting default configuration from card

### DIFF
--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -70,7 +70,7 @@ page 8351 "MCP Config Card"
                     field(Default; Rec.Default)
                     {
                         Caption = 'Default';
-                        ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Use the Set as Default and Clear Default actions on the configuration list to change this.';
+                        ToolTip = 'Specifies whether this configuration is the default. The default configuration is used when no configuration is specified by a connection. Use the Set as Default and Clear Default actions to change this.';
                         Editable = false;
                     }
                     field(AllowProdChanges; Rec.AllowProdChanges)
@@ -134,6 +134,34 @@ page 8351 "MCP Config Card"
         }
         area(Processing)
         {
+            action(SetAsDefault)
+            {
+                Caption = 'Set as Default';
+                ToolTip = 'Set this configuration as the default. It will be used when no configuration is specified by a connection.';
+                Image = Approve;
+                AccessByPermission = tabledata "MCP Configuration" = M;
+                Enabled = not Rec.Default;
+
+                trigger OnAction()
+                begin
+                    MCPConfigImplementation.SetAsDefaultConfiguration(Rec.SystemId);
+                    CurrPage.Update(false);
+                end;
+            }
+            action(ClearDefault)
+            {
+                Caption = 'Clear Default';
+                ToolTip = 'Remove the default designation from this configuration. The system will revert to built-in default settings.';
+                Image = Undo;
+                AccessByPermission = tabledata "MCP Configuration" = M;
+                Enabled = Rec.Default;
+
+                trigger OnAction()
+                begin
+                    MCPConfigImplementation.ClearDefaultConfiguration();
+                    CurrPage.Update(false);
+                end;
+            }
             action(Validate)
             {
                 Caption = 'Validate';
@@ -178,6 +206,8 @@ page 8351 "MCP Config Card"
         area(Promoted)
         {
             actionref(Promoted_Copy; Copy) { }
+            actionref(Promoted_SetAsDefault; SetAsDefault) { }
+            actionref(Promoted_ClearDefault; ClearDefault) { }
             actionref(Promoted_Validate; Validate) { }
             group(Promoted_Advanced)
             {

--- a/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
+++ b/src/System Application/App/MCP/src/Configuration/Pages/MCPConfigCard.Page.al
@@ -134,6 +134,17 @@ page 8351 "MCP Config Card"
         }
         area(Processing)
         {
+            action(Validate)
+            {
+                Caption = 'Validate';
+                ToolTip = 'Validates the MCP configuration to ensure all settings and tools are correctly configured.';
+                Image = ValidateEmailLoggingSetup;
+
+                trigger OnAction()
+                begin
+                    MCPConfigImplementation.ValidateConfiguration(Rec, false);
+                end;
+            }
             action(SetAsDefault)
             {
                 Caption = 'Set as Default';
@@ -160,17 +171,6 @@ page 8351 "MCP Config Card"
                 begin
                     MCPConfigImplementation.ClearDefaultConfiguration();
                     CurrPage.Update(false);
-                end;
-            }
-            action(Validate)
-            {
-                Caption = 'Validate';
-                ToolTip = 'Validates the MCP configuration to ensure all settings and tools are correctly configured.';
-                Image = ValidateEmailLoggingSetup;
-
-                trigger OnAction()
-                begin
-                    MCPConfigImplementation.ValidateConfiguration(Rec, false);
                 end;
             }
             group(Advanced)
@@ -206,9 +206,9 @@ page 8351 "MCP Config Card"
         area(Promoted)
         {
             actionref(Promoted_Copy; Copy) { }
+            actionref(Promoted_Validate; Validate) { }
             actionref(Promoted_SetAsDefault; SetAsDefault) { }
             actionref(Promoted_ClearDefault; ClearDefault) { }
-            actionref(Promoted_Validate; Validate) { }
             group(Promoted_Advanced)
             {
                 Caption = 'Advanced';

--- a/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
+++ b/src/System Application/Test/MCP/src/MCPConfigTest.Codeunit.al
@@ -1265,6 +1265,28 @@ codeunit 130130 "MCP Config Test"
     end;
 
     [Test]
+    procedure TestSetAsDefaultConfigurationFromCard()
+    var
+        MCPConfiguration: Record "MCP Configuration";
+        MCPConfigCard: TestPage "MCP Config Card";
+        ConfigId: Guid;
+    begin
+        // [GIVEN] An active configuration is open on the card
+        EnsureSystemDefaultExists();
+        ConfigId := CreateMCPConfig(true, false, false, false);
+        MCPConfiguration.GetBySystemId(ConfigId);
+        MCPConfigCard.OpenEdit();
+        MCPConfigCard.GoToRecord(MCPConfiguration);
+
+        // [WHEN] Set as Default is invoked
+        MCPConfigCard.SetAsDefault.Invoke();
+
+        // [THEN] Configuration is marked as default
+        MCPConfiguration.GetBySystemId(ConfigId);
+        Assert.IsTrue(MCPConfiguration.Default, 'Configuration should be marked as default');
+    end;
+
+    [Test]
     procedure TestClearDefaultConfiguration()
     var
         MCPConfiguration: Record "MCP Configuration";
@@ -1284,6 +1306,32 @@ codeunit 130130 "MCP Config Test"
         Assert.IsFalse(MCPConfiguration.Default, 'Configuration should not be marked as default');
 
         // [THEN] System default is re-marked as default
+        SystemDefault.Get('');
+        Assert.IsTrue(SystemDefault.Default, 'System default should be re-marked as default');
+    end;
+
+    [Test]
+    procedure TestClearDefaultConfigurationFromCard()
+    var
+        MCPConfiguration: Record "MCP Configuration";
+        SystemDefault: Record "MCP Configuration";
+        MCPConfigCard: TestPage "MCP Config Card";
+        ConfigId: Guid;
+    begin
+        // [GIVEN] A designated default configuration is open on the card
+        EnsureSystemDefaultExists();
+        ConfigId := CreateMCPConfig(true, false, false, false);
+        MCPConfig.SetAsDefaultConfiguration(ConfigId);
+        MCPConfiguration.GetBySystemId(ConfigId);
+        MCPConfigCard.OpenEdit();
+        MCPConfigCard.GoToRecord(MCPConfiguration);
+
+        // [WHEN] Clear Default is invoked
+        MCPConfigCard.ClearDefault.Invoke();
+
+        // [THEN] The system default is restored
+        MCPConfiguration.GetBySystemId(ConfigId);
+        Assert.IsFalse(MCPConfiguration.Default, 'Configuration should not be marked as default');
         SystemDefault.Get('');
         Assert.IsTrue(SystemDefault.Default, 'System default should be re-marked as default');
     end;


### PR DESCRIPTION
## Summary
- add **Set as Default** and **Clear Default** actions to the MCP configuration card
- promote both actions and update the Default field guidance
- add card-level regression tests for setting and clearing the default configuration

## Test plan
- added `TestSetAsDefaultConfigurationFromCard`
- added `TestClearDefaultConfigurationFromCard`
- local execution was blocked because the AL MCP server requires a restart to reload its package-cache and assembly-probing settings

Fixes [AB#649752](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649752)




