### PR TITLE
[29.0] Backport #10988: Add price-specific Copy Item event

### DIFF
--- a/src/Layers/W1/BaseApp/Inventory/Item/CopyItem.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Item/CopyItem.Codeunit.al
@@ -378,7 +378,13 @@ codeunit 730 "Copy Item"
     var
         NewPriceListLine: Record "Price List Line";
         PriceListLine: Record "Price List Line";
+        IsHandled: Boolean;
     begin
+        IsHandled := false;
+        OnBeforeCopyItemPriceListLines2(FromItemNo, ToItemNo, PriceType, AmountType, IsHandled);
+        if IsHandled then
+            exit;
+
         PriceListLine.SetRange("Price Type", PriceType);
         PriceListLine.SetRange("Amount Type", AmountType);
         PriceListLine.SetRange("Asset Type", PriceListLine."Asset Type"::Item);
@@ -547,6 +553,11 @@ codeunit 730 "Copy Item"
 
     [IntegrationEvent(false, false)]
     local procedure OnBeforeCopyItemPriceListLines(FromItemNo: Code[20]; ToItemNo: Code[20]; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    local procedure OnBeforeCopyItemPriceListLines2(FromItemNo: Code[20]; ToItemNo: Code[20]; PriceType: Enum "Price Type"; AmountType: Enum "Price Amount Type"; var IsHandled: Boolean)
     begin
     end;
 


### PR DESCRIPTION
Backports microsoft/BCApps#10988 to `releases/29.0`.

Adds `OnBeforeCopyItemPriceListLines2` to the price-specific `CopyItemPriceListLines` overload, exposing `PriceType` and `AmountType` and allowing subscribers to handle the copy before filters and inserts run.

## Included commit

- https://github.com/microsoft/BCApps/commit/7c44a915ef4850daa0b5180537bebadd0623f06a

Related to [AB#462363](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/462363)
Related to microsoft/ALAppExtensions#21991
