### PR TITLE
[main] Bug 649837 Export to Excel All exported rows if Show Currency is enabled in General Ledger Setup.

### DIFF
--- a/src/Layers/W1/BaseApp/Finance/Currency/ShowCurrencyGenLedgSetup.PageExt.al
+++ b/src/Layers/W1/BaseApp/Finance/Currency/ShowCurrencyGenLedgSetup.PageExt.al
@@ -6,6 +6,7 @@
 namespace Microsoft.Finance.Currency;
 
 using Microsoft.Finance.GeneralLedger.Setup;
+using System.Environment.Configuration;
 
 pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
 {
@@ -18,6 +19,7 @@ pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Show Currency';
                 importance = Additional;
+                visible = IsSaaSExcelAddinEnabled;
 
                 trigger OnValidate()
                 begin
@@ -29,6 +31,7 @@ pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
                 ApplicationArea = Basic, Suite;
                 Caption = 'Currency Symbol Position';
                 importance = Additional;
+                visible = IsSaaSExcelAddinEnabled;
 
                 trigger OnValidate()
                 begin
@@ -40,6 +43,7 @@ pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
 
     var
         RestartSession: Boolean;
+        IsSaaSExcelAddinEnabled: Boolean;
 
     trigger OnQueryClosePage(CloseAction: Action): Boolean
     var
@@ -50,5 +54,12 @@ pageextension 60 ShowCurrencyGenLedgSetup extends "General Ledger Setup"
                 SessionSetting.Init();
                 SessionSetting.RequestSessionUpdate(false);
             end;
+    end;
+
+    trigger OnOpenPage()
+    var
+        ServerSetting: Codeunit "Server Setting";
+    begin
+        IsSaaSExcelAddinEnabled := ServerSetting.GetIsSaasExcelAddinEnabled();
     end;
 }


### PR DESCRIPTION
[Bug 649837](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649837): [master][all-e]Export to Excel applies selected Purchase Order Currency to All exported rows if Show Currency is enabled in General Ledger Setup.

Fixes [AB#649837](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649837)

Issue
Export to Excel applies selected Purchase Order Currency to All exported rows if Show Currency is enabled in General Ledger Setup.
Cause
[28.0] Remove entry-point to Currency Codes feature on GL Setup (was not intended for release)
Solution
Added field Visible= false as reference bug suggests the feature is not released.




