### PR TITLE
[Security] Retire legacy JSON helper codeunits

### DIFF
--- a/src/Apps/IN/INGST/app/GSTSales/src/Codeunit/eInvoiceJsonHandler.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTSales/src/Codeunit/eInvoiceJsonHandler.Codeunit.al
@@ -96,10 +96,10 @@ codeunit 18147 "e-Invoice Json Handler"
 
     procedure GetEInvoiceResponse(var RecRef: RecordRef)
     var
-        JSONManagement: Codeunit "JSON Management";
         QRGenerator: Codeunit "QR Generator";
         TempBlob: Codeunit "Temp Blob";
         FieldRef: FieldRef;
+        ResponseJson: JsonObject;
         JsonString: Text;
         TempIRNTxt: Text;
         TempDateTime: DateTime;
@@ -111,14 +111,14 @@ codeunit 18147 "e-Invoice Json Handler"
         if (JsonString = '') or (JsonString = '[]') then
             exit;
 
-        JSONManagement.InitializeObject(JsonString);
-        if JSONManagement.GetValue(IRNTxt) <> '' then begin
+        ResponseJson.ReadFrom(JsonString);
+        if GetJsonValue(ResponseJson, IRNTxt) <> '' then begin
             FieldRef := RecRef.Field(SalesInvoiceHeader.FieldNo("IRN Hash"));
-            FieldRef.Value := JSONManagement.GetValue(IRNTxt);
+            FieldRef.Value := GetJsonValue(ResponseJson, IRNTxt);
             FieldRef := RecRef.Field(SalesInvoiceHeader.FieldNo("Acknowledgement No."));
-            FieldRef.Value := JSONManagement.GetValue(AcknowledgementNoTxt);
+            FieldRef.Value := GetJsonValue(ResponseJson, AcknowledgementNoTxt);
 
-            AcknowledgementDateTimeText := JSONManagement.GetValue(AcknowledgementDateTxt);
+            AcknowledgementDateTimeText := GetJsonValue(ResponseJson, AcknowledgementDateTxt);
             Evaluate(AcknowledgementDate, CopyStr(AcknowledgementDateTimeText, 1, 10));
             Evaluate(AcknowledgementTime, CopyStr(AcknowledgementDateTimeText, 11, 8));
             TempDateTime := CreateDateTime(AcknowledgementDate, AcknowledgementTime);
@@ -127,12 +127,25 @@ codeunit 18147 "e-Invoice Json Handler"
             FieldRef.Value := TempDateTime;
             FieldRef := RecRef.Field(SalesInvoiceHeader.FieldNo(IsJSONImported));
             FieldRef.Value := true;
-            QRGenerator.GenerateQRCodeImage(JSONManagement.GetValue(SignedQRCodeTxt), TempBlob);
+            QRGenerator.GenerateQRCodeImage(GetJsonValue(ResponseJson, SignedQRCodeTxt), TempBlob);
             FieldRef := RecRef.Field(SalesInvoiceHeader.FieldNo("QR Code"));
             TempBlob.ToRecordRef(RecRef, SalesInvoiceHeader.FieldNo("QR Code"));
             RecRef.Modify();
         end else
             Error(IRNHashErr, TempIRNTxt);
+    end;
+
+    local procedure GetJsonValue(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if not JsonToken.IsValue() then
+            exit('');
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit('');
+        exit(JsonToken.AsValue().AsText());
     end;
 
     procedure GenerateQRCodeforB2C(var SalesInvoiceHeader: Record "Sales Invoice Header")

--- a/src/Apps/IN/INGST/app/GSTSales/src/Codeunit/eInvoiceJsonHandler.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTSales/src/Codeunit/eInvoiceJsonHandler.Codeunit.al
@@ -17,7 +17,6 @@ using Microsoft.Sales.Customer;
 using Microsoft.Sales.History;
 using Microsoft.Sales.Receivables;
 using System.Security.Encryption;
-using System.Text;
 using System.Utilities;
 
 codeunit 18147 "e-Invoice Json Handler"

--- a/src/Apps/IN/INGST/app/GSTService/src/Codeunit/eInvoiceJsonHandlerforSer.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTService/src/Codeunit/eInvoiceJsonHandlerforSer.Codeunit.al
@@ -16,7 +16,6 @@ using Microsoft.Sales.Customer;
 using Microsoft.Sales.Receivables;
 using Microsoft.Service.History;
 using System.Security.Encryption;
-using System.Text;
 using System.Utilities;
 
 codeunit 18160 "e-Invoice Json Handler for Ser"

--- a/src/Apps/IN/INGST/app/GSTService/src/Codeunit/eInvoiceJsonHandlerforSer.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTService/src/Codeunit/eInvoiceJsonHandlerforSer.Codeunit.al
@@ -91,10 +91,10 @@ codeunit 18160 "e-Invoice Json Handler for Ser"
 
     procedure GetEInvoiceResponse(var RecRef: RecordRef)
     var
-        JSONManagement: Codeunit "JSON Management";
         QRGenerator: Codeunit "QR Generator";
         TempBlob: Codeunit "Temp Blob";
         FieldRef: FieldRef;
+        ResponseJson: JsonObject;
         JsonString: Text;
         TempIRNTxt: Text;
         TempDateTime: DateTime;
@@ -106,14 +106,14 @@ codeunit 18160 "e-Invoice Json Handler for Ser"
         if (JsonString = '') or (JsonString = '[]') then
             exit;
 
-        JSONManagement.InitializeObject(JsonString);
+        ResponseJson.ReadFrom(JsonString);
         FieldRef := RecRef.Field(ServiceInvoiceHeader.FieldNo("IRN Hash"));
         TempIRNTxt := FieldRef.Value;
-        if TempIRNTxt = JSONManagement.GetValue(IRNTxt) then begin
+        if TempIRNTxt = GetJsonValue(ResponseJson, IRNTxt) then begin
             FieldRef := RecRef.Field(ServiceInvoiceHeader.FieldNo("Acknowledgement No."));
-            FieldRef.Value := JSONManagement.GetValue(AcknowledgementNoTxt);
+            FieldRef.Value := GetJsonValue(ResponseJson, AcknowledgementNoTxt);
 
-            AcknowledgementDateTimeText := JSONManagement.GetValue(AcknowledgementDateTxt);
+            AcknowledgementDateTimeText := GetJsonValue(ResponseJson, AcknowledgementDateTxt);
             Evaluate(AcknowledgementDate, CopyStr(AcknowledgementDateTimeText, 1, 10));
             Evaluate(AcknowledgementTime, CopyStr(AcknowledgementDateTimeText, 11, 8));
             TempDateTime := CreateDateTime(AcknowledgementDate, AcknowledgementTime);
@@ -122,12 +122,25 @@ codeunit 18160 "e-Invoice Json Handler for Ser"
             FieldRef.Value := TempDateTime;
             FieldRef := RecRef.Field(ServiceInvoiceHeader.FieldNo(IsJSONImported));
             FieldRef.Value := true;
-            QRGenerator.GenerateQRCodeImage(JSONManagement.GetValue(SignedQRCodeTxt), TempBlob);
+            QRGenerator.GenerateQRCodeImage(GetJsonValue(ResponseJson, SignedQRCodeTxt), TempBlob);
             FieldRef := RecRef.Field(ServiceInvoiceHeader.FieldNo("QR Code"));
             TempBlob.ToRecordRef(RecRef, ServiceInvoiceHeader.FieldNo("QR Code"));
             RecRef.Modify();
         end else
             Error(IRNHashErr, TempIRNTxt);
+    end;
+
+    local procedure GetJsonValue(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if not JsonToken.IsValue() then
+            exit('');
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit('');
+        exit(JsonToken.AsValue().AsText());
     end;
 
     local procedure GetResponseText() ResponseText: Text

--- a/src/Apps/IN/INGST/app/GSTStockTransfer/src/codeunit/EInvJsonHandlerForTransShpt.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTStockTransfer/src/codeunit/EInvJsonHandlerForTransShpt.Codeunit.al
@@ -11,7 +11,6 @@ using Microsoft.Inventory.Location;
 using Microsoft.Inventory.Transfer;
 using Microsoft.QRGeneration;
 using System.Security.Encryption;
-using System.Text;
 using System.Utilities;
 
 codeunit 18023 "E-InvJsonHandlerForTransShpt"

--- a/src/Apps/IN/INGST/app/GSTStockTransfer/src/codeunit/EInvJsonHandlerForTransShpt.Codeunit.al
+++ b/src/Apps/IN/INGST/app/GSTStockTransfer/src/codeunit/EInvJsonHandlerForTransShpt.Codeunit.al
@@ -612,10 +612,10 @@ codeunit 18023 "E-InvJsonHandlerForTransShpt"
 
     procedure GetEInvoiceResponse(var RecRef: RecordRef)
     var
-        JSONManagement: Codeunit "JSON Management";
         QRGenerator: Codeunit "QR Generator";
         TempBlob: Codeunit "Temp Blob";
         FieldRef: FieldRef;
+        ResponseJson: JsonObject;
         JsonString: Text;
         TempIRNTxt: Text;
         TempDateTime: DateTime;
@@ -627,14 +627,14 @@ codeunit 18023 "E-InvJsonHandlerForTransShpt"
         if (JsonString = '') or (JsonString = '[]') then
             exit;
 
-        JSONManagement.InitializeObject(JsonString);
-        if JSONManagement.GetValue(IRNTxt) <> '' then begin
+        ResponseJson.ReadFrom(JsonString);
+        if GetJsonValue(ResponseJson, IRNTxt) <> '' then begin
             FieldRef := RecRef.Field(TransferShipmentHeader.FieldNo("IRN Hash"));
-            FieldRef.Value := JSONManagement.GetValue(IRNTxt);
+            FieldRef.Value := GetJsonValue(ResponseJson, IRNTxt);
             FieldRef := RecRef.Field(TransferShipmentHeader.FieldNo("Acknowledgement No."));
-            FieldRef.Value := JSONManagement.GetValue(AcknowledgementNoTxt);
+            FieldRef.Value := GetJsonValue(ResponseJson, AcknowledgementNoTxt);
 
-            AcknowledgementDateTimeText := JSONManagement.GetValue(AcknowledgementDateTxt);
+            AcknowledgementDateTimeText := GetJsonValue(ResponseJson, AcknowledgementDateTxt);
             Evaluate(AcknowledgementDate, CopyStr(AcknowledgementDateTimeText, 1, 10));
             Evaluate(AcknowledgementTime, CopyStr(AcknowledgementDateTimeText, 11, 8));
             TempDateTime := CreateDateTime(AcknowledgementDate, AcknowledgementTime);
@@ -643,12 +643,25 @@ codeunit 18023 "E-InvJsonHandlerForTransShpt"
             FieldRef.Value := TempDateTime;
             FieldRef := RecRef.Field(TransferShipmentHeader.FieldNo(IsJSONImported));
             FieldRef.Value := true;
-            QRGenerator.GenerateQRCodeImage(JSONManagement.GetValue(SignedQRCodeTxt), TempBlob);
+            QRGenerator.GenerateQRCodeImage(GetJsonValue(ResponseJson, SignedQRCodeTxt), TempBlob);
             FieldRef := RecRef.Field(TransferShipmentHeader.FieldNo("QR Code"));
             TempBlob.ToRecordRef(RecRef, TransferShipmentHeader.FieldNo("QR Code"));
             RecRef.Modify();
         end else
             Error(IRNHashErr, TempIRNTxt);
+    end;
+
+    local procedure GetJsonValue(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if not JsonToken.IsValue() then
+            exit('');
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit('');
+        exit(JsonToken.AsValue().AsText());
     end;
 
     local procedure GetResponseText() ResponseText: Text

--- a/src/Apps/W1/AMCBanking365Fundamentals/app/Codeunits/AMCBankRESTRequestMgt.Codeunit.al
+++ b/src/Apps/W1/AMCBanking365Fundamentals/app/Codeunits/AMCBankRESTRequestMgt.Codeunit.al
@@ -199,9 +199,10 @@ codeunit 20124 "AMC Bank REST Request Mgt."
         end;
     end;
 
+#if not CLEAN30
+    [Obsolete('Use GetJsonObjectFromBlob with the native JsonObject type instead.', '30.0')]
     procedure GetJsonObjectFromBlob(ResponseTempBlob: Codeunit "Temp Blob"; var ReponseJObject: DotNet JObject)
     var
-        JSONManagement: Codeunit "JSON Management";
         JSONText: Text;
         JsonInStream: InStream;
     begin
@@ -209,11 +210,29 @@ codeunit 20124 "AMC Bank REST Request Mgt."
         if ResponseTempBlob.HasValue() then begin
             ResponseTempBlob.CreateInStream(JsonInStream);
             JsonInStream.ReadText(JSONText);
-            JSONManagement.InitializeFromString(JSONText);
-            JSONManagement.GetJSONObject(ReponseJObject);
+            if not TryParseJObject(ReponseJObject, JSONText) then
+                Clear(ReponseJObject);
         end;
     end;
 
+    [TryFunction]
+    local procedure TryParseJObject(var JsonObject: DotNet JObject; JsonText: Text)
+    begin
+        JsonObject := JsonObject.Parse(JsonText);
+    end;
+#endif
+
+    procedure GetJsonObjectFromBlob(ResponseTempBlob: Codeunit "Temp Blob"; var ResponseJsonObject: JsonObject)
+    var
+        JsonInStream: InStream;
+    begin
+        Clear(ResponseJsonObject);
+        if ResponseTempBlob.HasValue() then begin
+            ResponseTempBlob.CreateInStream(JsonInStream);
+            if not ResponseJsonObject.ReadFrom(JsonInStream) then
+                Clear(ResponseJsonObject);
+        end;
+    end;
 
     procedure LogHttpActivity(SoapCall: Text; AppCaller: Text[30]; LogMessage: Text; HintText: Text; SupportUrl: Text; LogHttpContent: HttpContent; ResponseResult: Text) Id: Integer;
     var
@@ -269,16 +288,20 @@ codeunit 20124 "AMC Bank REST Request Mgt."
 
     local procedure CleanSecureContent(LogHttpContent: HttpContent; var LogInStream: Instream);
     var
-        JSONManagement: Codeunit "JSON Management";
+        JsonObject: JsonObject;
         baseHttpContent: HttpContent;
         LogText: Text;
     begin
         LogHttpContent.ReadAs(LogText);
-        JSONManagement.InitializeObject(LogText);
-        if (JSONManagement.GetValue('modulepassword') <> '') then
-            JSONManagement.SetValue('modulepassword', '**********');
+        if LogText <> '' then
+            if not JsonObject.ReadFrom(LogText) then
+                LogText := ''
+            else begin
+                if GetJsonValue(JsonObject, 'modulepassword') <> '' then
+                    JsonObject.Replace('modulepassword', '**********');
+                JsonObject.WriteTo(LogText);
+            end;
 
-        LogText := JSONManagement.WriteObjectToString();
         baseHttpContent.WriteFrom(LogText);
         baseHttpContent.ReadAs(LogInStream);
 
@@ -287,9 +310,8 @@ codeunit 20124 "AMC Bank REST Request Mgt."
     procedure HasResponseErrors(ResponseTempBlob: Codeunit "Temp Blob"; RestCall: Text; JsonErrorKeyName: Text; Var ResponseResult: Text; AppCaller: Text[30]): Boolean;
     var
         AMCBankingSetup: Record "AMC Banking Setup";
-        JSONManagement: Codeunit "JSON Management";
-        SyslogJSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        ResponseJsonObject: JsonObject;
+        SyslogJsonObject: JsonObject;
         LogId: Integer;
         HttpContent: HttpContent;
         ResponseInStream: InStream;
@@ -300,19 +322,20 @@ codeunit 20124 "AMC Bank REST Request Mgt."
         //Get result of call
         AMCBankingSetup.GET();
 
-        GetJsonObjectFromBlob(ResponseTempBlob, JObject);
+        GetJsonObjectFromBlob(ResponseTempBlob, ResponseJsonObject);
         ResponseTempBlob.CreateInStream(ResponseInStream);
 
-        JSONManagement.InitializeObjectFromJObject(JObject);
-        SysLogText := JSONManagement.GetValue(JsonErrorKeyName);
+        SysLogText := GetJsonValue(ResponseJsonObject, JsonErrorKeyName);
 
-        SyslogJSONManagement.InitializeFromString(SysLogText);
-        ResponseResult := lowercase(SyslogJSONManagement.GetValue('syslogtype'));
+        if SysLogText <> '' then
+            if not SyslogJsonObject.ReadFrom(SysLogText) then
+                Clear(SyslogJsonObject);
+        ResponseResult := LowerCase(GetJsonValue(SyslogJsonObject, 'syslogtype'));
         if (ResponseResult <> 'ok') then begin
 
-            GLBResponseErrorText := SyslogJSONManagement.GetValue('text');
-            HintText := SyslogJSONManagement.GetValue('hinttext');
-            URLText := SyslogJSONManagement.GetValue('url');
+            GLBResponseErrorText := GetJsonValue(SyslogJsonObject, 'text');
+            HintText := GetJsonValue(SyslogJsonObject, 'hinttext');
+            URLText := GetJsonValue(SyslogJsonObject, 'url');
 
             HttpContent.WriteFrom(ResponseInStream);
             LogId := LogHttpActivity(RestCall, AppCaller, GLBResponseErrorText, HintText, URLText, HttpContent, ResponseResult);
@@ -335,6 +358,22 @@ codeunit 20124 "AMC Bank REST Request Mgt."
         end;
 
         EXIT(FALSE);
+    end;
+
+    local procedure GetJsonValue(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+        JsonText: Text;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
+        JsonToken.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure ShowResponseError(ResponseResult: Text);
@@ -376,4 +415,3 @@ codeunit 20124 "AMC Bank REST Request Mgt."
 }
 #endif
 #pragma warning restore AS0018
-

--- a/src/Apps/W1/AMCBanking365Fundamentals/app/Pages/AMCBankSignuptoService.Page.al
+++ b/src/Apps/W1/AMCBanking365Fundamentals/app/Pages/AMCBankSignuptoService.Page.al
@@ -202,13 +202,12 @@ page 20109 "AMC Bank Signup to Service"
     var
         CountryRegion: Record "Country/Region";
         EnvironmentInformation: Codeunit "Environment Information";
-        JSONManagement: Codeunit "JSON Management";
         EasyRegistrationTempBlob: Codeunit "Temp Blob";
         HttpRequestMessage: HttpRequestMessage;
         HttpResponseMessage: HttpResponseMessage;
         HttpContent: HttpContent;
-        JObject: DotNet JObject;
-        ResponseJsonObject: DotNet JObject;
+        RequestJsonObject: JsonObject;
+        ResponseJsonObject: JsonObject;
         Handled: Boolean;
         restcall: text;
         ResponseResult: Text;
@@ -223,28 +222,27 @@ page 20109 "AMC Bank Signup to Service"
 
         if (CountryRegion.Get(rec."Country/Region Code")) then;
 
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JObject);
-        JSONManagement.AddJPropertyToJObject(JObject, 'companyname', rec.name);
-        JSONManagement.AddJPropertyToJObject(JObject, 'address1', rec.Address);
-        JSONManagement.AddJPropertyToJObject(JObject, 'address2', rec."Address 2");
-        JSONManagement.AddJPropertyToJObject(JObject, 'zipcode', rec."Post Code");
-        JSONManagement.AddJPropertyToJObject(JObject, 'city', rec.City);
-        JSONManagement.AddJPropertyToJObject(JObject, 'country', CountryRegion."ISO Code");
-        JSONManagement.AddJPropertyToJObject(JObject, 'state', rec.County);
-        JSONManagement.AddJPropertyToJObject(JObject, 'vatid', GetVatIdwithCountryId(CountryRegion));
-        JSONManagement.AddJPropertyToJObject(JObject, 'currency', CompanyCurrency);
-        JSONManagement.AddJPropertyToJObject(JObject, 'fullname', AdminUserName);
-        JSONManagement.AddJPropertyToJObject(JObject, 'email', AdminEmail);
-        JSONManagement.AddJPropertyToJObject(JObject, 'phone', rec."Phone No.");
-        JSONManagement.AddJPropertyToJObject(JObject, 'erp', 'Dyn. Nav');
-        JSONManagement.AddJPropertyToJObject(JObject, 'moduleguid', DelStr(AMCBankingMgt.GetLicenseNumber(), 1, 2));
-        JSONManagement.AddJPropertyToJObject(JObject, 'moduleprefix', 'BC');
-        JSONManagement.AddJPropertyToJObject(JObject, 'modulepostfix', GetModulePostFix(AMCBankingSetup));
-        JSONManagement.AddJPropertyToJObject(JObject, 'sandbox', EnvironmentInformation.IsSandbox());
-        JSONManagement.AddJPropertyToJObject(JObject, 'businessappinstalled', AMCBankingMgt.IsAMCBusinessInstalled());
+        RequestJsonObject.Add('companyname', rec.name);
+        RequestJsonObject.Add('address1', rec.Address);
+        RequestJsonObject.Add('address2', rec."Address 2");
+        RequestJsonObject.Add('zipcode', rec."Post Code");
+        RequestJsonObject.Add('city', rec.City);
+        RequestJsonObject.Add('country', CountryRegion."ISO Code");
+        RequestJsonObject.Add('state', rec.County);
+        RequestJsonObject.Add('vatid', GetVatIdwithCountryId(CountryRegion));
+        RequestJsonObject.Add('currency', CompanyCurrency);
+        RequestJsonObject.Add('fullname', AdminUserName);
+        RequestJsonObject.Add('email', AdminEmail);
+        RequestJsonObject.Add('phone', rec."Phone No.");
+        RequestJsonObject.Add('erp', 'Dyn. Nav');
+        RequestJsonObject.Add('moduleguid', DelStr(AMCBankingMgt.GetLicenseNumber(), 1, 2));
+        RequestJsonObject.Add('moduleprefix', 'BC');
+        RequestJsonObject.Add('modulepostfix', GetModulePostFix(AMCBankingSetup));
+        RequestJsonObject.Add('sandbox', EnvironmentInformation.IsSandbox());
+        RequestJsonObject.Add('businessappinstalled', AMCBankingMgt.IsAMCBusinessInstalled());
 
-        HttpContent.WriteFrom(JSONManagement.WriteObjectToString());
+        RequestJsonObject.WriteTo(ResponseResult);
+        HttpContent.WriteFrom(ResponseResult);
         HttpRequestMessage.Content(HttpContent);
 
         //Set Content-Type header
@@ -256,18 +254,28 @@ page 20109 "AMC Bank Signup to Service"
         AMCBankRESTRequestMgt.GetRestResponse(HttpResponseMessage, EasyRegistrationTempBlob);
         if (not AMCBankRESTRequestMgt.HasResponseErrors(EasyRegistrationTempBlob, restcall, 'syslog', ResponseResult, AMCBankingMgt.GetAppCaller())) then begin
             AMCBankRESTRequestMgt.GetJsonObjectFromBlob(EasyRegistrationTempBlob, ResponseJsonObject);
-            JSONManagement.InitializeObjectFromJObject(ResponseJsonObject);
-            if (JSONManagement.GetValue('modulepassword') <> '') then begin
+            if GetJsonValue(ResponseJsonObject, 'modulepassword') <> '' then begin
                 AMCBankingSetup."User Name" := CopyStr(BCLicenseNumberText, 1, 50);
-                AMCBankingSetup.SavePassword(JSONManagement.GetValue('modulepassword'));
+                AMCBankingSetup.SavePassword(GetJsonValue(ResponseJsonObject, 'modulepassword'));
                 AMCBankingSetup.Modify();
             end;
-            exit(JSONManagement.GetValue('url'));
+            exit(GetJsonValue(ResponseJsonObject, 'url'));
         end
         else
             AMCBankRESTRequestMgt.ShowResponseError(ResponseResult);
+    end;
 
-        exit('');
+    local procedure GetJsonValue(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if not JsonToken.IsValue() then
+            exit('');
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit('');
+        exit(JsonToken.AsValue().AsText());
     end;
 
     local procedure GetModulePostFix(AMCBankingSetup: Record "AMC Banking Setup"): Text

--- a/src/Apps/W1/AMCBanking365Fundamentals/app/Pages/AMCBankSignuptoService.Page.al
+++ b/src/Apps/W1/AMCBanking365Fundamentals/app/Pages/AMCBankSignuptoService.Page.al
@@ -8,11 +8,9 @@ namespace Microsoft.Bank.Payment;
 using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.Company;
-using System;
 using System.Environment;
 using System.Environment.Configuration;
 using System.Security.AccessControl;
-using System.Text;
 using System.Utilities;
 
 page 20109 "AMC Bank Signup to Service"

--- a/src/Apps/W1/AMCBanking365Fundamentals/test/src/Integration/ServiceConnectionTest.Codeunit.al
+++ b/src/Apps/W1/AMCBanking365Fundamentals/test/src/Integration/ServiceConnectionTest.Codeunit.al
@@ -86,6 +86,48 @@ codeunit 134414 "Service Connection Test"
           'AMC Banking Setup Connection have wrong status');
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure HasResponseErrorsHandlesMissingInvalidSyslogAndEmptyResponse()
+    var
+        AMCBankRESTRequestMgt: Codeunit "AMC Bank REST Request Mgt.";
+    begin
+        Initialize();
+
+        VerifyResponseWithoutValidSyslog(AMCBankRESTRequestMgt, '');
+        VerifyResponseWithoutValidSyslog(AMCBankRESTRequestMgt, '{}');
+        VerifyResponseWithoutValidSyslog(AMCBankRESTRequestMgt, '{"syslog":null}');
+        VerifyResponseWithoutValidSyslog(AMCBankRESTRequestMgt, '{"syslog":"not json"}');
+        VerifyResponseWithoutValidSyslog(AMCBankRESTRequestMgt, 'not json');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure LogHttpActivityDoesNotLogInvalidJsonContent()
+    var
+        ActivityLog: Record "Activity Log";
+        AMCBankRESTRequestMgt: Codeunit "AMC Bank REST Request Mgt.";
+        HttpContent: HttpContent;
+        DetailedInfoInStream: InStream;
+        ActualContent: Text;
+        InvalidContent: Text;
+        ActivityId: Integer;
+    begin
+        Initialize();
+        InvalidContent := 'not json';
+        HttpContent.WriteFrom(InvalidContent);
+
+        ActivityId := AMCBankRESTRequestMgt.LogHttpActivity('REST', 'TEST', 'error', '', '', HttpContent, 'error');
+
+        ActivityLog.Get(ActivityId);
+        ActivityLog.CalcFields("Detailed Info");
+        ActivityLog."Detailed Info".CreateInStream(DetailedInfoInStream);
+        DetailedInfoInStream.ReadText(ActualContent);
+        Assert.AreEqual('', ActualContent, 'Invalid JSON log content must not be logged.');
+        ActivityLog.Delete();
+        Commit();
+    end;
+
     local procedure Initialize()
     var
         AMCBankingSetup: Record "AMC Banking Setup";
@@ -97,6 +139,32 @@ codeunit 134414 "Service Connection Test"
         end;
         AMCBankingSetup."AMC Enabled" := true;
         AMCBankingSetup.Modify();
+    end;
+
+    local procedure VerifyResponseWithoutValidSyslog(var AMCBankRESTRequestMgt: Codeunit "AMC Bank REST Request Mgt."; ResponseText: Text)
+    var
+        ActivityLog: Record "Activity Log";
+        ResponseTempBlob: Codeunit "Temp Blob";
+        ResponseOutStream: OutStream;
+        ResponseResult: Text;
+        ActivityId: Integer;
+    begin
+        if ResponseText <> '' then begin
+            ResponseTempBlob.CreateOutStream(ResponseOutStream);
+            ResponseOutStream.WriteText(ResponseText);
+        end;
+
+        Assert.IsFalse(
+            AMCBankRESTRequestMgt.HasResponseErrors(ResponseTempBlob, 'REST', 'syslog', ResponseResult, 'TEST'),
+            'A response without a valid syslog must retain the legacy non-error classification.');
+        Assert.AreEqual('', ResponseResult, 'A response without a valid syslog must have an empty result.');
+
+        ActivityId := AMCBankRESTRequestMgt.GetGlobalToActivityId();
+        Assert.IsTrue(ActivityLog.Get(ActivityId), 'A response without a valid syslog must still be logged.');
+        Assert.AreEqual(Format(ActivityLog.Status::Failed), Format(ActivityLog.Status), 'The response must retain the legacy failed log status.');
+        Assert.AreEqual(Format(AMCBankWebLogStatus::Failed), Format(ActivityLog."AMC Bank WebLog Status"), 'The response must retain the legacy failed web log status.');
+        ActivityLog.Delete();
+        Commit();
     end;
 
     local procedure ServiceExist(Desc: Text): Boolean

--- a/src/Apps/W1/APIV1/test/src/APIV1CashFlowStatementE2E.Codeunit.al
+++ b/src/Apps/W1/APIV1/test/src/APIV1CashFlowStatementE2E.Codeunit.al
@@ -71,24 +71,19 @@ codeunit 139717 "APIV1 - CashFlow Statement E2E"
 
     local procedure GetIncomeStatementJSON(var AccScheduleLineEntity: Record "Acc. Schedule Line Entity") IncomeStatementJSON: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        "Newtonsoft.Json.Linq.JObject": DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
         if AccScheduleLineEntity."Line No." = 0 then
             AccScheduleLineEntity."Line No." := LibraryRandom.RandIntInRange(1, 10000);
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'lineNumber', AccScheduleLineEntity."Line No.");
+        JsonObject.Add('lineNumber', AccScheduleLineEntity."Line No.");
 
         if AccScheduleLineEntity.Description = '' then
             AccScheduleLineEntity.Description := LibraryUtility.GenerateGUID();
 
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'display', AccScheduleLineEntity.Description);
-
-        IncomeStatementJSON := JSONManagement.WriteObjectToString();
+        JsonObject.Add('display', AccScheduleLineEntity.Description);
+        JsonObject.WriteTo(IncomeStatementJSON);
     end;
 }
-
 
 
 

--- a/src/Apps/W1/APIV1/test/src/APIV1JournalLinesE2E.Codeunit.al
+++ b/src/Apps/W1/APIV1/test/src/APIV1JournalLinesE2E.Codeunit.al
@@ -31,7 +31,7 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         JournalLineJSON: Text;
         DimensionJSON: Text;
         Response: Text;
-        "Newtonsoft.Json.Linq.JArray": Dotnet JArray;
+        DimensionsJsonArray: JsonArray;
         FoundInResponse: Boolean;
         CurrentIndex: Integer;
     begin
@@ -56,11 +56,11 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         LibraryGraphMgt.PostToWebService(TargetURL, JournalLineJSON, Response);
 
         // [THEN] The dimension on the journal line should have the overriden dimension value.
-        GetDimensionsFromJSONText(Response, "Newtonsoft.Json.Linq.JArray");
+        GetDimensionsFromJSONText(Response, DimensionsJsonArray);
 
         FoundInResponse := false;
-        for CurrentIndex := 0 to "Newtonsoft.Json.Linq.JArray".Count() - 1 do
-            if JObjectMatchesDimension("Newtonsoft.Json.Linq.JArray".Item(CurrentIndex), DifferentDimensionValue) then
+        for CurrentIndex := 0 to DimensionsJsonArray.Count() - 1 do
+            if JObjectMatchesDimension(DimensionsJsonArray, CurrentIndex, DifferentDimensionValue) then
                 FoundInResponse := true;
 
         Assert.IsTrue(FoundInResponse, 'The overwritten dimension value was not found on the response.');
@@ -79,7 +79,7 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         Response: Text;
         FoundDefault: Boolean;
         FoundExtra: Boolean;
-        "Newtonsoft.Json.Linq.JArray": Dotnet JArray;
+        DimensionsJsonArray: JsonArray;
         CurrentIndex: Integer;
     begin
         // [SCENARIO] A journal line is added through the API on an account with default dimension, when specifying a different dimension on its creation it should have the default dimension added on top of the specified.
@@ -102,15 +102,15 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         JournalLineJSON := LibraryGraphMgt.AddComplexTypetoJSON(JournalLineJSON, 'dimensions', '[' + DimensionJSON + ']');
 
         LibraryGraphMgt.PostToWebService(TargetURL, JournalLineJSON, Response);
-        GetDimensionsFromJSONText(Response, "Newtonsoft.Json.Linq.JArray");
+        GetDimensionsFromJSONText(Response, DimensionsJsonArray);
 
         // [THEN] The response should include both the default and the specified dimension.
         FoundDefault := false;
         FoundExtra := false;
-        for CurrentIndex := 0 to "Newtonsoft.Json.Linq.JArray".Count() - 1 do begin
-            if JObjectMatchesDimension("Newtonsoft.Json.Linq.JArray".Item(CurrentIndex), DefaultDimensionValue) then
+        for CurrentIndex := 0 to DimensionsJsonArray.Count() - 1 do begin
+            if JObjectMatchesDimension(DimensionsJsonArray, CurrentIndex, DefaultDimensionValue) then
                 FoundDefault := true;
-            if JObjectMatchesDimension("Newtonsoft.Json.Linq.JArray".Item(CurrentIndex), ExtraDimensionValue) then
+            if JObjectMatchesDimension(DimensionsJsonArray, CurrentIndex, ExtraDimensionValue) then
                 FoundExtra := true;
         end;
 
@@ -128,7 +128,7 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         Response: Text;
         CurrentIndex: Integer;
         FoundInResponse: Boolean;
-        "Newtonsoft.Json.Linq.JArray": Dotnet JArray;
+        DimensionsJsonArray: JsonArray;
     begin
         // [SCENARIO] A journal line is added through the API on an account with default dimension, without specifying dimension on its creation it should have the default dimensions added.
         Initialize();
@@ -146,11 +146,11 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         LibraryGraphMgt.PostToWebService(TargetURL, JournalLineJSON, Response);
 
         // [THEN] The response should include the default dimension from the account on the journal line.
-        GetDimensionsFromJSONText(Response, "Newtonsoft.Json.Linq.JArray");
+        GetDimensionsFromJSONText(Response, DimensionsJsonArray);
 
         FoundInResponse := false;
-        for CurrentIndex := 0 to "Newtonsoft.Json.Linq.JArray".Count() - 1 do
-            if JObjectMatchesDimension("Newtonsoft.Json.Linq.JArray".Item(CurrentIndex), DimensionValue) then
+        for CurrentIndex := 0 to DimensionsJsonArray.Count() - 1 do
+            if JObjectMatchesDimension(DimensionsJsonArray, CurrentIndex, DimensionValue) then
                 FoundInResponse := true;
 
         Assert.IsTrue(FoundInResponse, 'The default dimension and dimension value was not found on the response.');
@@ -189,30 +189,41 @@ codeunit 139745 "APIV1 - Journal Lines E2E"
         LibraryDimension: Codeunit "Library - Dimension";
         LibraryGraphMgt: Codeunit "Library - Graph Mgt";
         LibraryRandom: Codeunit "Library - Random";
-        JSONManagement: Codeunit "JSON Management";
         Assert: Codeunit "Assert";
         VATProdPostingGroupBlankMsg: Label 'VAT Prod. Posting Group must be blank';
 
-    procedure JObjectMatchesDimension("Newtonsoft.Json.Linq.JObject": Dotnet JObject; DimensionValue: Record "Dimension Value"): Boolean
+    procedure JObjectMatchesDimension(DimensionsJsonArray: JsonArray; Index: Integer; DimensionValue: Record "Dimension Value"): Boolean
     var
+        JsonObject: JsonObject;
         Dimension: Text;
     begin
-        JSONManagement.GetStringPropertyValueFromJObjectByPath("Newtonsoft.Json.Linq.JObject", 'code', Dimension);
+        JsonObject := DimensionsJsonArray.GetObject(Index);
+        Dimension := GetJsonTokenText(JsonObject, 'code');
         if Dimension = DimensionValue."Dimension Code" then begin
-            JSONManagement.GetStringPropertyValueFromJObjectByPath("Newtonsoft.Json.Linq.JObject", 'valueCode', Dimension);
+            Dimension := GetJsonTokenText(JsonObject, 'valueCode');
             Assert.AreEqual(Dimension, DimensionValue.Code, 'Dimension has required code but different value code');
             exit(true);
         end;
         exit(false);
     end;
 
-    procedure GetDimensionsFromJSONText(Response: Text; var "Newtonsoft.Json.Linq.JArray": Dotnet JArray)
+    local procedure GetJsonTokenText(JsonObject: JsonObject; PropertyName: Text): Text
     var
-        "Newtonsoft.Json.Linq.JObject": Dotnet JObject;
+        JsonToken: JsonToken;
     begin
-        JSONManagement.InitializeObject(Response);
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
-        JSONManagement.GetArrayPropertyValueFromJObjectByName("Newtonsoft.Json.Linq.JObject", 'dimensions', "Newtonsoft.Json.Linq.JArray");
+        if not JsonObject.Get(PropertyName, JsonToken) or not JsonToken.IsValue() then
+            exit('');
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit('');
+        exit(JsonToken.AsValue().AsText());
+    end;
+
+    procedure GetDimensionsFromJSONText(Response: Text; var DimensionsJsonArray: JsonArray)
+    var
+        ResponseJsonObject: JsonObject;
+    begin
+        ResponseJsonObject.ReadFrom(Response);
+        DimensionsJsonArray := ResponseJsonObject.GetArray('dimensions');
     end;
 
     procedure CreateGeneralJournalBatch(var GenJournalBatch: Record "Gen. Journal Batch"; BalAccountType: Enum "Sales Document Type"; BalAccountNo: Code[20])

--- a/src/Apps/W1/APIV1/test/src/APIV1RetEarningsE2E.Codeunit.al
+++ b/src/Apps/W1/APIV1/test/src/APIV1RetEarningsE2E.Codeunit.al
@@ -71,24 +71,19 @@ codeunit 139721 "APIV1 - Ret. Earnings E2E"
 
     local procedure GetIncomeStatementJSON(var AccScheduleLineEntity: Record "Acc. Schedule Line Entity") IncomeStatementJSON: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        "Newtonsoft.Json.Linq.JObject": DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
         if AccScheduleLineEntity."Line No." = 0 then
             AccScheduleLineEntity."Line No." := LibraryRandom.RandIntInRange(1, 10000);
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'lineNumber', AccScheduleLineEntity."Line No.");
+        JsonObject.Add('lineNumber', AccScheduleLineEntity."Line No.");
 
         if AccScheduleLineEntity.Description = '' then
             AccScheduleLineEntity.Description := LibraryUtility.GenerateGUID();
 
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'display', AccScheduleLineEntity.Description);
-
-        IncomeStatementJSON := JSONManagement.WriteObjectToString();
+        JsonObject.Add('display', AccScheduleLineEntity.Description);
+        JsonObject.WriteTo(IncomeStatementJSON);
     end;
 }
-
 
 
 

--- a/src/Apps/W1/APIV1/test/src/APIV1SalesInvLinesE2E.Codeunit.al
+++ b/src/Apps/W1/APIV1/test/src/APIV1SalesInvLinesE2E.Codeunit.al
@@ -239,7 +239,7 @@ codeunit 139734 "APIV1 - Sales Inv. Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        EVALUATE(LineNo, LineNoFromJSON);
+        EVALUATE(LineNo, LineNoFromJSON, 9);
         SalesLine.SetRange("Document Type", SalesHeader."Document Type"::Invoice);
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         SalesLine.SetRange("Line No.", LineNo);
@@ -622,7 +622,7 @@ codeunit 139734 "APIV1 - Sales Inv. Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        EVALUATE(LineNo, LineNoFromJSON);
+        EVALUATE(LineNo, LineNoFromJSON, 9);
         ApiSalesLine.SETRANGE("Document Type", SalesHeader."Document Type"::Invoice);
         ApiSalesLine.SETRANGE("Document No.", SalesHeader."No.");
         ApiSalesLine.SETRANGE("Line No.", LineNo);
@@ -1167,7 +1167,7 @@ codeunit 139734 "APIV1 - Sales Inv. Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         SalesLine.SetRange("Document Type", SalesHeader."Document Type"::Invoice);
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         SalesLine.SetRange("Line No.", LineNo);
@@ -1377,7 +1377,8 @@ codeunit 139734 "APIV1 - Sales Inv. Lines E2E"
     local procedure VerifySalesInvoiceLinesForSalesHeader(var SalesHeader: Record "Sales Header"; ObjectTxt: Text)
     var
         SalesLine: Record "Sales Line";
-        JSONManagement: Codeunit "JSON Management";
+        JsonArray: JsonArray;
+        JsonToken: JsonToken;
         CurrentIndex: Integer;
         LineJsonTxt: Text;
     begin
@@ -1386,10 +1387,11 @@ codeunit 139734 "APIV1 - Sales Inv. Lines E2E"
         SalesLine.FINDSET();
         CurrentIndex := 0;
 
-        JSONManagement.InitializeCollection(ObjectTxt);
+        JsonArray.ReadFrom(ObjectTxt);
         REPEAT
-            Assert.IsTrue(JSONManagement.GetObjectFromCollectionByIndex(LineJsonTxt, CurrentIndex),
+            Assert.IsTrue(JsonArray.Get(CurrentIndex, JsonToken),
               STRSUBSTNO('Could not find line %1.', SalesLine."Line No."));
+            JsonToken.WriteTo(LineJsonTxt);
             VerifySalesLineResponseWithSalesLine(SalesLine, LineJsonTxt);
             CurrentIndex += 1;
         UNTIL SalesLine.NEXT() = 0;

--- a/src/Apps/W1/APIV2/test/src/APIV2CashFlowStatementE2E.Codeunit.al
+++ b/src/Apps/W1/APIV2/test/src/APIV2CashFlowStatementE2E.Codeunit.al
@@ -71,24 +71,19 @@ codeunit 139817 "APIV2 - CashFlow Statement E2E"
 
     local procedure GetIncomeStatementJSON(var AccScheduleLineEntity: Record "Acc. Schedule Line Entity") IncomeStatementJSON: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        "Newtonsoft.Json.Linq.JObject": DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
         if AccScheduleLineEntity."Line No." = 0 then
             AccScheduleLineEntity."Line No." := LibraryRandom.RandIntInRange(1, 10000);
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'lineNumber', AccScheduleLineEntity."Line No.");
+        JsonObject.Add('lineNumber', AccScheduleLineEntity."Line No.");
 
         if AccScheduleLineEntity.Description = '' then
             AccScheduleLineEntity.Description := LibraryUtility.GenerateGUID();
 
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'display', AccScheduleLineEntity.Description);
-
-        IncomeStatementJSON := JSONManagement.WriteObjectToString();
+        JsonObject.Add('display', AccScheduleLineEntity.Description);
+        JsonObject.WriteTo(IncomeStatementJSON);
     end;
 }
-
 
 
 

--- a/src/Apps/W1/APIV2/test/src/APIV2ItemsE2E.Codeunit.al
+++ b/src/Apps/W1/APIV2/test/src/APIV2ItemsE2E.Codeunit.al
@@ -595,14 +595,13 @@ codeunit 139800 "APIV2 - Items E2E"
         Item: Record "Item";
         GenProductPostingGroup: Record "Gen. Product Posting Group";
         InventoryPostingGroup: Record "Inventory Posting Group";
-        JSONManagement: Codeunit "JSON Management";
         ItemGUID: Guid;
         GenProdPostGroupId: Text;
         InventoryPostGroupId: Text;
         TargetURL: Text;
         Response: Text;
         ResponseId: Text;
-        "Newtonsoft.Json.Linq.JObject": Dotnet JObject;
+        JsonObject: JsonObject;
     begin
         // [SCENARIO] Create an item with Gen. Prod. Post. Group and Inventory Post. Group. Verify they can be read from the response when expanding them.
         // [GIVEN] an Item, with a Gen. Prod. Post. Group and with and Inventory Post. Group
@@ -628,12 +627,12 @@ codeunit 139800 "APIV2 - Items E2E"
         LibraryGraphMgt.GetFromWebService(Response, TargetURL);
 
         // [THEN] the response should include them as properties
-        LibraryGraphMgt.GetComplexPropertyFromJSON(Response, 'generalProductPostingGroup', "Newtonsoft.Json.Linq.JObject");
-        JSONManagement.GetStringPropertyValueFromJObjectByName("Newtonsoft.Json.Linq.JObject", 'id', ResponseId);
+        LibraryGraphMgt.GetComplexPropertyFromJSON(Response, 'generalProductPostingGroup', JsonObject);
+        ResponseId := JsonObject.GetText('id');
         Assert.AreEqual(GenProdPostGroupId, LowerCase(ResponseId), 'The id of the gen. prod. post. group is not the one on the response.');
 
-        LibraryGraphMgt.GetComplexPropertyFromJSON(Response, 'inventoryPostingGroup', "Newtonsoft.Json.Linq.JObject");
-        JSONManagement.GetStringPropertyValueFromJObjectByName("Newtonsoft.Json.Linq.JObject", 'id', ResponseId);
+        LibraryGraphMgt.GetComplexPropertyFromJSON(Response, 'inventoryPostingGroup', JsonObject);
+        ResponseId := JsonObject.GetText('id');
         Assert.AreEqual(InventoryPostGroupId, LowerCase(ResponseId), 'The id of the inventory post. group is not the one on the response.');
     end;
 
@@ -879,7 +878,6 @@ codeunit 139800 "APIV2 - Items E2E"
         Assert.IsFalse(Item.IsEmpty(), 'Item does not exist');
     end;
 }
-
 
 
 

--- a/src/Apps/W1/APIV2/test/src/APIV2LocationsE2E.Codeunit.al
+++ b/src/Apps/W1/APIV2/test/src/APIV2LocationsE2E.Codeunit.al
@@ -225,17 +225,17 @@ codeunit 139868 "APIV2 - Locations E2E"
 
     local procedure GetSalesOrderLineWithLocationJSON(Item: Record Item; var Location: Record Location) SalesOrderLineJSON: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        "Newtonsoft.Json.Linq.JObject": DotNet JObject;
+        SalesOrderLineJsonObject: JsonObject;
+        LocationJsonObject: JsonObject;
         LocationJSON: Text;
     begin
         SalesOrderLineJSON := LibraryGraphMgt.AddPropertytoJSON(SalesOrderLineJSON, 'itemId', FormatGuid(Item.SystemId));
         SalesOrderLineJSON := LibraryGraphMgt.AddPropertytoJSON(SalesOrderLineJSON, 'quantity', Random(5));
         LocationJSON := GetLocationJSON(Location);
-        JSONManagement.InitializeObject(SalesOrderLineJSON);
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
-        JSONManagement.AddJObjectToJObject("Newtonsoft.Json.Linq.JObject", 'location', LocationJSON);
-        SalesOrderLineJSON := JSONManagement.WriteObjectToString();
+        SalesOrderLineJsonObject.ReadFrom(SalesOrderLineJSON);
+        LocationJsonObject.ReadFrom(LocationJSON);
+        SalesOrderLineJsonObject.Add('location', LocationJsonObject);
+        SalesOrderLineJsonObject.WriteTo(SalesOrderLineJSON);
         exit(SalesOrderLineJSON);
     end;
 

--- a/src/Apps/W1/APIV2/test/src/APIV2PurchOrderLinesE2E.Codeunit.al
+++ b/src/Apps/W1/APIV2/test/src/APIV2PurchOrderLinesE2E.Codeunit.al
@@ -196,7 +196,7 @@ codeunit 139852 "APIV2 - Purch. Order Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
         PurchaseLine.SetRange("Line No.", LineNo);
@@ -378,7 +378,7 @@ codeunit 139852 "APIV2 - Purch. Order Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         ApiPurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
         ApiPurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
         ApiPurchaseLine.SetRange("Line No.", LineNo);
@@ -963,7 +963,7 @@ codeunit 139852 "APIV2 - Purch. Order Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         PurchaseLine.SetRange("Document No.", PurchaseHeader."No.");
         PurchaseLine.SetRange("Document Type", PurchaseHeader."Document Type"::Order);
         PurchaseLine.SetRange("Line No.", LineNo);
@@ -1078,12 +1078,10 @@ codeunit 139852 "APIV2 - Purch. Order Lines E2E"
 
     local procedure VerifyPurchaseIdsSetFromTxt(PurchaseLine: Record "Purchase Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        "Newtonsoft.Json.Linq.JObject": DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
-        LibraryGraphDocumentTools.VerifyPurchaseIdsSet(PurchaseLine, "Newtonsoft.Json.Linq.JObject");
+        JsonObject.ReadFrom(JObjectTxt);
+        LibraryGraphDocumentTools.VerifyPurchaseIdsSet(PurchaseLine, JsonObject);
     end;
 
     local procedure VerifyIdsAreBlank(JsonObjectTxt: Text)

--- a/src/Apps/W1/APIV2/test/src/APIV2RetEarningsE2E.Codeunit.al
+++ b/src/Apps/W1/APIV2/test/src/APIV2RetEarningsE2E.Codeunit.al
@@ -71,24 +71,19 @@ codeunit 139821 "APIV2 - Ret. Earnings E2E"
 
     local procedure GetIncomeStatementJSON(var AccScheduleLineEntity: Record "Acc. Schedule Line Entity") IncomeStatementJSON: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        "Newtonsoft.Json.Linq.JObject": DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject("Newtonsoft.Json.Linq.JObject");
         if AccScheduleLineEntity."Line No." = 0 then
             AccScheduleLineEntity."Line No." := LibraryRandom.RandIntInRange(1, 10000);
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'lineNumber', AccScheduleLineEntity."Line No.");
+        JsonObject.Add('lineNumber', AccScheduleLineEntity."Line No.");
 
         if AccScheduleLineEntity.Description = '' then
             AccScheduleLineEntity.Description := LibraryUtility.GenerateGUID();
 
-        JSONManagement.AddJPropertyToJObject("Newtonsoft.Json.Linq.JObject", 'display', AccScheduleLineEntity.Description);
-
-        IncomeStatementJSON := JSONManagement.WriteObjectToString();
+        JsonObject.Add('display', AccScheduleLineEntity.Description);
+        JsonObject.WriteTo(IncomeStatementJSON);
     end;
 }
-
 
 
 

--- a/src/Apps/W1/APIV2/test/src/APIV2SalesInvLinesE2E.Codeunit.al
+++ b/src/Apps/W1/APIV2/test/src/APIV2SalesInvLinesE2E.Codeunit.al
@@ -234,7 +234,7 @@ codeunit 139834 "APIV2 - Sales Inv. Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         SalesLine.SetRange("Document Type", SalesHeader."Document Type"::Invoice);
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         SalesLine.SetRange("Line No.", LineNo);
@@ -603,7 +603,7 @@ codeunit 139834 "APIV2 - Sales Inv. Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         ApiSalesLine.SetRange("Document Type", SalesHeader."Document Type"::Invoice);
         ApiSalesLine.SetRange("Document No.", SalesHeader."No.");
         ApiSalesLine.SetRange("Line No.", LineNo);
@@ -1174,7 +1174,7 @@ codeunit 139834 "APIV2 - Sales Inv. Lines E2E"
         Assert.IsTrue(
           LibraryGraphMgt.GetObjectIDFromJSON(ResponseText, 'sequence', LineNoFromJSON), 'Could not find sequence');
 
-        Evaluate(LineNo, LineNoFromJSON);
+        Evaluate(LineNo, LineNoFromJSON, 9);
         SalesLine.SetRange("Document Type", SalesHeader."Document Type"::Invoice);
         SalesLine.SetRange("Document No.", SalesHeader."No.");
         SalesLine.SetRange("Line No.", LineNo);
@@ -1396,7 +1396,8 @@ codeunit 139834 "APIV2 - Sales Inv. Lines E2E"
     local procedure VerifySalesInvoiceLinesForSalesHeader(var SalesHeader: Record "Sales Header"; ObjectTxt: Text)
     var
         SalesLine: Record "Sales Line";
-        JSONManagement: Codeunit "JSON Management";
+        JsonArray: JsonArray;
+        JsonToken: JsonToken;
         CurrentIndex: Integer;
         LineJsonTxt: Text;
     begin
@@ -1405,10 +1406,11 @@ codeunit 139834 "APIV2 - Sales Inv. Lines E2E"
         SalesLine.FindSet();
         CurrentIndex := 0;
 
-        JSONManagement.InitializeCollection(ObjectTxt);
+        JsonArray.ReadFrom(ObjectTxt);
         repeat
-            Assert.IsTrue(JSONManagement.GetObjectFromCollectionByIndex(LineJsonTxt, CurrentIndex),
+            Assert.IsTrue(JsonArray.Get(CurrentIndex, JsonToken),
               StrSubstNo('Could not find line %1.', SalesLine."Line No."));
+            JsonToken.WriteTo(LineJsonTxt);
             VerifySalesLineResponseWithSalesLine(SalesLine, LineJsonTxt);
             CurrentIndex += 1;
         until SalesLine.next() = 0;

--- a/src/Apps/W1/EDocumentConnectors/ForNAV/App/src/Integration/ForNAVProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/ForNAV/App/src/Integration/ForNAVProcessing.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.EServices.EDocumentConnector.ForNAV;
 using Microsoft.EServices.EDocument;
 using Microsoft.eServices.EDocument.Integration.Receive;
 using Microsoft.eServices.EDocument.Integration.Send;
-using System.Text;
 using System.Utilities;
 
 codeunit 6419 "ForNAV Processing"

--- a/src/Apps/W1/EDocumentConnectors/ForNAV/App/src/Integration/ForNAVProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/ForNAV/App/src/Integration/ForNAVProcessing.Codeunit.al
@@ -120,33 +120,34 @@ codeunit 6419 "ForNAV Processing"
 
     local procedure GetNumberOfReceivedDocuments(InputTxt: Text): Integer
     var
-        JsonManagement: Codeunit "JSON Management";
-        Value: Text;
+        ResponseJson: JsonObject;
+        ItemsToken: JsonToken;
     begin
-        if not JsonManagement.InitializeFromString(InputTxt) then
+        if not ResponseJson.ReadFrom(InputTxt) then
             exit(0);
 
-        JsonManagement.GetArrayPropertyValueAsStringByName('items', Value);
-        JsonManagement.InitializeCollection(Value);
-
-        exit(JsonManagement.GetCollectionCount());
+        if not ResponseJson.Get('items', ItemsToken) or not ItemsToken.IsArray() then
+            exit(0);
+        exit(ItemsToken.AsArray().Count());
     end;
 
     local procedure ParseSendFileResponse(HttpContentResponse: HttpContent): Text
     var
-        JsonManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
+        IdToken: JsonToken;
         Result: Text;
-        Value: Text;
     begin
         Result := ParseJsonString(HttpContentResponse);
         if Result = '' then
             exit('');
 
-        if not JsonManagement.InitializeFromString(Result) then
+        if not ResponseJson.ReadFrom(Result) then
             exit('');
-
-        JsonManagement.GetStringPropertyValueByName('id', Value);
-        exit(Value);
+        if ResponseJson.Get('id', IdToken) and IdToken.IsValue() then begin
+            if IdToken.AsValue().IsNull() or IdToken.AsValue().IsUndefined() then
+                exit('');
+            exit(IdToken.AsValue().AsText());
+        end;
     end;
 
     local procedure SetEDocument(EDocEntryNo: Integer; FileId: Text)
@@ -165,29 +166,13 @@ codeunit 6419 "ForNAV Processing"
     procedure ParseJsonString(HttpContentResponse: HttpContent): Text
     var
         ResponseObject: JsonObject;
-        Response: Text;
         Result: Text;
-        IsJsonResponse: Boolean;
     begin
         HttpContentResponse.ReadAs(Result);
-        IsJsonResponse := ResponseObject.ReadFrom(Result);
-        if IsJsonResponse then
-            ResponseObject.WriteTo(Response)
-        else
-            exit('');
-
-        if not TryInitJson(Response) then
+        if not ResponseObject.ReadFrom(Result) then
             exit('');
 
         exit(Result);
-    end;
-
-    [TryFunction]
-    local procedure TryInitJson(JsonTxt: Text)
-    var
-        JsonManagement: Codeunit "JSON Management";
-    begin
-        JSONManagement.InitializeObject(JsonTxt);
     end;
 
     procedure GetDocument(var EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; DocumentMetadata: codeunit "Temp Blob"; ReceiveContext: Codeunit ReceiveContext)

--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroConnection.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroConnection.Codeunit.al
@@ -7,7 +7,6 @@ namespace Microsoft.EServices.EDocumentConnector;
 using Microsoft.EServices.EDocument;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Posting;
-using System.Text;
 using System.Utilities;
 codeunit 6361 "Pagero Connection"
 {

--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroConnection.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroConnection.Codeunit.al
@@ -154,52 +154,41 @@ codeunit 6361 "Pagero Connection"
 
     procedure ParseGetADocumentResponse(InputTxt: Text): Text
     var
-        JsonManagement: Codeunit "JSON Management";
-        JsonManagement2: Codeunit "JSON Management";
-        Value: Text;
-        IncrementalTable: Text;
+        ResponseJson: JsonObject;
+        ItemJson: JsonObject;
+        ItemsToken: JsonToken;
+        IdToken: JsonToken;
     begin
-        if not JsonManagement.InitializeFromString(InputTxt) then
+        if not ResponseJson.ReadFrom(InputTxt) then
             exit('');
 
-        JsonManagement.GetArrayPropertyValueAsStringByName('items', Value);
-        JsonManagement.InitializeCollection(Value);
-
-        if JsonManagement.GetCollectionCount() > 0 then begin
-            JsonManagement.GetObjectFromCollectionByIndex(IncrementalTable, 0);
-            JsonManagement2.InitializeObject(IncrementalTable);
-            JsonManagement2.GetArrayPropertyValueAsStringByName('id', Value);
-            exit(Value);
+        if not ResponseJson.Get('items', ItemsToken) then
+            exit('');
+        if not ItemsToken.IsArray() then
+            exit('');
+        if ItemsToken.AsArray().Count() = 0 then
+            exit('');
+        ItemsToken.AsArray().Get(0, ItemsToken);
+        if not ItemsToken.IsObject() then
+            exit('');
+        ItemJson := ItemsToken.AsObject();
+        if ItemJson.Get('id', IdToken) and IdToken.IsValue() then begin
+            if IdToken.AsValue().IsNull() or IdToken.AsValue().IsUndefined() then
+                exit('');
+            exit(IdToken.AsValue().AsText());
         end;
-        exit('');
     end;
 
     procedure ParseJsonString(HttpContentResponse: HttpContent): Text
     var
         ResponseJObject: JsonObject;
-        ResponseJson: Text;
         Result: Text;
-        IsJsonResponse: Boolean;
     begin
         HttpContentResponse.ReadAs(Result);
-        IsJsonResponse := ResponseJObject.ReadFrom(Result);
-        if IsJsonResponse then
-            ResponseJObject.WriteTo(ResponseJson)
-        else
-            exit('');
-
-        if not TryInitJson(ResponseJson) then
+        if not ResponseJObject.ReadFrom(Result) then
             exit('');
 
         exit(Result);
-    end;
-
-    [TryFunction]
-    local procedure TryInitJson(JsonTxt: Text)
-    var
-        JsonManagement: Codeunit "JSON Management";
-    begin
-        JSONManagement.InitializeObject(JsonTxt);
     end;
 
     local procedure CheckIfSuccessfulRequest(EDocument: Record "E-Document"; HttpResponse: HttpResponseMessage): Boolean

--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroProcessing.Codeunit.al
@@ -333,16 +333,15 @@ codeunit 6369 "Pagero Processing"
 
     local procedure GetNumberOfReceivedDocuments(InputTxt: Text): Integer
     var
-        JsonManagement: Codeunit "JSON Management";
-        Value: Text;
+        ResponseJson: JsonObject;
+        ItemsToken: JsonToken;
     begin
-        if not JsonManagement.InitializeFromString(InputTxt) then
+        if not ResponseJson.ReadFrom(InputTxt) then
             exit(0);
 
-        JsonManagement.GetArrayPropertyValueAsStringByName('items', Value);
-        JsonManagement.InitializeCollection(Value);
-
-        exit(JsonManagement.GetCollectionCount());
+        if not ResponseJson.Get('items', ItemsToken) or not ItemsToken.IsArray() then
+            exit(0);
+        exit(ItemsToken.AsArray().Count());
     end;
 
     local procedure CheckIfDocumentStatusSuccessful(EDocument: Record "E-Document"; var EDocumentService: Record "E-Document Service"; var HttpRequestMessage: HttpRequestMessage; var HttpResponse: HttpResponseMessage): Boolean
@@ -384,51 +383,55 @@ codeunit 6369 "Pagero Processing"
 
     local procedure IsFilePartsDocumentProcessed(HttpResponse: HttpResponseMessage; var Status: Text; var FilepartID: Text; var ErrorDescription: Text): Boolean
     var
-        JsonManagement: Codeunit "JSON Management";
         HttpContentResponse: HttpContent;
-        IncrementalTable, Result, Value : Text;
+        ResponseJson: JsonObject;
+        ItemJson: JsonObject;
+        ErrorJson: JsonObject;
+        ItemsToken: JsonToken;
+        ErrorToken: JsonToken;
+        Result: Text;
     begin
         HttpContentResponse := HttpResponse.Content;
         Result := ParseJsonString(HttpContentResponse);
         if Result = '' then
             Error(ParseErr);
 
-        if not JsonManagement.InitializeFromString(Result) then
+        if not ResponseJson.ReadFrom(Result) then
             Error(ParseErr);
 
-        JsonManagement.GetArrayPropertyValueAsStringByName('items', Value);
-        JsonManagement.InitializeCollection(Value);
+        if not ResponseJson.Get('items', ItemsToken) or not ItemsToken.IsArray() then
+            Error(ParseErr);
 
         // A Filepart which has been successfully processed will not be visible in the API.
-        if JsonManagement.GetCollectionCount() = 0 then
+        if ItemsToken.AsArray().Count() = 0 then
             exit(true);
 
-        JsonManagement.GetObjectFromCollectionByIndex(IncrementalTable, 0);
-        JsonManagement.InitializeObject(IncrementalTable);
-
-        JsonManagement.GetStringPropertyValueByName('status', Status);
-        JsonManagement.GetStringPropertyValueByName('id', FilepartID);
-        JsonManagement.GetArrayPropertyValueAsStringByName('error', ErrorDescription);
-        JsonManagement.InitializeFromString(ErrorDescription);
-        JsonManagement.GetArrayPropertyValueAsStringByName('description', ErrorDescription);
+        ItemsToken.AsArray().Get(0, ItemsToken);
+        if not ItemsToken.IsObject() then
+            Error(ParseErr);
+        ItemJson := ItemsToken.AsObject();
+        Status := ItemJson.GetText('status', true);
+        FilepartID := ItemJson.GetText('id', true);
+        if ItemJson.Get('error', ErrorToken) and ErrorToken.IsObject() then begin
+            ErrorJson := ErrorToken.AsObject();
+            if ErrorJson.Get('description', ErrorToken) and ErrorToken.IsArray() then
+                ErrorToken.AsArray().WriteTo(ErrorDescription);
+        end;
         exit(false);
     end;
 
     local procedure ParseSendFileResponse(HttpContentResponse: HttpContent): Text
     var
-        JsonManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         Result: Text;
-        Value: Text;
     begin
         Result := ParseJsonString(HttpContentResponse);
         if Result = '' then
             exit('');
 
-        if not JsonManagement.InitializeFromString(Result) then
+        if not ResponseJson.ReadFrom(Result) then
             exit('');
-
-        JsonManagement.GetStringPropertyValueByName('id', Value);
-        exit(Value);
+        exit(ResponseJson.GetText('id', true));
     end;
 
     local procedure SetEDocumentFileID(EDocEntryNo: Integer; FileId: Text)
@@ -484,29 +487,13 @@ codeunit 6369 "Pagero Processing"
     procedure ParseJsonString(HttpContentResponse: HttpContent): Text
     var
         ResponseJObject: JsonObject;
-        ResponseJson: Text;
         Result: Text;
-        IsJsonResponse: Boolean;
     begin
         HttpContentResponse.ReadAs(Result);
-        IsJsonResponse := ResponseJObject.ReadFrom(Result);
-        if IsJsonResponse then
-            ResponseJObject.WriteTo(ResponseJson)
-        else
-            exit('');
-
-        if not TryInitJson(ResponseJson) then
+        if not ResponseJObject.ReadFrom(Result) then
             exit('');
 
         exit(Result);
-    end;
-
-    [TryFunction]
-    local procedure TryInitJson(JsonTxt: Text)
-    var
-        JsonManagement: Codeunit "JSON Management";
-    begin
-        JSONManagement.InitializeObject(JsonTxt);
     end;
 
     local procedure SelectEDocumentService() EDocumentService: Record "E-Document Service"

--- a/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/app/PageroProcessing.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.eServices.EDocument.Integration.Receive;
 using Microsoft.Foundation.AuditCodes;
 using Microsoft.Purchases.Document;
 using System.Telemetry;
-using System.Text;
 using System.Utilities;
 
 codeunit 6369 "Pagero Processing"

--- a/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/Pagero/test/src/IntegrationTests.Codeunit.al
@@ -245,6 +245,9 @@ codeunit 148192 "Integration Tests"
         EDocumentPage.GoToRecord(EDocument);
         EDocumentPage.ErrorMessagesPart.First();
         Assert.AreEqual('Error', EDocumentPage.ErrorMessagesPart."Message Type".Value(), IncorrectValueErr);
+        Assert.IsTrue(
+            EDocumentPage.ErrorMessagesPart.Description.Value().Contains('The document could not be processed by the receiver.'),
+            'The error message should contain the description returned by Pagero.');
         EDocumentPage.Close();
 
         // [WHEN] User sends the document again, which restarts the filepart in Pagero

--- a/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpProcessing.Codeunit.al
+++ b/src/Apps/W1/EDocumentConnectors/SignUp/app/src/SignUpProcessing.Codeunit.al
@@ -136,7 +136,7 @@ codeunit 6445 "SignUp Processing"
     procedure ReceiveDocuments(var EDocumentService: Record "E-Document Service"; DocumentsMetadataTempBlobList: Codeunit "Temp Blob List"; ReceiveContext: Codeunit ReceiveContext)
     var
         TempBlob: Codeunit "Temp Blob";
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         ContentData: Text;
         HttpRequestMessage: HttpRequestMessage;
         HttpResponseMessage: HttpResponseMessage;
@@ -153,11 +153,12 @@ codeunit 6445 "SignUp Processing"
         if not HttpResponseMessage.Content.ReadAs(ContentData) then
             exit;
 
-        if not JsonManagement.InitializeFromString(ContentData) then
+        if not ResponseJson.ReadFrom(ContentData) then
             exit;
 
-        JsonManagement.GetArrayPropertyValueAsStringByName(this.InboxTxt, ContentData);
-        JsonArray.ReadFrom(ContentData);
+        if not ResponseJson.Get(this.InboxTxt, JsonToken) or not JsonToken.IsArray() then
+            exit;
+        JsonArray := JsonToken.AsArray();
 
         foreach JsonToken in JsonArray do begin
             Clear(TempBlob);
@@ -230,7 +231,7 @@ codeunit 6445 "SignUp Processing"
 
     local procedure ParseDocumentResponse(HttpContentResponse: HttpContent; var Status: Text; var StatusDescription: Text): Boolean
     var
-        JsonManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         Result: Text;
     begin
         Status := '';
@@ -240,10 +241,10 @@ codeunit 6445 "SignUp Processing"
         if Result = '' then
             exit;
 
-        if not JsonManagement.InitializeFromString(Result) then
+        if not ResponseJson.ReadFrom(Result) then
             exit;
 
-        if not this.GetStatus(JsonManagement, Status) then
+        if not this.GetStatus(ResponseJson, Status) then
             exit;
 
         case Status of
@@ -297,34 +298,32 @@ codeunit 6445 "SignUp Processing"
 
     local procedure GetNumberOfReceivedDocuments(InputTxt: Text): Integer
     var
-        JsonManagement: Codeunit "JSON Management";
-        Value: Text;
+        ResponseJson: JsonObject;
+        InboxToken: JsonToken;
     begin
         InputTxt := this.LeaveJustNewLine(InputTxt);
 
-        if not JsonManagement.InitializeFromString(InputTxt) then
+        if not ResponseJson.ReadFrom(InputTxt) then
             exit(0);
 
-        JsonManagement.GetArrayPropertyValueAsStringByName(this.InboxTxt, Value);
-        JsonManagement.InitializeCollection(Value);
-
-        exit(JsonManagement.GetCollectionCount());
+        if not ResponseJson.Get(this.InboxTxt, InboxToken) or not InboxToken.IsArray() then
+            exit(0);
+        exit(InboxToken.AsArray().Count());
     end;
 
     local procedure ParseSendFileResponse(HttpContentResponse: HttpContent): Text
     var
-        JsonManagement: Codeunit "JSON Management";
-        Result, Value : Text;
+        ResponseJson: JsonObject;
+        Result: Text;
     begin
         Result := this.SignUpHelpersImpl.ParseJsonString(HttpContentResponse);
         if Result = '' then
             exit;
 
-        if not JsonManagement.InitializeFromString(Result) then
+        if not ResponseJson.ReadFrom(Result) then
             exit;
 
-        JsonManagement.GetStringPropertyValueByName(this.TransactionIdTxt, Value);
-        exit(Value);
+        exit(ResponseJson.GetText(this.TransactionIdTxt, true));
     end;
 
     local procedure SetEDocumentFileID(EDocEntryNo: Integer; FileId: Text)
@@ -341,12 +340,16 @@ codeunit 6445 "SignUp Processing"
         EDocument.Modify();
     end;
 
-    local procedure GetStatus(var JsonManagement: Codeunit "Json Management"; var Status: Text): Boolean
+    local procedure GetStatus(ResponseJson: JsonObject; var Status: Text): Boolean
+    var
+        StatusToken: JsonToken;
     begin
-        if not JsonManagement.GetArrayPropertyValueAsStringByName(this.StatusTxt, Status) then
+        if not ResponseJson.Get(this.StatusTxt, StatusToken) or not StatusToken.IsValue() then
             exit;
 
-        Status := Status.ToLower();
+        if StatusToken.AsValue().IsNull() or StatusToken.AsValue().IsUndefined() then
+            exit(false);
+        Status := StatusToken.AsValue().AsText().ToLower();
         exit(true);
     end;
 
@@ -386,15 +389,20 @@ codeunit 6445 "SignUp Processing"
 
     local procedure ParseContentData(var InputText: Text): Boolean
     var
-        JsonManagement: Codeunit "JSON Management";
         Base64Convert: Codeunit "Base64 Convert";
-        Value: Text;
+        ResponseJson: JsonObject;
+        DocumentToken: JsonToken;
     begin
-        if not JsonManagement.InitializeFromString(InputText) then
+        if not ResponseJson.ReadFrom(InputText) then
             exit;
 
-        JsonManagement.GetArrayPropertyValueAsStringByName(this.DocumentTxt, Value);
-        InputText := Base64Convert.FromBase64(Value);
+        if not ResponseJson.Get(this.DocumentTxt, DocumentToken) or not DocumentToken.IsValue() then
+            exit;
+        if DocumentToken.AsValue().IsNull() or DocumentToken.AsValue().IsUndefined() then begin
+            InputText := '';
+            exit(true);
+        end;
+        InputText := Base64Convert.FromBase64(DocumentToken.AsValue().AsText());
         exit(true);
     end;
 

--- a/src/Apps/W1/HybridBCLast/app/src/codeunits/W1Management.Codeunit.al
+++ b/src/Apps/W1/HybridBCLast/app/src/codeunits/W1Management.Codeunit.al
@@ -2,7 +2,6 @@ namespace Microsoft.DataMigration.BC;
 
 using Microsoft.DataMigration;
 using System.Environment;
-using System.Text;
 using System.Upgrade;
 
 codeunit 4026 "W1 Management"

--- a/src/Apps/W1/HybridBCLast/app/src/codeunits/W1Management.Codeunit.al
+++ b/src/Apps/W1/HybridBCLast/app/src/codeunits/W1Management.Codeunit.al
@@ -41,16 +41,19 @@ codeunit 4026 "W1 Management"
         HybridReplicationSummary: Record "Hybrid Replication Summary";
         HybridCloudManagement: Codeunit "Hybrid Cloud Management";
         HybridBCLastWizard: Codeunit "Hybrid BC Last Wizard";
-        JsonManagement: Codeunit "JSON Management";
-        JsonValue: Variant;
+        NotificationJson: JsonObject;
+        JsonToken: JsonToken;
         SyncedVersion: BigInteger;
     begin
         if not HybridCloudManagement.CanHandleNotification(SubscriptionId, HybridBCLastWizard.ProductId()) then
             exit;
 
-        JsonManagement.InitializeObject(NotificationText);
-        if JsonManagement.GetPropertyValueByName('SyncedVersion', JsonValue) then
-            SyncedVersion := JsonValue;
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        if NotificationJson.Get('SyncedVersion', JsonToken) then
+            if JsonToken.IsValue() then
+                if not (JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined()) then
+                    SyncedVersion := JsonToken.AsValue().AsBigInteger();
 
         HybridReplicationSummary.Get(RunId);
         HybridReplicationSummary."Synced Version" := SyncedVersion;

--- a/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/HybridCloudManagement.Codeunit.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/HybridCloudManagement.Codeunit.al
@@ -17,7 +17,6 @@ using System.Reflection;
 using System.Security.AccessControl;
 using System.Security.User;
 using System.Telemetry;
-using System.Text;
 using System.Threading;
 using System.Upgrade;
 

--- a/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/HybridCloudManagement.Codeunit.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/HybridCloudManagement.Codeunit.al
@@ -934,7 +934,8 @@ codeunit 4001 "Hybrid Cloud Management"
 
     procedure CheckFixDataOnReplicationCompleted(NotificationText: Text): Boolean
     var
-        JsonManagement: Codeunit "JSON Management";
+        NotificationJson: JsonObject;
+        ServiceTypeToken: JsonToken;
         ServiceType: Text;
         FixData: Boolean;
         Handled: Boolean;
@@ -943,8 +944,11 @@ codeunit 4001 "Hybrid Cloud Management"
         if Handled then
             exit(FixData);
 
-        JsonManagement.InitializeObject(NotificationText);
-        JsonManagement.GetStringPropertyValueByName('ServiceType', ServiceType);
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        if NotificationJson.Get('ServiceType', ServiceTypeToken) and ServiceTypeToken.IsValue() then
+            if not ServiceTypeToken.AsValue().IsNull() and not ServiceTypeToken.AsValue().IsUndefined() then
+                ServiceType := ServiceTypeToken.AsValue().AsText();
         if not IsReplicationCompleted(ServiceType) then
             exit(false);
 
@@ -2078,12 +2082,13 @@ codeunit 4001 "Hybrid Cloud Management"
     procedure SetUpgradePendingOnReplicationRunCompleted(RunId: Text[50]; SubscriptionId: Text; NotificationText: Text)
     var
         HybridReplicationSummary: Record "Hybrid Replication Summary";
-        JsonManagement: Codeunit "JSON Management";
+        NotificationJson: JsonObject;
     begin
         HybridReplicationSummary.Get(RunId);
 
-        JsonManagement.InitializeObject(NotificationText);
-        if CompaniesReplicatedSuccessfully(HybridReplicationSummary, JsonManagement) then begin
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        if CompaniesReplicatedSuccessfully(HybridReplicationSummary, NotificationJson) then begin
             HybridReplicationSummary.Status := HybridReplicationSummary.Status::UpgradePending;
             HybridReplicationSummary.Modify();
             SetPendingOnHybridCompanyStatus();
@@ -2233,9 +2238,10 @@ codeunit 4001 "Hybrid Cloud Management"
         CloudMigrationStatusText := ReadyForReplicationStatusLbl;
     end;
 
-    internal procedure CompaniesReplicatedSuccessfully(var HybridReplicationSummary: Record "Hybrid Replication Summary"; var JsonManagement: Codeunit "JSON Management"): Boolean
+    internal procedure CompaniesReplicatedSuccessfully(var HybridReplicationSummary: Record "Hybrid Replication Summary"; NotificationJson: JsonObject): Boolean
     var
         HybridCompany: Record "Hybrid Company";
+        ServiceTypeToken: JsonToken;
         ServiceType: Text;
     begin
         if HybridReplicationSummary.Status <> HybridReplicationSummary.Status::Completed then
@@ -2248,8 +2254,11 @@ codeunit 4001 "Hybrid Cloud Management"
         if HybridCompany.IsEmpty() then
             exit(false);
 
-        if not JsonManagement.GetStringPropertyValueByName('ServiceType', ServiceType) then
+        if not NotificationJson.Get('ServiceType', ServiceTypeToken) or not ServiceTypeToken.IsValue() then
             exit(false);
+        if ServiceTypeToken.AsValue().IsNull() or ServiceTypeToken.AsValue().IsUndefined() then
+            exit(false);
+        ServiceType := ServiceTypeToken.AsValue().AsText();
 
         exit(IsReplicationCompleted(ServiceType));
     end;

--- a/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/NotificationHandler.Codeunit.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/NotificationHandler.Codeunit.al
@@ -5,11 +5,9 @@
 
 namespace Microsoft.DataMigration;
 
-using Microsoft.CRM.Outlook;
 using System.Environment;
 using System.Integration;
 using System.Telemetry;
-using System.Text;
 
 codeunit 4014 "Notification Handler"
 {

--- a/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/NotificationHandler.Codeunit.al
+++ b/src/Apps/W1/HybridBaseDeployment/app/src/codeunits/NotificationHandler.Codeunit.al
@@ -73,7 +73,7 @@ codeunit 4014 "Notification Handler"
 
     local procedure HandleServiceNotification(var WebhookNotification: Record "Webhook Notification")
     var
-        JsonManagement: Codeunit "JSON Management";
+        NotificationJson: JsonObject;
         NotificationInStream: InStream;
         NotificationText: Text;
         ServiceType: Text;
@@ -82,8 +82,9 @@ codeunit 4014 "Notification Handler"
         WebhookNotification.Notification.CreateInStream(NotificationInStream);
         NotificationInStream.ReadText(NotificationText);
 
-        JsonManagement.InitializeObject(NotificationText);
-        JsonManagement.GetStringPropertyValueByName('ServiceType', ServiceType);
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        GetJsonTokenText(NotificationJson, 'ServiceType', ServiceType);
 
         case ServiceType of
             UpgradeAvailableServiceTypeTxt:
@@ -98,17 +99,19 @@ codeunit 4014 "Notification Handler"
     local procedure GetExtensionRefreshErrorMessage(ExtensionRefreshTxt: Text): Text
     var
         HybridMessageManagement: Codeunit "Hybrid Message Management";
-        JsonManagement: Codeunit "JSON Management";
+        ExtensionRefreshJson: JsonObject;
         MessageCode: Text;
         ErrorMessage: Text;
         Value: Text;
     begin
-        JsonManagement.InitializeObject(ExtensionRefreshTxt);
-        if JsonManagement.GetStringPropertyValueByName('ErrorCode', MessageCode) then
+        if ExtensionRefreshTxt = '' then
+            exit('');
+        ExtensionRefreshJson.ReadFrom(ExtensionRefreshTxt);
+        if GetJsonTokenText(ExtensionRefreshJson, 'ErrorCode', MessageCode) then
             if MessageCode <> '' then
                 ErrorMessage := HybridMessageManagement.ResolveMessageCode(CopyStr(MessageCode, 1, 10), '');
 
-        if JsonManagement.GetStringPropertyValueByName('FailedExtensions', Value) then
+        if GetJsonTokenText(ExtensionRefreshJson, 'FailedExtensions', Value) then
             ErrorMessage += ' ' + Value;
         exit(ErrorMessage);
     end;
@@ -119,9 +122,8 @@ codeunit 4014 "Notification Handler"
         IntelligentCloudSetup: Record "Intelligent Cloud Setup";
         HybridCloudManagement: Codeunit "Hybrid Cloud Management";
         HybridMessageManagement: Codeunit "Hybrid Message Management";
-        JsonManagement: Codeunit "JSON Management";
-        OutlookSynchTypeConv: Codeunit "Outlook Synch. Type Conv";
         AuditLog: Codeunit "Audit Log";
+        NotificationJson: JsonObject;
         Value: Text;
         Details: Text;
         MessageCode: Text;
@@ -131,8 +133,9 @@ codeunit 4014 "Notification Handler"
         TelemetryDictionary: Dictionary of [Text, Text];
         HasFailures: Boolean;
     begin
-        JsonManagement.InitializeObject(NotificationText);
-        JsonManagement.GetStringPropertyValueByName('RunId', Value);
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        GetJsonTokenText(NotificationJson, 'RunId', Value);
 
         if HybridReplicationSummary.Get(Value) then begin
             PreviousHybridReplicationSummary.Copy(HybridReplicationSummary);
@@ -148,22 +151,21 @@ codeunit 4014 "Notification Handler"
         HybridReplicationSummary."Trigger Type" := PreviousHybridReplicationSummary."Trigger Type";
         HybridReplicationSummary.Insert();
 
-        if JsonManagement.GetStringPropertyValueByName('StartTime', Value) then
-            if Evaluate(HybridReplicationSummary."Start Time", Value) then
-                HybridReplicationSummary."Start Time" := OutlookSynchTypeConv.UTC2LocalDT(HybridReplicationSummary."Start Time");
+        if GetJsonTokenText(NotificationJson, 'StartTime', Value) then
+            if not Evaluate(HybridReplicationSummary."Start Time", Value, 9) then;
 
-        if JsonManagement.GetStringPropertyValueByName('TriggerType', Value) then
+        if GetJsonTokenText(NotificationJson, 'TriggerType', Value) then
             if not Evaluate(HybridReplicationSummary."Trigger Type", Value) then;
 
-        if JsonManagement.GetStringPropertyValueByName('ReplicationType', Value) and (HybridReplicationSummary.ReplicationType = 0) then
+        if GetJsonTokenText(NotificationJson, 'ReplicationType', Value) and (HybridReplicationSummary.ReplicationType = 0) then
             if not Evaluate(HybridReplicationSummary.ReplicationType, Value) then;
 
-        if JsonManagement.GetStringPropertyValueByName('Status', Value) then begin
+        if GetJsonTokenText(NotificationJson, 'Status', Value) then begin
             Session.LogMessage('0000EV0', StrSubstNo(HybridReplicationStatusMsg, Format(Value), Format(HybridReplicationSummary.ReplicationType)), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', CloudMigrationTok);
             if not Evaluate(HybridReplicationSummary.Status, Value) then;
         end;
 
-        if JsonManagement.GetStringPropertyValueByName('Details', Details) or JsonManagement.GetStringPropertyValueByName('Code', MessageCode) then begin
+        if GetJsonTokenText(NotificationJson, 'Details', Details) or GetJsonTokenText(NotificationJson, 'Code', MessageCode) then begin
             if MessageCode <> '' then begin
                 Details := HybridMessageManagement.ResolveMessageCode(CopyStr(MessageCode, 1, 10), Details);
                 HybridReplicationSummary.SetDetails(Details);
@@ -179,17 +181,17 @@ codeunit 4014 "Notification Handler"
         end;
 
         if HybridReplicationSummary.Status = HybridReplicationSummary.Status::Completed then begin
-            if JsonManagement.GetStringPropertyValueByName('ExtensionRefreshFailed', Value) then
+            if GetJsonTokenText(NotificationJson, 'ExtensionRefreshFailed', Value) then
                 HybridReplicationSummary.AddDetails(GetExtensionRefreshErrorMessage(Value));
 
-            if JsonManagement.GetStringPropertyValueByName('ExtensionRefreshUnexpectedError', Value) then
+            if GetJsonTokenText(NotificationJson, 'ExtensionRefreshUnexpectedError', Value) then
                 HybridReplicationSummary.AddDetails(GetExtensionRefreshErrorMessage(Value));
         end;
 
         if HybridReplicationSummary.Status <> HybridReplicationSummary.Status::InProgress then
             HybridReplicationSummary."End Time" := CurrentDateTime();
 
-        if JsonManagement.GetStringPropertyValueByName('ServiceType', ServiceType) then
+        if GetJsonTokenText(NotificationJson, 'ServiceType', ServiceType) then
             if HybridCloudManagement.IsReplicationCompleted(ServiceType) then begin
                 if PreviousHybridReplicationSummary.Status = PreviousHybridReplicationSummary.Status::InProgress then
                     Clear(PreviousDetails);
@@ -338,11 +340,12 @@ codeunit 4014 "Notification Handler"
     local procedure ProcessUpgradeAvailableNotification(NotificationText: Text)
     var
         IntelligentCloudSetup: Record "Intelligent Cloud Setup";
-        JsonManagement: Codeunit "JSON Management";
+        NotificationJson: JsonObject;
         Version: Text;
     begin
-        JsonManagement.InitializeObject(NotificationText);
-        JsonManagement.GetStringPropertyValueByName('Version', Version);
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        GetJsonTokenText(NotificationJson, 'Version', Version);
 
         IntelligentCloudSetup.SetLatestVersion(Version);
     end;
@@ -373,10 +376,28 @@ codeunit 4014 "Notification Handler"
     [TryFunction]
     local procedure TryParsePipelineRunId(Details: Text; var PipelineRunId: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        DetailsJson: JsonObject;
     begin
-        JSONManagement.InitializeObject(Details);
-        JSONManagement.GetStringPropertyValueByName('pipelineRunId', PipelineRunId)
+        if Details <> '' then
+            if not DetailsJson.ReadFrom(Details) then
+                Error('');
+        GetJsonTokenText(DetailsJson, 'pipelineRunId', PipelineRunId)
+    end;
+
+    local procedure GetJsonTokenText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit(true);
+            Value := JsonToken.AsValue().AsText();
+        end else
+            JsonToken.WriteTo(Value);
+        exit(true);
     end;
 
     local procedure SourceSupported(ProductId: Text[250]; WarningType: Enum "Cloud Migration Warning Type") Supported: Boolean

--- a/src/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
+++ b/src/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
@@ -138,55 +138,57 @@ codeunit 4016 "Hybrid GP Management"
     var
         HybridReplicationDetail: Record "Hybrid Replication Detail";
         HybridMessageManagement: Codeunit "Hybrid Message Management";
-        JsonManagement: Codeunit "JSON Management";
-        JsonManagement2: Codeunit "JSON Management";
         HelperFunctions: Codeunit "Helper Functions";
+        NotificationJson: JsonObject;
+        IncrementalTableJson: JsonObject;
+        ErrorJson: JsonObject;
+        TablesArray: JsonArray;
+        ErrorsArray: JsonArray;
+        JsonToken: JsonToken;
         ErrorCode: Text;
         ErrorMessage: Text;
-        Errors: Text;
-        IncrementalTable: Text;
         IncrementalTableCount: Integer;
         Value: Text;
         i: Integer;
         j: Integer;
     begin
         Session.LogMessage('0000FVL', UpdateStatusOnHybridReplicationCompletedMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', HelperFunctions.GetTelemetryCategory());
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
         // Get table information, iterate through and create detail records for each
         for j := 1 to 2 do begin
-            JsonManagement.InitializeObject(NotificationText);
-
             // Wrapping these in if/then pairs to ensure backward-compatibility
             if j = 1 then
-                if (not JsonManagement.GetArrayPropertyValueAsStringByName('IncrementalTables', Value)) then exit;
+                if not TryGetJsonArray(NotificationJson, 'IncrementalTables', TablesArray) then
+                    exit;
             if j = 2 then
-                if (not JsonManagement.GetArrayPropertyValueAsStringByName('GPHistoryTables', Value)) then exit;
-            JsonManagement.InitializeCollection(Value);
-            IncrementalTableCount := JsonManagement.GetCollectionCount();
+                if not TryGetJsonArray(NotificationJson, 'GPHistoryTables', TablesArray) then
+                    exit;
+            IncrementalTableCount := TablesArray.Count();
 
             for i := 0 to IncrementalTableCount - 1 do begin
-                JsonManagement.GetObjectFromCollectionByIndex(IncrementalTable, i);
-                JsonManagement.InitializeObject(IncrementalTable);
+                TablesArray.Get(i, JsonToken);
+                IncrementalTableJson := JsonToken.AsObject();
 
                 HybridReplicationDetail.Init();
                 HybridReplicationDetail."Run ID" := RunId;
-                JsonManagement.GetStringPropertyValueByName('TableName', Value);
+                Value := GetJsonTokenText(IncrementalTableJson, 'TableName');
                 HybridReplicationDetail."Table Name" := CopyStr(Value, 1, 250);
 
-                JsonManagement.GetStringPropertyValueByName('CompanyName', Value);
+                Value := GetJsonTokenText(IncrementalTableJson, 'CompanyName');
                 HybridReplicationDetail."Company Name" := CopyStr(Value, 1, 250);
 
                 HybridReplicationDetail.Status := HybridReplicationDetail.Status::Successful;
-                if JsonManagement.GetStringPropertyValueByName('Errors', Errors) and Errors.StartsWith('[') then begin
-                    JsonManagement2.InitializeCollection(Errors);
-                    if JsonManagement2.GetCollectionCount() > 0 then begin
-                        JsonManagement2.GetObjectFromCollectionByIndex(Value, 0);
-                        JsonManagement2.InitializeObject(Value);
-                        JsonManagement2.GetStringPropertyValueByName('Code', ErrorCode);
-                        JsonManagement2.GetStringPropertyValueByName('Message', ErrorMessage);
+                if TryGetJsonArray(IncrementalTableJson, 'Errors', ErrorsArray) then begin
+                    if ErrorsArray.Count() > 0 then begin
+                        ErrorsArray.Get(0, JsonToken);
+                        ErrorJson := JsonToken.AsObject();
+                        ErrorCode := GetJsonTokenText(ErrorJson, 'Code');
+                        ErrorMessage := GetJsonTokenText(ErrorJson, 'Message');
                     end;
                 end else begin
-                    JsonManagement.GetStringPropertyValueByName('ErrorMessage', ErrorMessage);
-                    JsonManagement.GetStringPropertyValueByName('ErrorCode', ErrorCode);
+                    ErrorMessage := GetJsonTokenText(IncrementalTableJson, 'ErrorMessage');
+                    ErrorCode := GetJsonTokenText(IncrementalTableJson, 'ErrorCode');
                 end;
 
                 if (ErrorMessage <> '') or (ErrorCode <> '') then begin
@@ -200,6 +202,40 @@ codeunit 4016 "Hybrid GP Management"
                 HybridReplicationDetail.Insert();
             end;
         end;
+    end;
+
+    local procedure TryGetJsonArray(JsonObject: JsonObject; PropertyName: Text; var JsonArray: JsonArray): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(JsonArray);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if JsonToken.IsArray() then begin
+            JsonArray := JsonToken.AsArray();
+            exit(true);
+        end;
+        if not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(false);
+        exit(JsonArray.ReadFrom(JsonToken.AsValue().AsText()));
+    end;
+
+    local procedure GetJsonTokenText(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+        JsonText: Text;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
+        JsonToken.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Hybrid Message Management", 'OnResolveMessageCode', '', false, false)]
@@ -228,16 +264,17 @@ codeunit 4016 "Hybrid GP Management"
         HybridReplicationSummary: Record "Hybrid Replication Summary";
         HybridCompanyStatus: Record "Hybrid Company Status";
         HybridCloudManagement: Codeunit "Hybrid Cloud Management";
-        JsonManagement: Codeunit "JSON Management";
         HelperFunctions: Codeunit "Helper Functions";
+        NotificationJson: JsonObject;
         ServiceType: Text;
     begin
         // Do not process migration data for a diagnostic run since there should be none
         if HybridReplicationSummary.Get(RunId) and (HybridReplicationSummary.ReplicationType = HybridReplicationSummary.ReplicationType::Diagnostic) then
             exit;
 
-        JsonManagement.InitializeObject(NotificationText);
-        JsonManagement.GetStringPropertyValueByName('ServiceType', ServiceType);
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
+        ServiceType := GetJsonTokenText(NotificationJson, 'ServiceType');
         Session.LogMessage('0000FXA', StartingHandleInitializationOfGPSynchronizationTelemetryMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', HelperFunctions.GetTelemetryCategory());
 
         if ServiceType = ReplicationCompletedServiceTypeTxt then begin

--- a/src/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
+++ b/src/Apps/W1/HybridGP/app/src/codeunits/HybridGPManagement.codeunit.al
@@ -3,7 +3,6 @@ namespace Microsoft.DataMigration.GP;
 using Microsoft.DataMigration;
 using System.Environment;
 using System.Integration;
-using System.Text;
 
 codeunit 4016 "Hybrid GP Management"
 {

--- a/src/Apps/W1/HybridSL/app/src/codeunits/SLHybridManagement.Codeunit.al
+++ b/src/Apps/W1/HybridSL/app/src/codeunits/SLHybridManagement.Codeunit.al
@@ -8,7 +8,6 @@ namespace Microsoft.DataMigration.SL;
 using Microsoft.DataMigration;
 using System.Environment;
 using System.Integration;
-using System.Text;
 
 codeunit 47013 "SL Hybrid Management"
 {

--- a/src/Apps/W1/HybridSL/app/src/codeunits/SLHybridManagement.Codeunit.al
+++ b/src/Apps/W1/HybridSL/app/src/codeunits/SLHybridManagement.Codeunit.al
@@ -102,7 +102,7 @@ codeunit 47013 "SL Hybrid Management"
         HybridReplicationSummary: Record "Hybrid Replication Summary";
         HybridCloudManagement: Codeunit "Hybrid Cloud Management";
         SLHelperFunctions: Codeunit "SL Helper Functions";
-        JsonManagement: Codeunit "JSON Management";
+        NotificationJson: JsonObject;
         ServiceType: Text;
     begin
         if HybridCloudManagement.CanHandleNotification(SubscriptionId, ProductIdLbl) then begin
@@ -110,8 +110,9 @@ codeunit 47013 "SL Hybrid Management"
             if HybridReplicationSummary.Get(RunID) and (HybridReplicationSummary.ReplicationType = HybridReplicationSummary.ReplicationType::Diagnostic) then
                 exit;
 
-            JsonManagement.InitializeObject(NotificationText);
-            JsonManagement.GetStringPropertyValueByName('ServiceType', ServiceType);
+            if NotificationText <> '' then
+                NotificationJson.ReadFrom(NotificationText);
+            ServiceType := GetJsonTokenText(NotificationJson, 'ServiceType');
             Session.LogMessage('0000FXA', StartingHandleInitializationofSLSynchronizationTelemetryMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', SLHelperFunctions.GetTelemetryCategory());
 
             if ServiceType = ReplicationCompletedServiceTypeTxt then begin
@@ -128,54 +129,57 @@ codeunit 47013 "SL Hybrid Management"
     var
         HybridReplicationDetail: Record "Hybrid Replication Detail";
         HybridMessageManagement: Codeunit "Hybrid Message Management";
-        JsonManagement: Codeunit "JSON Management";
-        JsonManagement2: Codeunit "JSON Management";
         SLHelperFunctions: Codeunit "SL Helper Functions";
+        NotificationJson: JsonObject;
+        IncrementalTableJson: JsonObject;
+        ErrorJson: JsonObject;
+        TablesArray: JsonArray;
+        ErrorsArray: JsonArray;
+        JsonToken: JsonToken;
         IncrementalTableCount: Integer;
         i: Integer;
         j: Integer;
         ErrorCode: Text;
         ErrorMessage: Text;
-        Errors: Text;
-        IncrementalTable: Text;
         Value: Text;
     begin
         Session.LogMessage('0000FVL', UpdateStatusOnHybridReplicationCompletedMsg, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', SLHelperFunctions.GetTelemetryCategory());
+        if NotificationText <> '' then
+            NotificationJson.ReadFrom(NotificationText);
         // Get table information, iterate through and create detail records for each
         for j := 1 to 2 do begin
-            JsonManagement.InitializeObject(NotificationText);
             // Wrapping these in if/then pairs to ensure backward-compatibility
             if j = 1 then
-                if (not JsonManagement.GetArrayPropertyValueAsStringByName('IncrementalTables', Value)) then exit;
+                if not TryGetJsonArray(NotificationJson, 'IncrementalTables', TablesArray) then
+                    exit;
             if j = 2 then
-                if (not JsonManagement.GetArrayPropertyValueAsStringByName('SLHistoryTables', Value)) then exit;
-            JsonManagement.InitializeCollection(Value);
-            IncrementalTableCount := JsonManagement.GetCollectionCount();
+                if not TryGetJsonArray(NotificationJson, 'SLHistoryTables', TablesArray) then
+                    exit;
+            IncrementalTableCount := TablesArray.Count();
 
             for i := 0 to IncrementalTableCount - 1 do begin
-                JsonManagement.GetObjectFromCollectionByIndex(IncrementalTable, i);
-                JsonManagement.InitializeObject(IncrementalTable);
+                TablesArray.Get(i, JsonToken);
+                IncrementalTableJson := JsonToken.AsObject();
 
                 HybridReplicationDetail.Init();
                 HybridReplicationDetail."Run ID" := RunId;
-                JsonManagement.GetStringPropertyValueByName('TableName', Value);
+                Value := GetJsonTokenText(IncrementalTableJson, 'TableName');
                 HybridReplicationDetail."Table Name" := CopyStr(Value, 1, 250);
 
-                JsonManagement.GetStringPropertyValueByName('CompanyName', Value);
+                Value := GetJsonTokenText(IncrementalTableJson, 'CompanyName');
                 HybridReplicationDetail."Company Name" := CopyStr(Value, 1, 250);
 
                 HybridReplicationDetail.Status := HybridReplicationDetail.Status::Successful;
-                if JsonManagement.GetStringPropertyValueByName('Errors', Errors) and Errors.StartsWith('[') then begin
-                    JsonManagement2.InitializeCollection(Errors);
-                    if JsonManagement2.GetCollectionCount() > 0 then begin
-                        JsonManagement2.GetObjectFromCollectionByIndex(Value, 0);
-                        JsonManagement2.InitializeObject(Value);
-                        JsonManagement2.GetStringPropertyValueByName('Code', ErrorCode);
-                        JsonManagement2.GetStringPropertyValueByName('Message', ErrorMessage);
+                if TryGetJsonArray(IncrementalTableJson, 'Errors', ErrorsArray) then begin
+                    if ErrorsArray.Count() > 0 then begin
+                        ErrorsArray.Get(0, JsonToken);
+                        ErrorJson := JsonToken.AsObject();
+                        ErrorCode := GetJsonTokenText(ErrorJson, 'Code');
+                        ErrorMessage := GetJsonTokenText(ErrorJson, 'Message');
                     end;
                 end else begin
-                    JsonManagement.GetStringPropertyValueByName('ErrorMessage', ErrorMessage);
-                    JsonManagement.GetStringPropertyValueByName('ErrorCode', ErrorCode);
+                    ErrorMessage := GetJsonTokenText(IncrementalTableJson, 'ErrorMessage');
+                    ErrorCode := GetJsonTokenText(IncrementalTableJson, 'ErrorCode');
                 end;
                 if (ErrorMessage <> '') or (ErrorCode <> '') then begin
                     HybridReplicationDetail.Status := HybridReplicationDetail.Status::Failed;
@@ -187,6 +191,40 @@ codeunit 47013 "SL Hybrid Management"
                 HybridReplicationDetail.Insert();
             end;
         end;
+    end;
+
+    local procedure TryGetJsonArray(JsonObject: JsonObject; PropertyName: Text; var JsonArray: JsonArray): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(JsonArray);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if JsonToken.IsArray() then begin
+            JsonArray := JsonToken.AsArray();
+            exit(true);
+        end;
+        if not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(false);
+        exit(JsonArray.ReadFrom(JsonToken.AsValue().AsText()));
+    end;
+
+    local procedure GetJsonTokenText(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+        JsonText: Text;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
+        JsonToken.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"Hybrid Message Management", OnResolveMessageCode, '', false, false)]

--- a/src/Apps/W1/ImageAnalysis/test/src/codeunits/ItemAttrPopulateTest.Codeunit.al
+++ b/src/Apps/W1/ImageAnalysis/test/src/codeunits/ItemAttrPopulateTest.Codeunit.al
@@ -3,7 +3,6 @@ namespace Microsoft.Utility.ImageAnalysis;
 using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Item.Attribute;
 using System.AI;
-using System.Text;
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved. 
 // Licensed under the MIT License. See License.txt in the project root for license information. 

--- a/src/Apps/W1/ImageAnalysis/test/src/codeunits/ItemAttrPopulateTest.Codeunit.al
+++ b/src/Apps/W1/ImageAnalysis/test/src/codeunits/ItemAttrPopulateTest.Codeunit.al
@@ -27,7 +27,7 @@ codeunit 139592 "Item Attr Populate Test"
         ImageAnalysisTagBlacklist: Record "MS - Img. Analyzer Blacklist";
         ImageAnalysisResult: Codeunit "Image Analysis Result";
         ItemAttrPopulate: Codeunit "Item Attr Populate";
-        JsonManagement: Codeunit "JSON Management";
+        ResultJson: JsonObject;
         ConfidencePercent: Decimal;
         UpdatedDescription: Text[100];
     begin
@@ -36,11 +36,11 @@ codeunit 139592 "Item Attr Populate Test"
         Initialize();
         CreateTestItem(Item);
 
-        JsonManagement.InitializeObject('{"tags":[{"name":"furniture","confidence":0.998513400554657},{"name":"seat","confidence":0.99785393476486206},' +
+        ResultJson.ReadFrom('{"tags":[{"name":"furniture","confidence":0.998513400554657},{"name":"seat","confidence":0.99785393476486206},' +
       '{"name":"chair","confidence":0.978925347328186},{"name":"blue","confidence":0.90790148973464966}],"requestId":"2c15a4c1-9271-4584-a30e-342d7fdf206b"' +
       ',"metadata":{"width":500,"height":600,"format":"Jpeg"},"faces":[],"color":{"dominantColorForeground":"White","dominantColorBackground":"White",' +
       '"dominantColors":["White","Blue"],"accentColor":"0D48BE","isBWImg":false}}');
-        ImageAnalysisResult.SetResult(JsonManagement, Enum::"Image Analysis Type"::Tags);
+        ImageAnalysisResult.SetResult(ResultJson, Enum::"Image Analysis Type"::Tags);
 
         // [When] We try to populate the tags table
         ItemAttrPopulate.BuildTagListPrepopulateCategoryAndAttributes(Item, ImageAnalysisResult, ImageAnalysisTags, ConfidencePercent);
@@ -124,7 +124,7 @@ codeunit 139592 "Item Attr Populate Test"
         Item: Record Item;
         ImageAnalysisResult: Codeunit "Image Analysis Result";
         ItemAttrPopulate: Codeunit "Item Attr Populate";
-        JsonManagement: Codeunit "JSON Management";
+        ResultJson: JsonObject;
         ConfidencePercent: Decimal;
     begin
         // [Scenario] Check the item is not populated correctly in a success case
@@ -132,10 +132,10 @@ codeunit 139592 "Item Attr Populate Test"
         Initialize();
         CreateTestItem(Item);
 
-        JsonManagement.InitializeObject('{"tags":[{"name":"furniture","confidence":0.098513400554657},{"name":"seat","confidence":0.09785393476486206},' +
+        ResultJson.ReadFrom('{"tags":[{"name":"furniture","confidence":0.098513400554657},{"name":"seat","confidence":0.09785393476486206},' +
       '{"name":"chair","confidence":0.078925347328186},{"name":"blue","confidence":0.00790148973464966}],"requestId":"2c15a4c1-9271-4584-a30e-342d7fdf206b"' +
       ',"metadata":{"width":500,"height":600,"format":"Jpeg"}}');
-        ImageAnalysisResult.SetResult(JsonManagement, Enum::"Image Analysis Type"::Tags);
+        ImageAnalysisResult.SetResult(ResultJson, Enum::"Image Analysis Type"::Tags);
 
         // [When] We try to populate the item
         ItemAttrPopulate.BuildTagListPrepopulateCategoryAndAttributes(Item, ImageAnalysisResult, ImageAnalysisTags, ConfidencePercent);

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIFinanceTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIFinanceTest.Codeunit.al
@@ -104,7 +104,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyVendorLedgerEntry(Response: Text; PurchInvHeader: Record "Purch. Inv. Header"; VendorLedgerEntry: Record "Vendor Ledger Entry"; DetailedVendLedgerEntry: Record "Detailed Vendor Ledg. Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.dvleEntryNo == ' + Format(Format(DetailedVendLedgerEntry."Entry No.") + ')]')), 'Vendor ledger entry not found.');
@@ -193,7 +193,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyCustomerLedgerEntry(Response: Text; SalesInvHeader: Record "Sales Invoice Header"; CustomerLedgerEntry: Record "Cust. Ledger Entry"; DetailedCustLedgerEntry: Record "Detailed Cust. Ledg. Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.dcleEntryNo == ' + Format(Format(DetailedCustLedgerEntry."Entry No.") + ')]')), 'Customer ledger entry not found.');
@@ -253,7 +253,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyGLAccount(Response: Text; GLAccount: Record "G/L Account")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.accountNo == ''' + Format(GLAccount."No.") + ''')]'), 'G/L account not found.');
@@ -291,7 +291,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyGLAccountCategory(Response: Text; GLAccountCategory: Record "G/L Account Category")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(GLAccountCategory."Entry No.") + ')]'), 'G/L account category not found.');
@@ -327,7 +327,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyGLBudgetName(Response: Text; GLBudgetName: Record "G/L Budget Name")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.budgetName == ''' + Format(GLBudgetName.Name) + ''')]'), 'G/L budget name not found.');
@@ -372,7 +372,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyGLBudgetEntry(Response: Text; GLBudgetEntry: Record "G/L Budget Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(GLBudgetEntry."Entry No.") + ')]'), 'G/L budget entry not found.');
@@ -518,7 +518,7 @@ codeunit 139876 "E2E PowerBI Finance Test"
 
     local procedure VerifyPostedGLEntry(Response: Text; GLAccount: Record "G/L Account"; GLEntry: Record "G/L Entry"; EntryShouldExist: Boolean)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         if EntryShouldExist then begin

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIFinanceTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIFinanceTest.Codeunit.al
@@ -19,7 +19,6 @@ using Microsoft.Sales.History;
 using Microsoft.Sales.Receivables;
 using System.TestLibraries.Security.AccessControl;
 using System.TestLibraries.Utilities;
-using System.Text;
 using System.Utilities;
 
 /// <summary>

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIInventoryTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIInventoryTest.Codeunit.al
@@ -34,7 +34,6 @@ using Microsoft.Warehouse.Ledger;
 using Microsoft.Warehouse.Setup;
 using Microsoft.Warehouse.Structure;
 using System.TestLibraries.Security.AccessControl;
-using System.Text;
 using System.Utilities;
 
 /// <summary>

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIInventoryTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIInventoryTest.Codeunit.al
@@ -98,7 +98,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyZone(Response: Text; Zone: Record Zone)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.zoneCode == ''' + Format(Zone.Code) + ''')]'), 'Zone not found.');
@@ -140,7 +140,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyBin(Response: Text; Bin: Record Bin)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.binCode == ''' + Format(Bin.Code) + ''')]'), 'Bin not found.');
@@ -190,7 +190,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifySalesLine(Response: Text; SalesLine: Record "Sales Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         if (SalesLine.Type = SalesLine.Type::Item) and (SalesLine."Outstanding Qty. (Base)" <> 0) then begin
@@ -286,7 +286,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyPurchLine(Response: Text; PurchLine: Record "Purchase Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         if (PurchLine.Type = PurchLine.Type::Item) and (PurchLine."Outstanding Qty. (Base)" <> 0) then begin
@@ -396,7 +396,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyRequisitionLine(Response: Text; RequisitionLine: Record "Requisition Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(RequisitionLine."No.") + ''')]'), 'Requisition line not found.');
@@ -490,7 +490,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyTransferLine(Response: Text; TransferLine: Record "Transfer Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(TransferLine."Item No.") + ''')]'), 'Transfer line not found.');
@@ -575,7 +575,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyServiceLine(Response: Text; ServiceLine: Record "Service Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(ServiceLine."No.") + ''')]'), 'Service line not found.');
@@ -671,7 +671,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyItemLedgerEntry(Response: Text; ItemLedgerEntry: Record "Item Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
         BoolText: Text;
     begin
         JsonMgt.InitializeObject(Response);
@@ -738,7 +738,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyWhseActivityLine(Response: Text; WhseActivityLine: Record "Warehouse Activity Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
         BoolText: Text;
     begin
         JsonMgt.InitializeObject(Response);
@@ -795,7 +795,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyWhseEntry(Response: Text; WhseEntry: Record "Warehouse Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(WhseEntry."Item No.") + ''')]'), 'Warehouse entry not found.');
@@ -878,7 +878,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyFromBinWhseJournalLine(Response: Text; WhseJournalLine: Record "Warehouse Journal Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(WhseJournalLine."Item No.") + ''')]'), 'Warehouse journal line not found.');
@@ -927,7 +927,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyToBinWhseJournalLine(Response: Text; WhseJournalLine: Record "Warehouse Journal Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(WhseJournalLine."Item No.") + ''')]'), 'Warehouse journal line not found.');
@@ -1012,7 +1012,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyInventoryValue(Response: Text; ValueEntry: Record "Value Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
 
     begin
         JsonMgt.InitializeObject(Response);
@@ -1096,7 +1096,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyAssemblyHeader(Response: Text; AssemblyHeader: Record "Assembly Header")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.documentNo == ''' + Format(AssemblyHeader."No.") + ''')]'), 'Assembly header not found.');
@@ -1171,7 +1171,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyAssemblyLine(Response: Text; AssemblyLine: Record "Assembly Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(AssemblyLine."No.") + ''')]'), 'Assembly line not found.');
@@ -1261,7 +1261,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyJobPlanningLine(Response: Text; JobPlanningLine: Record "Job Planning Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(JobPlanningLine."No.") + ''')]'), 'Job planning line not found.');
@@ -1365,7 +1365,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyProdOrderLine(Response: Text; ProdOrderLine: Record "Prod. Order Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
 
     begin
         JsonMgt.InitializeObject(Response);
@@ -1465,7 +1465,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyProdOrderCompLine(Response: Text; ProdOrderComp: Record "Prod. Order Component")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.documentNo == ''' + Format(ProdOrderComp."Prod. Order No.") + ''')]'), 'Production order component line not found.');
@@ -1552,7 +1552,7 @@ codeunit 139877 "E2E PowerBI Inventory Test"
 
     local procedure VerifyPlanningComponent(Response: Text; PlanningComponent: Record "Planning Component")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(PlanningComponent."Item No.") + ''')]'), 'Planning component not found.');

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIManufacturingTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIManufacturingTest.Codeunit.al
@@ -102,7 +102,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyInventoryAdjmtEntries(Response: Text; InventoryAdjmtEntry: Record "Inventory Adjmt. Entry (Order)"; Index: Integer)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[' + Format(Index) + ']'), 'Inventory Adjustment Entry not found.');
@@ -156,7 +156,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyCalendarEntry(Response: Text; CalendarEntry: Record "Calendar Entry"; Index: Integer)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[' + Format(Index) + ']'), 'Calendar entry not found.');
@@ -202,7 +202,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyMachineCenter(Response: Text; MachineCenter: Record "Machine Center")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(MachineCenter."No.") + ''')]'), 'Machine center not found.');
@@ -245,7 +245,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
     local procedure VerifyWorkCenter(Response: Text; WorkCenter: Record "Work Center")
     var
         WorkCenterGroup: Record "Work Center Group";
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(WorkCenter."No.") + ''')]'), 'Work center not found.');
@@ -308,7 +308,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
     local procedure VerifyProdOrderLine(Response: Text; ProdOrderLine: Record "Prod. Order Line")
     var
         Location: Record Location;
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.prodOrderNo == ''' + Format(ProdOrderLine."Prod. Order No.") + ''')]'), 'Production order line not found.');
@@ -386,7 +386,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
     local procedure VerifyProdOrderCompLine(Response: Text; ProdOrderComp: Record "Prod. Order Component")
     var
         Location: Record Location;
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.prodOrderNo == ''' + Format(ProdOrderComp."Prod. Order No.") + ''')]'), 'Production order component not found.');
@@ -455,7 +455,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyProdOrderRoutingLine(Response: Text; ProdOrderRoutingLine: Record "Prod. Order Routing Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@prodOrderNo == ''' + Format(ProdOrderRoutingLine."Prod. Order No.") + ''')]'), 'Production order routing line not found.');
@@ -542,7 +542,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyProdItemLedgerEntry(Response: Text; ItemLedgerEntry: Record "Item Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemNo == ''' + Format(ItemLedgerEntry."Item No.") + ''')]'), 'Item ledger entry not found.');
@@ -655,7 +655,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyCapacityLedgerEntry(Response: Text; CapacityLedgerEntry: Record "Capacity Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.orderNo == ''' + Format(CapacityLedgerEntry."Order No.") + ''')]'), 'Capacity ledger entry not found.');
@@ -696,7 +696,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
         Item: Record Item;
         ProdOrder: Record "Production Order";
         ProdOrder2: Record "Production Order";
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
         Uri: Codeunit Uri;
         TargetURL: Text;
         Response: Text;
@@ -744,7 +744,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
         end;
     end;
 
-    local procedure VerifyProdOrderCapNeeded(var JsonMgt: Codeunit "JSON Management")
+    local procedure VerifyProdOrderCapNeeded(var JsonMgt: Codeunit "Library - Graph Mgt")
     var
         ProdOrderCapNeeded: Record "Prod. Order Capacity Need";
     begin
@@ -859,7 +859,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyManufacturingSetup(Response: Text; CapacityUnitOfMeasure: Record "Capacity Unit of Measure")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.showCapacityIn == ''' + Format(CapacityUnitOfMeasure.Code) + ''')]'), 'Show Capacity In not found.');
@@ -913,7 +913,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyProductionOrder(Response: Text; ProdOrder: Record "Production Order")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(ProdOrder."No.") + ''')]'), 'Production order not found.');
@@ -958,7 +958,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyRoutingLinks(Response: Text; RoutingLink: Record "Routing Link")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.code == ''' + Format(RoutingLink.Code) + ''')]'), 'Routing link not found.');
@@ -996,7 +996,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyRoutingHeaders(Response: Text; RoutingHeader: Record "Routing Header")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(RoutingHeader."No.") + ''')]'), 'Routing header not found.');
@@ -1036,7 +1036,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyWorkCenterGroups(Response: Text; WorkCenterGroup: Record "Work Center Group")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.code == ''' + Format(WorkCenterGroup.Code) + ''')]'), 'Work center group not found.');
@@ -1105,7 +1105,7 @@ codeunit 139878 "E2E PowerBI Manufacturing Test"
 
     local procedure VerifyManufacturingValueEntry(Response: Text; ValueEntry: Record "Value Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(ValueEntry."Entry No.") + ')]'), 'Value entry not found.');

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIManufacturingTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIManufacturingTest.Codeunit.al
@@ -23,7 +23,6 @@ using Microsoft.Manufacturing.Setup;
 using Microsoft.Manufacturing.WorkCenter;
 using Microsoft.PowerBIReports.Test;
 using System.TestLibraries.Security.AccessControl;
-using System.Text;
 using System.Utilities;
 
 /// <summary>

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIProjectTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIProjectTest.Codeunit.al
@@ -12,7 +12,6 @@ using Microsoft.Projects.Project.Ledger;
 using Microsoft.Projects.Project.Planning;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.Vendor;
-using System.Text;
 using System.Utilities;
 
 /// <summary>

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIProjectTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIProjectTest.Codeunit.al
@@ -77,7 +77,7 @@ codeunit 139879 "E2E PowerBI Project Test"
 
     local procedure VerifyJob(Response: Text; Job: Record Job)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
         BoolText: Text;
     begin
         JsonMgt.InitializeObject(Response);
@@ -132,7 +132,7 @@ codeunit 139879 "E2E PowerBI Project Test"
 
     local procedure VerifyJobTask(Response: Text; JobTask: Record "Job Task")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.jobTaskNo == ''' + Format(JobTask."Job Task No.") + ''')]'), 'Job task not found.');
@@ -184,7 +184,7 @@ codeunit 139879 "E2E PowerBI Project Test"
 
     local procedure VerifyJobPlanningLine(Response: Text; JobPlanningLine: Record "Job Planning Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(JobPlanningLine."No.") + ''')]'), 'Job planning line not found.');
@@ -252,7 +252,7 @@ codeunit 139879 "E2E PowerBI Project Test"
 
     local procedure VerifyJobLedgerEntry(Response: Text; JobLedgerEntry: Record "Job Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(JobLedgerEntry."No.") + ''')]'), 'Job ledger entry not found.');
@@ -306,7 +306,7 @@ codeunit 139879 "E2E PowerBI Project Test"
 
     local procedure VerifyOutstandingPOLine(Response: Text; PurchaseLine: Record "Purchase Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
         OutstandingAmountLCY: Decimal;
     begin
         JsonMgt.InitializeObject(Response);
@@ -423,7 +423,7 @@ codeunit 139879 "E2E PowerBI Project Test"
 
     local procedure VerifyRcvdNotInvdPOLine(Response: Text; PurchaseLine: Record "Purchase Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + Format(PurchaseLine."No.") + ''')]'), 'Received not invoiced PO line not found.');
@@ -466,7 +466,7 @@ codeunit 139879 "E2E PowerBI Project Test"
     begin
         if Value = '' then
             exit(0);
-        Evaluate(Output, Value);
+        Evaluate(Output, Value, 9);
         exit(Output);
     end;
 

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIPurchasesTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIPurchasesTest.Codeunit.al
@@ -124,7 +124,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyPurchOrderLine(Response: Text; PurchHeader: Record "Purchase Header"; PurchLine: Record "Purchase Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(PurchLine."Line No.") + ')]'), 'Purchase line not found.');
@@ -175,7 +175,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyItemBudgetEntry(Response: Text; ItemBudgetEntry: Record "Item Budget Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(ItemBudgetEntry."Entry No.") + ')]'), 'Item budget entry not found.');
@@ -254,7 +254,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyPurchValueEntryV2(Response: Text; PurchaseHeader: Record "Purchase Header"; ValueEntry: Record "Value Entry"; ItemLedgerEntry: Record "Item Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemLedgerEntryNo == ' + Format(ItemLedgerEntry."Entry No.") + ')]'), 'Purchase item ledger entry not found.');
@@ -358,7 +358,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyReceivedNotInvoiced(Response: Text; PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(PurchaseLine."Line No.") + ')]'), 'Purchase item ledger entry not found.');
@@ -496,7 +496,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyPurchaseLine(Response: Text; PurchaseHeader: Record "Purchase Header"; PurchaseLine: Record "Purchase Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(PurchaseLine."Line No.") + ')]'), 'Purchase line not found.');
@@ -590,7 +590,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyPurchaseInvoiceLine(Response: Text; PurchInvHeader: Record "Purch. Inv. Header"; PurcInvLine: Record "Purch. Inv. Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(PurcInvLine."Line No.") + ')]'), 'Purchase invoice line not found.');
@@ -667,7 +667,7 @@ codeunit 139880 "E2E PowerBI Purchases Test"
 
     local procedure VerifyPurchaseCreditLine(Response: Text; PurchCrMemoHeader: Record "Purch. Cr. Memo Hdr."; PurcCrMemoLine: Record "Purch. Cr. Memo Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(PurcCrMemoLine."Line No.") + ')]'), 'Purchase credit memo line not found.');

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBIPurchasesTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBIPurchasesTest.Codeunit.al
@@ -14,7 +14,6 @@ using Microsoft.Projects.Resources.Resource;
 using Microsoft.Purchases.Document;
 using Microsoft.Purchases.History;
 using System.TestLibraries.Security.AccessControl;
-using System.Text;
 using System.Utilities;
 
 /// <summary>

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBISalesTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBISalesTest.Codeunit.al
@@ -85,7 +85,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyItemBudget(Response: Text; ItemBudgetName: Record "Item Budget Name")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.budgetName == ''' + Format(ItemBudgetName.Name) + ''')]'), 'Item budget name not found.');
@@ -132,7 +132,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesOrderLine(Response: Text; SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(SalesLine."Line No.") + ')]'), 'Sales line not found.');
@@ -187,7 +187,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyItemBudgetEntry(Response: Text; ItemBudgetEntry: Record "Item Budget Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(ItemBudgetEntry."Entry No.") + ')]'), 'Item budget entry not found.');
@@ -233,7 +233,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesValueEntryV2(Response: Text; SalesHeader: Record "Sales Header"; ValueEntry: Record "Value Entry"; ItemLedgerEntry: Record "Item Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.itemLedgerEntryNo == ' + Format(ItemLedgerEntry."Entry No.") + ')]'), 'Sales item ledger entry not found.');
@@ -299,7 +299,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyShippedNotInvoiced(Response: Text; SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(SalesLine."Line No.") + ')]'), 'Sales item ledger entry not found.');
@@ -362,7 +362,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesLineV2(Response: Text; SalesHeader: Record "Sales Header"; SalesLine: Record "Sales Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(SalesLine."Line No.") + ')]'), 'Sales line not found.');
@@ -441,7 +441,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyOpportunity(Response: Text; Opportunity: Record Opportunity)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.opportunityNo == ''' + Format(Opportunity."No.") + ''')]'), 'Opportunity not found.');
@@ -503,7 +503,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyOpportunityEntry(Response: Text; OpportunityEntry: Record "Opportunity Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.opportunityEntryEntryNo == ' + Format(OpportunityEntry."Entry No.") + ')]'), 'Opportunity Entry No not found.');
@@ -564,7 +564,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesCycleStage(Response: Text; SalesCycleStage: Record "Sales Cycle Stage")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.salesCycleCode == ''' + SalesCycleStage."Sales Cycle Code" + ''')]'), 'Sales Cycle Code not found.');
@@ -607,7 +607,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyCloseOpportunityCode(Response: Text; CloseOpportunityCode: Record "Close Opportunity Code")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.closeOpportunityCode == ''' + CloseOpportunityCode.Code + ''')]'), 'Sales Cycle Code not found.');
@@ -664,7 +664,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesCreditLines(Response: Text; SalesCrMemoHeader: Record "Sales Cr.Memo Header"; SalesCrMemoLine: Record "Sales Cr.Memo Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(SalesCrMemoLine."Line No.") + ')]'), 'Sales line not found.');
@@ -738,7 +738,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesInvoiceLines(Response: Text; SalesInvoiceHeader: Record "Sales Invoice Header"; SalesInvoiceLine: Record "Sales Invoice Line")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.lineNo == ' + Format(SalesInvoiceLine."Line No.") + ')]'), 'Sales line not found.');
@@ -828,7 +828,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesInvoiceProjectLedgerEntry(Response: Text; SalesInvoiceHeader: Record "Sales Invoice Header"; JobLedgerEntry: Record "Job Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(JobLedgerEntry."Entry No.") + ')]'), 'Project ledger entry not found.');
@@ -938,7 +938,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifySalesCreditProjectLedgerEntry(Response: Text; SalesCrMemoHeader: Record "Sales Cr.Memo Header"; JobLedgerEntry: Record "Job Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(JobLedgerEntry."Entry No.") + ')]'), 'Project ledger entry not found.');
@@ -997,7 +997,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyContact(Response: Text; Contact: Record Contact)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.contactNo == ''' + Format(Contact."No.") + ''')]'), 'Contact not found.');
@@ -1046,7 +1046,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyItemCategory(Response: Text; ItemCategory: Record "Item Category"; ParentCategoryCode: Code[20])
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.code == ''' + Format(ItemCategory.Code) + ''')]'), 'Item Category not found.');
@@ -1084,7 +1084,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyReturnReason(Response: Text; ReturnReason: Record "Return Reason")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.reasonCode == ''' + Format(ReturnReason.Code) + ''')]'), 'Return Reason not found.');
@@ -1122,7 +1122,7 @@ codeunit 139881 "E2E PowerBI Sales Test"
 
     local procedure VerifyResource(Response: Text; Resource: Record Resource)
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.resourceNo == ''' + Format(Resource."No.") + ''')]'), 'Resource not found.');

--- a/src/Apps/W1/PowerBIReports/Test/E2EPowerBISalesTest.Codeunit.al
+++ b/src/Apps/W1/PowerBIReports/Test/E2EPowerBISalesTest.Codeunit.al
@@ -17,7 +17,6 @@ using Microsoft.Projects.Project.Planning;
 using Microsoft.Projects.Resources.Resource;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
-using System.Text;
 using System.Utilities;
 
 /// <summary>

--- a/src/Apps/W1/Sustainability/test/src/PowerBISustainabilityTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/PowerBISustainabilityTest.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.Sustainability.PowerBIReports;
 using Microsoft.Sustainability.Scorecard;
 using System.Security.User;
 using System.TestLibraries.Security.AccessControl;
-using System.Text;
 
 codeunit 148215 "PowerBI Sustainability Test"
 {

--- a/src/Apps/W1/Sustainability/test/src/PowerBISustainabilityTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/PowerBISustainabilityTest.Codeunit.al
@@ -72,7 +72,7 @@ codeunit 148215 "PowerBI Sustainability Test"
 
     procedure VerifySustainabilityLedgerEntry(Response: Text; SustainabilityLedgerEntry: Record "Sustainability Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(Format(SustainabilityLedgerEntry."Entry No.") + ')]')), 'Sustainability ledger entry not found.');
@@ -135,7 +135,7 @@ codeunit 148215 "PowerBI Sustainability Test"
 
     procedure VerifyEmployeeLedgerEntry(Response: Text; EmployeeLedgerEntry: Record "Employee Ledger Entry")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.entryNo == ' + Format(Format(EmployeeLedgerEntry."Entry No.") + ')]')), 'Employee ledger entry not found.');
@@ -352,7 +352,7 @@ codeunit 148215 "PowerBI Sustainability Test"
 
     procedure VerifySustainabilityGoal(Response: Text; SustainabilityGoal: Record "Sustainability Goal")
     var
-        JsonMgt: Codeunit "JSON Management";
+        JsonMgt: Codeunit "Library - Graph Mgt";
     begin
         JsonMgt.InitializeObject(Response);
         Assert.IsTrue(JsonMgt.SelectTokenFromRoot('$..value[?(@.no == ''' + SustainabilityGoal."No." + ''')]'), 'Sustainability goal not found.');

--- a/src/Layers/APAC/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/APAC/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -7463,15 +7463,11 @@ codeunit 134920 "ERM General Journal UT"
 
     local procedure GetGenJnlBatchJson(NewGenJnlBatchName: Code[10]; GenJnlTemplateName: Code[10]) GenJnlBatchJson: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Name', NewGenJnlBatchName);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Journal_Template_Name', GenJnlTemplateName);
-
-        GenJnlBatchJson := JSONManagement.WriteObjectToString();
+        JsonObject.Add('Name', NewGenJnlBatchName);
+        JsonObject.Add('Journal_Template_Name', GenJnlTemplateName);
+        JsonObject.WriteTo(GenJnlBatchJson);
     end;
 
     local procedure CreateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; SeriesCode: Code[20]; StartDate: Date)
@@ -7574,4 +7570,3 @@ codeunit 134920 "ERM General Journal UT"
         IsHandled := true;
     end;
 }
-

--- a/src/Layers/CH/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/CH/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -7261,15 +7261,11 @@ codeunit 134920 "ERM General Journal UT"
 
     local procedure GetGenJnlBatchJson(NewGenJnlBatchName: Code[10]; GenJnlTemplateName: Code[10]) GenJnlBatchJson: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Name', NewGenJnlBatchName);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Journal_Template_Name', GenJnlTemplateName);
-
-        GenJnlBatchJson := JSONManagement.WriteObjectToString();
+        JsonObject.Add('Name', NewGenJnlBatchName);
+        JsonObject.Add('Journal_Template_Name', GenJnlTemplateName);
+        JsonObject.WriteTo(GenJnlBatchJson);
     end;
 
     local procedure CreateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; SeriesCode: Code[20]; StartDate: Date)
@@ -7372,4 +7368,3 @@ codeunit 134920 "ERM General Journal UT"
         IsHandled := true;
     end;
 }
-

--- a/src/Layers/CZ/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/CZ/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -7467,15 +7467,11 @@ codeunit 134920 "ERM General Journal UT"
 
     local procedure GetGenJnlBatchJson(NewGenJnlBatchName: Code[10]; GenJnlTemplateName: Code[10]) GenJnlBatchJson: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Name', NewGenJnlBatchName);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Journal_Template_Name', GenJnlTemplateName);
-
-        GenJnlBatchJson := JSONManagement.WriteObjectToString();
+        JsonObject.Add('Name', NewGenJnlBatchName);
+        JsonObject.Add('Journal_Template_Name', GenJnlTemplateName);
+        JsonObject.WriteTo(GenJnlBatchJson);
     end;
 
     local procedure CreateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; SeriesCode: Code[20]; StartDate: Date)
@@ -7578,4 +7574,3 @@ codeunit 134920 "ERM General Journal UT"
         IsHandled := true;
     end;
 }
-

--- a/src/Layers/DK/DemoTool/DemoDataImporter.Codeunit.al
+++ b/src/Layers/DK/DemoTool/DemoDataImporter.Codeunit.al
@@ -6,8 +6,8 @@ codeunit 101017 "Demo Data Importer"
         DemoDataSetup: Record "Demo Data Setup";
         DemoDataFile: Record "Demo Data File";
         CreateGettingStartedData: Codeunit "Create Getting Started Data";
-        TblsArray: DotNet JArray;
-        TblObj: DotNet JObject;
+        TablesArray: JsonArray;
+        TableToken: JsonToken;
     begin
         CreateGettingStartedData.ImportDemoDataFiles();
 
@@ -19,29 +19,28 @@ codeunit 101017 "Demo Data Importer"
         if not DemoDataFile.FindSet() then
             exit;
 
-        CachedRefrencesTable := CachedRefrencesTable.Hashtable();
+        Clear(CachedRefrencesTable);
 
         repeat
             ReadDemoDataFile(DemoDataFile);
 
-            JSONManagement.InitializeObject(JsonTxt);
-            JSONManagement.GetJSONObject(JsonObject);
-            TblsArray := JsonObject.Item('tables');
-            OptionsTable := OptionsTable.Hashtable();
-            RefrencesTable := RefrencesTable.Hashtable();
-            foreach TblObj in TblsArray do
-                ImportTable(TblObj);
+            JsonObject.ReadFrom(JsonTxt);
+            TablesArray := JsonObject.GetArray('tables');
+            Clear(OptionsTable);
+            Clear(RefrencesTable);
+            foreach TableToken in TablesArray do
+                ImportTable(TableToken.AsObject());
         until DemoDataFile.Next() = 0;
     end;
 
     var
-        JSONManagement: Codeunit "JSON Management";
-        OptionsTable: DotNet Hashtable;
-        RefrencesTable: DotNet Hashtable;
-        CachedRefrencesTable: DotNet Hashtable;
-        JsonObject: DotNet JObject;
+        OptionsTable: Dictionary of [Text, Integer];
+        RefrencesTable: Dictionary of [Text, Text];
+        CachedRefrencesTable: Dictionary of [Text, Text];
+        JsonObject: JsonObject;
         JsonTxt: Text;
         LanguageCode: Code[10];
+        OptionValueNotFoundErr: Label 'The option value mapping %1 was not found.', Comment = '%1 = Option value mapping key';
 
     local procedure ReadDemoDataFile(DemoDataFile: Record "Demo Data File")
     var
@@ -52,36 +51,36 @@ codeunit 101017 "Demo Data Importer"
         InStrm.Read(JsonTxt);
     end;
 
-    local procedure InsertEntry(RowObj: DotNet JObject; TableId: Integer)
+    local procedure InsertEntry(RowObj: JsonObject; TableId: Integer)
     var
         "Field": Record "Field";
-        IEnumerable: DotNet GenericIEnumerable1;
-        IEnumerator: DotNet GenericIEnumerator1;
-        JProp: DotNet JProperty;
         FRef: FieldRef;
         RecRef: RecordRef;
         TempVar: Variant;
-        ValToken: DotNet JToken;
+        ValueToken: JsonToken;
+        LocalizedValueToken: JsonToken;
+        LocalizedValues: JsonObject;
+        FieldName: Text;
         TempInt: Integer;
         TempBool: Boolean;
     begin
         RecRef.Open(TableId);
 
-        IEnumerable := RowObj.Properties();
-        IEnumerator := IEnumerable.GetEnumerator();
-
-        while IEnumerator.MoveNext() do begin
-            JProp := IEnumerator.Current;
-            if not IsNull(JProp.SelectToken('$..@')) then begin
-                ValToken := JProp.SelectToken('$..' + LanguageCode);
-                TempVar := ValToken.ToString();
+        foreach FieldName in RowObj.Keys() do begin
+            RowObj.Get(FieldName, ValueToken);
+            if ValueToken.IsObject() then begin
+                LocalizedValues := ValueToken.AsObject();
+                if LocalizedValues.Get(LanguageCode, LocalizedValueToken) then
+                    TempVar := GetJsonValueAsText(LocalizedValueToken)
+                else
+                    Clear(TempVar);
             end else
-                TempVar := JProp.Value();
+                TempVar := GetJsonValueAsText(ValueToken);
 
-            if RefrencesTable.Contains(Format(TableId) + '/' + Format(JProp.Name)) then
-                TempVar := GetRefrencedValue(Format(TableId) + '/' + Format(JProp.Name), Format(TempVar));
+            if RefrencesTable.ContainsKey(Format(TableId) + '/' + FieldName) then
+                TempVar := GetRefrencedValue(Format(TableId) + '/' + FieldName, Format(TempVar));
 
-            FRef := RecRef.Field(GetFieldNo(TableId, JProp.Name, Field));
+            FRef := RecRef.Field(GetFieldNo(TableId, FieldName, Field));
             case Field.Type of
                 Field.Type::Option:
                     FRef.Validate(GetVal(Format(TableId) + '.' + Format(Field.FieldName) + '.' + Format(TempVar)));
@@ -118,94 +117,75 @@ codeunit 101017 "Demo Data Importer"
         exit(Field."No.");
     end;
 
-    local procedure ImportTable(TblJObj: DotNet JObject)
+    local procedure ImportTable(TableJson: JsonObject)
     var
-        RowsArray: DotNet JArray;
-        MetadataJTok: DotNet JToken;
-        JTok: DotNet JToken;
-        RowObj: DotNet JObject;
-        TempVar: Variant;
+        RowsArray: JsonArray;
+        MetadataToken: JsonToken;
+        JsonToken: JsonToken;
+        RowToken: JsonToken;
         TblID: Integer;
     begin
-        JSONManagement.GetPropertyValueFromJObjectByName(TblJObj, 'table', TempVar);
-        Evaluate(TblID, Format(TempVar));
+        TblID := TableJson.GetInteger('table');
 
-        if TblJObj.TryGetValue('FieldMetaData', MetadataJTok) then begin
-            JSONManagement.GetObjectPropertyValueFromJObjectByName(MetadataJTok, 'Options', JTok);
-            if not IsNull(JTok) then
-                InitOptionsTable(OptionsTable, JTok, TblID);
+        if TableJson.Get('FieldMetaData', MetadataToken) and MetadataToken.IsObject() then begin
+            if MetadataToken.AsObject().Get('Options', JsonToken) and JsonToken.IsObject() then
+                InitOptionsTable(JsonToken.AsObject(), TblID);
 
-            JSONManagement.GetObjectPropertyValueFromJObjectByName(MetadataJTok, 'Refrences', JTok);
-            if not IsNull(JTok) then
-                InitRefrencesTable(JTok, TblID);
+            if MetadataToken.AsObject().Get('Refrences', JsonToken) and JsonToken.IsObject() then
+                InitRefrencesTable(JsonToken.AsObject(), TblID);
         end;
 
-        JSONManagement.GetArrayPropertyValueFromJObjectByName(TblJObj, 'rows', RowsArray);
-        foreach RowObj in RowsArray do
-            InsertEntry(RowObj, TblID);
+        RowsArray := TableJson.GetArray('rows');
+        foreach RowToken in RowsArray do
+            InsertEntry(RowToken.AsObject(), TblID);
     end;
 
-    local procedure InitOptionsTable(OptionsTable: DotNet Hashtable; OptionsJObj: DotNet JObject; TableId: Integer)
+    local procedure InitOptionsTable(OptionsJson: JsonObject; TableId: Integer)
     var
-        IEnumerable: DotNet GenericIEnumerable1;
-        IEnumerator: DotNet GenericIEnumerator1;
-        OptJObj: DotNet JProperty;
+        OptionName: Text;
     begin
-        IEnumerable := OptionsJObj.Properties();
-        IEnumerator := IEnumerable.GetEnumerator();
-
-        while IEnumerator.MoveNext() do begin
-            OptJObj := IEnumerator.Current;
-            PopulateOptionsTbl(OptionsTable, OptJObj, TableId);
-        end;
+        foreach OptionName in OptionsJson.Keys() do
+            PopulateOptionsTbl(OptionsJson, OptionName, TableId);
     end;
 
-    local procedure PopulateOptionsTbl(OptionsTable: DotNet Hashtable; OptionsJProperty: DotNet JProperty; TableID: Integer)
+    local procedure PopulateOptionsTbl(OptionsJson: JsonObject; OptionName: Text; TableID: Integer)
     var
-        JTok: DotNet JToken;
-        LocJTok: DotNet JToken;
-        TempVar: Variant;
+        LanguagesToken: JsonToken;
+        LanguageToken: JsonToken;
+        LanguagesJson: JsonObject;
     begin
-        TempVar := OptionsJProperty.Name;
-        JTok := OptionsJProperty.SelectToken('$..ENU');
-        if not IsNull(JTok) then
-            AddOptionsToDic(OptionsTable, JTok.ToString(), TableID, Format(TempVar));
+        if not OptionsJson.Get(OptionName, LanguagesToken) or not LanguagesToken.IsObject() then
+            exit;
+        LanguagesJson := LanguagesToken.AsObject();
+        if LanguagesJson.Get('ENU', LanguageToken) then
+            AddOptionsToDic(GetJsonValueAsText(LanguageToken), TableID, OptionName);
 
-        LocJTok := OptionsJProperty.SelectToken('$..' + LanguageCode);
-        if not IsNull(LocJTok) then
-            AddOptionsToDic(OptionsTable, LocJTok.ToString(), TableID, Format(TempVar));
+        if LanguagesJson.Get(LanguageCode, LanguageToken) then
+            AddOptionsToDic(GetJsonValueAsText(LanguageToken), TableID, OptionName);
     end;
 
-    local procedure InitRefrencesTable(RefJObj: DotNet JObject; TableId: Integer)
+    local procedure InitRefrencesTable(ReferencesJson: JsonObject; TableId: Integer)
     var
-        IEnumerable: DotNet GenericIEnumerable1;
-        IEnumerator: DotNet GenericIEnumerator1;
-        JProp: DotNet JProperty;
+        ReferenceToken: JsonToken;
+        FieldName: Text;
         KeyStr: Text;
     begin
-        IEnumerable := RefJObj.Properties();
-        IEnumerator := IEnumerable.GetEnumerator();
-
-        while IEnumerator.MoveNext() do begin
-            JProp := IEnumerator.Current;
-            KeyStr := Format(TableId) + '/' + Format(JProp.Name);
+        foreach FieldName in ReferencesJson.Keys() do begin
+            ReferencesJson.Get(FieldName, ReferenceToken);
+            KeyStr := Format(TableId) + '/' + FieldName;
             if not RefrencesTable.ContainsKey(KeyStr) then
-                RefrencesTable.Add(KeyStr, Format(JProp.Value));
+                RefrencesTable.Add(KeyStr, GetJsonValueAsText(ReferenceToken));
         end;
     end;
 
-    local procedure AddOptionsToDic(OptionsTable: DotNet Hashtable; OptionString: DotNet String; TableID: Integer; OptionName: Text)
+    local procedure AddOptionsToDic(OptionString: Text; TableID: Integer; OptionName: Text)
     var
-        CommaChar: DotNet String;
-        Arr: DotNet Array;
         KeyStr: Text;
         I: Integer;
         OptText: Text;
     begin
-        CommaChar := ',';
-        Arr := OptionString.Split(CommaChar.ToCharArray());
         I := 0;
-        foreach OptText in Arr do begin
+        foreach OptText in OptionString.Split(',') do begin
             KeyStr := Format(TableID) + '.' + Format(OptionName) + '.' + OptText;
             if not OptionsTable.ContainsKey(KeyStr) then
                 OptionsTable.Add(KeyStr, I);
@@ -215,21 +195,30 @@ codeunit 101017 "Demo Data Importer"
 
     local procedure GetVal(KeyTxt: Text): Integer
     var
-        ValVar: Variant;
         ValInt: Integer;
     begin
-        ValVar := OptionsTable.Item(KeyTxt);
-        Evaluate(ValInt, Format(ValVar));
+        if not OptionsTable.Get(KeyTxt, ValInt) then
+            Error(OptionValueNotFoundErr, KeyTxt);
         exit(ValInt);
     end;
 
     local procedure GetRefrencedValue("Key": Text; RefValue: Text): Text
     var
-        CommaChar: DotNet String;
-        Arr: DotNet Array;
-        RefAdd: DotNet String;
-        TempVar: Variant;
-        JsonPath: Text;
+        TablesToken: JsonToken;
+        TableToken: JsonToken;
+        RowsToken: JsonToken;
+        RowToken: JsonToken;
+        FieldToken: JsonToken;
+        LanguageToken: JsonToken;
+        TableObject: JsonObject;
+        RowObject: JsonObject;
+        FieldObject: JsonObject;
+        ReferenceParts: List of [Text];
+        ReferenceAddress: Text;
+        CacheKey: Text;
+        Result: Text;
+        ReferenceTableId: Integer;
+        ReferenceFieldName: Text;
     begin
         if RefValue = '' then
             exit('');
@@ -237,19 +226,59 @@ codeunit 101017 "Demo Data Importer"
         if LanguageCode = 'ENU' then
             exit(RefValue);
 
-        RefAdd := RefrencesTable.Item(Key);
-        if CachedRefrencesTable.Contains(RefAdd.ToString() + '/' + RefValue) then
-            exit(Format(CachedRefrencesTable.Item(RefAdd.ToString() + '/' + RefValue)));
+        RefrencesTable.Get(Key, ReferenceAddress);
+        CacheKey := ReferenceAddress + '/' + RefValue;
+        if CachedRefrencesTable.Get(CacheKey, Result) then
+            exit(Result);
 
-        CommaChar := '/';
-        Arr := RefAdd.Split(CommaChar.ToCharArray());
-        JsonPath := StrSubstNo('$..tables[?(@.table == %1)].rows[?(@.%2.ENU == ''%3'')].%2.%4',
-            Arr.GetValue(0), Arr.GetValue(1), RefValue, LanguageCode);
-        TempVar := JsonObject.SelectToken(JsonPath);
-        if not IsNull(TempVar) then
-            CachedRefrencesTable.Add(RefAdd.ToString() + '/' + RefValue, Format(TempVar));
+        ReferenceParts := ReferenceAddress.Split('/');
+        Evaluate(ReferenceTableId, ReferenceParts.Get(1));
+        ReferenceFieldName := ReferenceParts.Get(2);
 
-        exit(Format(TempVar));
+        if not JsonObject.Get('tables', TablesToken) then
+            exit('');
+        if not TablesToken.IsArray() then
+            exit('');
+        foreach TableToken in TablesToken.AsArray() do
+            if TableToken.IsObject() then begin
+                TableObject := TableToken.AsObject();
+                if TableObject.GetInteger('table') = ReferenceTableId then
+                    if TableObject.Get('rows', RowsToken) then
+                        if RowsToken.IsArray() then
+                            foreach RowToken in RowsToken.AsArray() do
+                                if RowToken.IsObject() then begin
+                                    RowObject := RowToken.AsObject();
+                                    if RowObject.Get(ReferenceFieldName, FieldToken) then
+                                        if FieldToken.IsObject() then begin
+                                            FieldObject := FieldToken.AsObject();
+                                            if FieldObject.Get('ENU', LanguageToken) then
+                                                if LanguageToken.IsValue() then
+                                                    if not LanguageToken.AsValue().IsNull() then
+                                                        if not LanguageToken.AsValue().IsUndefined() then
+                                                            if LanguageToken.AsValue().AsText() = RefValue then
+                                                                if FieldObject.Get(LanguageCode, LanguageToken) then
+                                                                    if LanguageToken.IsValue() then
+                                                                        if not LanguageToken.AsValue().IsNull() then
+                                                                            if not LanguageToken.AsValue().IsUndefined() then begin
+                                                                                Result := LanguageToken.AsValue().AsText();
+                                                                                CachedRefrencesTable.Add(CacheKey, Result);
+                                                                                exit(Result);
+                                                                            end;
+                                        end;
+                                end;
+            end;
+    end;
+
+    local procedure GetJsonValueAsText(JsonToken: JsonToken): Text
+    var
+        JsonText: Text;
+    begin
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
+        JsonToken.WriteTo(JsonText);
+        exit(JsonText);
     end;
 }
-

--- a/src/Layers/ES/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/ES/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -7496,15 +7496,11 @@ codeunit 134920 "ERM General Journal UT"
 
     local procedure GetGenJnlBatchJson(NewGenJnlBatchName: Code[10]; GenJnlTemplateName: Code[10]) GenJnlBatchJson: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Name', NewGenJnlBatchName);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Journal_Template_Name', GenJnlTemplateName);
-
-        GenJnlBatchJson := JSONManagement.WriteObjectToString();
+        JsonObject.Add('Name', NewGenJnlBatchName);
+        JsonObject.Add('Journal_Template_Name', GenJnlTemplateName);
+        JsonObject.WriteTo(GenJnlBatchJson);
     end;
 
     local procedure CreateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; SeriesCode: Code[20]; StartDate: Date)
@@ -7607,4 +7603,3 @@ codeunit 134920 "ERM General Journal UT"
         IsHandled := true;
     end;
 }
-

--- a/src/Layers/GB/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
+++ b/src/Layers/GB/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
@@ -15,7 +15,6 @@ using System.Reflection;
 using System.Security.AccessControl;
 #endif
 using System.Security.User;
-using System.Text;
 using System.Xml;
 
 

--- a/src/Layers/GB/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
+++ b/src/Layers/GB/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
@@ -57,24 +57,21 @@ codeunit 1485 "Rolecenter Selector Mgt."
     var
         AllObj: Record AllObj;
         ApplicationObjectMetadata: Record "Application Object Metadata";
-        JSONManagement: Codeunit "JSON Management";
         XMLDOMManagement: Codeunit "XML DOM Management";
         ReturnXmlDocument: DotNet XmlDocument;
         ReturnedXMLNodeList: DotNet XmlNodeList;
         ActivityButtonsXmlNode: DotNet XmlNode;
         BucketXmlNode: DotNet XmlNode;
         FeatureXmlNode: DotNet XmlNode;
-        FeatureBucketsJArray: DotNet JArray;
-        FeatureBucketJObject: DotNet JObject;
-        FeatureJArray: DotNet JArray;
-        FeatureJObject: DotNet JObject;
+        FeatureBucketsJArray: JsonArray;
+        FeatureBucketJObject: JsonObject;
+        FeatureJArray: JsonArray;
+        FeatureJObject: JsonObject;
         Instream: InStream;
+        JsonText: Text;
         Tooltip: Text;
         Caption: Text;
     begin
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(FeatureBucketsJArray);
-
         AllObj.Get(AllObj."Object Type"::Page, RolecenterId);
         ApplicationObjectMetadata.Get(AllObj."App Runtime Package ID", ApplicationObjectMetadata."Object Type"::Page, RolecenterId);
         ApplicationObjectMetadata.CalcFields(Metadata);
@@ -83,33 +80,35 @@ codeunit 1485 "Rolecenter Selector Mgt."
         XMLDOMManagement.LoadXMLDocumentFromInStream(Instream, ReturnXmlDocument);
         ReturnedXMLNodeList := ReturnXmlDocument.GetElementsByTagName(ActionContainerXmlElementLbl);
 
-        if not GetActivityButtonsActionContainerXmlNode(ActivityButtonsXmlNode, ReturnedXMLNodeList) then
-            exit(FeatureBucketsJArray.ToString());
+        if not GetActivityButtonsActionContainerXmlNode(ActivityButtonsXmlNode, ReturnedXMLNodeList) then begin
+            FeatureBucketsJArray.WriteTo(JsonText);
+            exit(JsonText);
+        end;
 
         foreach BucketXmlNode in ActivityButtonsXmlNode.ChildNodes do begin
-            JSONManagement.InitializeEmptyObject();
-            JSONManagement.GetJSONObject(FeatureBucketJObject);
+            Clear(FeatureBucketJObject);
             GetLanguageSpecificCaptionAndTooltip(BucketXmlNode, Caption, Tooltip);
-            JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonNameElementLbl, Caption);
-            JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonTooltipLbl, Tooltip);
+            FeatureBucketJObject.Add(JsonNameElementLbl, Caption);
+            FeatureBucketJObject.Add(JsonTooltipLbl, Tooltip);
 
-            FeatureJArray := FeatureJArray.JArray();
+            Clear(FeatureJArray);
             foreach FeatureXmlNode in BucketXmlNode.ChildNodes do
                 if IsNodePromoted(FeatureXmlNode) then begin
-                    FeatureJObject := FeatureJObject.JObject();
+                    Clear(FeatureJObject);
                     GetLanguageSpecificCaptionAndTooltip(FeatureXmlNode, Caption, Tooltip);
-                    JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonNameElementLbl, Caption);
-                    JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonTooltipLbl, Tooltip);
-                    JSONManagement.AddJObjectToJArray(FeatureJArray, FeatureJObject);
+                    FeatureJObject.Add(JsonNameElementLbl, Caption);
+                    FeatureJObject.Add(JsonTooltipLbl, Tooltip);
+                    FeatureJArray.Add(FeatureJObject);
                 end;
 
-            if FeatureJArray.Count > 0 then begin
-                JSONManagement.AddJArrayToJObject(FeatureBucketJObject, JsonRowElementLbl, FeatureJArray);
-                JSONManagement.AddJObjectToJArray(FeatureBucketsJArray, FeatureBucketJObject);
+            if FeatureJArray.Count() > 0 then begin
+                FeatureBucketJObject.Add(JsonRowElementLbl, FeatureJArray);
+                FeatureBucketsJArray.Add(FeatureBucketJObject);
             end;
         end;
 
-        exit(FeatureBucketsJArray.ToString());
+        FeatureBucketsJArray.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure BuildJsonFromPageActionTable(RolecenterId: Integer): Text
@@ -117,20 +116,19 @@ codeunit 1485 "Rolecenter Selector Mgt."
         PageAction: Record "Page Action";
         BucketPageAction: Record "Page Action";
         FeaturePageAction: Record "Page Action";
-        JSONManagement: Codeunit "JSON Management";
-        FeatureBucketsJArray: DotNet JArray;
-        FeatureBucketJObject: DotNet JObject;
-        FeatureJArray: DotNet JArray;
-        FeatureJObject: DotNet JObject;
+        FeatureBucketsJArray: JsonArray;
+        FeatureBucketJObject: JsonObject;
+        FeatureJArray: JsonArray;
+        FeatureJObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(FeatureBucketsJArray);
-
         PageAction.SetRange("Page ID", RolecenterId);
         PageAction.SetRange("Action Type", PageAction."Action Type"::ActionContainer);
         PageAction.SetRange("Action Subtype", PageAction."Action Subtype"::ActivityButtons);
-        if not PageAction.FindFirst() then
-            exit(FeatureBucketsJArray.ToString());
+        if not PageAction.FindFirst() then begin
+            FeatureBucketsJArray.WriteTo(JsonText);
+            exit(JsonText);
+        end;
 
         BucketPageAction.SetRange("Page ID", RolecenterId);
         BucketPageAction.SetRange("Parent Action ID", PageAction."Action ID");
@@ -138,13 +136,12 @@ codeunit 1485 "Rolecenter Selector Mgt."
         BucketPageAction.SetRange(Indentation, 1);
         if BucketPageAction.FindSet() then
             repeat
-                JSONManagement.InitializeEmptyObject();
-                JSONManagement.GetJSONObject(FeatureBucketJObject);
-                JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonNameElementLbl, BucketPageAction.Caption);
-                JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonTooltipLbl,
+                Clear(FeatureBucketJObject);
+                FeatureBucketJObject.Add(JsonNameElementLbl, BucketPageAction.Caption);
+                FeatureBucketJObject.Add(JsonTooltipLbl,
                   BucketPageAction.ToolTip1 + BucketPageAction.ToolTip2 + BucketPageAction.ToolTip3 + BucketPageAction.ToolTip4);
 
-                FeatureJArray := FeatureJArray.JArray();
+                Clear(FeatureJArray);
                 FeaturePageAction.SetRange("Page ID", RolecenterId);
                 FeaturePageAction.SetRange("Parent Action ID", BucketPageAction."Action ID");
                 FeaturePageAction.SetRange("Action Type", FeaturePageAction."Action Type"::Action);
@@ -153,54 +150,50 @@ codeunit 1485 "Rolecenter Selector Mgt."
 
                 if FeaturePageAction.FindSet() then
                     repeat
-                        FeatureJObject := FeatureJObject.JObject();
-                        JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonNameElementLbl, FeaturePageAction.Caption);
-                        JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonTooltipLbl,
+                        Clear(FeatureJObject);
+                        FeatureJObject.Add(JsonNameElementLbl, FeaturePageAction.Caption);
+                        FeatureJObject.Add(JsonTooltipLbl,
                           FeaturePageAction.ToolTip1 + FeaturePageAction.ToolTip2 + FeaturePageAction.ToolTip3 + FeaturePageAction.ToolTip4);
-                        JSONManagement.AddJObjectToJArray(FeatureJArray, FeatureJObject);
+                        FeatureJArray.Add(FeatureJObject);
                     until FeaturePageAction.Next() = 0;
 
-                if FeatureJArray.Count > 0 then begin
-                    JSONManagement.AddJArrayToJObject(FeatureBucketJObject, JsonRowElementLbl, FeatureJArray);
-                    JSONManagement.AddJObjectToJArray(FeatureBucketsJArray, FeatureBucketJObject);
+                if FeatureJArray.Count() > 0 then begin
+                    FeatureBucketJObject.Add(JsonRowElementLbl, FeatureJArray);
+                    FeatureBucketsJArray.Add(FeatureBucketJObject);
                 end;
             until BucketPageAction.Next() = 0;
 
-        exit(FeatureBucketsJArray.ToString());
+        FeatureBucketsJArray.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure BuildPageDataJsonForRolecenterSelector(): Text
     var
         AllProfile: Record "All Profile";
-        JSONManagement: Codeunit "JSON Management";
-        PageDataJObject: DotNet JObject;
-        ProfileJArray: DotNet JArray;
-        ProfileJObject: DotNet JObject;
+        PageDataJObject: JsonObject;
+        ProfileJArray: JsonArray;
+        ProfileJObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(PageDataJObject);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonHeaderLbl, DropdownLbl);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonDefaultActionLbl, ActionCaptionTxt);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonDisclaimerTextLbl, DisclaimerTxt);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonActionDescriptionLbl, ActionDescriptionTxt);
-
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(ProfileJArray);
+        PageDataJObject.Add(JsonHeaderLbl, DropdownLbl);
+        PageDataJObject.Add(JsonDefaultActionLbl, ActionCaptionTxt);
+        PageDataJObject.Add(JsonDisclaimerTextLbl, DisclaimerTxt);
+        PageDataJObject.Add(JsonActionDescriptionLbl, ActionDescriptionTxt);
 
         AllProfile.SetRange(Enabled, true);
         if AllProfile.FindSet() then
             repeat
-                JSONManagement.InitializeEmptyObject();
-                JSONManagement.GetJSONObject(ProfileJObject);
-                JSONManagement.AddJPropertyToJObject(ProfileJObject, JsonProfileNameLbl, Format(AllProfile.RecordId));
-                JSONManagement.AddJPropertyToJObject(ProfileJObject, JsonProfileDescriptionLbl, AllProfile.Description);
-                JSONManagement.AddJPropertyToJObject(ProfileJObject, JsonRolecenterIdLbl, AllProfile."Role Center ID");
-                JSONManagement.AddJObjectToJArray(ProfileJArray, ProfileJObject);
+                Clear(ProfileJObject);
+                ProfileJObject.Add(JsonProfileNameLbl, Format(AllProfile.RecordId));
+                ProfileJObject.Add(JsonProfileDescriptionLbl, AllProfile.Description);
+                ProfileJObject.Add(JsonRolecenterIdLbl, AllProfile."Role Center ID");
+                ProfileJArray.Add(ProfileJObject);
             until AllProfile.Next() = 0;
 
-        JSONManagement.AddJArrayToJObject(PageDataJObject, JsonDropdownContentLbl, ProfileJArray);
+        PageDataJObject.Add(JsonDropdownContentLbl, ProfileJArray);
 
-        exit(PageDataJObject.ToString());
+        PageDataJObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     [Scope('OnPrem')]
@@ -333,4 +326,3 @@ codeunit 1485 "Rolecenter Selector Mgt."
     end;
 #endif
 }
-

--- a/src/Layers/IT/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/IT/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -7462,15 +7462,11 @@ codeunit 134920 "ERM General Journal UT"
 
     local procedure GetGenJnlBatchJson(NewGenJnlBatchName: Code[10]; GenJnlTemplateName: Code[10]) GenJnlBatchJson: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Name', NewGenJnlBatchName);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Journal_Template_Name', GenJnlTemplateName);
-
-        GenJnlBatchJson := JSONManagement.WriteObjectToString();
+        JsonObject.Add('Name', NewGenJnlBatchName);
+        JsonObject.Add('Journal_Template_Name', GenJnlTemplateName);
+        JsonObject.WriteTo(GenJnlBatchJson);
     end;
 
     local procedure CreateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; SeriesCode: Code[20]; StartDate: Date)
@@ -7573,4 +7569,3 @@ codeunit 134920 "ERM General Journal UT"
         IsHandled := true;
     end;
 }
-

--- a/src/Layers/W1/BaseApp/HybridDeployment.Codeunit.al
+++ b/src/Layers/W1/BaseApp/HybridDeployment.Codeunit.al
@@ -222,7 +222,13 @@ codeunit 6060 "Hybrid Deployment"
 
         for i := 0 to ErrorsArray.Count() - 1 do begin
             ErrorsArray.Get(i, ErrorToken);
-            ErrorToken.WriteTo(TempError);
+            if ErrorToken.IsValue() then begin
+                if ErrorToken.AsValue().IsNull() or ErrorToken.AsValue().IsUndefined() then
+                    TempError := ''
+                else
+                    TempError := ErrorToken.AsValue().AsText();
+            end else
+                ErrorToken.WriteTo(TempError);
 
             // Check if the error contains an error code and fetch the message
             TempMessage := GetErrorMessage(TempError);

--- a/src/Layers/W1/BaseApp/HybridDeployment.Codeunit.al
+++ b/src/Layers/W1/BaseApp/HybridDeployment.Codeunit.al
@@ -55,6 +55,7 @@ codeunit 6060 "Hybrid Deployment"
         SqlTimeoutErr: Label 'The server timed out while attempting to connect to the specified SQL server.';
         TooManyReplicationRunsErr: Label 'Cannot start replication because a replication is currently in progress. Please try again at a later time.';
         NoAdfCapacityErr: Label 'The cloud migration service is temporarily unable to process your request. Please try again at a later time.';
+        InvalidErrorsJsonErr: Label 'The Errors property in the replication response must contain a JSON object.';
         RaisingOnCanStartUpgradeForCompanyTxt: Label 'Raising OnCanStartUpgrade for company %1.', Locked = true;
         VerifyingIfUpgradeCanBeStartedMsg: Label 'Verifying if upgrade can be started. Target version %1.%2, current version %3.%4', Locked = true;
         CloudMigrationTok: Label 'CloudMigration', Locked = true;
@@ -69,7 +70,7 @@ codeunit 6060 "Hybrid Deployment"
     [Scope('OnPrem')]
     procedure CreateIntegrationRuntime(var RuntimeName: Text; var PrimaryKey: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         InstanceId: Text;
         JsonOutput: Text;
     begin
@@ -78,9 +79,9 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedCreatingIRErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('Name', RuntimeName);
-        JSONManagement.GetStringPropertyValueByName('PrimaryKey', PrimaryKey);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        RuntimeName := GetJsonTokenText(ResponseJson, 'Name');
+        PrimaryKey := GetJsonTokenText(ResponseJson, 'PrimaryKey');
     end;
 
     [Scope('OnPrem')]
@@ -166,7 +167,7 @@ codeunit 6060 "Hybrid Deployment"
     [Scope('OnPrem')]
     procedure GetIntegrationRuntimeKeys(var PrimaryKey: Text; var SecondaryKey: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         InstanceId: Text;
         JsonOutput: Text;
     begin
@@ -175,17 +176,22 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedGettingIRKeyErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('PrimaryKey', PrimaryKey);
-        JSONManagement.GetStringPropertyValueByName('SecondaryKey', SecondaryKey);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        PrimaryKey := GetJsonTokenText(ResponseJson, 'PrimaryKey');
+        SecondaryKey := GetJsonTokenText(ResponseJson, 'SecondaryKey');
     end;
 
     [Scope('OnPrem')]
     procedure GetReplicationRunStatus(RunId: Text; var Status: Text; var Errors: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
+        ErrorsJson: JsonObject;
+        ErrorsArray: JsonArray;
+        ErrorsToken: JsonToken;
+        ErrorToken: JsonToken;
         InstanceId: Text;
         JsonOutput: Text;
+        ErrorsText: Text;
         TempError: Text;
         TempMessage: Text;
         i: Integer;
@@ -195,16 +201,29 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedGettingStatusErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('Status', Status);
-        JSONManagement.GetStringPropertyValueByName('Errors', Errors);
-        JSONManagement.InitializeObject(Errors);
-        JSONManagement.GetArrayPropertyValueAsStringByName('$values', Errors);
-        JSONManagement.InitializeCollection(Errors);
-
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        Status := GetJsonTokenText(ResponseJson, 'Status');
         Errors := '';
-        for i := 0 to JSONManagement.GetCollectionCount() - 1 do begin
-            JSONManagement.GetObjectFromCollectionByIndex(TempError, i);
+        if not ResponseJson.Get('Errors', ErrorsToken) then
+            exit;
+        if ErrorsToken.IsValue() then begin
+            if ErrorsToken.AsValue().IsNull() or ErrorsToken.AsValue().IsUndefined() then
+                exit;
+            ErrorsText := ErrorsToken.AsValue().AsText();
+            if ErrorsText = '' then
+                exit;
+            if not ErrorsToken.ReadFrom(ErrorsText) then
+                Error(InvalidErrorsJsonErr);
+        end;
+        if not ErrorsToken.IsObject() then
+            Error(InvalidErrorsJsonErr);
+        ErrorsJson := ErrorsToken.AsObject();
+        if ErrorsJson.Get('$values', ErrorsToken) and ErrorsToken.IsArray() then
+            ErrorsArray := ErrorsToken.AsArray();
+
+        for i := 0 to ErrorsArray.Count() - 1 do begin
+            ErrorsArray.Get(i, ErrorToken);
+            ErrorToken.WriteTo(TempError);
 
             // Check if the error contains an error code and fetch the message
             TempMessage := GetErrorMessage(TempError);
@@ -225,7 +244,7 @@ codeunit 6060 "Hybrid Deployment"
     [Scope('OnPrem')]
     procedure GetVersionInformation(var DeployedVersion: Text; var LatestVersion: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         InstanceId: Text;
         JsonOutput: Text;
     begin
@@ -234,15 +253,15 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedGettingVersionInformationErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('DeployedVersion', DeployedVersion);
-        JSONManagement.GetStringPropertyValueByName('LatestVersion', LatestVersion);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        DeployedVersion := GetJsonTokenText(ResponseJson, 'DeployedVersion');
+        LatestVersion := GetJsonTokenText(ResponseJson, 'LatestVersion');
     end;
 
     [Scope('OnPrem')]
     procedure InitiateDataLakeMigration(var RunId: Text; StorageAccountName: Text; StorageAccountKey: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         InstanceId: Text;
         JsonOutput: Text;
     begin
@@ -251,8 +270,8 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedDataLakeErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('RunId', RunId);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        RunId := GetJsonTokenText(ResponseJson, 'RunId');
     end;
 
     [Scope('OnPrem')]
@@ -265,7 +284,7 @@ codeunit 6060 "Hybrid Deployment"
     [Scope('OnPrem')]
     procedure RegenerateIntegrationRuntimeKeys(var PrimaryKey: Text; var SecondaryKey: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         InstanceId: Text;
         JsonOutput: Text;
     begin
@@ -274,9 +293,9 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedRegeneratingIRKeyErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('PrimaryKey', PrimaryKey);
-        JSONManagement.GetStringPropertyValueByName('SecondaryKey', SecondaryKey);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        PrimaryKey := GetJsonTokenText(ResponseJson, 'PrimaryKey');
+        SecondaryKey := GetJsonTokenText(ResponseJson, 'SecondaryKey');
     end;
 
     [Scope('OnPrem')]
@@ -291,7 +310,7 @@ codeunit 6060 "Hybrid Deployment"
     [Scope('OnPrem')]
     procedure RunReplication(var RunId: Text; ReplicationType: Integer)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
         InstanceId: Text;
         JsonOutput: Text;
     begin
@@ -302,8 +321,8 @@ codeunit 6060 "Hybrid Deployment"
 
         RetryGetStatus(InstanceId, FailedRunReplicationErr, JsonOutput);
 
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('RunId', RunId);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        RunId := GetJsonTokenText(ResponseJson, 'RunId');
     end;
 
     [Scope('OnPrem')]
@@ -612,11 +631,34 @@ codeunit 6060 "Hybrid Deployment"
     [TryFunction]
     local procedure TryGetError(JsonOutput: Text; var ErrorCode: Text; var Message: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
+        ResponseJson: JsonObject;
     begin
-        JSONManagement.InitializeObject(JsonOutput);
-        JSONManagement.GetStringPropertyValueByName('ErrorCode', ErrorCode);
-        JSONManagement.GetStringPropertyValueByName('Message', Message);
+        ReadJsonObjectIfNotEmpty(JsonOutput, ResponseJson);
+        ErrorCode := GetJsonTokenText(ResponseJson, 'ErrorCode');
+        Message := GetJsonTokenText(ResponseJson, 'Message');
+    end;
+
+    local procedure ReadJsonObjectIfNotEmpty(JsonText: Text; var JsonObject: JsonObject)
+    begin
+        Clear(JsonObject);
+        if JsonText <> '' then
+            JsonObject.ReadFrom(JsonText);
+    end;
+
+    local procedure GetJsonTokenText(JsonObject: JsonObject; PropertyName: Text): Text
+    var
+        JsonToken: JsonToken;
+        JsonText: Text;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit('');
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
+        JsonToken.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     local procedure GetErrorMessage(JsonOutput: Text) Message: Text
@@ -742,4 +784,3 @@ codeunit 6060 "Hybrid Deployment"
     begin
     end;
 }
-

--- a/src/Layers/W1/BaseApp/HybridDeployment.Codeunit.al
+++ b/src/Layers/W1/BaseApp/HybridDeployment.Codeunit.al
@@ -8,7 +8,6 @@ using Microsoft.Foundation.Company;
 using Microsoft.Upgrade;
 using System.Integration;
 using System.Security.AccessControl;
-using System.Text;
 using System.Upgrade;
 
 codeunit 6060 "Hybrid Deployment"

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtContact.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtContact.Codeunit.al
@@ -19,7 +19,10 @@ codeunit 5458 "Graph Collection Mgt - Contact"
     end;
 
     var
-        JSONManagement: Codeunit "JSON Management";
+        JsonArrayState: JsonArray;
+        JsonObjectState: JsonObject;
+        SelectedCollectionIndex: Integer;
+        HasSelectedCollectionIndex: Boolean;
         WebsiteType: Option Other,Home,Work,Blog,"Profile";
         PhoneType: Option Home,Business,Mobile,Other,Assistant,HomeFax,BusinessFax,OtherFax,Pager,Radio;
         AddressType: Option Unknown,Home,Business,Other;
@@ -38,316 +41,300 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetEmailAddress(Index: Integer; var Name: Text; var Address: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         Clear(Name);
         Clear(Address);
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Name', Name);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Address', Address);
+        GetJObjectFromCollectionByIndex(JObject, Index);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Name', Name);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Address', Address);
     end;
 
     procedure AddEmailAddress(Name: Text; Address: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         if Address = '' then
             exit;
 
-        JObject := JObject.JObject();
-        JSONManagement.AddJPropertyToJObject(JObject, 'Name', Name);
-        JSONManagement.AddJPropertyToJObject(JObject, 'Address', Address);
-        JSONManagement.AddJObjectToCollection(JObject);
+        JObject.Add('Name', Name);
+        JObject.Add('Address', Address);
+        AddJObjectToCollection(JObject);
     end;
 
     procedure UpdateEmailAddress(EmailAddressesString: Text; Index: Integer; Address: Text): Text
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        JSONManagement.InitializeCollection(EmailAddressesString);
-        if Index > JSONManagement.GetCollectionCount() then // cannot add where index would leave empty slots.
+        InitializeCollection(EmailAddressesString);
+        if Index > GetCollectionCount() then // cannot add where index would leave empty slots.
             exit(EmailAddressesString);
 
-        if JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index) then begin
-            JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'Name', '');
-            JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'Address', Address)
+        if GetJObjectFromCollectionByIndex(JObject, Index) then begin
+            ReplaceOrAddJPropertyInJObject(JObject, 'Name', '');
+            ReplaceOrAddJPropertyInJObject(JObject, 'Address', Address)
         end else
             AddEmailAddress('', Address);
 
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure GetWebsiteByIndex(Index: Integer; var Type: Option; var Address: Text; var DisplayName: Text; var Name: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetEnumPropertyValueFromJObjectByName(JObject, 'Type', Type);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Address', Address);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'DisplayName', DisplayName);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Name', Name);
+        GetJObjectFromCollectionByIndex(JObject, Index);
+        GetEnumPropertyValueFromJObjectByName(JObject, 'Type', Type);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Address', Address);
+        GetStringPropertyValueFromJObjectByName(JObject, 'DisplayName', DisplayName);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Name', Name);
     end;
 
     local procedure GetWebsiteByType(Type: Option; var Address: Text; var DisplayName: Text; var Name: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         WebsiteType := Type;
-        if not JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(WebsiteType, 0, 0)) then
+        if not GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(WebsiteType, 0, 0)) then
             exit;
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Address', Address);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'DisplayName', DisplayName);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Name', Name);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Address', Address);
+        GetStringPropertyValueFromJObjectByName(JObject, 'DisplayName', DisplayName);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Name', Name);
     end;
 
     procedure AddWebsite(Type: Option; Address: Text; DisplayName: Text; Name: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         if Address = '' then
             exit;
-        JObject := JObject.JObject();
         WebsiteType := Type;
-        JSONManagement.AddJPropertyToJObject(JObject, 'Type', Format(WebsiteType, 0, 0));
-        JSONManagement.AddJPropertyToJObject(JObject, 'Address', Address);
-        JSONManagement.AddJPropertyToJObject(JObject, 'DisplayName', DisplayName);
-        JSONManagement.AddJPropertyToJObject(JObject, 'Name', Name);
-        JSONManagement.AddJObjectToCollection(JObject);
+        JObject.Add('Type', Format(WebsiteType, 0, 0));
+        JObject.Add('Address', Address);
+        JObject.Add('DisplayName', DisplayName);
+        JObject.Add('Name', Name);
+        AddJObjectToCollection(JObject);
     end;
 
     procedure UpdateWebsite(Type: Option; Address: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         WebsiteType := Type;
-        if not JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(WebsiteType, 0, 0)) then begin
+        if not GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(WebsiteType, 0, 0)) then begin
             if Address = '' then
                 exit;
-            JObject := JObject.JObject();
-            JSONManagement.AddJObjectToCollection(JObject);
+            AddJObjectToCollection(JObject);
         end else
             JObject.Remove('Type');
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'Address', Address);
+        ReplaceOrAddJPropertyInJObject(JObject, 'Address', Address);
     end;
 
     procedure GetImAddress(Index: Integer; var ImAddress: Text)
     var
-        JObject: DotNet JObject;
+        JsonToken: JsonToken;
     begin
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetStringValueFromJObject(JObject, ImAddress);
+        GetTokenFromCollectionByIndex(JsonToken, Index);
+        GetStringValueFromJsonToken(JsonToken, ImAddress);
     end;
 
     procedure AddImAddress(ImAddress: Text)
-    var
-        JObject: DotNet JObject;
     begin
         if ImAddress = '' then
             exit;
 
-        JObject := JObject.JObject();
-        JSONManagement.AddJValueToJObject(JObject, ImAddress);
-        JSONManagement.AddJObjectToCollection(JObject);
+        AddValueToCollection(ImAddress);
     end;
 
     procedure GetPhoneByIndex(Index: Integer; var Type: Option; var Number: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetEnumPropertyValueFromJObjectByName(JObject, 'Type', Type);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Number', Number);
+        GetJObjectFromCollectionByIndex(JObject, Index);
+        GetEnumPropertyValueFromJObjectByName(JObject, 'Type', Type);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Number', Number);
     end;
 
     procedure GetPhoneByType(Type: Option; var Number: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         PhoneType := Type;
-        if not JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0)) then
+        if not GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0)) then
             exit;
 
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Number', Number);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Number', Number);
     end;
 
     procedure AddPhone(Type: Option; Number: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         PhoneType := Type;
         if Number = '' then
             exit;
 
-        JObject := JObject.JObject();
-        JSONManagement.AddJPropertyToJObject(JObject, 'Type', Format(PhoneType, 0, 0));
-        JSONManagement.AddJPropertyToJObject(JObject, 'Number', Number);
-        JSONManagement.AddJObjectToCollection(JObject);
+        JObject.Add('Type', Format(PhoneType, 0, 0));
+        JObject.Add('Number', Number);
+        AddJObjectToCollection(JObject);
     end;
 
     procedure GetPostalAddressByIndex(Index: Integer; var Type: Option; var PostOfficeBox: Text; var Street: Text; var City: Text; var State: Text; var CountryOrRegion: Text; var PostalCode: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetEnumPropertyValueFromJObjectByName(JObject, 'Type', Type);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'PostOfficeBox', PostOfficeBox);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Street', Street);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'City', City);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'State', State);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'CountryOrRegion', CountryOrRegion);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'PostalCode', PostalCode);
+        GetJObjectFromCollectionByIndex(JObject, Index);
+        GetEnumPropertyValueFromJObjectByName(JObject, 'Type', Type);
+        GetStringPropertyValueFromJObjectByName(JObject, 'PostOfficeBox', PostOfficeBox);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Street', Street);
+        GetStringPropertyValueFromJObjectByName(JObject, 'City', City);
+        GetStringPropertyValueFromJObjectByName(JObject, 'State', State);
+        GetStringPropertyValueFromJObjectByName(JObject, 'CountryOrRegion', CountryOrRegion);
+        GetStringPropertyValueFromJObjectByName(JObject, 'PostalCode', PostalCode);
     end;
 
     local procedure GetPostalAddressByType(Type: Option; var Address: Text[100]; var Address2: Text[50]; var City: Text[30]; var County: Text[30]; var CountryRegionCode: Code[10]; var PostCode: Code[20])
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         value: Text;
     begin
         AddressType := Type;
-        if not JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)) then
+        if not GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)) then
             exit;
 
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'Street', value);
+        GetStringPropertyValueFromJObjectByName(JObject, 'Street', value);
         SplitStreet(value, Address, Address2);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'City', value);
+        GetStringPropertyValueFromJObjectByName(JObject, 'City', value);
         City := CopyStr(value, 1, MaxStrLen(value));
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'State', value);
+        GetStringPropertyValueFromJObjectByName(JObject, 'State', value);
         County := CopyStr(value, 1, MaxStrLen(value));
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'CountryOrRegion', value);
+        GetStringPropertyValueFromJObjectByName(JObject, 'CountryOrRegion', value);
         CountryRegionCode := FindCountryRegionCode(value);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'PostalCode', value);
+        GetStringPropertyValueFromJObjectByName(JObject, 'PostalCode', value);
         PostCode := CopyStr(value, 1, MaxStrLen(PostCode));
     end;
 
     procedure AddPostalAddress(Type: Option; PostOfficeBox: Text; Street: Text; City: Text; State: Text; CountryOrRegion: Text; PostalCode: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        JObject := JObject.JObject();
         AddressType := Type;
-        JSONManagement.AddJPropertyToJObject(JObject, 'Type', Format(AddressType, 0, 0));
-        JSONManagement.AddJPropertyToJObject(JObject, 'PostOfficeBox', PostOfficeBox);
-        JSONManagement.AddJPropertyToJObject(JObject, 'Street', Street);
-        JSONManagement.AddJPropertyToJObject(JObject, 'City', City);
-        JSONManagement.AddJPropertyToJObject(JObject, 'State', State);
-        JSONManagement.AddJPropertyToJObject(JObject, 'CountryOrRegion', CountryOrRegion);
-        JSONManagement.AddJPropertyToJObject(JObject, 'PostalCode', PostalCode);
-        JSONManagement.AddJObjectToCollection(JObject);
+        JObject.Add('Type', Format(AddressType, 0, 0));
+        JObject.Add('PostOfficeBox', PostOfficeBox);
+        JObject.Add('Street', Street);
+        JObject.Add('City', City);
+        JObject.Add('State', State);
+        JObject.Add('CountryOrRegion', CountryOrRegion);
+        JObject.Add('PostalCode', PostalCode);
+        AddJObjectToCollection(JObject);
     end;
 
     procedure GetChildren(Index: Integer; var Child: Text)
     var
-        JObject: DotNet JObject;
+        JsonToken: JsonToken;
     begin
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetStringValueFromJObject(JObject, Child);
+        GetTokenFromCollectionByIndex(JsonToken, Index);
+        GetStringValueFromJsonToken(JsonToken, Child);
     end;
 
     procedure AddChildren(Child: Text)
-    var
-        JObject: DotNet JObject;
     begin
         if Child = '' then
             exit;
 
-        JObject := JObject.JObject();
-        JSONManagement.AddJValueToJObject(JObject, Child);
-        JSONManagement.AddJObjectToCollection(JObject);
+        AddValueToCollection(Child);
     end;
 
     procedure GetFlag(var CompletedDateTime: Text; var CompletedTimeZone: Text; var DueDateTime: Text; var DueTimeZone: Text; var StartDateTime: Text; var StartTimeZone: Text; var FlagStatus: Option)
     var
-        JsonObject: DotNet JObject;
-        JObjectVariant: Variant;
+        CurrentJsonObject: JsonObject;
+        NestedJsonObject: JsonObject;
+        JsonToken: JsonToken;
     begin
-        JSONManagement.GetJSONObject(JsonObject);
-        if JSONManagement.GetPropertyValueFromJObjectByName(JsonObject, 'CompletedDateTime', JObjectVariant) then begin
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JObjectVariant, 'CompletedDateTime', CompletedDateTime);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JObjectVariant, 'CompletedTimeZone', CompletedTimeZone);
+        GetJSONObject(CurrentJsonObject);
+        if CurrentJsonObject.Get('CompletedDateTime', JsonToken) and JsonToken.IsObject() then begin
+            NestedJsonObject := JsonToken.AsObject();
+            GetStringPropertyValueFromJObjectByName(NestedJsonObject, 'CompletedDateTime', CompletedDateTime);
+            GetStringPropertyValueFromJObjectByName(NestedJsonObject, 'CompletedTimeZone', CompletedTimeZone);
         end;
-        if JSONManagement.GetPropertyValueFromJObjectByName(JsonObject, 'DueDateTime', JObjectVariant) then begin
-            ;
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JObjectVariant, 'DateTime', DueDateTime);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JObjectVariant, 'TimeZone', DueTimeZone);
+        if CurrentJsonObject.Get('DueDateTime', JsonToken) and JsonToken.IsObject() then begin
+            NestedJsonObject := JsonToken.AsObject();
+            GetStringPropertyValueFromJObjectByName(NestedJsonObject, 'DateTime', DueDateTime);
+            GetStringPropertyValueFromJObjectByName(NestedJsonObject, 'TimeZone', DueTimeZone);
         end;
-        if JSONManagement.GetPropertyValueFromJObjectByName(JsonObject, 'StartDateTime', JObjectVariant) then begin
-            ;
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JObjectVariant, 'DateTime', StartDateTime);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JObjectVariant, 'TimeZone', StartTimeZone);
+        if CurrentJsonObject.Get('StartDateTime', JsonToken) and JsonToken.IsObject() then begin
+            NestedJsonObject := JsonToken.AsObject();
+            GetStringPropertyValueFromJObjectByName(NestedJsonObject, 'DateTime', StartDateTime);
+            GetStringPropertyValueFromJObjectByName(NestedJsonObject, 'TimeZone', StartTimeZone);
         end;
 
-        JSONManagement.GetEnumPropertyValueFromJObjectByName(JsonObject, 'FlagStatus', FlagStatusOption);
+        GetEnumPropertyValueFromJObjectByName(CurrentJsonObject, 'FlagStatus', FlagStatusOption);
         FlagStatus := FlagStatusOption;
     end;
 
     procedure AddFlag(CompletedDateTime: Text; CompletedTimeZone: Text; DueDateTime: Text; DueTimeZone: Text; StartDateTime: Text; StartTimeZone: Text; FlagStatus: Option)
     var
-        JObject: DotNet JObject;
-        JsonObject: DotNet JObject;
+        JObject: JsonObject;
+        CurrentJsonObject: JsonObject;
     begin
-        JSONManagement.GetJSONObject(JsonObject);
+        GetJSONObject(CurrentJsonObject);
 
-        JObject := JObject.JObject();
-        JSONManagement.AddJPropertyToJObject(JObject, 'DateTime', CompletedDateTime);
-        JSONManagement.AddJPropertyToJObject(JObject, 'TimeZone', CompletedTimeZone);
-        JSONManagement.AddJObjectToJObject(JsonObject, 'CompletedDateTime', JObject);
-        JObject := JObject.JObject();
+        JObject.Add('DateTime', CompletedDateTime);
+        JObject.Add('TimeZone', CompletedTimeZone);
+        CurrentJsonObject.Add('CompletedDateTime', JObject);
+        Clear(JObject);
 
-        JSONManagement.AddJPropertyToJObject(JObject, 'DateTime', DueDateTime);
-        JSONManagement.AddJPropertyToJObject(JObject, 'TimeZone', DueTimeZone);
-        JSONManagement.AddJObjectToJObject(JsonObject, 'DueDateTime', JObject);
-        JObject := JObject.JObject();
-        JSONManagement.AddJPropertyToJObject(JObject, 'DateTime', StartDateTime);
-        JSONManagement.AddJPropertyToJObject(JObject, 'TimeZone', StartTimeZone);
-        JSONManagement.AddJObjectToJObject(JsonObject, 'StartDateTime', JObject);
+        JObject.Add('DateTime', DueDateTime);
+        JObject.Add('TimeZone', DueTimeZone);
+        CurrentJsonObject.Add('DueDateTime', JObject);
+        Clear(JObject);
+        JObject.Add('DateTime', StartDateTime);
+        JObject.Add('TimeZone', StartTimeZone);
+        CurrentJsonObject.Add('StartDateTime', JObject);
         FlagStatusOption := FlagStatus;
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'FlagStatus', Format(FlagStatusOption, 0, 0));
+        CurrentJsonObject.Add('FlagStatus', Format(FlagStatusOption, 0, 0));
     end;
 
     procedure GetCategory(Index: Integer; var Category: Text)
     var
-        JObject: DotNet JObject;
+        JsonToken: JsonToken;
     begin
-        if Index >= JSONManagement.GetCollectionCount() then
+        if Index >= GetCollectionCount() then
             exit;
 
-        JSONManagement.GetJObjectFromCollectionByIndex(JObject, Index);
-        JSONManagement.GetStringValueFromJObject(JObject, Category);
+        GetTokenFromCollectionByIndex(JsonToken, Index);
+        GetStringValueFromJsonToken(JsonToken, Category);
     end;
 
     procedure AddCategory(Category: Text)
-    var
-        JObject: DotNet JObject;
     begin
-        JObject := JObject.JObject();
-        JSONManagement.AddJValueToJObject(JObject, Category);
-        JSONManagement.AddJObjectToCollection(JObject);
+        AddValueToCollection(Category);
     end;
 
     local procedure HasPostalAddress(Type: Option): Boolean
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         AddressType := Type;
-        exit(JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)))
+        exit(GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)))
     end;
 
     procedure HasHomeAddressOrPhone(PostalAddressesString: Text; PhonesString: Text; WebsitesString: Text): Boolean
@@ -355,11 +342,11 @@ codeunit 5458 "Graph Collection Mgt - Contact"
         HasAddress: Boolean;
         HasPhones: Boolean;
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         HasAddress := HasPostalAddress(AddressType::Home);
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         HasPhones := HasPhone(PhoneType::Home) or HasPhone(PhoneType::HomeFax);
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         exit(HasAddress or HasPhones or HasWebsite(WebsiteType::Home));
     end;
 
@@ -368,17 +355,17 @@ codeunit 5458 "Graph Collection Mgt - Contact"
         HasAddress: Boolean;
         HasPhones: Boolean;
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         HasAddress := HasPostalAddress(AddressType::Business);
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         HasPhones := HasPhone(PhoneType::Business) or HasPhone(PhoneType::BusinessFax);
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         exit(HasAddress or HasPhones or HasWebsite(WebsiteType::Work));
     end;
 
     procedure HasBusinessAddress(PostalAddressesString: Text): Boolean
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         exit(HasPostalAddress(AddressType::Business));
     end;
 
@@ -387,237 +374,235 @@ codeunit 5458 "Graph Collection Mgt - Contact"
         HasAddress: Boolean;
         HasPhones: Boolean;
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         HasAddress := HasPostalAddress(AddressType::Other);
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         HasPhones := HasPhone(PhoneType::Other) or HasPhone(PhoneType::OtherFax);
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         exit(HasAddress or HasPhones or HasWebsite(WebsiteType::Other));
     end;
 
     local procedure UpdatePostalAddress(Type: Option; Address: Text[100]; Address2: Text[50]; City: Text[30]; County: Text[30]; CountryRegionCode: Code[10]; PostCode: Code[20])
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         AddressType := Type;
         if (Address = '') and (Address2 = '') and (City = '') and (County = '') and (PostCode = '') then begin
-            if JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)) then
-                JObject.Remove();
+            if GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)) then
+                RemoveSelectedJObjectFromCollection();
             exit;
         end;
 
-        if not JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)) then begin
-            JObject := JObject.JObject();
-            JSONManagement.AddJPropertyToJObject(JObject, 'Type', Format(AddressType, 0, 0));
-            JSONManagement.AddJObjectToCollection(JObject);
-            JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0));
+        if not GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0)) then begin
+            JObject.Add('Type', Format(AddressType, 0, 0));
+            AddJObjectToCollection(JObject);
+            GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(AddressType, 0, 0));
         end;
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'Street', ConcatenateStreet(Address, Address2));
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'City', City);
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'State', County);
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'CountryOrRegion', CountryRegionCode);
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'PostalCode', PostCode);
+        ReplaceOrAddJPropertyInJObject(JObject, 'Street', ConcatenateStreet(Address, Address2));
+        ReplaceOrAddJPropertyInJObject(JObject, 'City', City);
+        ReplaceOrAddJPropertyInJObject(JObject, 'State', County);
+        ReplaceOrAddJPropertyInJObject(JObject, 'CountryOrRegion', CountryRegionCode);
+        ReplaceOrAddJPropertyInJObject(JObject, 'PostalCode', PostCode);
     end;
 
     procedure UpdateHomeAddress(PostalAddressesString: Text; Address: Text[100]; Address2: Text[50]; City: Text[30]; County: Text[30]; CountryRegionCode: Code[10]; PostCode: Code[20]): Text
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         UpdatePostalAddress(AddressType::Home, Address, Address2, City, County, CountryRegionCode, PostCode);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateBusinessAddress(PostalAddressesString: Text; Address: Text[100]; Address2: Text[50]; City: Text[30]; County: Text[30]; CountryRegionCode: Code[10]; PostCode: Code[20]): Text
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         UpdatePostalAddress(AddressType::Business, Address, Address2, City, County, CountryRegionCode, PostCode);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateOtherAddress(PostalAddressesString: Text; Address: Text[100]; Address2: Text[50]; City: Text[30]; County: Text[30]; CountryRegionCode: Code[10]; PostCode: Code[20]): Text
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         UpdatePostalAddress(AddressType::Other, Address, Address2, City, County, CountryRegionCode, PostCode);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure GetHomeAddress(PostalAddressesString: Text; var Address: Text[100]; var Address2: Text[50]; var City: Text[30]; var County: Text[30]; var CountryRegionCode: Code[10]; var PostCode: Code[20])
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         GetPostalAddressByType(AddressType::Home, Address, Address2, City, County, CountryRegionCode, PostCode);
     end;
 
     procedure GetBusinessAddress(PostalAddressesString: Text; var Address: Text[100]; var Address2: Text[50]; var City: Text[30]; var County: Text[30]; var CountryRegionCode: Code[10]; var PostCode: Code[20])
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         GetPostalAddressByType(AddressType::Business, Address, Address2, City, County, CountryRegionCode, PostCode);
     end;
 
     procedure GetOtherAddress(PostalAddressesString: Text; var Address: Text[100]; var Address2: Text[50]; var City: Text[30]; var County: Text[30]; var CountryRegionCode: Code[10]; var PostCode: Code[20])
     begin
-        JSONManagement.InitializeCollection(PostalAddressesString);
+        InitializeCollection(PostalAddressesString);
         GetPostalAddressByType(AddressType::Other, Address, Address2, City, County, CountryRegionCode, PostCode);
     end;
 
     local procedure HasPhone(Type: Option): Boolean
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         PhoneType := Type;
-        exit(JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0)));
+        exit(GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0)));
     end;
 
     local procedure UpdatePhone(Type: Option; Number: Text)
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         PhoneType := Type;
-        if not JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0)) then begin
+        if not GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0)) then begin
             if Number = '' then
                 exit;
-            JObject := JObject.JObject();
-            JSONManagement.AddJPropertyToJObject(JObject, 'Type', Format(PhoneType, 0, 0));
-            JSONManagement.AddJObjectToCollection(JObject);
-            JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0))
+            JObject.Add('Type', Format(PhoneType, 0, 0));
+            AddJObjectToCollection(JObject);
+            GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(PhoneType, 0, 0))
         end;
-        JSONManagement.ReplaceOrAddJPropertyInJObject(JObject, 'Number', Number);
+        ReplaceOrAddJPropertyInJObject(JObject, 'Number', Number);
     end;
 
     procedure UpdateHomePhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Home, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateBusinessPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Business, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateMobilePhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Mobile, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateOtherPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Other, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateAssistantPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Assistant, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateHomeFaxPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::HomeFax, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateBusinessFaxPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::BusinessFax, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateOtherFaxPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::OtherFax, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdatePagerPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Pager, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateRadioPhone(PhonesString: Text; Number: Text): Text
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         UpdatePhone(PhoneType::Radio, Number);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure GetHomePhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Home, Number);
     end;
 
     procedure GetBusinessPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Business, Number);
     end;
 
     procedure GetMobilePhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Mobile, Number);
     end;
 
     procedure GetOtherPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Other, Number);
     end;
 
     procedure GetAssistantPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Assistant, Number);
     end;
 
     procedure GetHomeFaxPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::HomeFax, Number);
     end;
 
     procedure GetBusinessFaxPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::BusinessFax, Number);
     end;
 
     procedure GetOtherFaxPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::OtherFax, Number);
     end;
 
     procedure GetPagerPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Pager, Number);
     end;
 
     procedure GetRadioPhone(PhonesString: Text; var Number: Text)
     begin
-        JSONManagement.InitializeCollection(PhonesString);
+        InitializeCollection(PhonesString);
         GetPhoneByType(PhoneType::Radio, Number);
     end;
 
     local procedure HasWebsite(Type: Option): Boolean
     var
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         WebsiteType := Type;
-        exit(JSONManagement.GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(WebsiteType, 0, 0)));
+        exit(GetJObjectFromCollectionByPropertyValue(JObject, 'Type', Format(WebsiteType, 0, 0)));
     end;
 
     procedure GetWorkWebsite(WebsitesString: Text; var Address: Text[80])
@@ -625,7 +610,7 @@ codeunit 5458 "Graph Collection Mgt - Contact"
         Name: Text;
         DisplayName: Text;
     begin
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         GetWebsiteByType(WebsiteType::Work, Address, Name, DisplayName);
     end;
 
@@ -634,22 +619,22 @@ codeunit 5458 "Graph Collection Mgt - Contact"
         Name: Text;
         DisplayName: Text;
     begin
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         GetWebsiteByType(WebsiteType::Home, Address, Name, DisplayName);
     end;
 
     procedure UpdateWorkWebsite(WebsitesString: Text; Address: Text[80]): Text
     begin
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         UpdateWebsite(WebsiteType::Work, Address);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure UpdateHomeWebsite(WebsitesString: Text; Address: Text[80]): Text
     begin
-        JSONManagement.InitializeCollection(WebsitesString);
+        InitializeCollection(WebsitesString);
         UpdateWebsite(WebsiteType::Home, Address);
-        exit(JSONManagement.WriteCollectionToString());
+        exit(WriteCollectionToString());
     end;
 
     procedure HasBusinessType(BusinessTypeString: Text): Boolean
@@ -660,28 +645,28 @@ codeunit 5458 "Graph Collection Mgt - Contact"
     [TryFunction]
     procedure TryGetBusinessTypeValue(BusinessTypeString: Text; var Value: Text)
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(BusinessTypeString);
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId);
+        InitializeObject(BusinessTypeString);
+        GetJSONObject(JsonObject);
+        GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId);
         if not (PropertyId = BusinessTypePropertyIdTxt) then
             Error(PropertyIdErr, BusinessTypePropertyIdTxt, PropertyId);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'Value', Value);
+        GetStringPropertyValueFromJObjectByName(JsonObject, 'Value', Value);
         Evaluate(BusinessType, Value, 0);
     end;
 
     procedure GetBusinessType(BusinessTypeString: Text; var Type: Option)
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(BusinessTypeString);
-        JSONManagement.GetJSONObject(JsonObject);
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        InitializeObject(BusinessTypeString);
+        GetJSONObject(JsonObject);
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = BusinessTypePropertyIdTxt then begin
-                JSONManagement.GetEnumPropertyValueFromJObjectByName(JsonObject, 'Value', BusinessType);
+                GetEnumPropertyValueFromJObjectByName(JsonObject, 'Value', BusinessType);
                 Type := BusinessType;
                 exit;
             end;
@@ -691,39 +676,39 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure AddBusinessType(Type: Option): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
         BusinessType := Type;
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', BusinessTypePropertyIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', Format(BusinessType, 0, 0));
-        exit(JSONManagement.WriteObjectToString());
+        JsonObject.Add('PropertyId', BusinessTypePropertyIdTxt);
+        JsonObject.Add('Value', Format(BusinessType, 0, 0));
+        exit(WriteObjectToString());
     end;
 
     local procedure HasExtendedProperty(ExtendedPropertyString: Text; ExpectedPropertyId: Text): Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(ExtendedPropertyString);
-        JSONManagement.GetJSONObject(JsonObject);
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        InitializeObject(ExtendedPropertyString);
+        GetJSONObject(JsonObject);
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             exit(ExpectedPropertyId = PropertyId);
     end;
 
     local procedure GetExtendedPropertyBoolValue(ExtendedPropertyString: Text; ExpectedPropertyId: Text; var Value: Text)
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
         BooleanValue: Boolean;
     begin
-        JSONManagement.InitializeObject(ExtendedPropertyString);
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId);
+        InitializeObject(ExtendedPropertyString);
+        GetJSONObject(JsonObject);
+        GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId);
         if not (PropertyId = ExpectedPropertyId) then
             Error(PropertyIdErr, ExpectedPropertyId, PropertyId);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'Value', Value);
+        GetStringPropertyValueFromJObjectByName(JsonObject, 'Value', Value);
         Evaluate(BooleanValue, Value, 2);
     end;
 
@@ -734,15 +719,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetIsCustomer(IsCustomerString: Text) IsCustomer: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsCustomerString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsCustomerString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsCustomerPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsCustomer);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsCustomer);
                 exit(IsCustomer);
             end;
 
@@ -757,15 +742,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure AddIsCustomer(IsCustomer: Boolean): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
 
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', IsCustomerPropertyIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', Format(IsCustomer, 0, 2));
+        JsonObject.Add('PropertyId', IsCustomerPropertyIdTxt);
+        JsonObject.Add('Value', Format(IsCustomer, 0, 2));
 
-        exit(JSONManagement.WriteObjectToString());
+        exit(WriteObjectToString());
     end;
 
     procedure HasIsVendor(IsVendorString: Text): Boolean
@@ -775,15 +760,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetIsVendor(IsVendorString: Text) IsVendor: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsVendorString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsVendorString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsVendorPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsVendor);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsVendor);
                 exit(IsVendor);
             end;
         exit(false);
@@ -797,15 +782,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure AddIsVendor(IsVendor: Boolean): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
 
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', IsVendorPropertyIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', Format(IsVendor, 0, 2));
+        JsonObject.Add('PropertyId', IsVendorPropertyIdTxt);
+        JsonObject.Add('Value', Format(IsVendor, 0, 2));
 
-        exit(JSONManagement.WriteObjectToString());
+        exit(WriteObjectToString());
     end;
 
     procedure HasIsBank(IsBankString: Text): Boolean
@@ -815,15 +800,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetIsBank(IsBankString: Text) IsBank: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsBankString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsBankString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsBankPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsBank);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsBank);
                 exit(IsBank);
             end;
         exit(false);
@@ -837,28 +822,28 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure AddIsBank(IsBank: Boolean): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
 
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', IsBankPropertyIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', Format(IsBank, 0, 2));
+        JsonObject.Add('PropertyId', IsBankPropertyIdTxt);
+        JsonObject.Add('Value', Format(IsBank, 0, 2));
 
-        exit(JSONManagement.WriteObjectToString());
+        exit(WriteObjectToString());
     end;
 
     procedure GetIsNavCreated(IsNavCreatedString: Text) IsNavCreated: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsNavCreatedString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsNavCreatedString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsNavCreatedPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsNavCreated);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsNavCreated);
                 exit(IsNavCreated);
             end;
         exit(false);
@@ -866,41 +851,41 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure AddIsNavCreated(IsNavCreated: Boolean): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
 
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', IsNavCreatedPropertyIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', Format(IsNavCreated, 0, 2));
+        JsonObject.Add('PropertyId', IsNavCreatedPropertyIdTxt);
+        JsonObject.Add('Value', Format(IsNavCreated, 0, 2));
 
-        exit(JSONManagement.WriteObjectToString());
+        exit(WriteObjectToString());
     end;
 
     procedure GetNavIntegrationId(NavIntegrationIdString: Text) NavIntegrationId: Guid
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(NavIntegrationIdString);
-        JSONManagement.GetJSONObject(JsonObject);
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        InitializeObject(NavIntegrationIdString);
+        GetJSONObject(JsonObject);
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = NavIntegrationIdTxt then
-                JSONManagement.GetGuidPropertyValueFromJObjectByName(JsonObject, 'Value', NavIntegrationId);
+                GetGuidPropertyValueFromJObjectByName(JsonObject, 'Value', NavIntegrationId);
 
         exit(NavIntegrationId);
     end;
 
     procedure AddNavIntegrationId(IntegrationId: Guid): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', NavIntegrationIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', IntegrationId);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
+        JsonObject.Add('PropertyId', NavIntegrationIdTxt);
+        JsonObject.Add('Value', Format(IntegrationId, 0, 9));
 
-        exit(JSONManagement.WriteObjectToString());
+        exit(WriteObjectToString());
     end;
 
     procedure HasIsContact(IsContactString: Text): Boolean
@@ -910,15 +895,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetIsContact(IsContactString: Text) IsContact: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsContactString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsContactString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsContactPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsContact);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsContact);
                 exit(IsContact);
             end;
 
@@ -933,15 +918,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure AddIsContact(IsContact: Boolean): Text
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeEmptyObject();
+        GetJSONObject(JsonObject);
 
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'PropertyId', IsContactPropertyIdTxt);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Value', Format(IsContact, 0, 2));
+        JsonObject.Add('PropertyId', IsContactPropertyIdTxt);
+        JsonObject.Add('Value', Format(IsContact, 0, 2));
 
-        exit(JSONManagement.WriteObjectToString());
+        exit(WriteObjectToString());
     end;
 
     procedure HasIsLead(IsLeadString: Text): Boolean
@@ -951,15 +936,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetIsLead(IsLeadString: Text) IsLead: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsLeadString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsLeadString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsLeadPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsLead);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsLead);
                 exit(IsLead);
             end;
 
@@ -979,15 +964,15 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure GetIsPartner(IsPartnerString: Text) IsPartner: Boolean
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         PropertyId: Text;
     begin
-        JSONManagement.InitializeObject(IsPartnerString);
-        JSONManagement.GetJSONObject(JsonObject);
+        InitializeObject(IsPartnerString);
+        GetJSONObject(JsonObject);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
+        if GetStringPropertyValueFromJObjectByName(JsonObject, 'PropertyId', PropertyId) then
             if PropertyId = IsPartnerPropertyIdTxt then begin
-                JSONManagement.GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsPartner);
+                GetBoolPropertyValueFromJObjectByName(JsonObject, 'Value', IsPartner);
                 exit(IsPartner);
             end;
 
@@ -1122,32 +1107,198 @@ codeunit 5458 "Graph Collection Mgt - Contact"
 
     procedure InitializeCollection(JSONString: Text)
     begin
-        JSONManagement.InitializeCollection(JSONString);
+        ResetSelectedCollectionIndex();
+        Clear(JsonArrayState);
+        if JSONString <> '' then
+            JsonArrayState.ReadFrom(JSONString);
     end;
 
     procedure InitializeObject(JSONString: Text)
     begin
-        JSONManagement.InitializeObject(JSONString);
+        ResetSelectedCollectionIndex();
+        Clear(JsonObjectState);
+        if JSONString <> '' then
+            JsonObjectState.ReadFrom(JSONString);
     end;
 
     procedure IsBlankOrEmptyJsonObject(JSONString: Text): Boolean
-    var
-        JSONManagement2: Codeunit "JSON Management";
-        EmptyJsonObjectString: Text;
     begin
-        JSONManagement2.InitializeEmptyObject();
-        EmptyJsonObjectString := JSONManagement2.WriteObjectToString();
-        exit((JSONString = '') or (JSONString = EmptyJsonObjectString));
+        exit((JSONString = '') or (JSONString = '{}'));
     end;
 
     procedure WriteCollectionToString(): Text
+    var
+        JsonText: Text;
     begin
-        exit(JSONManagement.WriteCollectionToString());
+        JsonArrayState.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure WriteObjectToString(): Text
+    var
+        JsonText: Text;
     begin
-        exit(JSONManagement.WriteObjectToString());
+        JsonObjectState.WriteTo(JsonText);
+        exit(JsonText);
+    end;
+
+    local procedure InitializeEmptyObject()
+    begin
+        ResetSelectedCollectionIndex();
+        Clear(JsonObjectState);
+    end;
+
+    local procedure GetCollectionCount(): Integer
+    begin
+        exit(JsonArrayState.Count());
+    end;
+
+    local procedure GetJSONObject(var JObject: JsonObject)
+    begin
+        JObject := JsonObjectState;
+    end;
+
+    local procedure GetJObjectFromCollectionByIndex(var JObject: JsonObject; Index: Integer): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        ResetSelectedCollectionIndex();
+        if not GetTokenFromCollectionByIndex(JsonToken, Index) then
+            exit(false);
+        if not JsonToken.IsObject() then
+            exit(false);
+        JObject := JsonToken.AsObject();
+        SelectedCollectionIndex := Index;
+        HasSelectedCollectionIndex := true;
+        exit(true);
+    end;
+
+    local procedure GetTokenFromCollectionByIndex(var JsonToken: JsonToken; Index: Integer): Boolean
+    begin
+        if (Index < 0) or (Index >= JsonArrayState.Count()) then
+            exit(false);
+        exit(JsonArrayState.Get(Index, JsonToken));
+    end;
+
+    local procedure GetJObjectFromCollectionByPropertyValue(var JObject: JsonObject; PropertyName: Text; Value: Text): Boolean
+    var
+        CandidateToken: JsonToken;
+        CandidateObject: JsonObject;
+        CandidateValue: Text;
+        Index: Integer;
+    begin
+        ResetSelectedCollectionIndex();
+        Clear(JObject);
+        for Index := 0 to JsonArrayState.Count() - 1 do begin
+            JsonArrayState.Get(Index, CandidateToken);
+            if CandidateToken.IsObject() then begin
+                CandidateObject := CandidateToken.AsObject();
+                if GetStringPropertyValueFromJObjectByName(CandidateObject, PropertyName, CandidateValue) then
+                    if CandidateValue = Value then begin
+                        JObject := CandidateObject;
+                        SelectedCollectionIndex := Index;
+                        HasSelectedCollectionIndex := true;
+                        exit(true);
+                    end;
+            end;
+        end;
+    end;
+
+    local procedure RemoveSelectedJObjectFromCollection()
+    begin
+        if not HasSelectedCollectionIndex then
+            exit;
+        if SelectedCollectionIndex < 0 then begin
+            ResetSelectedCollectionIndex();
+            exit;
+        end;
+        if SelectedCollectionIndex >= JsonArrayState.Count() then begin
+            ResetSelectedCollectionIndex();
+            exit;
+        end;
+        JsonArrayState.RemoveAt(SelectedCollectionIndex);
+        ResetSelectedCollectionIndex();
+    end;
+
+    local procedure GetStringPropertyValueFromJObjectByName(JObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit(true);
+            Value := JsonToken.AsValue().AsText();
+        end else
+            JsonToken.WriteTo(Value);
+        exit(true);
+    end;
+
+    local procedure GetStringValueFromJsonToken(JsonToken: JsonToken; var Value: Text)
+    begin
+        Clear(Value);
+        if not JsonToken.IsValue() then
+            exit;
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit;
+        Value := JsonToken.AsValue().AsText();
+    end;
+
+    local procedure ResetSelectedCollectionIndex()
+    begin
+        SelectedCollectionIndex := -1;
+        HasSelectedCollectionIndex := false;
+    end;
+
+    local procedure GetEnumPropertyValueFromJObjectByName(JObject: JsonObject; PropertyName: Text; var Value: Option)
+    var
+        TextValue: Text;
+    begin
+        GetStringPropertyValueFromJObjectByName(JObject, PropertyName, TextValue);
+        Evaluate(Value, TextValue, 0);
+    end;
+
+    local procedure GetBoolPropertyValueFromJObjectByName(JObject: JsonObject; PropertyName: Text; var Value: Boolean): Boolean
+    var
+        TextValue: Text;
+    begin
+        if not GetStringPropertyValueFromJObjectByName(JObject, PropertyName, TextValue) then
+            exit(false);
+        Evaluate(Value, TextValue, 2);
+        exit(true);
+    end;
+
+    local procedure GetGuidPropertyValueFromJObjectByName(JObject: JsonObject; PropertyName: Text; var Value: Guid): Boolean
+    var
+        TextValue: Text;
+    begin
+        if not GetStringPropertyValueFromJObjectByName(JObject, PropertyName, TextValue) then
+            exit(false);
+        exit(Evaluate(Value, TextValue));
+    end;
+
+    local procedure AddJObjectToCollection(JObject: JsonObject)
+    begin
+        JsonArrayState.Add(JObject.AsToken().Clone());
+    end;
+
+    local procedure AddValueToCollection(Value: Text)
+    begin
+        JsonArrayState.Add(Value);
+    end;
+
+    local procedure ReplaceOrAddJPropertyInJObject(var JObject: JsonObject; PropertyName: Text; Value: Text): Boolean
+    var
+        OldValue: Text;
+    begin
+        if JObject.Contains(PropertyName) then begin
+            GetStringPropertyValueFromJObjectByName(JObject, PropertyName, OldValue);
+            JObject.Replace(PropertyName, Value);
+            exit(OldValue <> Value);
+        end;
+        JObject.Add(PropertyName, Value);
+        exit(true);
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtContact.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtContact.Codeunit.al
@@ -9,7 +9,6 @@ using Microsoft.CRM.Contact;
 using Microsoft.Foundation.Address;
 using System;
 using System.Reflection;
-using System.Text;
 
 codeunit 5458 "Graph Collection Mgt - Contact"
 {

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtItem.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtItem.Codeunit.al
@@ -7,10 +7,8 @@ namespace Microsoft.Integration.Graph;
 using Microsoft.API.Upgrade;
 using Microsoft.Foundation.UOM;
 using Microsoft.Inventory.Item;
-using System;
 using System.DateTime;
 using System.Reflection;
-using System.Text;
 
 codeunit 5470 "Graph Collection Mgt - Item"
 {

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtItem.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtItem.Codeunit.al
@@ -103,9 +103,8 @@ codeunit 5470 "Graph Collection Mgt - Item"
     var
         ItemUnitOfMeasure: Record "Item Unit of Measure";
         GraphMgtComplexTypes: Codeunit "Graph Mgt - Complex Types";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        ItemUOMConversionJObject: DotNet JObject;
+        JsonObject: JsonObject;
+        ItemUOMConversionJObject: JsonObject;
         UnitOfMeasureJSON: Text;
     begin
         UnitOfMeasureJSON := GraphMgtComplexTypes.GetUnitOfMeasureJSON(UnitOfMeasureCode);
@@ -116,16 +115,13 @@ codeunit 5470 "Graph Collection Mgt - Item"
         if not ItemUnitOfMeasure.Get(Item."No.", UnitOfMeasureCode) then
             exit(UnitOfMeasureJSON);
 
-        JSONManagement.InitializeObject(UnitOfMeasureJSON);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(UnitOfMeasureJSON);
 
-        ItemUOMConversionJObject := ItemUOMConversionJObject.JObject();
-        JSONManagement.AddJPropertyToJObject(
-          ItemUOMConversionJObject, UOMConversionComplexTypeToUnitOfMeasure(), Item."Base Unit of Measure");
-        JSONManagement.AddJPropertyToJObject(
-          ItemUOMConversionJObject, UOMConversionComplexTypeFromToConversionRate(), ItemUnitOfMeasure."Qty. per Unit of Measure");
-        JSONManagement.AddJObjectToJObject(JsonObject, UOMConversionComplexTypeName(), ItemUOMConversionJObject);
-        exit(JSONManagement.WriteObjectToString());
+        ItemUOMConversionJObject.Add(UOMConversionComplexTypeToUnitOfMeasure(), Item."Base Unit of Measure");
+        ItemUOMConversionJObject.Add(UOMConversionComplexTypeFromToConversionRate(), ItemUnitOfMeasure."Qty. per Unit of Measure");
+        JsonObject.Add(UOMConversionComplexTypeName(), ItemUOMConversionJObject);
+        JsonObject.WriteTo(UnitOfMeasureJSON);
+        exit(UnitOfMeasureJSON);
     end;
 
     procedure UpdateOrCreateItemUnitOfMeasureFromSalesDocument(UnitOfMeasureJSONString: Text; var Item: Record Item; var TempFieldSet: Record "Field" temporary; var ItemModified: Boolean)
@@ -272,54 +268,60 @@ codeunit 5470 "Graph Collection Mgt - Item"
     procedure ParseJSONToUnitOfMeasure(UnitOfMeasureJSONString: Text; var UnitOfMeasure: Record "Unit of Measure")
     var
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         UnitCode: Text;
     begin
-        JSONManagement.InitializeObject(UnitOfMeasureJSONString);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(UnitOfMeasureJSONString);
 
         GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, UOMComplexTypeUnitCode(), UnitCode);
         UnitOfMeasure.Code := CopyStr(UnitCode, 1, MaxStrLen(UnitOfMeasure.Code));
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, UOMComplexTypeUnitName(), UnitOfMeasure.Description);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
+        TryGetJsonText(JsonObject, UOMComplexTypeUnitName(), UnitOfMeasure.Description);
+        TryGetJsonText(JsonObject, UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
     end;
 
     local procedure ParseJSONToItemUnitOfMeasure(UnitOfMeasureJSONString: Text; var Item: Record Item; var TempItemUnitOfMeasure: Record "Item Unit of Measure" temporary; var UnitOfMeasure: Record "Unit of Measure"; var BaseUnitOfMeasureCode: Code[10]): Boolean
     var
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        ConversionsTxt: Text;
+        JsonObject: JsonObject;
+        ConversionJsonObject: JsonObject;
+        ConversionJsonToken: JsonToken;
         FromToConversionRateTxt: Text;
         BaseUnitOfMeasureTxt: Text;
     begin
-        JSONManagement.InitializeObject(UnitOfMeasureJSONString);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(UnitOfMeasureJSONString);
 
-        if not JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, UOMConversionComplexTypeName(), ConversionsTxt) then
+        if not JsonObject.Get(UOMConversionComplexTypeName(), ConversionJsonToken) then
             exit(false);
 
-        if ConversionsTxt = '' then
+        if not ConversionJsonToken.IsObject() then
             exit(false);
 
-        if ConversionsTxt = 'null' then
-            exit(false);
-
-        JSONManagement.InitializeObject(ConversionsTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        ConversionJsonObject := ConversionJsonToken.AsObject();
 
         GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(
-          JsonObject, UOMConversionComplexTypeToUnitOfMeasure(), BaseUnitOfMeasureTxt);
+          ConversionJsonObject, UOMConversionComplexTypeToUnitOfMeasure(), BaseUnitOfMeasureTxt);
         BaseUnitOfMeasureCode := CopyStr(BaseUnitOfMeasureTxt, 1, 10);
 
         GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(
-          JsonObject, UOMConversionComplexTypeFromToConversionRate(), FromToConversionRateTxt);
-        Evaluate(TempItemUnitOfMeasure."Qty. per Unit of Measure", FromToConversionRateTxt);
+          ConversionJsonObject, UOMConversionComplexTypeFromToConversionRate(), FromToConversionRateTxt);
+        Evaluate(TempItemUnitOfMeasure."Qty. per Unit of Measure", FromToConversionRateTxt, 9);
         TempItemUnitOfMeasure."Item No." := Item."No.";
         TempItemUnitOfMeasure.Code := UnitOfMeasure.Code;
         TempItemUnitOfMeasure.Insert();
 
+        exit(true);
+    end;
+
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) or not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(true);
+        Value := JsonToken.AsValue().AsText();
         exit(true);
     end;
 
@@ -466,4 +468,3 @@ codeunit 5470 "Graph Collection Mgt - Item"
             Commit();
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtItem.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphCollectionMgtItem.Codeunit.al
@@ -268,13 +268,17 @@ codeunit 5470 "Graph Collection Mgt - Item"
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
         JsonObject: JsonObject;
         UnitCode: Text;
+        UnitName: Text;
+        UnitSymbol: Text;
     begin
         JsonObject.ReadFrom(UnitOfMeasureJSONString);
 
         GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, UOMComplexTypeUnitCode(), UnitCode);
         UnitOfMeasure.Code := CopyStr(UnitCode, 1, MaxStrLen(UnitOfMeasure.Code));
-        TryGetJsonText(JsonObject, UOMComplexTypeUnitName(), UnitOfMeasure.Description);
-        TryGetJsonText(JsonObject, UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
+        TryGetJsonText(JsonObject, UOMComplexTypeUnitName(), UnitName);
+        TryGetJsonText(JsonObject, UOMComplexTypeSymbol(), UnitSymbol);
+        UnitOfMeasure.Description := CopyStr(UnitName, 1, MaxStrLen(UnitOfMeasure.Description));
+        UnitOfMeasure.Symbol := CopyStr(UnitSymbol, 1, MaxStrLen(UnitOfMeasure.Symbol));
     end;
 
     local procedure ParseJSONToItemUnitOfMeasure(UnitOfMeasureJSONString: Text; var Item: Record Item; var TempItemUnitOfMeasure: Record "Item Unit of Measure" temporary; var UnitOfMeasure: Record "Unit of Measure"; var BaseUnitOfMeasureCode: Code[10]): Boolean

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
@@ -137,6 +137,7 @@ codeunit 5468 "Graph Mgt - Complex Types"
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
         JsonObject: JsonObject;
         CodeText: Text;
+        DescriptionText: Text;
     begin
         if JSON = NullJSONTxt then begin
             Clear(Code);
@@ -147,8 +148,9 @@ codeunit 5468 "Graph Mgt - Complex Types"
         JsonObject.ReadFrom(JSON);
 
         GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, CodePropertyTxt, CodeText);
-        TryGetJsonText(JsonObject, DescriptionPropertyTxt, Description);
+        TryGetJsonText(JsonObject, DescriptionPropertyTxt, DescriptionText);
         Code := CopyStr(CodeText, 1, MaxStrLen(Code));
+        Description := CopyStr(DescriptionText, 1, MaxStrLen(Description));
     end;
 
     procedure GetPostalAddressEDM(): Text

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
@@ -54,25 +54,22 @@ codeunit 5468 "Graph Mgt - Complex Types"
 
     procedure GetDocumentLineObjectDetailsJSON(No: Text; Name: Text): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-
         if No <> '' then
-            JSONManagement.AddJPropertyToJObject(JsonObject, DocumentLineObjectDetailsNoTxt, No);
+            JsonObject.Add(DocumentLineObjectDetailsNoTxt, No);
 
         if Name <> '' then
-            JSONManagement.AddJPropertyToJObject(JsonObject, DocumentLineObjectDetailsNameTxt, Name);
+            JsonObject.Add(DocumentLineObjectDetailsNameTxt, Name);
 
-        exit(JSONManagement.WriteObjectToString());
+        JsonObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure ParseDocumentLineObjectDetailsFromJSON(JSON: Text; var No: Code[20]; var Name: Text[100]; var Description: Text[50])
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         NoTxt: Text;
         NameTxt: Text;
         DescriptionTxt: Text;
@@ -81,15 +78,14 @@ codeunit 5468 "Graph Mgt - Complex Types"
         Clear(Name);
         Clear(Description);
 
-        JSONManagement.InitializeObject(JSON);
-        JSONManagement.GetJSONObject(JsonObject);
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, DocumentLineObjectDetailsNoTxt, NoTxt) then
+        JsonObject.ReadFrom(JSON);
+        if TryGetJsonText(JsonObject, DocumentLineObjectDetailsNoTxt, NoTxt) then
             No := CopyStr(NoTxt, 1, 20);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, DocumentLineObjectDetailsNameTxt, NameTxt) then
+        if TryGetJsonText(JsonObject, DocumentLineObjectDetailsNameTxt, NameTxt) then
             Name := CopyStr(NameTxt, 1, 50);
 
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, DocumentLineObjectDetailsDescriptionTxt, DescriptionTxt) then
+        if TryGetJsonText(JsonObject, DocumentLineObjectDetailsDescriptionTxt, DescriptionTxt) then
             Description := CopyStr(DescriptionTxt, 1, 50);
     end;
 
@@ -104,18 +100,15 @@ codeunit 5468 "Graph Mgt - Complex Types"
 
     procedure GetBookingsDateJSON(DateTime: DateTime; var JSON: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         DateString: Text;
     begin
         DateString := Format(DateTime, 0, '<Year4>-<Month,2>-<Day,2>T<Hours24,2>:<Minutes,2>:<Seconds,2>.0000001Z');
 
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'dateTime', DateString);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'timeZone', 'UTC');
+        JsonObject.Add('dateTime', DateString);
+        JsonObject.Add('timeZone', 'UTC');
 
-        JSON := JSONManagement.WriteObjectToString();
+        JsonObject.WriteTo(JSON);
     end;
 
     procedure GetCodeAndDescriptionEDM(TypeName: Text[32]; CodeField: Code[50]; DescriptionField: Text[250]): Text
@@ -134,21 +127,17 @@ codeunit 5468 "Graph Mgt - Complex Types"
 
     procedure GetCodeAndDescriptionJSON("Code": Code[50]; Description: Text[250]; var JSON: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, CodePropertyTxt, Code);
-        JSONManagement.AddJPropertyToJObject(JsonObject, DescriptionPropertyTxt, Description);
-        JSON := JSONManagement.WriteObjectToString();
+        JsonObject.Add(CodePropertyTxt, Code);
+        JsonObject.Add(DescriptionPropertyTxt, Description);
+        JsonObject.WriteTo(JSON);
     end;
 
     procedure GetCodeAndDescriptionFromJSON(JSON: Text; var "Code": Code[50]; var Description: Text[250])
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         CodeText: Text;
     begin
         if JSON = NullJSONTxt then begin
@@ -157,11 +146,10 @@ codeunit 5468 "Graph Mgt - Complex Types"
             exit;
         end;
 
-        JSONManagement.InitializeObject(JSON);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JSON);
 
         GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, CodePropertyTxt, CodeText);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, DescriptionPropertyTxt, Description);
+        TryGetJsonText(JsonObject, DescriptionPropertyTxt, Description);
         Code := CopyStr(CodeText, 1, MaxStrLen(Code));
     end;
 
@@ -188,9 +176,9 @@ codeunit 5468 "Graph Mgt - Complex Types"
     procedure GetUnitOfMeasureJSON(UnitOfMeasureCode: Code[20]): Text
     var
         UnitOfMeasure: Record "Unit of Measure";
-        JSONManagement: Codeunit "JSON Management";
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        JsonText: Text;
     begin
         if UnitOfMeasureCode = '' then
             exit('');
@@ -198,26 +186,23 @@ codeunit 5468 "Graph Mgt - Complex Types"
         if not UnitOfMeasure.Get(UnitOfMeasureCode) then
             exit('');
 
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-
         // TODO: Refactor from item
-        JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitOfMeasure.Code);
+        JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitOfMeasure.Code);
         if UnitOfMeasure.Description <> '' then
-            JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitName(), UnitOfMeasure.Description);
+            JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeUnitName(), UnitOfMeasure.Description);
 
         if UnitOfMeasure.Symbol <> '' then
-            JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
+            JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
 
-        exit(JSONManagement.WriteObjectToString());
+        JsonObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure ApplyPostalAddressFromJSON(JSON: Text; var EntityRecRef: RecordRef; Line1FieldNo: Integer; Line2FieldNo: Integer; CityFieldNo: Integer; StateFieldNo: Integer; CountryCodeFieldNo: Integer; PostCodeFieldNo: Integer)
     var
         GraphCollectionMgtContact: Codeunit "Graph Collection Mgt - Contact";
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         TempStreet: Text;
         Line1: Text[100];
         Line2: Text[50];
@@ -227,13 +212,12 @@ codeunit 5468 "Graph Mgt - Complex Types"
         PostCode: Text;
     begin
         if NullJSONTxt <> JSON then begin
-            JSONManagement.InitializeObject(JSON);
-            JSONManagement.GetJSONObject(JsonObject);
+            JsonObject.ReadFrom(JSON);
 
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, 'street', TempStreet);
             GraphCollectionMgtContact.SplitStreet(TempStreet, Line1, Line2);
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, 'city', City);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'state', State);
+            TryGetJsonText(JsonObject, 'state', State);
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, 'countryLetterCode', CountryCode);
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(JsonObject, 'postalCode', PostCode);
         end;
@@ -250,19 +234,15 @@ codeunit 5468 "Graph Mgt - Complex Types"
     procedure GetPostalAddressJSON(Line1: Text; Line2: Text; City: Text; State: Text; CountryCode: Code[10]; PostCode: Code[20]; var JSON: Text)
     var
         GraphCollectionMgtContact: Codeunit "Graph Collection Mgt - Contact";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.Add('street', GraphCollectionMgtContact.ConcatenateStreet(Line1, Line2));
+        JsonObject.Add('city', City);
+        JsonObject.Add('state', State);
+        JsonObject.Add('countryLetterCode', CountryCode);
+        JsonObject.Add('postalCode', PostCode);
 
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'street', GraphCollectionMgtContact.ConcatenateStreet(Line1, Line2));
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'city', City);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'state', State);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'countryLetterCode', CountryCode);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'postalCode', PostCode);
-
-        JSON := JSONManagement.WriteObjectToString();
+        JsonObject.WriteTo(JSON);
     end;
 
     procedure GetDimensionEDM(): Text
@@ -279,53 +259,50 @@ codeunit 5468 "Graph Mgt - Complex Types"
     procedure GetDimensionsJSON(DimensionSetId: Integer): Text
     var
         DimensionSetEntry: Record "Dimension Set Entry";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        JsonArray: DotNet JArray;
+        JsonObject: JsonObject;
+        JsonArray: JsonArray;
+        JsonText: Text;
     begin
         DimensionSetEntry.SetRange("Dimension Set ID", DimensionSetId);
         if not DimensionSetEntry.FindSet() then
             exit('');
 
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(JsonArray);
-
         repeat
             GetDimensionJObject(DimensionSetEntry, JsonObject);
-            JSONManagement.AddJObjectToJArray(JsonArray, JsonObject);
+            JsonArray.Add(JsonObject);
         until DimensionSetEntry.Next() = 0;
 
-        exit(JSONManagement.WriteCollectionToString());
+        JsonArray.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
-    local procedure GetDimensionJObject(var DimensionSetEntry: Record "Dimension Set Entry"; var JsonObject: DotNet JObject)
-    var
-        JSONManagement: Codeunit "JSON Management";
+    local procedure GetDimensionJObject(var DimensionSetEntry: Record "Dimension Set Entry"; var JsonObject: JsonObject)
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
+        Clear(JsonObject);
         DimensionSetEntry.CalcFields("Dimension Name", "Dimension Value Name");
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'code', DimensionSetEntry."Dimension Code");
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'displayName', DimensionSetEntry."Dimension Name");
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'valueCode', DimensionSetEntry."Dimension Value Code");
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'valueDisplayName', DimensionSetEntry."Dimension Value Name");
+        JsonObject.Add('code', DimensionSetEntry."Dimension Code");
+        JsonObject.Add('displayName', DimensionSetEntry."Dimension Name");
+        JsonObject.Add('valueCode', DimensionSetEntry."Dimension Value Code");
+        JsonObject.Add('valueDisplayName', DimensionSetEntry."Dimension Value Name");
     end;
 
     procedure GetDimensionSetFromJSON(DimensionsJSON: Text; OldDimensionSetId: Integer; var NewDimensionSetId: Integer)
     var
         TempDimensionSetEntry: Record "Dimension Set Entry" temporary;
         DimensionManagement: Codeunit DimensionManagement;
-        JSONManagement: Codeunit "JSON Management";
-        LineJsonObject: DotNet JObject;
+        DimensionsJsonArray: JsonArray;
+        LineJsonToken: JsonToken;
+        LineJsonObject: JsonObject;
         I: Integer;
         NumberOfLines: Integer;
         "Code": Code[20];
         Value: Code[20];
     begin
-        JSONManagement.InitializeCollection(DimensionsJSON);
-        NumberOfLines := JSONManagement.GetCollectionCount();
+        DimensionsJsonArray.ReadFrom(DimensionsJSON);
+        NumberOfLines := DimensionsJsonArray.Count();
         for I := 1 to NumberOfLines do begin
-            JSONManagement.GetJObjectFromCollectionByIndex(LineJsonObject, I - 1);
+            DimensionsJsonArray.Get(I - 1, LineJsonToken);
+            LineJsonObject := LineJsonToken.AsObject();
             GetDimensionFromJObject(LineJsonObject, Code, Value);
             TempDimensionSetEntry.Init();
             TempDimensionSetEntry."Dimension Set ID" := OldDimensionSetId;
@@ -337,7 +314,7 @@ codeunit 5468 "Graph Mgt - Complex Types"
         NewDimensionSetId := DimensionManagement.GetDimensionSetID(TempDimensionSetEntry);
     end;
 
-    local procedure GetDimensionFromJObject(var JsonObject: DotNet JObject; var "Code": Code[20]; var Value: Code[20])
+    local procedure GetDimensionFromJObject(JsonObject: JsonObject; var "Code": Code[20]; var Value: Code[20])
     var
         Dimension: Record Dimension;
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
@@ -351,6 +328,19 @@ codeunit 5468 "Graph Mgt - Complex Types"
             if not Dimension.Get(Code) then
                 Error(DimensionErr, Code);
         Value := CopyStr(ValueText, 1, MaxStrLen(Value));
+    end;
+
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) or not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(true);
+        Value := JsonToken.AsValue().AsText();
+        exit(true);
     end;
 
     [Scope('OnPrem')]
@@ -495,4 +485,3 @@ codeunit 5468 "Graph Mgt - Complex Types"
         exit(GraphMgtComplexTypes.GetDocumentLineObjectDetailsJSON(PurchInvLineAggregate."No.", Name));
     end;
 }
-

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
@@ -12,8 +12,6 @@ using Microsoft.Integration.Entity;
 using Microsoft.Inventory.Item;
 using Microsoft.Projects.Resources.Resource;
 using Microsoft.Sales.Customer;
-using System;
-using System.Text;
 
 codeunit 5468 "Graph Mgt - Complex Types"
 {

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtComplexTypes.Codeunit.al
@@ -298,6 +298,11 @@ codeunit 5468 "Graph Mgt - Complex Types"
         "Code": Code[20];
         Value: Code[20];
     begin
+        if DimensionsJSON = '' then begin
+            NewDimensionSetId := DimensionManagement.GetDimensionSetID(TempDimensionSetEntry);
+            exit;
+        end;
+
         DimensionsJsonArray.ReadFrom(DimensionsJSON);
         NumberOfLines := DimensionsJsonArray.Count();
         for I := 1 to NumberOfLines do begin

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtGeneralTools.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtGeneralTools.Codeunit.al
@@ -9,13 +9,14 @@ using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Company;
 using Microsoft.Purchases.History;
 using Microsoft.Sales.History;
+#if not CLEAN30
 using System;
+#endif
 using System.Environment;
 using System.Environment.Configuration;
 using System.Integration;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 
 codeunit 5465 "Graph Mgt - General Tools"

--- a/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtGeneralTools.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Integration/Graph/GraphMgtGeneralTools.Codeunit.al
@@ -46,15 +46,33 @@ codeunit 5465 "Graph Mgt - General Tools"
         JobQueueNotScheudledMsg: Label 'The job has been created and set to On Hold.';
         APIDataUpgradeCategoryLbl: Label 'APIUpgrade', Locked = true;
 
+#if not CLEAN30
+    [Obsolete('Use GetMandatoryStringPropertyFromJObject with the native JsonObject type instead.', '30.0')]
     [Scope('OnPrem')]
     procedure GetMandatoryStringPropertyFromJObject(var JsonObject: DotNet JObject; PropertyName: Text; var PropertyValue: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        Found: Boolean;
+        JsonToken: DotNet JToken;
     begin
-        Found := JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, PropertyName, PropertyValue);
-        if not Found then
+        if not JsonObject.TryGetValue(PropertyName, JsonToken) then
             Error(MissingFieldValueErr, PropertyName);
+        PropertyValue := Format(JsonToken);
+    end;
+#endif
+
+    procedure GetMandatoryStringPropertyFromJObject(JsonObject: JsonObject; PropertyName: Text; var PropertyValue: Text)
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(PropertyValue);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            Error(MissingFieldValueErr, PropertyName);
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit;
+            PropertyValue := JsonToken.AsValue().AsText();
+            exit;
+        end;
+        JsonToken.WriteTo(PropertyValue);
     end;
 
     procedure HandleUpdateReferencedIdFieldOnItem(var RecRef: RecordRef; NewId: Guid; var Handled: Boolean; DatabaseNumber: Integer; RecordFieldNumber: Integer)
@@ -359,4 +377,3 @@ codeunit 5465 "Graph Mgt - General Tools"
         exit(Format(Id).TrimStart('{').TrimEnd('}'));
     end;
 }
-

--- a/src/Layers/W1/BaseApp/JSONManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/JSONManagement.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN30
 // ------------------------------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
@@ -11,6 +12,9 @@ using System.Xml;
 
 codeunit 5459 "JSON Management"
 {
+    ObsoleteReason = 'Use the built-in AL JSON types or codeunit Json in namespace System.Text.Json instead.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '30.0';
 
     trigger OnRun()
     begin
@@ -750,4 +754,4 @@ codeunit 5459 "JSON Management"
     begin
     end;
 }
-
+#endif

--- a/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/FlowServiceManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/FlowServiceManagement.Codeunit.al
@@ -197,8 +197,8 @@ codeunit 6400 "Flow Service Management"
             TryGetJsonText(PropertiesJsonObject, 'displayName', EnvironmentDisplayName);
 
             TempFlowUserEnvironmentBuffer.Init();
-            TempFlowUserEnvironmentBuffer."Environment ID" := EnvironmentId;
-            TempFlowUserEnvironmentBuffer."Environment Display Name" := EnvironmentDisplayName;
+            TempFlowUserEnvironmentBuffer."Environment ID" := CopyStr(EnvironmentId, 1, MaxStrLen(TempFlowUserEnvironmentBuffer."Environment ID"));
+            TempFlowUserEnvironmentBuffer."Environment Display Name" := CopyStr(EnvironmentDisplayName, 1, MaxStrLen(TempFlowUserEnvironmentBuffer."Environment Display Name"));
 
             if EnvironmentInformation.GetLinkedPowerPlatformEnvironmentId() = TempFlowUserEnvironmentBuffer."Environment Id" then
                 TempFlowUserEnvironmentBuffer.Linked := true;
@@ -207,7 +207,7 @@ codeunit 6400 "Flow Service Management"
             FlowUserEnvironmentConfig.Reset();
             FlowUserEnvironmentConfig.SetRange("Environment ID", EnvironmentId);
             FlowUserEnvironmentConfig.SetRange("User Security ID", UserSecurityId());
-            TempFlowUserEnvironmentBuffer.Enabled := FlowUserEnvironmentConfig.FindFirst();
+            TempFlowUserEnvironmentBuffer.Enabled := not FlowUserEnvironmentConfig.IsEmpty();
 
             // check if environment is the default
             TempFlowUserEnvironmentBuffer.Default := IsJsonTrue(PropertiesJsonObject, 'isDefault');

--- a/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/FlowServiceManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/FlowServiceManagement.Codeunit.al
@@ -36,6 +36,7 @@ codeunit 6400 "Flow Service Management"
         PowerAutomatePickerTelemetryCategoryLbl: Label 'AL Power Automate Environment Picker', Locked = true;
         MicrosoftPowerAutomatePrivacyIdTxt: Label 'Power Automate', Locked = true;
         PowerPlatformTenantNotConfiguredErr: Label 'Power Automate cannot connect because this Business Central environment is not linked to a Power Platform tenant. Contact your system administrator to configure the Power Platform environment link.';
+        InvalidEnvironmentResponseErr: Label 'The Power Automate environments response is not valid JSON.';
 
 
     procedure GetFlowUrl(): Text
@@ -175,7 +176,8 @@ codeunit 6400 "Flow Service Management"
         ProvisioningState: Text;
     begin
         // Parse the ResponseText from Flow environments api for a list of environments
-        RootJsonObject.ReadFrom(ResponseText);
+        if not RootJsonObject.ReadFrom(ResponseText) then
+            Error(InvalidEnvironmentResponseErr);
         if not RootJsonObject.Get('value', JsonToken) then
             exit;
 

--- a/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/FlowServiceManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Modules/System/PowerAutomate/FlowServiceManagement.Codeunit.al
@@ -1,6 +1,5 @@
 namespace System.Automation;
 
-using System;
 using System.Azure.Identity;
 using System.Environment;
 using System.Integration;
@@ -18,7 +17,6 @@ codeunit 6400 "Flow Service Management"
 
     var
         AzureAdMgt: Codeunit "Azure AD Mgt.";
-        JObject: DotNet JObject;
 
         FlowUrlProdTxt: Label 'https://make.powerautomate.com/', Locked = true;
         FlowUrlTip1Txt: Label 'https://make.test.powerautomate.com/', Locked = true;
@@ -166,61 +164,98 @@ codeunit 6400 "Flow Service Management"
     var
         FlowUserEnvironmentConfig: Record "Flow User Environment Config";
         EnvironmentInformation: Codeunit "Environment Information";
-        Current: DotNet GenericKeyValuePair2;
-        JObj: DotNet JObject;
-        JObjProp: DotNet JObject;
-        ObjectEnumerator: DotNet IEnumerator;
-        JArray: DotNet JArray;
-        ArrayEnumerator: DotNet IEnumerator;
-        JToken: DotNet JToken;
-        JProperty: DotNet JProperty;
+        RootJsonObject: JsonObject;
+        EnvironmentJsonObject: JsonObject;
+        PropertiesJsonObject: JsonObject;
+        EnvironmentsJsonArray: JsonArray;
+        JsonToken: JsonToken;
+        PropertiesJsonToken: JsonToken;
+        EnvironmentId: Text;
+        EnvironmentDisplayName: Text;
+        ProvisioningState: Text;
     begin
         // Parse the ResponseText from Flow environments api for a list of environments
-        ObjectEnumerator := JObject.Parse(ResponseText).GetEnumerator();
+        RootJsonObject.ReadFrom(ResponseText);
+        if not RootJsonObject.Get('value', JsonToken) then
+            exit;
 
-        while ObjectEnumerator.MoveNext() do begin
-            Current := ObjectEnumerator.Current;
+        EnvironmentsJsonArray := JsonToken.AsArray();
+        foreach JsonToken in EnvironmentsJsonArray do begin
+            EnvironmentJsonObject := JsonToken.AsObject();
+            if not EnvironmentJsonObject.Get('properties', PropertiesJsonToken) then
+                continue;
+            if not PropertiesJsonToken.IsObject() then
+                continue;
 
-            if Format(Current.Key) = 'value' then begin
-                JArray := Current.Value();
-                ArrayEnumerator := JArray.GetEnumerator();
+            PropertiesJsonObject := PropertiesJsonToken.AsObject();
+            if not TryGetJsonText(PropertiesJsonObject, 'provisioningState', ProvisioningState) then
+                continue;
+            if LowerCase(ProvisioningState) <> 'succeeded' then
+                continue;
 
-                while ArrayEnumerator.MoveNext() do begin
-                    JObj := ArrayEnumerator.Current;
-                    JObjProp := JObj.SelectToken('properties');
+            TryGetJsonText(EnvironmentJsonObject, 'name', EnvironmentId);
+            TryGetJsonText(PropertiesJsonObject, 'displayName', EnvironmentDisplayName);
 
-                    if not IsNull(JObjProp) then begin
-                        JProperty := JObjProp.Property('provisioningState');
+            TempFlowUserEnvironmentBuffer.Init();
+            TempFlowUserEnvironmentBuffer."Environment ID" := EnvironmentId;
+            TempFlowUserEnvironmentBuffer."Environment Display Name" := EnvironmentDisplayName;
 
-                        // only interested in those that succeeded
-                        if LowerCase(Format(JProperty.Value)) = 'succeeded' then begin
-                            JToken := JObj.SelectToken('name');
-                            JProperty := JObjProp.Property('displayName');
+            if EnvironmentInformation.GetLinkedPowerPlatformEnvironmentId() = TempFlowUserEnvironmentBuffer."Environment Id" then
+                TempFlowUserEnvironmentBuffer.Linked := true;
 
-                            TempFlowUserEnvironmentBuffer.Init();
-                            TempFlowUserEnvironmentBuffer."Environment ID" := JToken.ToString();
-                            TempFlowUserEnvironmentBuffer."Environment Display Name" := Format(JProperty.Value);
+            // mark current environment as enabled/selected if it is currently the user selected environment
+            FlowUserEnvironmentConfig.Reset();
+            FlowUserEnvironmentConfig.SetRange("Environment ID", EnvironmentId);
+            FlowUserEnvironmentConfig.SetRange("User Security ID", UserSecurityId());
+            TempFlowUserEnvironmentBuffer.Enabled := FlowUserEnvironmentConfig.FindFirst();
 
-                            if EnvironmentInformation.GetLinkedPowerPlatformEnvironmentId() = TempFlowUserEnvironmentBuffer."Environment Id" then
-                                TempFlowUserEnvironmentBuffer.Linked := true;
+            // check if environment is the default
+            TempFlowUserEnvironmentBuffer.Default := IsJsonTrue(PropertiesJsonObject, 'isDefault');
 
-                            // mark current environment as enabled/selected if it is currently the user selected environment
-                            FlowUserEnvironmentConfig.Reset();
-                            FlowUserEnvironmentConfig.SetRange("Environment ID", JToken.ToString());
-                            FlowUserEnvironmentConfig.SetRange("User Security ID", UserSecurityId());
-                            TempFlowUserEnvironmentBuffer.Enabled := FlowUserEnvironmentConfig.FindFirst();
-
-                            // check if environment is the default
-                            JProperty := JObjProp.Property('isDefault');
-                            if LowerCase(Format(JProperty.Value)) = 'true' then
-                                TempFlowUserEnvironmentBuffer.Default := true;
-
-                            TempFlowUserEnvironmentBuffer.Insert();
-                        end;
-                    end;
-                end;
-            end;
+            TempFlowUserEnvironmentBuffer.Insert();
         end;
+    end;
+
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+
+        if not JsonToken.IsValue() then begin
+            JsonToken.WriteTo(Value);
+            exit(true);
+        end;
+
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(true);
+
+        Value := JsonToken.AsValue().AsText();
+        exit(true);
+    end;
+
+    local procedure IsJsonTrue(JsonObject: JsonObject; PropertyName: Text): Boolean
+    var
+        JsonToken: JsonToken;
+        JsonValue: JsonValue;
+        SerializedValue: Text;
+    begin
+        if not JsonObject.Get(PropertyName, JsonToken) or not JsonToken.IsValue() then
+            exit(false);
+
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(false);
+
+        JsonToken.WriteTo(SerializedValue);
+        if SerializedValue = 'true' then
+            exit(true);
+        if not SerializedValue.StartsWith('"') then
+            exit(false);
+
+        exit(LowerCase(JsonValue.AsText()) = 'true');
     end;
 
     procedure SaveFlowUserEnvironmentSelection(var TempFlowUserEnvironmentBuffer: Record "Flow User Environment Buffer" temporary)

--- a/src/Layers/W1/BaseApp/OtherCapabilities/AccountantPortal/InviteExternalAccountant.Codeunit.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/AccountantPortal/InviteExternalAccountant.Codeunit.al
@@ -4,7 +4,6 @@ using System;
 using System.Azure.Identity;
 using System.Environment.Configuration;
 using System.Integration;
-using System.Text;
 using System.Utilities;
 
 codeunit 9033 "Invite External Accountant"

--- a/src/Layers/W1/BaseApp/OtherCapabilities/AccountantPortal/InviteExternalAccountant.Codeunit.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/AccountantPortal/InviteExternalAccountant.Codeunit.al
@@ -49,33 +49,34 @@ codeunit 9033 "Invite External Accountant"
     [Scope('OnPrem')]
     procedure InvokeInvitationsRequest(DisplayName: Text; EmailAddress: Text; WebClientUrl: Text; var InvitedUserId: Guid; var InviteReedemUrl: Text; var ErrorMessage: Text): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        InviteUserIdJsonObject: DotNet JObject;
-        InviteUserIdObjectValue: Text;
+        RequestJsonObject: JsonObject;
+        ResponseJsonObject: JsonObject;
+        InviteUserJsonObject: JsonObject;
+        JsonToken: JsonToken;
         ResponseContent: Text;
         Body: Text;
         FoundInviteRedeemUrlValue: Boolean;
         FoundInvitedUserObjectValue: Boolean;
         FoundInviteUserIdValue: Boolean;
     begin
-        Body := '{';
-        Body := Body + '"invitedUserDisplayName" : "' + DisplayName + '",';
-        Body := Body + '"invitedUserEmailAddress" : "' + EmailAddress + '",';
-        Body := Body + '"inviteRedirectUrl" : "' + WebClientUrl + '",';
-        Body := Body + '"sendInvitationMessage" : "false"';
-        Body := Body + '}';
+        RequestJsonObject.Add('invitedUserDisplayName', DisplayName);
+        RequestJsonObject.Add('invitedUserEmailAddress', EmailAddress);
+        RequestJsonObject.Add('inviteRedirectUrl', WebClientUrl);
+        RequestJsonObject.Add('sendInvitationMessage', 'false');
+        RequestJsonObject.WriteTo(Body);
 
         if InvokeRequestWithGraphAccessToken(GetGraphInvitationsUrl(), 'POST', Body, ResponseContent) then begin
-            JSONManagement.InitializeObject(ResponseContent);
-            JSONManagement.GetJSONObject(JsonObject);
-            FoundInviteRedeemUrlValue :=
-              JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, InviteReedemUrlTxt, InviteReedemUrl);
-            FoundInvitedUserObjectValue :=
-              JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, InvitedUserIdTxt, InviteUserIdObjectValue);
-            JSONManagement.InitializeObject(InviteUserIdObjectValue);
-            JSONManagement.GetJSONObject(InviteUserIdJsonObject);
-            FoundInviteUserIdValue := JSONManagement.GetGuidPropertyValueFromJObjectByName(InviteUserIdJsonObject, IdTxt, InvitedUserId);
+            if ResponseContent = '' then begin
+                ErrorMessage := InsufficientDataReturnedFromInvitationsApiTxt;
+                exit(false);
+            end;
+            ResponseJsonObject.ReadFrom(ResponseContent);
+            FoundInviteRedeemUrlValue := TryGetJsonText(ResponseJsonObject, InviteReedemUrlTxt, InviteReedemUrl);
+            FoundInvitedUserObjectValue := ResponseJsonObject.Get(InvitedUserIdTxt, JsonToken) and JsonToken.IsObject();
+            if FoundInvitedUserObjectValue then begin
+                InviteUserJsonObject := JsonToken.AsObject();
+                FoundInviteUserIdValue := TryGetJsonText(InviteUserJsonObject, IdTxt, Body) and Evaluate(InvitedUserId, Body);
+            end;
 
             if FoundInviteRedeemUrlValue and FoundInvitedUserObjectValue and FoundInviteUserIdValue then
                 exit(true);
@@ -134,41 +135,41 @@ codeunit 9033 "Invite External Accountant"
     [Scope('OnPrem')]
     procedure InvokeIsExternalAccountantLicenseAvailable(var ErrorMessage: Text; var TargetLicense: Text): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        JsonArray: DotNet JArray;
-        PrepaidUnitsJsonObject: DotNet JObject;
+        ResponseJsonObject: JsonObject;
+        SkuJsonObject: JsonObject;
+        PrepaidUnitsJsonObject: JsonObject;
+        SkuJsonArray: JsonArray;
+        JsonToken: JsonToken;
         NumberSkus: Integer;
         ResponseContent: Text;
         SkuIdValue: Text;
         ConsumedUnitsValue: Decimal;
-        PrepaidUnitsValue: Text;
         EnabledUnitsValue: Decimal;
     begin
         if InvokeRequestWithGraphAccessToken(GetGraphSubscribedSkusUrl(), 'GET', '', ResponseContent) then begin
-            if not JSONManagement.TryParseJObjectFromString(JsonObject, ResponseContent) then
+            if not ResponseJsonObject.ReadFrom(ResponseContent) then
                 Error(ExternalAccountantLicenseAvailabilityErr);
 
-            if not JSONManagement.GetArrayPropertyValueFromJObjectByName(JsonObject, ValueTxt, JsonArray) then
+            if not ResponseJsonObject.Get(ValueTxt, JsonToken) or not JsonToken.IsArray() then
                 Error(ExternalAccountantLicenseAvailabilityErr);
-            JSONManagement.InitializeCollectionFromJArray(JsonArray);
+            SkuJsonArray := JsonToken.AsArray();
 
-            NumberSkus := JSONManagement.GetCollectionCount();
+            NumberSkus := SkuJsonArray.Count();
             while NumberSkus > 0 do begin
                 NumberSkus := NumberSkus - 1;
-                if JSONManagement.GetJObjectFromCollectionByIndex(JsonObject, NumberSkus) then begin
-                    if not JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, SkuIdTxt, SkuIdValue) then
+                if SkuJsonArray.Get(NumberSkus, JsonToken) and JsonToken.IsObject() then begin
+                    SkuJsonObject := JsonToken.AsObject();
+                    if not TryGetJsonText(SkuJsonObject, SkuIdTxt, SkuIdValue) then
                         Error(ExternalAccountantLicenseAvailabilityErr);
-                    if not JSONManagement.GetDecimalPropertyValueFromJObjectByName(JsonObject, ConsumedUnitsTxt, ConsumedUnitsValue) then
+                    if not TryGetJsonDecimal(SkuJsonObject, ConsumedUnitsTxt, ConsumedUnitsValue) then
                         Error(ExternalAccountantLicenseAvailabilityErr);
                     // Check to see if there is an external accountant license available.
                     if (SkuIdValue = ExternalAccountantLicenseSkuIdTxt) then begin
                         TargetLicense := SkuIdValue;
-                        if not JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, PrepaidUnitsTxt, PrepaidUnitsValue) then
+                        if not SkuJsonObject.Get(PrepaidUnitsTxt, JsonToken) or not JsonToken.IsObject() then
                             Error(ExternalAccountantLicenseAvailabilityErr);
-                        if not JSONManagement.TryParseJObjectFromString(PrepaidUnitsJsonObject, PrepaidUnitsValue) then
-                            Error(ExternalAccountantLicenseAvailabilityErr);
-                        if not JSONManagement.GetDecimalPropertyValueFromJObjectByName(PrepaidUnitsJsonObject, EnabledUnitsTxt, EnabledUnitsValue) then
+                        PrepaidUnitsJsonObject := JsonToken.AsObject();
+                        if not TryGetJsonDecimal(PrepaidUnitsJsonObject, EnabledUnitsTxt, EnabledUnitsValue) then
                             Error(ExternalAccountantLicenseAvailabilityErr);
 
                         if ConsumedUnitsValue < EnabledUnitsValue then
@@ -315,20 +316,45 @@ codeunit 9033 "Invite External Accountant"
 
     local procedure GetMessageFromErrorJSON(ResponseContent: Text): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        ErrorObjectValue: Text;
+        ResponseJsonObject: JsonObject;
+        ErrorJsonObject: JsonObject;
+        JsonToken: JsonToken;
         MessageValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseContent);
-        JSONManagement.GetJSONObject(JsonObject);
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, ErrorTxt, ErrorObjectValue) then begin
-            JSONManagement.InitializeObject(ErrorObjectValue);
-            JSONManagement.GetJSONObject(JsonObject);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, MessageTxt, MessageValue);
+        if ResponseContent = '' then
+            exit('');
+        if not ResponseJsonObject.ReadFrom(ResponseContent) then
+            exit('');
+
+        if ResponseJsonObject.Get(ErrorTxt, JsonToken) and JsonToken.IsObject() then begin
+            ErrorJsonObject := JsonToken.AsObject();
+            TryGetJsonText(ErrorJsonObject, MessageTxt, MessageValue);
         end;
 
         exit(MessageValue);
+    end;
+
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) or not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(true);
+        Value := JsonToken.AsValue().AsText();
+        exit(true);
+    end;
+
+    local procedure TryGetJsonDecimal(JsonObject: JsonObject; PropertyName: Text; var Value: Decimal): Boolean
+    var
+        JsonText: Text;
+    begin
+        Clear(Value);
+        if not TryGetJsonText(JsonObject, PropertyName, JsonText) then
+            exit(false);
+        exit(Evaluate(Value, JsonText, 9));
     end;
 
     local procedure GetGraphInvitationsUrl(): Text
@@ -399,4 +425,3 @@ codeunit 9033 "Invite External Accountant"
         // This event is called when the invitation process tries to create a user.
     end;
 }
-

--- a/src/Layers/W1/BaseApp/OtherCapabilities/Booking/BookingItem.Table.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/Booking/BookingItem.Table.al
@@ -197,17 +197,18 @@ table 6707 "Booking Item"
 
     local procedure GetDate(FieldNo: Integer) ParsedDateTime: DateTime
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        JsonToken: JsonToken;
         DateBlobString: Text;
-        DateTimeJsonValue: Text;
     begin
         DateBlobString := GetBlobString(FieldNo);
+        if DateBlobString = '' then
+            exit;
         if NullJSONTxt <> DateBlobString then begin
-            JSONManagement.InitializeObject(DateBlobString);
-            JSONManagement.GetJSONObject(JsonObject);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'dateTime', DateTimeJsonValue);
-            Evaluate(ParsedDateTime, DateTimeJsonValue);
+            JsonObject.ReadFrom(DateBlobString);
+            if JsonObject.Get('dateTime', JsonToken) and JsonToken.IsValue() then
+                if not JsonToken.AsValue().IsNull() and not JsonToken.AsValue().IsUndefined() then
+                    if not Evaluate(ParsedDateTime, JsonToken.AsValue().AsText()) then;
         end;
     end;
 
@@ -225,4 +226,3 @@ table 6707 "Booking Item"
         Allowed := ("Service Name" <> '') and not IsEmpty();
     end;
 }
-

--- a/src/Layers/W1/BaseApp/OtherCapabilities/Booking/BookingItem.Table.al
+++ b/src/Layers/W1/BaseApp/OtherCapabilities/Booking/BookingItem.Table.al
@@ -1,8 +1,6 @@
 namespace Microsoft.Booking;
 
 using Microsoft.Integration.Graph;
-using System;
-using System.Text;
 using System.Utilities;
 
 table 6707 "Booking Item"

--- a/src/Layers/W1/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
@@ -9,7 +9,6 @@ using System.Apps;
 using System.Globalization;
 using System.Reflection;
 using System.Security.User;
-using System.Text;
 using System.Xml;
 
 codeunit 1485 "Rolecenter Selector Mgt."

--- a/src/Layers/W1/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/RoleCenters/RolecenterSelectorMgt.Codeunit.al
@@ -50,24 +50,21 @@ codeunit 1485 "Rolecenter Selector Mgt."
     var
         AllObj: Record AllObj;
         ApplicationObjectMetadata: Record "Application Object Metadata";
-        JSONManagement: Codeunit "JSON Management";
         XMLDOMManagement: Codeunit "XML DOM Management";
         ReturnXmlDocument: DotNet XmlDocument;
         ReturnedXMLNodeList: DotNet XmlNodeList;
         ActivityButtonsXmlNode: DotNet XmlNode;
         BucketXmlNode: DotNet XmlNode;
         FeatureXmlNode: DotNet XmlNode;
-        FeatureBucketsJArray: DotNet JArray;
-        FeatureBucketJObject: DotNet JObject;
-        FeatureJArray: DotNet JArray;
-        FeatureJObject: DotNet JObject;
+        FeatureBucketsJArray: JsonArray;
+        FeatureBucketJObject: JsonObject;
+        FeatureJArray: JsonArray;
+        FeatureJObject: JsonObject;
         Instream: InStream;
+        JsonText: Text;
         Tooltip: Text;
         Caption: Text;
     begin
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(FeatureBucketsJArray);
-
         AllObj.Get(AllObj."Object Type"::Page, RolecenterId);
         ApplicationObjectMetadata.Get(AllObj."App Runtime Package ID", ApplicationObjectMetadata."Object Type"::Page, RolecenterId);
         ApplicationObjectMetadata.CalcFields(Metadata);
@@ -76,33 +73,35 @@ codeunit 1485 "Rolecenter Selector Mgt."
         XMLDOMManagement.LoadXMLDocumentFromInStream(Instream, ReturnXmlDocument);
         ReturnedXMLNodeList := ReturnXmlDocument.GetElementsByTagName(ActionContainerXmlElementLbl);
 
-        if not GetActivityButtonsActionContainerXmlNode(ActivityButtonsXmlNode, ReturnedXMLNodeList) then
-            exit(FeatureBucketsJArray.ToString());
+        if not GetActivityButtonsActionContainerXmlNode(ActivityButtonsXmlNode, ReturnedXMLNodeList) then begin
+            FeatureBucketsJArray.WriteTo(JsonText);
+            exit(JsonText);
+        end;
 
         foreach BucketXmlNode in ActivityButtonsXmlNode.ChildNodes do begin
-            JSONManagement.InitializeEmptyObject();
-            JSONManagement.GetJSONObject(FeatureBucketJObject);
+            Clear(FeatureBucketJObject);
             GetLanguageSpecificCaptionAndTooltip(BucketXmlNode, Caption, Tooltip);
-            JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonNameElementLbl, Caption);
-            JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonTooltipLbl, Tooltip);
+            FeatureBucketJObject.Add(JsonNameElementLbl, Caption);
+            FeatureBucketJObject.Add(JsonTooltipLbl, Tooltip);
 
-            FeatureJArray := FeatureJArray.JArray();
+            Clear(FeatureJArray);
             foreach FeatureXmlNode in BucketXmlNode.ChildNodes do
                 if IsNodePromoted(FeatureXmlNode) then begin
-                    FeatureJObject := FeatureJObject.JObject();
+                    Clear(FeatureJObject);
                     GetLanguageSpecificCaptionAndTooltip(FeatureXmlNode, Caption, Tooltip);
-                    JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonNameElementLbl, Caption);
-                    JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonTooltipLbl, Tooltip);
-                    JSONManagement.AddJObjectToJArray(FeatureJArray, FeatureJObject);
+                    FeatureJObject.Add(JsonNameElementLbl, Caption);
+                    FeatureJObject.Add(JsonTooltipLbl, Tooltip);
+                    FeatureJArray.Add(FeatureJObject);
                 end;
 
-            if FeatureJArray.Count > 0 then begin
-                JSONManagement.AddJArrayToJObject(FeatureBucketJObject, JsonRowElementLbl, FeatureJArray);
-                JSONManagement.AddJObjectToJArray(FeatureBucketsJArray, FeatureBucketJObject);
+            if FeatureJArray.Count() > 0 then begin
+                FeatureBucketJObject.Add(JsonRowElementLbl, FeatureJArray);
+                FeatureBucketsJArray.Add(FeatureBucketJObject);
             end;
         end;
 
-        exit(FeatureBucketsJArray.ToString());
+        FeatureBucketsJArray.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure BuildJsonFromPageActionTable(RolecenterId: Integer): Text
@@ -110,20 +109,19 @@ codeunit 1485 "Rolecenter Selector Mgt."
         PageAction: Record "Page Action";
         BucketPageAction: Record "Page Action";
         FeaturePageAction: Record "Page Action";
-        JSONManagement: Codeunit "JSON Management";
-        FeatureBucketsJArray: DotNet JArray;
-        FeatureBucketJObject: DotNet JObject;
-        FeatureJArray: DotNet JArray;
-        FeatureJObject: DotNet JObject;
+        FeatureBucketsJArray: JsonArray;
+        FeatureBucketJObject: JsonObject;
+        FeatureJArray: JsonArray;
+        FeatureJObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(FeatureBucketsJArray);
-
         PageAction.SetRange("Page ID", RolecenterId);
         PageAction.SetRange("Action Type", PageAction."Action Type"::ActionContainer);
         PageAction.SetRange("Action Subtype", PageAction."Action Subtype"::ActivityButtons);
-        if not PageAction.FindFirst() then
-            exit(FeatureBucketsJArray.ToString());
+        if not PageAction.FindFirst() then begin
+            FeatureBucketsJArray.WriteTo(JsonText);
+            exit(JsonText);
+        end;
 
         BucketPageAction.SetRange("Page ID", RolecenterId);
         BucketPageAction.SetRange("Parent Action ID", PageAction."Action ID");
@@ -131,13 +129,12 @@ codeunit 1485 "Rolecenter Selector Mgt."
         BucketPageAction.SetRange(Indentation, 1);
         if BucketPageAction.FindSet() then
             repeat
-                JSONManagement.InitializeEmptyObject();
-                JSONManagement.GetJSONObject(FeatureBucketJObject);
-                JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonNameElementLbl, BucketPageAction.Caption);
-                JSONManagement.AddJPropertyToJObject(FeatureBucketJObject, JsonTooltipLbl,
+                Clear(FeatureBucketJObject);
+                FeatureBucketJObject.Add(JsonNameElementLbl, BucketPageAction.Caption);
+                FeatureBucketJObject.Add(JsonTooltipLbl,
                   BucketPageAction.ToolTip1 + BucketPageAction.ToolTip2 + BucketPageAction.ToolTip3 + BucketPageAction.ToolTip4);
 
-                FeatureJArray := FeatureJArray.JArray();
+                Clear(FeatureJArray);
                 FeaturePageAction.SetRange("Page ID", RolecenterId);
                 FeaturePageAction.SetRange("Parent Action ID", BucketPageAction."Action ID");
                 FeaturePageAction.SetRange("Action Type", FeaturePageAction."Action Type"::Action);
@@ -146,54 +143,50 @@ codeunit 1485 "Rolecenter Selector Mgt."
 
                 if FeaturePageAction.FindSet() then
                     repeat
-                        FeatureJObject := FeatureJObject.JObject();
-                        JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonNameElementLbl, FeaturePageAction.Caption);
-                        JSONManagement.AddJPropertyToJObject(FeatureJObject, JsonTooltipLbl,
+                        Clear(FeatureJObject);
+                        FeatureJObject.Add(JsonNameElementLbl, FeaturePageAction.Caption);
+                        FeatureJObject.Add(JsonTooltipLbl,
                           FeaturePageAction.ToolTip1 + FeaturePageAction.ToolTip2 + FeaturePageAction.ToolTip3 + FeaturePageAction.ToolTip4);
-                        JSONManagement.AddJObjectToJArray(FeatureJArray, FeatureJObject);
+                        FeatureJArray.Add(FeatureJObject);
                     until FeaturePageAction.Next() = 0;
 
-                if FeatureJArray.Count > 0 then begin
-                    JSONManagement.AddJArrayToJObject(FeatureBucketJObject, JsonRowElementLbl, FeatureJArray);
-                    JSONManagement.AddJObjectToJArray(FeatureBucketsJArray, FeatureBucketJObject);
+                if FeatureJArray.Count() > 0 then begin
+                    FeatureBucketJObject.Add(JsonRowElementLbl, FeatureJArray);
+                    FeatureBucketsJArray.Add(FeatureBucketJObject);
                 end;
             until BucketPageAction.Next() = 0;
 
-        exit(FeatureBucketsJArray.ToString());
+        FeatureBucketsJArray.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     procedure BuildPageDataJsonForRolecenterSelector(): Text
     var
         AllProfile: Record "All Profile";
-        JSONManagement: Codeunit "JSON Management";
-        PageDataJObject: DotNet JObject;
-        ProfileJArray: DotNet JArray;
-        ProfileJObject: DotNet JObject;
+        PageDataJObject: JsonObject;
+        ProfileJArray: JsonArray;
+        ProfileJObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(PageDataJObject);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonHeaderLbl, DropdownLbl);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonDefaultActionLbl, ActionCaptionTxt);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonDisclaimerTextLbl, DisclaimerTxt);
-        JSONManagement.AddJPropertyToJObject(PageDataJObject, JsonActionDescriptionLbl, ActionDescriptionTxt);
-
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(ProfileJArray);
+        PageDataJObject.Add(JsonHeaderLbl, DropdownLbl);
+        PageDataJObject.Add(JsonDefaultActionLbl, ActionCaptionTxt);
+        PageDataJObject.Add(JsonDisclaimerTextLbl, DisclaimerTxt);
+        PageDataJObject.Add(JsonActionDescriptionLbl, ActionDescriptionTxt);
 
         AllProfile.SetRange(Enabled, true);
         if AllProfile.FindSet() then
             repeat
-                JSONManagement.InitializeEmptyObject();
-                JSONManagement.GetJSONObject(ProfileJObject);
-                JSONManagement.AddJPropertyToJObject(ProfileJObject, JsonProfileNameLbl, Format(AllProfile.RecordId));
-                JSONManagement.AddJPropertyToJObject(ProfileJObject, JsonProfileDescriptionLbl, AllProfile.Description);
-                JSONManagement.AddJPropertyToJObject(ProfileJObject, JsonRolecenterIdLbl, AllProfile."Role Center ID");
-                JSONManagement.AddJObjectToJArray(ProfileJArray, ProfileJObject);
+                Clear(ProfileJObject);
+                ProfileJObject.Add(JsonProfileNameLbl, Format(AllProfile.RecordId));
+                ProfileJObject.Add(JsonProfileDescriptionLbl, AllProfile.Description);
+                ProfileJObject.Add(JsonRolecenterIdLbl, AllProfile."Role Center ID");
+                ProfileJArray.Add(ProfileJObject);
             until AllProfile.Next() = 0;
 
-        JSONManagement.AddJArrayToJObject(PageDataJObject, JsonDropdownContentLbl, ProfileJArray);
+        PageDataJObject.Add(JsonDropdownContentLbl, ProfileJArray);
 
-        exit(PageDataJObject.ToString());
+        PageDataJObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     [Scope('OnPrem')]
@@ -313,4 +306,3 @@ codeunit 1485 "Rolecenter Selector Mgt."
         exit(UpperCase('RoleCenterOverviewShowState'));
     end;
 }
-

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
@@ -195,7 +195,7 @@ codeunit 2020 "Image Analysis Management"
     procedure Analyze(var ImageAnalysisResult: Codeunit "Image Analysis Result"; AnalysisTypes: List of [Enum "Image Analysis Type"]): Boolean
     var
         ImageAnalysisSetup: Record "Image Analysis Setup";
-        ResultJSONManagement: Codeunit "JSON Management";
+        ResultJson: JsonObject;
         UsageLimitError: Text;
     begin
         Initialize();
@@ -215,7 +215,7 @@ codeunit 2020 "Image Analysis Management"
                 if ImageAnalysisSetup.IsUsageLimitReached(UsageLimitError, LimitValue, LimitType) then
                     SetLastError(UsageLimitError, true)
                 else
-                    if InvokeAnalysisWithAuth(ResultJSONManagement, Uri, Key, ImagePath, AnalysisTypes, GlobalLanguage()) then
+                    if InvokeAnalysisWithAuth(ResultJson, Uri, Key, ImagePath, AnalysisTypes, GlobalLanguage()) then
                         ImageAnalysisSetup.Increment()
                     else
                         if ImageAnalysisProvider.GetLastError() <> '' then
@@ -223,7 +223,7 @@ codeunit 2020 "Image Analysis Management"
                         else
                             SetLastError(GenericErrorErr, false);
 
-        ImageAnalysisResult.SetResult(ResultJSONManagement, AnalysisTypes);
+        ImageAnalysisResult.SetResult(ResultJson, AnalysisTypes);
         OnAfterImageAnalysis(ImageAnalysisResult);
 
         exit(not HasError());
@@ -239,10 +239,10 @@ codeunit 2020 "Image Analysis Management"
         ImageAnalysisProvider := ImageAnalysisWrapperV10;
     end;
 
-    local procedure InvokeAnalysisWithAuth(var JSONManagement: Codeunit "JSON Management"; BaseUrl: Text; ImageAnalysisKey: SecretText; Path: Text; AnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
+    local procedure InvokeAnalysisWithAuth(var ResultJson: JsonObject; BaseUrl: Text; ImageAnalysisKey: SecretText; Path: Text; AnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
     begin
         ImageAnalysisProvider.SetUseOAuth2(UseOAuth2);
-        exit(ImageAnalysisProvider.InvokeAnalysis(JSONManagement, BaseUrl, ImageAnalysisKey, Path, AnalysisTypes, LanguageId));
+        exit(ImageAnalysisProvider.InvokeAnalysis(ResultJson, BaseUrl, ImageAnalysisKey, Path, AnalysisTypes, LanguageId));
     end;
 
     procedure GetLastError(var Message: Text; var IsUsageLimitError: Boolean): Boolean
@@ -351,7 +351,7 @@ codeunit 2020 "Image Analysis Management"
         LimitValueTxt := ExtractParameterValue(ImageAnalysisParameters, 'limitvalue', true);
 
         LocalLimitType := MachineLearningKeyVaultMgmt.GetLimitTypeOptionFromText(LimitTypeTxt);
-        Evaluate(LocalLimitValue, LimitValueTxt);
+        Evaluate(LocalLimitValue, LimitValueTxt, 9);
 
         Scopes.Add(CognitiveServicesScopeTok);
         if not OAuth2.AcquireTokensWithCertificate(AppId, Cert, RedirectUrl, AuthUrl, Scopes, ApiToken, IdToken) then begin
@@ -405,7 +405,7 @@ codeunit 2020 "Image Analysis Management"
         LimitValueTxt := ExtractParameterValue(ImageAnalysisParameters, 'limitvalue', true);
 
         LocalLimitType := MachineLearningKeyVaultMgmt.GetLimitTypeOptionFromText(LimitTypeTxt);
-        Evaluate(LocalLimitValue, LimitValueTxt);
+        Evaluate(LocalLimitValue, LimitValueTxt, 9);
     end;
 
     internal procedure ToCommaSeparatedList(ImageAnalysisTypes: List of [Enum "Image Analysis Type"]) ListAsText: Text

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisManagement.Codeunit.al
@@ -5,7 +5,6 @@ using System.Azure.KeyVault;
 using System.Environment;
 using System.IO;
 using System.Security.Authentication;
-using System.Text;
 using System.Utilities;
 
 codeunit 2020 "Image Analysis Management"

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisProvider.Interface.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisProvider.Interface.al
@@ -1,14 +1,12 @@
 namespace System.AI;
 
-using System.Text;
-
 interface "Image Analysis Provider"
 {
     Access = Internal;
 
     procedure IsLanguageSupported(AnalysisTypes: List of [Enum "Image Analysis Type"]; Language: Integer): Boolean
 
-    procedure InvokeAnalysis(var JSONManagement: Codeunit "JSON Management"; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
+    procedure InvokeAnalysis(var ResultJson: JsonObject; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
     procedure SetUseOAuth2(UseOAuth2: Boolean);
     procedure IsMediaSupported(MediaID: Guid): Boolean;
 

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisResult.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisResult.Codeunit.al
@@ -6,13 +6,14 @@ using System.Text;
 codeunit 2021 "Image Analysis Result"
 {
     var
-        JSONManagement: Codeunit "JSON Management";
-        Result: DotNet JObject;
-        Tags: DotNet JArray;
-        Color: DotNet JObject;
-        DominantColors: DotNet JArray;
+        Result: JsonObject;
+        Tags: JsonArray;
+        Color: JsonObject;
+        DominantColors: JsonArray;
         LastAnalysisTypes: List of [Enum "Image Analysis Type"];
 
+#if not CLEAN30
+    [Obsolete('Use SetResult with the native JsonObject type instead.', '30.0')]
     procedure SetResult(InputJSONManagement: Codeunit "JSON Management"; AnalysisType: Enum "Image Analysis Type")
     var
         AnalysisTypes: List of [Enum "Image Analysis Type"];
@@ -21,73 +22,97 @@ codeunit 2021 "Image Analysis Result"
         SetResult(InputJSONManagement, AnalysisTypes);
     end;
 
+    [Obsolete('Use SetResult with the native JsonObject type instead.', '30.0')]
     procedure SetResult(InputJSONManagement: Codeunit "JSON Management"; AnalysisTypes: List of [Enum "Image Analysis Type"])
+    var
+        InputResult: JsonObject;
+        ResultText: Text;
     begin
-        Tags := Tags.JArray();
-        Color := Color.JObject();
-        DominantColors := DominantColors.JArray();
+        ResultText := InputJSONManagement.WriteObjectToString();
+        if ResultText <> '' then
+            InputResult.ReadFrom(ResultText);
+        SetResult(InputResult, AnalysisTypes);
+    end;
+#endif
+
+    procedure SetResult(InputResult: JsonObject; AnalysisType: Enum "Image Analysis Type")
+    var
+        AnalysisTypes: List of [Enum "Image Analysis Type"];
+    begin
+        AnalysisTypes.Add(AnalysisType);
+        SetResult(InputResult, AnalysisTypes);
+    end;
+
+    procedure SetResult(InputResult: JsonObject; AnalysisTypes: List of [Enum "Image Analysis Type"])
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Tags);
+        Clear(Color);
+        Clear(DominantColors);
 
         LastAnalysisTypes := AnalysisTypes;
 
-        InputJSONManagement.GetJSONObject(Result);
-        if IsNull(Result) then
+        Result := InputResult.Clone().AsObject();
+        if Result.Keys().Count() = 0 then
             exit;
 
-        if not JSONManagement.GetArrayPropertyValueFromJObjectByName(Result, 'tags', Tags) then
-            if not JSONManagement.GetArrayPropertyValueFromJObjectByName(Result, 'Predictions', Tags) then
-                if not JSONManagement.GetArrayPropertyValueFromJObjectByName(Result, 'predictions', Tags) then
-                    Tags := Tags.JArray();
+        if Result.Get('tags', JsonToken) and JsonToken.IsArray() then
+            Tags := JsonToken.AsArray()
+        else
+            if Result.Get('Predictions', JsonToken) and JsonToken.IsArray() then
+                Tags := JsonToken.AsArray()
+            else
+                if Result.Get('predictions', JsonToken) and JsonToken.IsArray() then
+                    Tags := JsonToken.AsArray();
 
-        Color := Color.JObject();
-        DominantColors := DominantColors.JArray();
-        if JSONManagement.GetObjectPropertyValueFromJObjectByName(Result, 'color', Color) then
-            JSONManagement.GetArrayPropertyValueFromJObjectByName(Color, 'dominantColors', DominantColors)
-        else begin
-            Color := Color.JObject();
-            DominantColors := DominantColors.JArray();
+        if Result.Get('color', JsonToken) and JsonToken.IsObject() then begin
+            Color := JsonToken.AsObject();
+            if Color.Get('dominantColors', JsonToken) and JsonToken.IsArray() then
+                DominantColors := JsonToken.AsArray();
         end;
     end;
 
     internal procedure GetResultVerbatim() ResultVerbatim: Text
     begin
-        if IsNull(Result) then
+        if Result.Keys().Count() = 0 then
             exit('');
 
-        ResultVerbatim := Result.ToString();
+        Result.WriteTo(ResultVerbatim);
     end;
 
     procedure TagCount(): Integer
     begin
-        exit(Tags.Count);
+        exit(Tags.Count());
     end;
 
     procedure TagName(Number: Integer): Text
     var
-        Tag: DotNet JObject;
+        Tag: JsonObject;
+        JsonToken: JsonToken;
         Name: Text;
     begin
-        JSONManagement.InitializeCollectionFromJArray(Tags);
-        if JSONManagement.GetJObjectFromCollectionByIndex(Tag, Number - 1) then begin
-            if not JSONManagement.GetStringPropertyValueFromJObjectByName(Tag, 'name', Name) then
-                if not JSONManagement.GetStringPropertyValueFromJObjectByName(Tag, 'Tag', Name) then
-                    JSONManagement.GetStringPropertyValueFromJObjectByName(Tag, 'tagName', Name);
+        if Tags.Get(Number - 1, JsonToken) and JsonToken.IsObject() then begin
+            Tag := JsonToken.AsObject();
+            if not TryGetJsonText(Tag, 'name', Name) then
+                if not TryGetJsonText(Tag, 'Tag', Name) then
+                    TryGetJsonText(Tag, 'tagName', Name);
             exit(Name)
         end;
     end;
 
     procedure TagConfidence(Number: Integer): Decimal
     var
-        Tag: DotNet JObject;
+        Tag: JsonObject;
+        JsonToken: JsonToken;
         Confidence: Decimal;
-        ConfidenceText: Text;
     begin
-        JSONManagement.InitializeCollectionFromJArray(Tags);
-        if JSONManagement.GetJObjectFromCollectionByIndex(Tag, Number - 1) then begin
-            if not JSONManagement.GetStringPropertyValueFromJObjectByName(Tag, 'confidence', ConfidenceText) then
-                if not JSONManagement.GetStringPropertyValueFromJObjectByName(Tag, 'Probability', ConfidenceText) then
-                    if not JSONManagement.GetStringPropertyValueFromJObjectByName(Tag, 'probability', ConfidenceText) then
-                        ConfidenceText := '0';
-            Evaluate(Confidence, ConfidenceText);
+        if Tags.Get(Number - 1, JsonToken) and JsonToken.IsObject() then begin
+            Tag := JsonToken.AsObject();
+            if not TryGetJsonDecimal(Tag, 'confidence', Confidence) then
+                if not TryGetJsonDecimal(Tag, 'Probability', Confidence) then
+                    if not TryGetJsonDecimal(Tag, 'probability', Confidence) then
+                        exit(0);
             exit(Confidence)
         end;
     end;
@@ -96,7 +121,7 @@ codeunit 2021 "Image Analysis Result"
     var
         ColorText: Text;
     begin
-        JSONManagement.GetStringPropertyValueFromJObjectByName(Color, 'dominantColorForeground', ColorText);
+        TryGetJsonText(Color, 'dominantColorForeground', ColorText);
         exit(ColorText);
     end;
 
@@ -104,24 +129,52 @@ codeunit 2021 "Image Analysis Result"
     var
         ColorText: Text;
     begin
-        JSONManagement.GetStringPropertyValueFromJObjectByName(Color, 'dominantColorBackground', ColorText);
+        TryGetJsonText(Color, 'dominantColorBackground', ColorText);
         exit(ColorText);
     end;
 
     procedure DominantColorCount(): Integer
     begin
-        exit(DominantColors.Count);
+        exit(DominantColors.Count());
     end;
 
     procedure DominantColor(Number: Integer): Text
     var
-        LocalDominantColor: DotNet JObject;
+        JsonToken: JsonToken;
     begin
-        JSONManagement.InitializeCollectionFromJArray(DominantColors);
-        if JSONManagement.GetJObjectFromCollectionByIndex(LocalDominantColor, Number - 1) then
-            exit(Format(LocalDominantColor));
+        if DominantColors.Get(Number - 1, JsonToken) and JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
     end;
 
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) or not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(true);
+        Value := JsonToken.AsValue().AsText();
+        exit(true);
+    end;
+
+    local procedure TryGetJsonDecimal(JsonObject: JsonObject; PropertyName: Text; var Value: Decimal): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if not JsonToken.IsValue() then
+            exit(false);
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit(false);
+        exit(Evaluate(Value, JsonToken.AsValue().AsText(), 9));
+    end;
 
     procedure GetLatestImageAnalysisTypes(var AnalysisType: List of [Enum "Image Analysis Type"])
     begin

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisResult.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisResult.Codeunit.al
@@ -1,7 +1,8 @@
 namespace System.AI;
 
-using System;
+#if not CLEAN30
 using System.Text;
+#endif
 
 codeunit 2021 "Image Analysis Result"
 {

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisWrapperV10.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisWrapperV10.Codeunit.al
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Text;
 using System.Utilities;
 
 codeunit 2024 "Image Analysis Wrapper V1.0" implements "Image Analysis Provider"
@@ -19,12 +18,12 @@ codeunit 2024 "Image Analysis Wrapper V1.0" implements "Image Analysis Provider"
         LastError: Text;
         HttpMessageHandler: DotNet HttpMessageHandler;
 
-    procedure InvokeAnalysis(var JSONManagement: Codeunit "JSON Management"; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
+    procedure InvokeAnalysis(var ResultJson: JsonObject; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
     begin
         if ImageAnalysisTypes.Count() > 1 then
             Error(OnlyOneAnalysisSupportedErr);
 
-        exit(TryInvokeAnalysisInternal(JSONManagement, BaseUrl, ImageAnalysisKey, ImagePath, ImageAnalysisTypes.Get(1)));
+        exit(TryInvokeAnalysisInternal(ResultJson, BaseUrl, ImageAnalysisKey, ImagePath, ImageAnalysisTypes.Get(1)));
     end;
 
     /// <summary>
@@ -37,7 +36,7 @@ codeunit 2024 "Image Analysis Wrapper V1.0" implements "Image Analysis Provider"
     end;
 
     [TryFunction]
-    local procedure TryInvokeAnalysisInternal(var JSONManagement: Codeunit "JSON Management"; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisType: Enum "Image Analysis Type")
+    local procedure TryInvokeAnalysisInternal(var ResultJson: JsonObject; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisType: Enum "Image Analysis Type")
     var
         FileManagement: Codeunit "File Management";
         HttpClient: DotNet HttpClient;
@@ -52,8 +51,9 @@ codeunit 2024 "Image Analysis Wrapper V1.0" implements "Image Analysis Provider"
         Task: DotNet Task1;
         File: DotNet File;
         FileStream: DotNet FileStream;
-        JsonResult: DotNet JObject;
+        JsonToken: JsonToken;
         MessageText: Text;
+        ResponseText: Text;
         PostParameters: Text;
     begin
         if IsNull(HttpMessageHandler) then
@@ -91,15 +91,19 @@ codeunit 2024 "Image Analysis Wrapper V1.0" implements "Image Analysis Provider"
         HttpResponseMessage := Task.Result;
         HttpContent := HttpResponseMessage.Content;
         Task := HttpContent.ReadAsStringAsync();
-        JSONManagement.InitializeObject(Task.Result);
+        ResponseText := Task.Result;
+        Clear(ResultJson);
+        if ResponseText <> '' then
+            ResultJson.ReadFrom(ResponseText);
 
         FileStream.Dispose();
         StreamContent.Dispose();
         HttpClient.Dispose();
 
         if not HttpResponseMessage.IsSuccessStatusCode then begin
-            JSONManagement.GetJSONObject(JsonResult);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JsonResult, 'message', MessageText);
+            if ResultJson.Get('message', JsonToken) and JsonToken.IsValue() then
+                if not JsonToken.AsValue().IsNull() and not JsonToken.AsValue().IsUndefined() then
+                    MessageText := JsonToken.AsValue().AsText();
             if HasCustomVisionUri(BaseUrl) then
                 LastError := StrSubstNo(CognitiveServicesErr, CustomVisionServiceTxt, MessageText, HttpResponseMessage.StatusCode)
             else

--- a/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisWrapperV32.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/AI/ImageAnalysis/ImageAnalysisWrapperV32.Codeunit.al
@@ -4,7 +4,6 @@ using System;
 using System.Environment;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Utilities;
 
 codeunit 2023 "Image Analysis Wrapper V3.2" implements "Image Analysis Provider"
@@ -28,9 +27,9 @@ codeunit 2023 "Image Analysis Wrapper V3.2" implements "Image Analysis Provider"
         UseOAuth2: Boolean;
         LastError: Text;
 
-    procedure InvokeAnalysis(var JSONManagement: Codeunit "JSON Management"; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
+    procedure InvokeAnalysis(var ResultJson: JsonObject; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer): Boolean
     begin
-        exit(TryInvokeAnalysisInternal(JSONManagement, BaseUrl, ImageAnalysisKey, ImagePath, ImageAnalysisTypes, LanguageId));
+        exit(TryInvokeAnalysisInternal(ResultJson, BaseUrl, ImageAnalysisKey, ImagePath, ImageAnalysisTypes, LanguageId));
     end;
 
     /// <summary>
@@ -43,7 +42,7 @@ codeunit 2023 "Image Analysis Wrapper V3.2" implements "Image Analysis Provider"
     end;
 
     [TryFunction]
-    local procedure TryInvokeAnalysisInternal(var JSONManagement: Codeunit "JSON Management"; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer)
+    local procedure TryInvokeAnalysisInternal(var ResultJson: JsonObject; BaseUrl: Text; ImageAnalysisKey: SecretText; ImagePath: Text; ImageAnalysisTypes: List of [Enum "Image Analysis Type"]; LanguageId: Integer)
     var
         PostUrl: Text;
         Language: Text[10];
@@ -55,21 +54,23 @@ codeunit 2023 "Image Analysis Wrapper V3.2" implements "Image Analysis Provider"
         PostUrl := BuildUri(BaseUrl, Language, ImageAnalysisTypes);
         PrepareRequest(HttpRequestMessage, PostUrl, ImageAnalysisKey);
         AddContent(HttpRequestMessage, ImagePath);
-        SendRequest(HttpRequestMessage, JSONManagement);
+        SendRequest(HttpRequestMessage, ResultJson);
 
-        LogCorrelationToTelemetry(JSONManagement);
+        LogCorrelationToTelemetry(ResultJson);
     end;
 
-    local procedure LogCorrelationToTelemetry(var JSONManagement: Codeunit "JSON Management")
+    local procedure LogCorrelationToTelemetry(ResultJson: JsonObject)
     var
         ImageAnalysisManagement: Codeunit "Image Analysis Management";
-        JsonResult: DotNet JObject;
+        JsonToken: JsonToken;
         RequestIdAsGuid: Guid;
         RequestIdPresent: Boolean;
     begin
-        JSONManagement.GetJSONObject(JsonResult);
-
-        RequestIdPresent := JSONManagement.GetGuidPropertyValueFromJObjectByName(JsonResult, 'requestId', RequestIdAsGuid);
+        if ResultJson.Get('requestId', JsonToken) then
+            if JsonToken.IsValue() then
+                if not JsonToken.AsValue().IsNull() then
+                    if not JsonToken.AsValue().IsUndefined() then
+                        RequestIdPresent := Evaluate(RequestIdAsGuid, JsonToken.AsValue().AsText());
 
         Session.LogMessage('0000K10', StrSubstNo(RequestIdTelemetryMsg, RequestIdPresent, RequestIdAsGuid),
             Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', ImageAnalysisManagement.GetTelemetryCategory());
@@ -165,10 +166,10 @@ codeunit 2023 "Image Analysis Wrapper V3.2" implements "Image Analysis Provider"
     end;
 
     [NonDebuggable]
-    local procedure SendRequest(HttpRequestMsg: HttpRequestMessage; var JSONManagement: Codeunit "JSON Management")
+    local procedure SendRequest(HttpRequestMsg: HttpRequestMessage; var ResultJson: JsonObject)
     var
         ImageAnalysisManagement: Codeunit "Image Analysis Management";
-        JsonResult: DotNet JObject;
+        JsonToken: JsonToken;
         HttpResponseMessage: HttpResponseMessage;
         ResponseHttpContent: HttpContent;
         HttpClient: HttpClient;
@@ -189,11 +190,14 @@ codeunit 2023 "Image Analysis Wrapper V3.2" implements "Image Analysis Provider"
             ResponseHttpContent.ReadAs(HttpContentText);
         end;
 
-        JSONManagement.InitializeObject(HttpContentText);
+        Clear(ResultJson);
+        if HttpContentText <> '' then
+            ResultJson.ReadFrom(HttpContentText);
 
         if not IsSuccessStatusCode then begin
-            JSONManagement.GetJSONObject(JsonResult);
-            JSONManagement.GetStringPropertyValueFromJObjectByName(JsonResult, 'message', MessageText);
+            if ResultJson.Get('message', JsonToken) and JsonToken.IsValue() then
+                if not JsonToken.AsValue().IsNull() and not JsonToken.AsValue().IsUndefined() then
+                    MessageText := JsonToken.AsValue().AsText();
             LastError := StrSubstNo(CognitiveServicesErr, ComputerVisionApiTxt, MessageText, HttpStatusCode);
             Error('');
         end;

--- a/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
@@ -9,7 +9,6 @@ using System.Environment.Configuration;
 using System.Integration;
 using System.Reflection;
 using System.Security.AccessControl;
-using System.Text;
 using System.Threading;
 using System.Utilities;
 

--- a/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
@@ -278,32 +278,28 @@ codeunit 6154 "API Webhook Notification Send"
 
     local procedure GetPayloadPerNotificationUrl(NotificationUrlNumber: Integer; var SubscriptionIds: List of [Text[150]]): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonArray: DotNet JArray;
+        JsonArray: JsonArray;
         SubscriptionId: Text[150];
         PayloadPerNotificationUrl: Text;
     begin
         Session.LogMessage('00006ZX', StrSubstNo(CollectPayloadPerNotificationUrlMsg, NotificationUrlNumber, SubscriptionIds.Count()), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', APIWebhookCategoryLbl);
 
-        JSONManagement.InitializeEmptyCollection();
-        JSONManagement.GetJsonArray(JsonArray);
-
         foreach SubscriptionId in SubscriptionIds do
-            AddPayloadPerSubscription(JSONManagement, JsonArray, SubscriptionId);
+            AddPayloadPerSubscription(JsonArray, SubscriptionId);
 
         if JsonArray.Count() = 0 then begin
             Session.LogMessage('000029X', StrSubstNo(EmptyPayloadPerNotificationUrlErr, NotificationUrlNumber), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', APIWebhookCategoryLbl);
             exit('')
         end;
 
-        PayloadPerNotificationUrl := JsonArray.ToString();
+        JsonArray.WriteTo(PayloadPerNotificationUrl);
         FormatPayloadPerNotificationUrl(PayloadPerNotificationUrl, SubscriptionsPerNotificationUrlDictionary.Keys().Get(NotificationUrlNumber));
         exit(PayloadPerNotificationUrl);
     end;
 
-    local procedure AddPayloadPerSubscription(var JSONManagement: Codeunit "JSON Management"; var JsonArray: DotNet JArray; SubscriptionId: Text[150])
+    local procedure AddPayloadPerSubscription(var JsonArray: JsonArray; SubscriptionId: Text[150])
     var
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         I: Integer;
         SubscriptionSystemId: Guid;
     begin
@@ -328,7 +324,7 @@ codeunit 6154 "API Webhook Notification Send"
 
         repeat
             if GetEntityJObject(TempAPIWebhookNotificationAggr, JsonObject) then begin
-                JSONManagement.AddJObjectToJArray(JsonArray, JsonObject);
+                JsonArray.Add(JsonObject);
                 I += 1;
                 Session.LogMessage('00006ZW', StrSubstNo(CollectNotificationPayloadMsg, SubscriptionSystemId, TempAPIWebhookNotificationAggr."Entity ID", ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"),
                     DateTimeToString(TempAPIWebhookNotificationAggr."Last Modified Date Time")), Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', APIWebhookCategoryLbl);
@@ -344,26 +340,20 @@ codeunit 6154 "API Webhook Notification Send"
     local procedure FormatPayloadPerNotificationUrl(var PayloadPerNotificationUrl: Text; NotificationUrl: Text)
     var
         APIWebhookSubscription: Record "API Webhook Subscription";
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        JsonArray: DotNet JArray;
+        JsonObject: JsonObject;
+        JsonArray: JsonArray;
     begin
         if PayloadPerNotificationUrl = '' then
             exit;
 
         if SubscriptionsTypeNotificationUrlDictionary.Get(NotificationUrl) = APIWebhookSubscription."Subscription Type"::Regular then begin
-            JSONManagement.InitializeCollection(PayloadPerNotificationUrl);
-            JSONManagement.GetJsonArray(JsonArray);
-            JSONManagement.InitializeEmptyObject();
-            JSONManagement.GetJSONObject(JsonObject);
-            JSONManagement.AddJArrayToJObject(JsonObject, 'value', JsonArray);
-            PayloadPerNotificationUrl := JsonObject.ToString();
+            JsonArray.ReadFrom(PayloadPerNotificationUrl);
+            JsonObject.Add('value', JsonArray);
+            JsonObject.WriteTo(PayloadPerNotificationUrl);
         end else begin
-            JSONManagement.InitializeEmptyObject();
-            JSONManagement.GetJSONObject(JsonObject);
-            JSONManagement.AddJPropertyToJObject(JsonObject, 'ProviderName', 'dyn365bc');
-            JSONManagement.AddJPropertyToJObject(JsonObject, 'Request', PayloadPerNotificationUrl);
-            PayloadPerNotificationUrl := JsonObject.ToString();
+            JsonObject.Add('ProviderName', 'dyn365bc');
+            JsonObject.Add('Request', PayloadPerNotificationUrl);
+            JsonObject.WriteTo(PayloadPerNotificationUrl);
         end;
     end;
 
@@ -1277,9 +1267,8 @@ codeunit 6154 "API Webhook Notification Send"
         exit(false);
     end;
 
-    local procedure GetEntityJObject(var TempAPIWebhookNotificationAggr: Record "API Webhook Notification Aggr" temporary; var JSONObject: DotNet JObject): Boolean
+    local procedure GetEntityJObject(var TempAPIWebhookNotificationAggr: Record "API Webhook Notification Aggr" temporary; var JSONObject: JsonObject): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
         ResourceUrl: Text;
         LastModifiedDateTime: DateTime;
         SubscriptionSystemId: Guid;
@@ -1304,17 +1293,16 @@ codeunit 6154 "API Webhook Notification Send"
                 Session.LogMessage('00006P3', StrSubstNo(EmptyLastModifiedDateTimeMsg, SubscriptionSystemId, TempAPIWebhookNotificationAggr."Entity ID", ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"),
                     TempAPIWebhookNotificationAggr."Attempt No."), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', APIWebhookCategoryLbl);
 
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JSONObject);
-        JSONManagement.AddJPropertyToJObject(JSONObject, 'subscriptionId', TempAPIWebhookSubscription."Subscription Id");
-        JSONManagement.AddJPropertyToJObject(JSONObject, 'clientState', TempAPIWebhookSubscription."Client State");
-        JSONManagement.AddJPropertyToJObject(JSONObject, 'expirationDateTime', TempAPIWebhookSubscription."Expiration Date Time");
-        JSONManagement.AddJPropertyToJObject(JSONObject, 'resource', ResourceUrl);
-        JSONManagement.AddJPropertyToJObject(JSONObject, 'changeType', ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"));
-        JSONManagement.AddJPropertyToJObject(JSONObject, 'lastModifiedDateTime', LastModifiedDateTime);
+        Clear(JSONObject);
+        JSONObject.Add('subscriptionId', TempAPIWebhookSubscription."Subscription Id");
+        JSONObject.Add('clientState', TempAPIWebhookSubscription."Client State");
+        JSONObject.Add('expirationDateTime', TempAPIWebhookSubscription."Expiration Date Time");
+        JSONObject.Add('resource', ResourceUrl);
+        JSONObject.Add('changeType', ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"));
+        JSONObject.Add('lastModifiedDateTime', LastModifiedDateTime);
         if ((TempAPIWebhookSubscription."Subscription Type" = TempAPIWebhookSubscription."Subscription Type"::Dataverse) and
             (TempAPIWebhookNotificationAggr."Change Type" <> TempAPIWebhookNotificationAggr."Change Type"::Collection)) then
-            JSONManagement.AddJPropertyToJObject(JSONObject, 'initiatingAadUserId', GetAadUserId(TempAPIWebhookNotificationAggr."Created By User SID"));
+            JSONObject.Add('initiatingAadUserId', GetAadUserId(TempAPIWebhookNotificationAggr."Created By User SID"));
         exit(true);
     end;
 
@@ -1897,17 +1885,8 @@ codeunit 6154 "API Webhook Notification Send"
 
     [Scope('OnPrem')]
     procedure DateTimeToUtcString(DateTimeValue: DateTime): Text
-    var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        UtcDateTimeString: Text;
     begin
-        // TODO replace getting UTC through JSON with the new function when such function is implemented on the platform side
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'value', DateTimeValue);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, 'value', UtcDateTimeString);
-        exit(UtcDateTimeString);
+        exit(Format(DateTimeValue, 0, 9));
     end;
 
     local procedure LogActivity(ActivityFailed: Boolean; ActivityDescription: Text; ActivityMessage: Text)
@@ -1939,4 +1918,3 @@ codeunit 6154 "API Webhook Notification Send"
     begin
     end;
 }
-

--- a/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/API/Webhooks/APIWebhookNotificationSend.Codeunit.al
@@ -322,7 +322,7 @@ codeunit 6154 "API Webhook Notification Send"
             TempAPIWebhookNotificationAggr.FindLast();
 
         repeat
-            if GetEntityJObject(TempAPIWebhookNotificationAggr, JsonObject) then begin
+            if GetEntityJsonObject(TempAPIWebhookNotificationAggr, JsonObject) then begin
                 JsonArray.Add(JsonObject);
                 I += 1;
                 Session.LogMessage('00006ZW', StrSubstNo(CollectNotificationPayloadMsg, SubscriptionSystemId, TempAPIWebhookNotificationAggr."Entity ID", ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"),
@@ -1266,7 +1266,7 @@ codeunit 6154 "API Webhook Notification Send"
         exit(false);
     end;
 
-    local procedure GetEntityJObject(var TempAPIWebhookNotificationAggr: Record "API Webhook Notification Aggr" temporary; var JSONObject: JsonObject): Boolean
+    local procedure GetEntityJsonObject(var TempAPIWebhookNotificationAggr: Record "API Webhook Notification Aggr" temporary; var JsonObject: JsonObject): Boolean
     var
         ResourceUrl: Text;
         LastModifiedDateTime: DateTime;
@@ -1292,16 +1292,16 @@ codeunit 6154 "API Webhook Notification Send"
                 Session.LogMessage('00006P3', StrSubstNo(EmptyLastModifiedDateTimeMsg, SubscriptionSystemId, TempAPIWebhookNotificationAggr."Entity ID", ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"),
                     TempAPIWebhookNotificationAggr."Attempt No."), Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, 'Category', APIWebhookCategoryLbl);
 
-        Clear(JSONObject);
-        JSONObject.Add('subscriptionId', TempAPIWebhookSubscription."Subscription Id");
-        JSONObject.Add('clientState', TempAPIWebhookSubscription."Client State");
-        JSONObject.Add('expirationDateTime', TempAPIWebhookSubscription."Expiration Date Time");
-        JSONObject.Add('resource', ResourceUrl);
-        JSONObject.Add('changeType', ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"));
-        JSONObject.Add('lastModifiedDateTime', LastModifiedDateTime);
+        Clear(JsonObject);
+        JsonObject.Add('subscriptionId', TempAPIWebhookSubscription."Subscription Id");
+        JsonObject.Add('clientState', TempAPIWebhookSubscription."Client State");
+        JsonObject.Add('expirationDateTime', TempAPIWebhookSubscription."Expiration Date Time");
+        JsonObject.Add('resource', ResourceUrl);
+        JsonObject.Add('changeType', ChangeTypeToString(TempAPIWebhookNotificationAggr."Change Type"));
+        JsonObject.Add('lastModifiedDateTime', LastModifiedDateTime);
         if ((TempAPIWebhookSubscription."Subscription Type" = TempAPIWebhookSubscription."Subscription Type"::Dataverse) and
             (TempAPIWebhookNotificationAggr."Change Type" <> TempAPIWebhookNotificationAggr."Change Type"::Collection)) then
-            JSONObject.Add('initiatingAadUserId', GetAadUserId(TempAPIWebhookNotificationAggr."Created By User SID"));
+            JsonObject.Add('initiatingAadUserId', GetAadUserId(TempAPIWebhookNotificationAggr."Created By User SID"));
         exit(true);
     end;
 

--- a/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
@@ -1,5 +1,8 @@
 namespace System.IO;
 
+#if not CLEAN30
+using System;
+#endif
 using System.Reflection;
 using System.Utilities;
 
@@ -73,6 +76,8 @@ table 1236 "JSON Buffer"
         SystemStringTxt: Label 'System.String', Locked = true;
         StrictJSONScalarPatternTxt: Label '^(?:"(?:\\["\\/bfnrt]|\\u[0-9A-Fa-f]{4}|[^"\\\x00-\x1F])*"|-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?|true|false|null)$', Locked = true;
 
+#if not CLEAN30
+    [Obsolete('Use ReadFromBlobStrict for standard JSON. Json.NET-only syntax is not supported by the strict parser.', '30.0')]
     procedure ReadFromBlob(BlobFieldRef: FieldRef)
     var
         TypeHelper: Codeunit "Type Helper";
@@ -81,10 +86,62 @@ table 1236 "JSON Buffer"
     begin
         TempBlob.FromRecordRef(BlobFieldRef.Record(), BlobFieldRef.Number);
         TempBlob.CreateInStream(InStream, TEXTENCODING::UTF8);
+#pragma warning disable AL0432
         ReadFromText(TypeHelper.ReadAsTextWithSeparator(InStream, TypeHelper.CRLFSeparator()));
+#pragma warning restore AL0432
     end;
 
+    [Obsolete('Use ReadFromTextStrict for standard JSON. Json.NET-only syntax is not supported by the strict parser.', '30.0')]
     procedure ReadFromText(JSONText: Text)
+    var
+        JSONTextReader: DotNet JsonTextReader;
+        StringReader: DotNet StringReader;
+        TokenType: Integer;
+        FormatValue: Integer;
+    begin
+        if not IsTemporary then
+            Error(DevMsgNotTemporaryErr);
+        DeleteAll();
+        JSONTextReader := JSONTextReader.JsonTextReader(StringReader.StringReader(JSONText));
+        if JSONTextReader.Read() then
+            repeat
+                Init();
+                "Entry No." += 1;
+                Depth := JSONTextReader.Depth;
+                TokenType := JSONTextReader.TokenType;
+                "Token type" := TokenType;
+                if IsNull(JSONTextReader.Value) then
+                    Value := ''
+                else begin
+                    if JSONTextReader.ValueType.ToString() = 'System.DateTime' then
+                        FormatValue := 1
+                    else
+                        FormatValue := 0;
+                    SetValueWithoutModifying(Format(JSONTextReader.Value, 0, FormatValue));
+                end;
+
+                if IsNull(JSONTextReader.ValueType) then
+                    "Value Type" := ''
+                else
+                    "Value Type" := Format(JSONTextReader.ValueType);
+                Path := JSONTextReader.Path;
+                Insert();
+            until not JSONTextReader.Read();
+    end;
+#endif
+
+    procedure ReadFromBlobStrict(BlobFieldRef: FieldRef)
+    var
+        TypeHelper: Codeunit "Type Helper";
+        TempBlob: Codeunit "Temp Blob";
+        InStream: InStream;
+    begin
+        TempBlob.FromRecordRef(BlobFieldRef.Record(), BlobFieldRef.Number);
+        TempBlob.CreateInStream(InStream, TEXTENCODING::UTF8);
+        ReadFromTextStrict(TypeHelper.ReadAsTextWithSeparator(InStream, TypeHelper.CRLFSeparator()));
+    end;
+
+    procedure ReadFromTextStrict(JSONText: Text)
     var
         JSONToken: JsonToken;
     begin

--- a/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
@@ -1,6 +1,5 @@
-﻿namespace System.IO;
+namespace System.IO;
 
-using System;
 using System.Reflection;
 using System.Utilities;
 
@@ -65,6 +64,13 @@ table 1236 "JSON Buffer"
 
     var
         DevMsgNotTemporaryErr: Label 'This function can only be used when the record is temporary.';
+        InvalidJSONErr: Label 'The JSON text is invalid.';
+        UnsupportedJSONValueErr: Label 'The JSON text contains a value that is not supported by standard JSON.';
+        SystemBooleanTxt: Label 'System.Boolean', Locked = true;
+        SystemDateTimeTxt: Label 'System.DateTime', Locked = true;
+        SystemDoubleTxt: Label 'System.Double', Locked = true;
+        SystemInt64Txt: Label 'System.Int64', Locked = true;
+        SystemStringTxt: Label 'System.String', Locked = true;
 
     procedure ReadFromBlob(BlobFieldRef: FieldRef)
     var
@@ -79,39 +85,189 @@ table 1236 "JSON Buffer"
 
     procedure ReadFromText(JSONText: Text)
     var
-        JSONTextReader: DotNet JsonTextReader;
-        StringReader: DotNet StringReader;
-        TokenType: Integer;
-        FormatValue: Integer;
+        JSONToken: JsonToken;
     begin
         if not IsTemporary then
             Error(DevMsgNotTemporaryErr);
         DeleteAll();
-        JSONTextReader := JSONTextReader.JsonTextReader(StringReader.StringReader(JSONText));
-        if JSONTextReader.Read() then
-            repeat
-                Init();
-                "Entry No." += 1;
-                Depth := JSONTextReader.Depth;
-                TokenType := JSONTextReader.TokenType;
-                "Token type" := TokenType;
-                if IsNull(JSONTextReader.Value) then
-                    Value := ''
-                else begin
-                    if JSONTextReader.ValueType.ToString() = 'System.DateTime' then
-                        FormatValue := 1
-                    else
-                        FormatValue := 0;
-                    SetValueWithoutModifying(Format(JSONTextReader.Value, 0, FormatValue));
-                end;
 
-                if IsNull(JSONTextReader.ValueType) then
-                    "Value Type" := ''
+        if JSONText.Trim() = '' then
+            exit;
+
+        if ContainsJSONComment(JSONText) then
+            Error(InvalidJSONErr);
+
+        if not JSONToken.ReadFrom(JSONText) then
+            Error(InvalidJSONErr);
+
+        ReadJSONToken(JSONToken, 0);
+    end;
+
+    local procedure ReadJSONToken(JSONToken: JsonToken; TokenDepth: Integer)
+    var
+        ChildJSONToken: JsonToken;
+        JSONArray: JsonArray;
+        JSONObject: JsonObject;
+        ArrayIndex: Integer;
+        PropertyName: Text;
+    begin
+        case true of
+            JSONToken.IsObject():
+                begin
+                    InsertJSONBufferRow(TokenDepth, "Token type"::"Start Object", '', '', JSONToken.Path());
+                    JSONObject := JSONToken.AsObject();
+                    foreach PropertyName in JSONObject.Keys() do begin
+                        JSONObject.Get(PropertyName, ChildJSONToken);
+                        InsertJSONBufferRow(TokenDepth + 1, "Token type"::"Property Name", PropertyName, SystemStringTxt, ChildJSONToken.Path());
+                        ReadJSONToken(ChildJSONToken, TokenDepth + 1);
+                    end;
+                    InsertJSONBufferRow(TokenDepth, "Token type"::"End Object", '', '', JSONToken.Path());
+                end;
+            JSONToken.IsArray():
+                begin
+                    InsertJSONBufferRow(TokenDepth, "Token type"::"Start Array", '', '', JSONToken.Path());
+                    JSONArray := JSONToken.AsArray();
+                    for ArrayIndex := 0 to JSONArray.Count() - 1 do begin
+                        JSONArray.Get(ArrayIndex, ChildJSONToken);
+                        ReadJSONToken(ChildJSONToken, TokenDepth + 1);
+                    end;
+                    InsertJSONBufferRow(TokenDepth, "Token type"::"End Array", '', '', JSONToken.Path());
+                end;
+            JSONToken.IsValue():
+                ReadJSONValue(JSONToken, TokenDepth);
+            else
+                Error(UnsupportedJSONValueErr);
+        end;
+    end;
+
+    local procedure ReadJSONValue(JSONToken: JsonToken; TokenDepth: Integer)
+    var
+        JSONValue: JsonValue;
+        BigIntegerValue: BigInteger;
+        BooleanValue: Boolean;
+        DecimalValue: Decimal;
+        SerializedValue: Text;
+        ValueText: Text;
+    begin
+        JSONValue := JSONToken.AsValue();
+        if JSONValue.IsNull() then begin
+            InsertJSONBufferRow(TokenDepth, "Token type"::Null, '', '', JSONToken.Path());
+            exit;
+        end;
+        if JSONValue.IsUndefined() then
+            Error(UnsupportedJSONValueErr);
+
+        JSONToken.WriteTo(SerializedValue);
+        case SerializedValue of
+            'true',
+            'false':
+                begin
+                    BooleanValue := JSONValue.AsBoolean();
+                    if BooleanValue then
+                        ValueText := 'Yes'
+                    else
+                        ValueText := 'No';
+                    InsertJSONBufferRow(TokenDepth, "Token type"::Boolean, ValueText, SystemBooleanTxt, JSONToken.Path());
+                end;
+            else
+                if SerializedValue.StartsWith('"') then begin
+                    ValueText := JSONValue.AsText();
+                    if IsJSONDateTime(ValueText) then
+                        InsertJSONBufferRow(TokenDepth, "Token type"::Date, ValueText, SystemDateTimeTxt, JSONToken.Path())
+                    else
+                        InsertJSONBufferRow(TokenDepth, "Token type"::String, ValueText, SystemStringTxt, JSONToken.Path());
+                end else
+                    if (StrPos(SerializedValue, '.') = 0) and (StrPos(LowerCase(SerializedValue), 'e') = 0) then begin
+                        BigIntegerValue := JSONValue.AsBigInteger();
+                        InsertJSONBufferRow(TokenDepth, "Token type"::Integer, Format(BigIntegerValue), SystemInt64Txt, JSONToken.Path());
+                    end else begin
+                        DecimalValue := JSONValue.AsDecimal();
+                        InsertJSONBufferRow(TokenDepth, "Token type"::Decimal, Format(DecimalValue), SystemDoubleTxt, JSONToken.Path());
+                    end;
+        end;
+    end;
+
+    local procedure InsertJSONBufferRow(TokenDepth: Integer; TokenType: Option; NewValue: Text; NewValueType: Text; TokenPath: Text)
+    begin
+        Init();
+        "Entry No." += 1;
+        Depth := TokenDepth;
+        "Token type" := TokenType;
+        SetValueWithoutModifying(NewValue);
+        "Value Type" := CopyStr(NewValueType, 1, MaxStrLen("Value Type"));
+        Path := CopyStr(TokenPath, 1, MaxStrLen(Path));
+        Insert();
+    end;
+
+    local procedure IsJSONDateTime(ValueText: Text): Boolean
+    var
+        DateTimeValue: DateTime;
+        ValueToEvaluate: Text;
+    begin
+        if (StrLen(ValueText) < 19) or
+           (CopyStr(ValueText, 5, 1) <> '-') or
+           (CopyStr(ValueText, 8, 1) <> '-') or
+           (CopyStr(ValueText, 11, 1) <> 'T') or
+           (CopyStr(ValueText, 14, 1) <> ':') or
+           (CopyStr(ValueText, 17, 1) <> ':')
+        then
+            exit(false);
+
+        if Evaluate(DateTimeValue, ValueText, 9) then
+            exit(true);
+
+        ValueToEvaluate := ValueText;
+        if not HasJSONTimeZone(ValueToEvaluate) then
+            ValueToEvaluate += 'Z';
+
+        exit(Evaluate(DateTimeValue, ValueToEvaluate, 9));
+    end;
+
+    local procedure HasJSONTimeZone(ValueText: Text): Boolean
+    var
+        TimeZoneText: Text;
+    begin
+        if ValueText.EndsWith('Z') or ValueText.EndsWith('z') then
+            exit(true);
+        if StrLen(ValueText) <= 19 then
+            exit(false);
+
+        TimeZoneText := CopyStr(ValueText, 20);
+        exit(TimeZoneText.Contains('+') or TimeZoneText.Contains('-'));
+    end;
+
+    local procedure ContainsJSONComment(JSONText: Text): Boolean
+    var
+        Character: Text[1];
+        NextCharacter: Text[1];
+        CharacterIndex: Integer;
+        EscapedCharacter: Boolean;
+        InString: Boolean;
+    begin
+        for CharacterIndex := 1 to StrLen(JSONText) do begin
+            Character := CopyStr(JSONText, CharacterIndex, 1);
+            if InString then
+                if EscapedCharacter then
+                    EscapedCharacter := false
                 else
-                    "Value Type" := Format(JSONTextReader.ValueType);
-                Path := JSONTextReader.Path;
-                Insert();
-            until not JSONTextReader.Read();
+                    case Character of
+                        '\':
+                            EscapedCharacter := true;
+                        '"':
+                            InString := false;
+                    end
+            else
+                case Character of
+                    '"':
+                        InString := true;
+                    '/':
+                        begin
+                            NextCharacter := CopyStr(JSONText, CharacterIndex + 1, 1);
+                            if (NextCharacter = '/') or (NextCharacter = '*') then
+                                exit(true);
+                        end;
+                end;
+        end;
     end;
 
     procedure FindArray(var TempJSONBuffer: Record "JSON Buffer" temporary; ArrayName: Text): Boolean
@@ -224,4 +380,3 @@ table 1236 "JSON Buffer"
         OutStream.Write(NewValue);
     end;
 }
-

--- a/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
@@ -94,7 +94,7 @@ table 1236 "JSON Buffer"
         if JSONText.Trim() = '' then
             exit;
 
-        if ContainsJSONComment(JSONText) then
+        if ContainsJSONComment(JSONText) or ContainsUnquotedPropertyName(JSONText) then
             Error(InvalidJSONErr);
 
         if not TryReadJSONToken(JSONText, JSONToken) then
@@ -298,6 +298,57 @@ table 1236 "JSON Buffer"
         end;
     end;
 
+    local procedure ContainsUnquotedPropertyName(JSONText: Text): Boolean
+    var
+        Character: Text[1];
+        ContainerStack: Text;
+        CurrentContainer: Text[1];
+        PreviousCharacter: Text[1];
+        CharacterIndex: Integer;
+        EscapedCharacter: Boolean;
+        InString: Boolean;
+    begin
+        for CharacterIndex := 1 to StrLen(JSONText) do begin
+            Character := CopyStr(JSONText, CharacterIndex, 1);
+            if InString then begin
+                if EscapedCharacter then
+                    EscapedCharacter := false
+                else
+                    case Character of
+                        '\':
+                            EscapedCharacter := true;
+                        '"':
+                            InString := false;
+                    end;
+                continue;
+            end;
+
+            if Character.Trim() = '' then
+                continue;
+
+            Clear(CurrentContainer);
+            if ContainerStack <> '' then
+                CurrentContainer := CopyStr(ContainerStack, StrLen(ContainerStack), 1);
+            if CurrentContainer = '{' then
+                if (PreviousCharacter = '{') or (PreviousCharacter = ',') then
+                    if not (Character in ['"', '}']) then
+                        exit(true);
+
+            case Character of
+                '"':
+                    InString := true;
+                '{',
+                '[':
+                    ContainerStack += Character;
+                '}',
+                ']':
+                    if ContainerStack <> '' then
+                        ContainerStack := DelStr(ContainerStack, StrLen(ContainerStack), 1);
+            end;
+            PreviousCharacter := Character;
+        end;
+    end;
+
     procedure FindArray(var TempJSONBuffer: Record "JSON Buffer" temporary; ArrayName: Text): Boolean
     begin
         TempJSONBuffer.Copy(Rec, true);
@@ -383,7 +434,7 @@ table 1236 "JSON Buffer"
         if not "Value BLOB".HasValue() then
             exit(Value);
 
-        "Value BLOB".CreateInStream(InStream, TEXTENCODING::Windows);
+        "Value BLOB".CreateInStream(InStream, TEXTENCODING::UTF8);
         exit(TypeHelper.ReadAsTextWithSeparator(InStream, TypeHelper.LFSeparator()));
     end;
 
@@ -404,7 +455,7 @@ table 1236 "JSON Buffer"
         if NewValue = '' then
             exit;
 
-        "Value BLOB".CreateOutStream(OutStream, TEXTENCODING::Windows);
+        "Value BLOB".CreateOutStream(OutStream, TEXTENCODING::UTF8);
         OutStream.Write(NewValue);
     end;
 }

--- a/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
@@ -97,10 +97,38 @@ table 1236 "JSON Buffer"
         if ContainsJSONComment(JSONText) then
             Error(InvalidJSONErr);
 
-        if not JSONToken.ReadFrom(JSONText) then
+        if not TryReadJSONToken(JSONText, JSONToken) then
             Error(InvalidJSONErr);
 
         ReadJSONToken(JSONToken, 0);
+    end;
+
+    local procedure TryReadJSONToken(JSONText: Text; var JSONToken: JsonToken): Boolean
+    var
+        JSONArray: JsonArray;
+        JSONObject: JsonObject;
+        JSONValue: JsonValue;
+    begin
+        case CopyStr(JSONText.Trim(), 1, 1) of
+            '{':
+                begin
+                    if not JSONObject.ReadFrom(JSONText) then
+                        exit(false);
+                    JSONToken := JSONObject.AsToken();
+                end;
+            '[':
+                begin
+                    if not JSONArray.ReadFrom(JSONText) then
+                        exit(false);
+                    JSONToken := JSONArray.AsToken();
+                end;
+            else begin
+                if not JSONValue.ReadFrom(JSONText) then
+                    exit(false);
+                JSONToken := JSONValue.AsToken();
+            end;
+        end;
+        exit(true);
     end;
 
     local procedure ReadJSONToken(JSONToken: JsonToken; TokenDepth: Integer)

--- a/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JSONBuffer.Table.al
@@ -71,6 +71,7 @@ table 1236 "JSON Buffer"
         SystemDoubleTxt: Label 'System.Double', Locked = true;
         SystemInt64Txt: Label 'System.Int64', Locked = true;
         SystemStringTxt: Label 'System.String', Locked = true;
+        StrictJSONScalarPatternTxt: Label '^(?:"(?:\\["\\/bfnrt]|\\u[0-9A-Fa-f]{4}|[^"\\\x00-\x1F])*"|-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?|true|false|null)$', Locked = true;
 
     procedure ReadFromBlob(BlobFieldRef: FieldRef)
     var
@@ -123,12 +124,21 @@ table 1236 "JSON Buffer"
                     JSONToken := JSONArray.AsToken();
                 end;
             else begin
+                if not IsStrictJSONScalar(JSONText) then
+                    exit(false);
                 if not JSONValue.ReadFrom(JSONText) then
                     exit(false);
                 JSONToken := JSONValue.AsToken();
             end;
         end;
         exit(true);
+    end;
+
+    local procedure IsStrictJSONScalar(JSONText: Text): Boolean
+    var
+        Regex: Codeunit Regex;
+    begin
+        exit(Regex.IsMatch(JSONText.Trim(), StrictJSONScalarPatternTxt));
     end;
 
     local procedure ReadJSONToken(JSONToken: JsonToken; TokenDepth: Integer)

--- a/src/Layers/W1/BaseApp/System/DataExchange/JsonTextReaderWriter.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JsonTextReaderWriter.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN30
 namespace System.IO;
 
 using System;
@@ -5,6 +6,9 @@ using System.Utilities;
 
 codeunit 1234 "Json Text Reader/Writer"
 {
+    ObsoleteReason = 'Use the built-in AL JSON types and table "JSON Buffer" instead. Native AL JSON APIs do not support the Json.NET constructor expressions accepted by WriteStartConstructor.';
+    ObsoleteState = Pending;
+    ObsoleteTag = '30.0';
 
     trigger OnRun()
     begin
@@ -159,4 +163,4 @@ codeunit 1234 "Json Text Reader/Writer"
         JsonTextWriter.WritePropertyName(VariableName);
     end;
 }
-
+#endif

--- a/src/Layers/W1/BaseApp/System/DataExchange/JsonTextReaderWriter.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/DataExchange/JsonTextReaderWriter.Codeunit.al
@@ -22,7 +22,9 @@ codeunit 1234 "Json Text Reader/Writer"
 
     procedure ReadJSonToJSonBuffer(Json: Text; var JsonBuffer: Record "JSON Buffer")
     begin
+#pragma warning disable AL0432
         JsonBuffer.ReadFromText(Json);
+#pragma warning restore AL0432
     end;
 
     local procedure InitializeWriter()

--- a/src/Layers/W1/BaseApp/System/HttpWebRequestMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/HttpWebRequestMgt.Codeunit.al
@@ -4,7 +4,6 @@ using System;
 using System.Environment;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using System.Utilities;
 using System.Xml;
 

--- a/src/Layers/W1/BaseApp/System/HttpWebRequestMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/HttpWebRequestMgt.Codeunit.al
@@ -20,6 +20,7 @@ codeunit 1297 "Http Web Request Mgt."
         InternalErr: Label 'The remote service has returned the following error message:\\';
         NoCookieForYouErr: Label 'The web request has no cookies.';
         TimeoutErr: Label 'The server timed out waiting for the request.';
+        HttpErrorTxt: Label 'Http error %1 (%2)\%3', Comment = '%1 - Error code, %2 - Error name, %3 - Error description';
 
     [Scope('OnPrem')]
     procedure GetResponse(var ResponseInStream: InStream; var HttpStatusCode: DotNet HttpStatusCode; var ResponseHeaders: DotNet NameValueCollection): Boolean
@@ -136,7 +137,7 @@ codeunit 1297 "Http Web Request Mgt."
             name := ErrorJsonObject.GetText('name', true);
             description := ErrorJsonObject.GetText('description', true);
         end;
-        exit(StrSubstNo('Http error %1 (%2)\%3', code, name, description));
+        exit(StrSubstNo(HttpErrorTxt, code, name, description));
     end;
 
     [TryFunction]

--- a/src/Layers/W1/BaseApp/System/HttpWebRequestMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/HttpWebRequestMgt.Codeunit.al
@@ -122,13 +122,22 @@ codeunit 1297 "Http Web Request Mgt."
 
     procedure ParseFaultJsonResponse(ResponseJson: Text): Text
     var
-        JSONMgt: Codeunit "JSON Management";
+        ResponseJsonObject: JsonObject;
+        ErrorJsonObject: JsonObject;
+        JsonToken: JsonToken;
         "code": Text;
         name: Text;
         description: Text;
     begin
-        if JSONMgt.GetJsonWebResponseError(ResponseJson, code, name, description) then
-            exit(StrSubstNo('Http error %1 (%2)\%3', code, name, description));
+        if not ResponseJsonObject.ReadFrom(ResponseJson) then
+            exit('');
+        if ResponseJsonObject.Get('Error', JsonToken) and JsonToken.IsObject() then begin
+            ErrorJsonObject := JsonToken.AsObject();
+            code := ErrorJsonObject.GetText('code', true);
+            name := ErrorJsonObject.GetText('name', true);
+            description := ErrorJsonObject.GetText('description', true);
+        end;
+        exit(StrSubstNo('Http error %1 (%2)\%3', code, name, description));
     end;
 
     [TryFunction]
@@ -491,29 +500,33 @@ codeunit 1297 "Http Web Request Mgt."
 
     local procedure SetJSONContent(var ResponseJson: Text; ResponseInStream: InStream): Boolean
     var
-        JSONMgt: Codeunit "JSON Management";
-        ContentJson: Text;
+        ResponseJsonObject: JsonObject;
+        ContentJsonObject: JsonObject;
         Content: Text;
     begin
         if ResponseInStream.Read(Content) = 0 then
             exit(true);
 
-        if not JSONMgt.InitializeFromString(Content) then
+        if not ContentJsonObject.ReadFrom(Content) then
             exit(false);
 
-        ContentJson := JSONMgt.WriteObjectToString();
-        JSONMgt.InitializeObject(ResponseJson);
-        JSONMgt.AddJson('Content', ContentJson);
-        ResponseJson := JSONMgt.WriteObjectToString();
+        ResponseJsonObject.ReadFrom(ResponseJson);
+        if ResponseJsonObject.Contains('Content') then
+            ResponseJsonObject.Replace('Content', ContentJsonObject)
+        else
+            ResponseJsonObject.Add('Content', ContentJsonObject);
+        ResponseJsonObject.WriteTo(ResponseJson);
         exit(true);
     end;
 
     local procedure ParseWebResponseError(var ResponseJson: Text; WebException: DotNet WebException)
     var
-        JSONMgt: Codeunit "JSON Management";
         HttpWebResponse: DotNet HttpWebResponse;
         Convert: DotNet Convert;
         WebExceptionStatus: DotNet WebExceptionStatus;
+        ResponseJsonObject: JsonObject;
+        ErrorJsonObject: JsonObject;
+        ErrorDescriptionToken: JsonToken;
         ResponseInputStream: InStream;
         ErrorDescription: Text;
         StatusCode: Text;
@@ -542,17 +555,32 @@ codeunit 1297 "Http Web Request Mgt."
                 exit;
         end;
 
-        JSONMgt.SetJsonWebResponseError(ResponseJson, StatusCode, StatusCodeString, ErrorDescription);
+        if ResponseJson <> '' then
+            ResponseJsonObject.ReadFrom(ResponseJson);
+        ErrorJsonObject.Add('code', StatusCode);
+        ErrorJsonObject.Add('name', StatusCodeString);
+        ErrorJsonObject.Add('description', ErrorDescription);
+        if ResponseJsonObject.Contains('Error') then
+            ResponseJsonObject.Replace('Error', ErrorJsonObject)
+        else
+            ResponseJsonObject.Add('Error', ErrorJsonObject);
+        ResponseJsonObject.WriteTo(ResponseJson);
 
         // Try to get more details
         if WebExceptionResponse then begin
             ResponseInputStream := HttpWebResponse.GetResponseStream();
             if SetJSONContent(ResponseJson, ResponseInputStream) then
-                if JSONMgt.InitializeFromString(ResponseJson) then begin
-                    ErrorDescription := JSONMgt.GetValue('Content.error_description');
+                if ResponseJsonObject.ReadFrom(ResponseJson) then begin
+                    ErrorDescription := '';
+                    if ResponseJsonObject.SelectToken('Content.error_description', ErrorDescriptionToken) and ErrorDescriptionToken.IsValue() then
+                        if not ErrorDescriptionToken.AsValue().IsNull() and not ErrorDescriptionToken.AsValue().IsUndefined() then
+                            ErrorDescription := ErrorDescriptionToken.AsValue().AsText();
                     if ErrorDescription <> '' then begin
-                        JSONMgt.SetValue('Error.description', ErrorDescription);
-                        ResponseJson := JSONMgt.WriteObjectToString();
+                        ResponseJsonObject.Get('Error', ErrorDescriptionToken);
+                        ErrorJsonObject := ErrorDescriptionToken.AsObject();
+                        ErrorJsonObject.Replace('description', ErrorDescription);
+                        ResponseJsonObject.Replace('Error', ErrorJsonObject);
+                        ResponseJsonObject.WriteTo(ResponseJson);
                     end;
                 end;
         end;

--- a/src/Layers/W1/BaseApp/System/SOAPWebServiceRequestMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/SOAPWebServiceRequestMgt.Codeunit.al
@@ -3,7 +3,6 @@ namespace System.Integration;
 using Microsoft.Utilities;
 using System;
 using System.Reflection;
-using System.Text;
 using System.Utilities;
 using System.Xml;
 

--- a/src/Layers/W1/BaseApp/System/SOAPWebServiceRequestMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/SOAPWebServiceRequestMgt.Codeunit.al
@@ -351,14 +351,15 @@ codeunit 1290 "SOAP Web Service Request Mgt."
     [NonDebuggable]
     procedure GetTokenValue(WebTokenAsJson: Text; ClaimType: Text): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
-        ClaimValue: Text;
+        JsonObject: JsonObject;
+        JsonToken: JsonToken;
     begin
-        JSONManagement.InitializeObject(WebTokenAsJson);
-        JSONManagement.GetJSONObject(JObject);
-        if JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, ClaimType, ClaimValue) then
-            exit(ClaimValue);
+        JsonObject.ReadFrom(WebTokenAsJson);
+        if JsonObject.Get(ClaimType, JsonToken) and JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
     end;
 
     [NonDebuggable]
@@ -367,7 +368,7 @@ codeunit 1290 "SOAP Web Service Request Mgt."
         TypeHelper: Codeunit "Type Helper";
         Timestamp: Decimal;
     begin
-        if not Evaluate(Timestamp, GetTokenValue(WebTokenAsJson, ClaimType)) then
+        if not Evaluate(Timestamp, GetTokenValue(WebTokenAsJson, ClaimType), 9) then
             exit;
         exit(TypeHelper.EvaluateUnixTimestamp(Timestamp));
     end;
@@ -376,11 +377,10 @@ codeunit 1290 "SOAP Web Service Request Mgt."
     [NonDebuggable]
     procedure GetTokenDetailsAsJson(JsonWebToken: SecretText; var WebTokenAsJson: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
         JwtSecurityTokenHandler: DotNet JwtSecurityTokenHandler;
         JwtSecurityToken: DotNet JwtSecurityToken;
         Claim: DotNet Claim;
-        JObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
         if JsonWebToken.IsEmpty() then
             exit;
@@ -388,12 +388,10 @@ codeunit 1290 "SOAP Web Service Request Mgt."
         JwtSecurityTokenHandler := JwtSecurityTokenHandler.JwtSecurityTokenHandler();
         JwtSecurityToken := JwtSecurityTokenHandler.ReadToken(JsonWebToken.Unwrap());
 
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JObject);
         foreach Claim in JwtSecurityToken.Claims do
-            JSONManagement.AddJPropertyToJObject(JObject, Claim.Type, Claim.Value);
+            JsonObject.Add(Claim.Type, Claim.Value);
 
-        WebTokenAsJson := JObject.ToString();
+        JsonObject.WriteTo(WebTokenAsJson);
     end;
 
     [TryFunction]

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookSubscription.Table.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookSubscription.Table.al
@@ -339,10 +339,13 @@ table 469 "Workflow Webhook Subscription"
     local procedure AddEventConditionsWrapper(ConditionsPropertyName: Text; ConditionsObject: JsonObject; SourcePageNo: Integer; var EventConditions: FilterPageBuilder; var ConditionsCount: Integer)
     var
         ConditionsCollection: JsonToken;
+        ErrorText: Text;
     begin
         if ConditionsObject.Get(ConditionsPropertyName, ConditionsCollection) then begin
-            if not ConditionsCollection.IsArray() then
-                SendAndLogError(GetLastErrorText, StrSubstNo(UnableToParseJsonArrayErr, ConditionsPropertyName));
+            if not ConditionsCollection.IsArray() then begin
+                ErrorText := StrSubstNo(UnableToParseJsonArrayErr, ConditionsPropertyName);
+                SendAndLogError(ErrorText, ErrorText);
+            end;
             AddEventConditions(ConditionsCollection.AsArray(), EventConditions, SourcePageNo, ConditionsCount);
             ConditionsCount := ConditionsCount + 1;
         end;
@@ -412,8 +415,7 @@ table 469 "Workflow Webhook Subscription"
         Clear(ConditionsArray);
         if ConditionsTxt = '' then
             exit;
-        if not ConditionsArray.ReadFrom(ConditionsTxt) then
-            Error('');
+        ConditionsArray.ReadFrom(ConditionsTxt);
     end;
 
     [TryFunction]

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookSubscription.Table.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookSubscription.Table.al
@@ -138,8 +138,6 @@ table 469 "Workflow Webhook Subscription"
     end;
 
     var
-        JSONManagement: Codeunit "JSON Management";
-
         WorkflowWebhookSetup: Codeunit "Workflow Webhook Setup";
         UnableToParseEncodingErr: Label 'Unable to parse the Conditions. The provided Conditions were not in the correct Base64 encoded format.';
         UnableToParseInvalidJsonErr: Label 'Unable to parse the Conditions. The provided Conditions JSON was invalid.';
@@ -242,7 +240,11 @@ table 469 "Workflow Webhook Subscription"
         WorkflowEventHandling: Codeunit "Workflow Event Handling";
         RequestPageParametersHelper: Codeunit "Request Page Parameters Helper";
         EventConditions: FilterPageBuilder;
-        ConditionsObject: DotNet JObject;
+        ConditionsObject: JsonObject;
+#if not CLEAN30
+        LegacyConditionsObject: DotNet JObject;
+        ConditionsJsonText: Text;
+#endif
         ConditionsCount: Integer;
         Result: Text;
         IsHandled: Boolean;
@@ -316,9 +318,17 @@ table 469 "Workflow Webhook Subscription"
                         EventConditions, WorkflowWebhookSetup.GetPurchPayCategoryTxt(), DATABASE::Vendor));
                 end
             else begin
-                OnCreateWorkflowEventConditions(ConditionsTxt, EventCode, ConditionsObject, EventConditions, ConditionsCount, Result, IsHandled);
+                OnCreateWorkflowEventConditionsNative(ConditionsTxt, EventCode, ConditionsObject, EventConditions, ConditionsCount, Result, IsHandled);
                 if IsHandled then
                     exit(Result);
+
+#if not CLEAN30
+                ConditionsObject.WriteTo(ConditionsJsonText);
+                LegacyConditionsObject := LegacyConditionsObject.Parse(ConditionsJsonText);
+                OnCreateWorkflowEventConditions(ConditionsTxt, EventCode, LegacyConditionsObject, EventConditions, ConditionsCount, Result, IsHandled);
+                if IsHandled then
+                    exit(Result);
+#endif
 
                 SendAndLogError(
                   StrSubstNo(WorkflowWebhookSetup.GetUnsupportedWorkflowEventCodeErr(), EventCode),
@@ -327,36 +337,28 @@ table 469 "Workflow Webhook Subscription"
         end;
     end;
 
-    local procedure AddEventConditionsWrapper(ConditionsPropertyName: Text; ConditionsObject: DotNet JObject; SourcePageNo: Integer; var EventConditions: FilterPageBuilder; var ConditionsCount: Integer)
+    local procedure AddEventConditionsWrapper(ConditionsPropertyName: Text; ConditionsObject: JsonObject; SourcePageNo: Integer; var EventConditions: FilterPageBuilder; var ConditionsCount: Integer)
     var
-        ConditionsCollection: DotNet JToken;
+        ConditionsCollection: JsonToken;
     begin
-        if ConditionsObject.TryGetValue(ConditionsPropertyName, ConditionsCollection) then begin
-            if not TryInitializeCollection(ConditionsCollection) then
+        if ConditionsObject.Get(ConditionsPropertyName, ConditionsCollection) then begin
+            if not ConditionsCollection.IsArray() then
                 SendAndLogError(GetLastErrorText, StrSubstNo(UnableToParseJsonArrayErr, ConditionsPropertyName));
-            AddEventConditions(ConditionsCollection, EventConditions, SourcePageNo, ConditionsCount);
+            AddEventConditions(ConditionsCollection.AsArray(), EventConditions, SourcePageNo, ConditionsCount);
             ConditionsCount := ConditionsCount + 1;
         end;
     end;
 
-    [TryFunction]
-    local procedure TryInitializeCollection(var ConditionsCollection: DotNet JToken)
-    begin
-        JSONManagement.InitializeCollectionFromJArray(ConditionsCollection);
-        // need to do some action on the collection to check if it is of Collection type
-        if JSONManagement.GetCollectionCount() < 0 then
-            Error(GetLastErrorText);
-    end;
-
-    local procedure AddEventConditions(ConditionsArray: DotNet JObject; var EventConditions: FilterPageBuilder; SourcePageNo: Integer; ConditionIndex: Integer)
+    local procedure AddEventConditions(ConditionsArray: JsonArray; var EventConditions: FilterPageBuilder; SourcePageNo: Integer; ConditionIndex: Integer)
     var
         TableMetadata: Record "Table Metadata";
         PageControlField: Record "Page Control Field";
         RecRef: RecordRef;
         FieldRef: FieldRef;
-        ConditionName: DotNet JToken;
-        Condition: DotNet JObject;
-        ConditionValue: DotNet JToken;
+        ConditionToken: JsonToken;
+        ConditionName: JsonToken;
+        Condition: JsonObject;
+        ConditionValue: JsonToken;
         FieldId: Integer;
         tableNo: Integer;
     begin
@@ -369,20 +371,22 @@ table 469 "Workflow Webhook Subscription"
         PageControlField.Reset();
         PageControlField.SetFilter(PageNo, '%1', SourcePageNo);
 
-        foreach Condition in ConditionsArray do
-            if Condition.TryGetValue('Name', ConditionName) and Condition.TryGetValue('Value', ConditionValue) then begin
+        foreach ConditionToken in ConditionsArray do begin
+            Condition := ConditionToken.AsObject();
+            if Condition.Get('Name', ConditionName) and Condition.Get('Value', ConditionValue) then begin
                 // get id of the field from the page in the page's source table
-                PageControlField.SetFilter(ControlName, ConditionName.ToString());
+                PageControlField.SetFilter(ControlName, GetJsonTokenText(ConditionName));
                 if not PageControlField.FindFirst() then
-                    SendAndLogError(GetLastErrorText, StrSubstNo(NoControlOnPageErr, ConditionName.ToString(), GetPageName(SourcePageNo)));
+                    SendAndLogError(GetLastErrorText, StrSubstNo(NoControlOnPageErr, GetJsonTokenText(ConditionName), GetPageName(SourcePageNo)));
 
                 FieldId := PageControlField.FieldNo;
                 FieldRef := RecRef.Field(FieldId);
 
                 // filter Header/Lines Table
                 // throws an error message if can not convert types
-                FieldRef.SetFilter(ConditionValue.ToString());
+                FieldRef.SetFilter(GetJsonTokenText(ConditionValue));
             end;
+        end;
 
         // create Filter Page Builder
         TableMetadata.Get(tableNo);
@@ -390,11 +394,27 @@ table 469 "Workflow Webhook Subscription"
         EventConditions.SetView(EventConditions.Name(ConditionIndex), RecRef.GetView());
     end;
 
-    [TryFunction]
-    local procedure TryParseJson(ConditionsTxt: Text; var ConditionsArray: DotNet JObject)
+    local procedure GetJsonTokenText(JsonToken: JsonToken): Text
+    var
+        JsonText: Text;
     begin
-        JSONManagement.InitializeObject(ConditionsTxt);
-        JSONManagement.GetJSONObject(ConditionsArray);
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit('');
+            exit(JsonToken.AsValue().AsText());
+        end;
+        JsonToken.WriteTo(JsonText);
+        exit(JsonText);
+    end;
+
+    [TryFunction]
+    local procedure TryParseJson(ConditionsTxt: Text; var ConditionsArray: JsonObject)
+    begin
+        Clear(ConditionsArray);
+        if ConditionsTxt = '' then
+            exit;
+        if not ConditionsArray.ReadFrom(ConditionsTxt) then
+            Error('');
     end;
 
     [TryFunction]
@@ -455,8 +475,15 @@ table 469 "Workflow Webhook Subscription"
     end;
 
     [IntegrationEvent(true, false)]
+    local procedure OnCreateWorkflowEventConditionsNative(ConditionsTxt: Text; EventCode: Code[128]; ConditionsObject: JsonObject; var EventConditions: FilterPageBuilder; var ConditionsCount: Integer; var Result: Text; var IsHandled: Boolean)
+    begin
+    end;
+
+#if not CLEAN30
+    [Obsolete('Subscribe to OnCreateWorkflowEventConditionsNative with the native JsonObject type instead.', '30.0')]
+    [IntegrationEvent(true, false)]
     local procedure OnCreateWorkflowEventConditions(ConditionsTxt: Text; EventCode: Code[128]; ConditionsObject: DotNet JObject; var EventConditions: FilterPageBuilder; var ConditionsCount: Integer; var Result: Text; var IsHandled: Boolean)
     begin
     end;
+#endif
 }
-

--- a/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookSubscription.Table.al
+++ b/src/Layers/W1/BaseApp/System/Workflow/WorkflowWebhookSubscription.Table.al
@@ -11,7 +11,6 @@ using Microsoft.Utilities;
 using System;
 using System.Environment;
 using System.Reflection;
-using System.Text;
 
 table 469 "Workflow Webhook Subscription"
 {

--- a/src/Layers/W1/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
+++ b/src/Layers/W1/Tests/General Journal/ERMGeneralJournalUT.Codeunit.al
@@ -7462,15 +7462,11 @@ codeunit 134920 "ERM General Journal UT"
 
     local procedure GetGenJnlBatchJson(NewGenJnlBatchName: Code[10]; GenJnlTemplateName: Code[10]) GenJnlBatchJson: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Name', NewGenJnlBatchName);
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'Journal_Template_Name', GenJnlTemplateName);
-
-        GenJnlBatchJson := JSONManagement.WriteObjectToString();
+        JsonObject.Add('Name', NewGenJnlBatchName);
+        JsonObject.Add('Journal_Template_Name', GenJnlTemplateName);
+        JsonObject.WriteTo(GenJnlBatchJson);
     end;
 
     local procedure CreateNoSeriesLine(var NoSeriesLine: Record "No. Series Line"; SeriesCode: Code[20]; StartDate: Date)
@@ -7573,4 +7569,3 @@ codeunit 134920 "ERM General Journal UT"
         IsHandled := true;
     end;
 }
-

--- a/src/Layers/W1/Tests/Graph/GraphCollectMgtCustomer.Codeunit.al
+++ b/src/Layers/W1/Tests/Graph/GraphCollectMgtCustomer.Codeunit.al
@@ -107,6 +107,18 @@ codeunit 134631 "Graph Collect Mgt Customer"
         VerifyMatchingPostalAddress(PostalAddressJSON, Customer);
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure TestEmptyDimensionsJSON()
+    var
+        GraphMgtComplexTypes: Codeunit "Graph Mgt - Complex Types";
+        NewDimensionSetId: Integer;
+    begin
+        GraphMgtComplexTypes.GetDimensionSetFromJSON('', 0, NewDimensionSetId);
+
+        Assert.AreEqual(0, NewDimensionSetId, 'Blank dimensions JSON must produce an empty dimension set.');
+    end;
+
     local procedure FindCustomerWithAddress(var Customer: Record Customer)
     var
         CountryRegion: Record "Country/Region";
@@ -146,4 +158,3 @@ codeunit 134631 "Graph Collect Mgt Customer"
         Customer.TestField("Post Code", TempCustomer."Post Code");
     end;
 }
-

--- a/src/Layers/W1/Tests/Graph/GraphCollectMgtCustomer.Codeunit.al
+++ b/src/Layers/W1/Tests/Graph/GraphCollectMgtCustomer.Codeunit.al
@@ -114,6 +114,7 @@ codeunit 134631 "Graph Collect Mgt Customer"
         GraphMgtComplexTypes: Codeunit "Graph Mgt - Complex Types";
         NewDimensionSetId: Integer;
     begin
+        NewDimensionSetId := 42;
         GraphMgtComplexTypes.GetDimensionSetFromJSON('', 0, NewDimensionSetId);
 
         Assert.AreEqual(0, NewDimensionSetId, 'Blank dimensions JSON must produce an empty dimension set.');

--- a/src/Layers/W1/Tests/Graph/GraphCollectMgtItemUT.Codeunit.al
+++ b/src/Layers/W1/Tests/Graph/GraphCollectMgtItemUT.Codeunit.al
@@ -333,14 +333,13 @@ codeunit 134627 "Graph Collect Mgt Item UT"
 
     local procedure GenerateNoUOMJSONString(): Text
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitCode(), '');
-        exit(JSONManagement.WriteObjectToString());
+        JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeUnitCode(), '');
+        JsonObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     local procedure CreateTestItem(var Item: Record Item)
@@ -380,53 +379,47 @@ codeunit 134627 "Graph Collect Mgt Item UT"
 
     local procedure ConvertUnitOfMeasureToJSON(UnitOfMeasure: Record "Unit of Measure"): Text
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitOfMeasure.Code);
-        JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitName(), UnitOfMeasure.Description);
-        JSONManagement.AddJPropertyToJObject(JsonObject, GraphCollectionMgtItem.UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
-        exit(JSONManagement.WriteObjectToString());
+        JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitOfMeasure.Code);
+        JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeUnitName(), UnitOfMeasure.Description);
+        JsonObject.Add(GraphCollectionMgtItem.UOMComplexTypeSymbol(), UnitOfMeasure.Symbol);
+        JsonObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     local procedure ConvertUnitOfMeasureWithConversionsToJSON(var UnitOfMeasure: Record "Unit of Measure"; var BaseUnitOfMeasure: Record "Unit of Measure"; ConversionRate: Decimal): Text
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
-        JsonObject: DotNet JObject;
-        ComplexTypeJSONObject: DotNet JObject;
+        JsonObject: JsonObject;
+        ComplexTypeJSONObject: JsonObject;
+        JsonText: Text;
     begin
-        JSONManagement.InitializeObject(ConvertUnitOfMeasureToJSON(UnitOfMeasure));
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(ConvertUnitOfMeasureToJSON(UnitOfMeasure));
 
-        ComplexTypeJSONObject := ComplexTypeJSONObject.JObject();
-        JSONManagement.AddJPropertyToJObject(
-          ComplexTypeJSONObject, GraphCollectionMgtItem.UOMConversionComplexTypeToUnitOfMeasure(), BaseUnitOfMeasure.Code);
-        JSONManagement.AddJPropertyToJObject(
-          ComplexTypeJSONObject, GraphCollectionMgtItem.UOMConversionComplexTypeFromToConversionRate(), ConversionRate);
-        JSONManagement.AddJObjectToJObject(JsonObject, GraphCollectionMgtItem.UOMConversionComplexTypeName(), ComplexTypeJSONObject);
+        ComplexTypeJSONObject.Add(GraphCollectionMgtItem.UOMConversionComplexTypeToUnitOfMeasure(), BaseUnitOfMeasure.Code);
+        ComplexTypeJSONObject.Add(GraphCollectionMgtItem.UOMConversionComplexTypeFromToConversionRate(), ConversionRate);
+        JsonObject.Add(GraphCollectionMgtItem.UOMConversionComplexTypeName(), ComplexTypeJSONObject);
 
-        exit(JSONManagement.WriteObjectToString());
+        JsonObject.WriteTo(JsonText);
+        exit(JsonText);
     end;
 
     local procedure VerifyUOMJSON(BaseUOMJSON: Text; ExpectedUOMCode: Code[20])
     var
         UnitOfMeasure: Record "Unit of Measure";
-        JSONManagement: Codeunit "JSON Management";
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
         UnitCode: Text;
         UnitSymbol: Text;
         UnitName: Text;
     begin
-        JSONManagement.InitializeObject(BaseUOMJSON);
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitCode);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, GraphCollectionMgtItem.UOMComplexTypeSymbol(), UnitSymbol);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JsonObject, GraphCollectionMgtItem.UOMComplexTypeUnitName(), UnitName);
+        JsonObject.ReadFrom(BaseUOMJSON);
+        UnitCode := JsonObject.GetText(GraphCollectionMgtItem.UOMComplexTypeUnitCode(), true);
+        UnitSymbol := JsonObject.GetText(GraphCollectionMgtItem.UOMComplexTypeSymbol(), true);
+        UnitName := JsonObject.GetText(GraphCollectionMgtItem.UOMComplexTypeUnitName(), true);
 
         UnitOfMeasure.Init();
         if ExpectedUOMCode <> '' then
@@ -440,33 +433,27 @@ codeunit 134627 "Graph Collect Mgt Item UT"
     local procedure VerifyUnitOfMeasureConversionJSON(UOMWithConversionJSON: Text; var Item: Record Item; UOMCode: Code[20])
     var
         ItemUnitOfMeasure: Record "Item Unit of Measure";
-        JSONManagement: Codeunit "JSON Management";
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
-        JsonObject: DotNet JObject;
-        ConversionJObject: DotNet JObject;
-        ConversionJObjectVariant: Variant;
+        JsonObject: JsonObject;
+        ConversionJObject: JsonObject;
+        ConversionJsonToken: JsonToken;
         ConversionRateTxt: Text;
         ConversionRate: Decimal;
         ToUnitOfMeasure: Text;
     begin
         VerifyUOMJSON(UOMWithConversionJSON, UOMCode);
 
-        JSONManagement.InitializeObject(UOMWithConversionJSON);
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.GetPropertyValueFromJObjectByName(
-          JsonObject, GraphCollectionMgtItem.UOMConversionComplexTypeName(), ConversionJObjectVariant);
-        ConversionJObject := ConversionJObjectVariant;
+        JsonObject.ReadFrom(UOMWithConversionJSON);
+        JsonObject.Get(GraphCollectionMgtItem.UOMConversionComplexTypeName(), ConversionJsonToken);
+        ConversionJObject := ConversionJsonToken.AsObject();
 
-        JSONManagement.GetStringPropertyValueFromJObjectByName(
-          ConversionJObject, GraphCollectionMgtItem.UOMConversionComplexTypeFromToConversionRate(), ConversionRateTxt);
+        ConversionRateTxt := ConversionJObject.GetText(GraphCollectionMgtItem.UOMConversionComplexTypeFromToConversionRate());
         Evaluate(ConversionRate, ConversionRateTxt, 9);
 
-        JSONManagement.GetStringPropertyValueFromJObjectByName(
-          ConversionJObject, GraphCollectionMgtItem.UOMConversionComplexTypeToUnitOfMeasure(), ToUnitOfMeasure);
+        ToUnitOfMeasure := ConversionJObject.GetText(GraphCollectionMgtItem.UOMConversionComplexTypeToUnitOfMeasure());
 
         ItemUnitOfMeasure.Get(Item."No.", UOMCode);
         Assert.AreEqual(Item."Base Unit of Measure", ToUnitOfMeasure, 'ToUnitOfMeasure is not as expected');
         Assert.AreEqual(ItemUnitOfMeasure."Qty. per Unit of Measure", ConversionRate, 'ConversionRate is not as expected');
     end;
 }
-

--- a/src/Layers/W1/Tests/Graph/WFWHSubscriptionE2ETests.Codeunit.al
+++ b/src/Layers/W1/Tests/Graph/WFWHSubscriptionE2ETests.Codeunit.al
@@ -1422,19 +1422,14 @@ codeunit 135528 "WFWH Subscription E2E Tests"
 
     local procedure GetJSONFromWorkflowWebhookSubscription(var WorkflowWebhookSubscriptionRec: Record "Workflow Webhook Subscription") WorkflowWebhookSubscriptionJSON: Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeEmptyObject();
-        JSONManagement.GetJSONObject(JsonObject);
-        JSONManagement.AddJPropertyToJObject(
-          JsonObject, 'clientId', LowerCase(Format(WorkflowWebhookSubscriptionRec."Client Id", 0, 4)));
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'clientType', WorkflowWebhookSubscriptionRec."Client Type");
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'eventCode', WorkflowWebhookSubscriptionRec."Event Code");
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'conditions', WorkflowWebhookSubscriptionRec.GetConditions());
-        JSONManagement.AddJPropertyToJObject(JsonObject, 'notificationUrl', WorkflowWebhookSubscriptionRec.GetNotificationUrl());
-
-        WorkflowWebhookSubscriptionJSON := JSONManagement.WriteObjectToString();
+        JsonObject.Add('clientId', LowerCase(Format(WorkflowWebhookSubscriptionRec."Client Id", 0, 4)));
+        JsonObject.Add('clientType', WorkflowWebhookSubscriptionRec."Client Type");
+        JsonObject.Add('eventCode', WorkflowWebhookSubscriptionRec."Event Code");
+        JsonObject.Add('conditions', WorkflowWebhookSubscriptionRec.GetConditions());
+        JsonObject.Add('notificationUrl', WorkflowWebhookSubscriptionRec.GetNotificationUrl());
+        JsonObject.WriteTo(WorkflowWebhookSubscriptionJSON);
     end;
 
     local procedure MockDeleteFromWebService(var WorkflowWebhookSubscriptionRec: Record "Workflow Webhook Subscription"): Text
@@ -1454,4 +1449,3 @@ codeunit 135528 "WFWH Subscription E2E Tests"
         exit(String);
     end;
 }
-

--- a/src/Layers/W1/Tests/Integration/EnvironmentPickerTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration/EnvironmentPickerTest.Codeunit.al
@@ -19,6 +19,7 @@ codeunit 132677 "Environment Picker Test"
         MockLinkedEnvironmentLookup: Boolean;
         FailLinkedEnvironmentLookup: Boolean;
         ReturnEmptyEnvironmentResponse: Boolean;
+        MockEnvironmentResponse: Text;
 
     [Test]
     procedure CheckTheBasicBehaviour()
@@ -211,6 +212,105 @@ codeunit 132677 "Environment Picker Test"
     end;
 
     [Test]
+    procedure MalformedEnvironmentResponseFails()
+    var
+        TempFlowUserEnvironmentBuffer: Record "Flow User Environment Buffer" temporary;
+        EnvironmentPickerTest: Codeunit "Environment Picker Test";
+    begin
+        EnvironmentPickerTest.SetEnvironmentResponse('{');
+        BindSubscription(EnvironmentPickerTest);
+
+        asserterror FlowServiceManagement.GetEnvironments(TempFlowUserEnvironmentBuffer);
+    end;
+
+    [Test]
+    procedure OnlySucceededEnvironmentsAreIncludedCaseInsensitively()
+    var
+        TempFlowUserEnvironmentBuffer: Record "Flow User Environment Buffer" temporary;
+        EnvironmentPickerTest: Codeunit "Environment Picker Test";
+    begin
+        EnvironmentPickerTest.SetEnvironmentResponse(
+            '{"value":[' +
+            '{"name":"succeeded","properties":{"displayName":"Succeeded","provisioningState":"sUcCeEdEd","isDefault":false}},' +
+            '{"name":"failed","properties":{"displayName":"Failed","provisioningState":"Failed","isDefault":false}},' +
+            '{"name":"wrong-case","properties":{"displayName":"Wrong Case","ProvisioningState":"Succeeded","isDefault":false}}' +
+            ']}');
+        BindSubscription(EnvironmentPickerTest);
+
+        FlowServiceManagement.GetEnvironments(TempFlowUserEnvironmentBuffer);
+
+        LibraryAssert.AreEqual(1, TempFlowUserEnvironmentBuffer.Count(), 'Only environments with an exact provisioningState member set to succeeded must be included.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get('succeeded'), 'The succeeded environment was not included.');
+        LibraryAssert.AreEqual('Succeeded', TempFlowUserEnvironmentBuffer."Environment Display Name", 'The environment display name was parsed incorrectly.');
+    end;
+
+    [Test]
+    procedure BooleanAndTextDefaultValuesAreSupported()
+    var
+        TempFlowUserEnvironmentBuffer: Record "Flow User Environment Buffer" temporary;
+        EnvironmentPickerTest: Codeunit "Environment Picker Test";
+    begin
+        EnvironmentPickerTest.SetEnvironmentResponse(
+            '{"value":[' +
+            '{"name":"boolean-true","properties":{"displayName":"Boolean True","provisioningState":"Succeeded","isDefault":true}},' +
+            '{"name":"text-true","properties":{"displayName":"Text True","provisioningState":"Succeeded","isDefault":"TrUe"}},' +
+            '{"name":"boolean-false","properties":{"displayName":"Boolean False","provisioningState":"Succeeded","isDefault":false}},' +
+            '{"name":"text-false","properties":{"displayName":"Text False","provisioningState":"Succeeded","isDefault":"false"}}' +
+            ']}');
+        BindSubscription(EnvironmentPickerTest);
+
+        FlowServiceManagement.GetEnvironments(TempFlowUserEnvironmentBuffer);
+
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get('boolean-true'), 'The Boolean default environment was not included.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Default, 'Boolean true was not parsed as the default environment.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get('text-true'), 'The text default environment was not included.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Default, 'Text true was not parsed case-insensitively as the default environment.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get('boolean-false'), 'The Boolean non-default environment was not included.');
+        LibraryAssert.IsFalse(TempFlowUserEnvironmentBuffer.Default, 'Boolean false was parsed as the default environment.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get('text-false'), 'The text non-default environment was not included.');
+        LibraryAssert.IsFalse(TempFlowUserEnvironmentBuffer.Default, 'Text false was parsed as the default environment.');
+    end;
+
+    [Test]
+    procedure MissingNullAndNonObjectPropertiesAreSkipped()
+    var
+        TempFlowUserEnvironmentBuffer: Record "Flow User Environment Buffer" temporary;
+        EnvironmentPickerTest: Codeunit "Environment Picker Test";
+    begin
+        EnvironmentPickerTest.SetEnvironmentResponse(
+            '{"value":[' +
+            '{"name":"missing"},' +
+            '{"name":"null","properties":null},' +
+            '{"name":"text","properties":"not-an-object"},' +
+            '{"name":"wrong-case","Properties":{"displayName":"Wrong Case","provisioningState":"Succeeded","isDefault":false}},' +
+            '{"name":"valid","properties":{"displayName":"Valid","provisioningState":"Succeeded","isDefault":false}}' +
+            ']}');
+        BindSubscription(EnvironmentPickerTest);
+
+        FlowServiceManagement.GetEnvironments(TempFlowUserEnvironmentBuffer);
+
+        LibraryAssert.AreEqual(1, TempFlowUserEnvironmentBuffer.Count(), 'Environments without an exact object properties member must be skipped.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get('valid'), 'The valid environment was not included.');
+    end;
+
+    [Test]
+    procedure NullNameAndDisplayNameAreConvertedToBlankText()
+    var
+        TempFlowUserEnvironmentBuffer: Record "Flow User Environment Buffer" temporary;
+        EnvironmentPickerTest: Codeunit "Environment Picker Test";
+    begin
+        EnvironmentPickerTest.SetEnvironmentResponse(
+            '{"value":[{"name":null,"properties":{"displayName":null,"provisioningState":"Succeeded","isDefault":false}}]}');
+        BindSubscription(EnvironmentPickerTest);
+
+        FlowServiceManagement.GetEnvironments(TempFlowUserEnvironmentBuffer);
+
+        LibraryAssert.AreEqual(1, TempFlowUserEnvironmentBuffer.Count(), 'The environment with null text members was not included.');
+        LibraryAssert.IsTrue(TempFlowUserEnvironmentBuffer.Get(''), 'A null environment name must be converted to a blank ID.');
+        LibraryAssert.AreEqual('', TempFlowUserEnvironmentBuffer."Environment Display Name", 'A null display name must be converted to blank text.');
+    end;
+
+    [Test]
     [HandlerFunctions('HandleSessionSettingsChange')]
     procedure AcceptViaAssistedSetup()
     var
@@ -329,6 +429,12 @@ codeunit 132677 "Environment Picker Test"
             exit;
         end;
 
+        if MockEnvironmentResponse <> '' then begin
+            ResponseText := MockEnvironmentResponse;
+            Handled := true;
+            exit;
+        end;
+
         ResponseText := '{"value":[{"location":"unitedstates","name":"environment-id","properties":{"displayName":"environment name","createdTime":"2022-07-13T11:45:41.6980238Z","createdBy":{"id":"SYSTEM","displayName":"SYSTEM","type":"NotSpecified"},"provisioningState":"Succeeded","environmentSku":"Default","isDefault":"false","clientUris":{"admin":"https://admin.powerplatform.microsoft.com/environments/environment/environment-id/hub","maker":"https://make.powerapps.com/environments/environment-id/home"},"retentionPeriod":"P7D","states":{"management":{"id":"Ready"},"runtime":{"id":"Enabled"}},"protectionStatus":{"keyManagedBy":"Microsoft"},"connectedGroups":[],"lifecycleOperationsEnforcement":{"allowedOperations":[{"type":{"id":"Edit"}},{"type":{"id":"Provision"}},{"type":{"id":"Enable"}},{"type":{"id":"Disable"}},{"type":{"id":"DisableGovernanceConfiguration"}}],"disallowedOperations":[{"type":{"id":"Backup"},"reason":{"message":"Backup cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"Copy"},"reason":{"message":"Copy cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"Promote"},"reason":{"message":"Promote cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"Reset"},"reason":{"message":"Reset cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"Restore"},"reason":{"message":"Restore cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"Unlock"},"reason":{"message":"Unlock cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"UpdateProtectionStatus"},"reason":{"message":"UpdateProtectionStatus cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"EnableGovernanceConfiguration"},"reason":{"message":"EnableGovernanceConfiguration cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"UpdateGovernanceConfiguration"},"reason":{"message":"UpdateGovernanceConfiguration cannot be performed because there is no linked CDS instance or the CDS instance version is not supported."}},{"type":{"id":"Convert"},"reason":{"message":"Convert cannot be performed on environment of type Default."}},{"type":{"id":"Delete"},"reason":{"message":"Delete cannot be performed on environment of type Default."}},{"type":{"id":"Recover"},"reason":{"message":"Recover cannot be performed on environment of type Default."}},{"type":{"id":"NewCustomerManagedKey"},"reason":{"message":"NewCustomerManagedKey cannot be performed on environment of type Default."}},{"type":{"id":"RotateCustomerManagedKey"},"reason":{"message":"RotateCustomerManagedKey cannot be performed on environment of type Default."}},{"type":{"id":"RevertToMicrosoftKey"},"reason":{"message":"RevertToMicrosoftKey cannot be performed on environment of type Default."}},{"type":{"id":"NewNetworkInjection"},"reason":{"message":"NewNetworkInjection cannot be performed on environment of type Default."}},{"type":{"id":"SwapNetworkInjection"},"reason":{"message":"SwapNetworkInjection cannot be performed on environment of type Default."}},{"type":{"id":"RevertNetworkInjection"},"reason":{"message":"RevertNetworkInjection cannot be performed on environment of type Default."}},{"type":{"id":"NewIdentity"},"reason":{"message":"NewIdentity cannot be performed on environment of type Default."}},{"type":{"id":"SwapIdentity"},"reason":{"message":"SwapIdentity cannot be performed on environment of type Default."}},{"type":{"id":"RevertIdentity"},"reason":{"message":"RevertIdentity cannot be performed on environment of type Default."}}]},"governanceConfiguration":{"protectionLevel":"Basic"}}}]}';
         Handled := true;
     end;
@@ -356,5 +462,10 @@ codeunit 132677 "Environment Picker Test"
     procedure SetEmptyEnvironmentResponse()
     begin
         ReturnEmptyEnvironmentResponse := true;
+    end;
+
+    procedure SetEnvironmentResponse(ResponseText: Text)
+    begin
+        MockEnvironmentResponse := ResponseText;
     end;
 }

--- a/src/Layers/W1/Tests/Integration/EnvironmentPickerTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Integration/EnvironmentPickerTest.Codeunit.al
@@ -15,6 +15,7 @@ codeunit 132677 "Environment Picker Test"
         EnvironmentIdTxt: Label 'environment-id', Locked = true;
         EnvironmentNameTxt: Label 'environment name', Locked = true;
         MockEnvironmentLookupErr: Label 'The linked Power Platform environment lookup failed.', Locked = true;
+        InvalidEnvironmentResponseErr: Label 'The Power Automate environments response is not valid JSON.';
         MockLinkedEnvironmentId: Text;
         MockLinkedEnvironmentLookup: Boolean;
         FailLinkedEnvironmentLookup: Boolean;
@@ -221,6 +222,7 @@ codeunit 132677 "Environment Picker Test"
         BindSubscription(EnvironmentPickerTest);
 
         asserterror FlowServiceManagement.GetEnvironments(TempFlowUserEnvironmentBuffer);
+        LibraryAssert.ExpectedError(InvalidEnvironmentResponseErr);
     end;
 
     [Test]

--- a/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
@@ -18,9 +18,13 @@ codeunit 139210 "JSON Buffer Tests"
     var
         TempJSONBuffer: Record "JSON Buffer" temporary;
     begin
-        // [SCENARIO] Reading empty string does not cause errors
+        // [SCENARIO] Reading empty or whitespace JSON clears the buffer without causing errors
         LibraryLowerPermissions.SetO365Basic();
+        TempJSONBuffer.ReadFromText('{"value":1}');
         TempJSONBuffer.ReadFromText('');
+        Assert.RecordIsEmpty(TempJSONBuffer);
+        TempJSONBuffer.ReadFromText('   ');
+        Assert.RecordIsEmpty(TempJSONBuffer);
     end;
 
     [Test]
@@ -34,6 +38,7 @@ codeunit 139210 "JSON Buffer Tests"
         asserterror TempJSONBuffer.ReadFromText('Test');
         asserterror TempJSONBuffer.ReadFromText('{Test}');
         asserterror TempJSONBuffer.ReadFromText('{Test - 5}');
+        asserterror TempJSONBuffer.ReadFromText('true false');
     end;
 
     [Test]
@@ -87,6 +92,140 @@ codeunit 139210 "JSON Buffer Tests"
           TempResultArrayJSONBuffer.GetPropertyValue(PropertyValue, 'OtherVar'), 'could not find property value for OtherVar');
         Assert.AreEqual('TestValue', PropertyValue, '');
         Assert.IsTrue(TempResultArrayJSONBuffer.Next() = 0, 'There should not be any more elements');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReadRootJSONArray()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        // [SCENARIO] JSON Buffer supports a JSON array at the root
+        LibraryLowerPermissions.SetO365Basic();
+
+        TempJSONBuffer.ReadFromText('[1,{"value":"x"},[]]');
+
+        Assert.AreEqual(9, TempJSONBuffer.Count(), 'Not all JSON elements were read');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 0, TempJSONBuffer."Token type"::"Start Array", '', '', '');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Integer, '1', 'System.Int64', '[0]');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Start Object", '', '', '[1]');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"Property Name", 'value', 'System.String', '[1].value');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::String, 'x', 'System.String', '[1].value');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"End Object", '', '', '[1]');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Start Array", '', '', '[2]');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"End Array", '', '', '[2]');
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::"End Array", '', '', '');
+        VerifyContiguousEntryNumbers(TempJSONBuffer);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReadRootJSONScalars()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        // [SCENARIO] JSON Buffer supports each standard JSON scalar at the root
+        LibraryLowerPermissions.SetO365Basic();
+
+        TempJSONBuffer.ReadFromText('"root"');
+        Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root string must create one row');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::String, 'root', 'System.String', '');
+
+        TempJSONBuffer.ReadFromText('42');
+        Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root integer must replace the previous row');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Integer, '42', 'System.Int64', '');
+
+        TempJSONBuffer.ReadFromText('2.5');
+        Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root decimal must replace the previous row');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Decimal, Format(2.5), 'System.Double', '');
+
+        TempJSONBuffer.ReadFromText('true');
+        Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root Boolean must replace the previous row');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Boolean, 'Yes', 'System.Boolean', '');
+
+        TempJSONBuffer.ReadFromText('false');
+        Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root Boolean must replace the previous row');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Boolean, 'No', 'System.Boolean', '');
+
+        TempJSONBuffer.ReadFromText('null');
+        Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root null must replace the previous row');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Null, '', '', '');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReadNestedJSONAndPunctuationPathsInPropertyOrder()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        // [SCENARIO] JSON Buffer preserves object order and native paths through nested and empty containers
+        LibraryLowerPermissions.SetO365Basic();
+
+        TempJSONBuffer.ReadFromText('{"z":1,"a.b":{"emptyArray":[],"nested":[{"flag":true}]},"a":null,"emptyObject":{}}');
+
+        Assert.AreEqual(22, TempJSONBuffer.Count(), 'Not all JSON elements were read');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 0, TempJSONBuffer."Token type"::"Start Object", '', '', '');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'z', 'System.String', 'z');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Integer, '1', 'System.Int64', 'z');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'a.b', 'System.String', '[''a.b'']');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Start Object", '', '', '[''a.b'']');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"Property Name", 'emptyArray', 'System.String', '[''a.b''].emptyArray');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"Start Array", '', '', '[''a.b''].emptyArray');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"End Array", '', '', '[''a.b''].emptyArray');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"Property Name", 'nested', 'System.String', '[''a.b''].nested');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"Start Array", '', '', '[''a.b''].nested');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 3, TempJSONBuffer."Token type"::"Start Object", '', '', '[''a.b''].nested[0]');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 4, TempJSONBuffer."Token type"::"Property Name", 'flag', 'System.String', '[''a.b''].nested[0].flag');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 4, TempJSONBuffer."Token type"::Boolean, 'Yes', 'System.Boolean', '[''a.b''].nested[0].flag');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 3, TempJSONBuffer."Token type"::"End Object", '', '', '[''a.b''].nested[0]');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 2, TempJSONBuffer."Token type"::"End Array", '', '', '[''a.b''].nested');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"End Object", '', '', '[''a.b'']');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'a', 'System.String', 'a');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Null, '', '', 'a');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'emptyObject', 'System.String', 'emptyObject');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Start Object", '', '', 'emptyObject');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"End Object", '', '', 'emptyObject');
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::"End Object", '', '', '');
+        VerifyContiguousEntryNumbers(TempJSONBuffer);
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReadJSONNumberTypes()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+        ExponentValue: Decimal;
+        LargeIntegerValue: BigInteger;
+    begin
+        // [SCENARIO] JSON Buffer distinguishes integer and floating-point JSON number syntax
+        LibraryLowerPermissions.SetO365Basic();
+        ExponentValue := 1000;
+        Evaluate(LargeIntegerValue, '3000000000');
+
+        TempJSONBuffer.ReadFromText('{"integer":42,"negative":-7,"largeInteger":3000000000,"decimal":2.3,"exponent":1e3}');
+
+        Assert.AreEqual(12, TempJSONBuffer.Count(), 'Not all JSON elements were read');
+        TempJSONBuffer.FindFirst();
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 0, TempJSONBuffer."Token type"::"Start Object", '', '', '');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'integer', 'System.String', 'integer');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Integer, '42', 'System.Int64', 'integer');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'negative', 'System.String', 'negative');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Integer, '-7', 'System.Int64', 'negative');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'largeInteger', 'System.String', 'largeInteger');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Integer, Format(LargeIntegerValue), 'System.Int64', 'largeInteger');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'decimal', 'System.String', 'decimal');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Decimal, Format(2.3), 'System.Double', 'decimal');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::"Property Name", 'exponent', 'System.String', 'exponent');
+        VerifyJSONBufferAndFindNext(TempJSONBuffer, 1, TempJSONBuffer."Token type"::Decimal, Format(ExponentValue), 'System.Double', 'exponent');
+        VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::"End Object", '', '', '');
     end;
 
     [Test]
@@ -218,6 +357,67 @@ codeunit 139210 "JSON Buffer Tests"
         TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', LongString));
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.AreEqual(LongString, PropertyValue, 'Invalid string');
+        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::String);
+        TempJSONBuffer.FindFirst();
+        TempJSONBuffer.CalcFields("Value BLOB");
+        Assert.IsTrue(TempJSONBuffer."Value BLOB".HasValue(), 'The long value was not stored in the BLOB');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReadJSONFromBlob()
+    var
+        SourceJSONBuffer: Record "JSON Buffer" temporary;
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+        BlobFieldRef: FieldRef;
+        SourceRecordRef: RecordRef;
+        OutStream: OutStream;
+        PropertyValue: Text;
+    begin
+        // [SCENARIO] JSON Buffer continues to support UTF-8 JSON stored in a BLOB field
+        LibraryLowerPermissions.SetO365Basic();
+        SourceJSONBuffer."Entry No." := 1;
+        SourceJSONBuffer."Value BLOB".CreateOutStream(OutStream, TEXTENCODING::UTF8);
+        OutStream.WriteText('{"fromBlob":true}');
+        SourceJSONBuffer.Insert();
+        SourceRecordRef.GetTable(SourceJSONBuffer);
+        BlobFieldRef := SourceRecordRef.Field(SourceJSONBuffer.FieldNo("Value BLOB"));
+
+        TempJSONBuffer.ReadFromBlob(BlobFieldRef);
+
+        Assert.AreEqual(4, TempJSONBuffer.Count(), 'Not all JSON elements were read from the BLOB');
+        Assert.IsTrue(TempJSONBuffer.GetPropertyValue(PropertyValue, 'fromBlob'), 'The BLOB property was not found');
+        Assert.AreEqual('Yes', PropertyValue, 'The BLOB property value is incorrect');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure RejectJsonNetOnlyInput()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        // [SCENARIO] Native JSON parsing rejects Json.NET extensions that are not standard JSON
+        LibraryLowerPermissions.SetO365Basic();
+
+        asserterror TempJSONBuffer.ReadFromText('{"value":1/*comment*/}');
+        asserterror TempJSONBuffer.ReadFromText('new Date(123)');
+        asserterror TempJSONBuffer.ReadFromText('undefined');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure ReadCommentMarkersInsideJSONString()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+        PropertyValue: Text;
+    begin
+        // [SCENARIO] Comment markers inside a JSON string are ordinary string content
+        LibraryLowerPermissions.SetO365Basic();
+
+        TempJSONBuffer.ReadFromText('{"url":"https://example.test/path/*segment*/"}');
+
+        Assert.IsTrue(TempJSONBuffer.GetPropertyValue(PropertyValue, 'url'), 'The URL property was not found');
+        Assert.AreEqual('https://example.test/path/*segment*/', PropertyValue, 'The URL property value is incorrect');
     end;
 
     [Test]
@@ -225,21 +425,22 @@ codeunit 139210 "JSON Buffer Tests"
     procedure FormatJSONDateTimeWithoutSeconds()
     var
         TempJSONBuffer: Record "JSON Buffer" temporary;
-        DateTime: DotNet DateTime;
-        CultureInfo: DotNet CultureInfo;
         DateTimeString: Text;
         PropertyValue: Text;
     begin
-        // [SCENARIO] JSON Buffer supports formatting DateTime containing no seconds and milliseconds
+        // [SCENARIO] A date-time-like string without seconds remains a string
         LibraryLowerPermissions.SetO365Basic();
 
         // [WHEN] A JSON string containing a DateTime without seconds or milliseconds is read
-        DateTimeString := DateTime.UtcNow.ToString('yyyy-MM-ddTHH:mm', CultureInfo.InvariantCulture);
+        DateTimeString := '2025-12-31T23:59';
         TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', DateTimeString));
 
-        // [THEN] JSON Buffer contains formatted DateTime without seconds or milliseconds
+        // [THEN] JSON Buffer preserves the value as a string without seconds or milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.IsFalse(PropertyValue.Contains('.'), 'DateTime contains seconds and milliseconds');
+        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::String);
+        Assert.IsTrue(TempJSONBuffer.FindFirst(), 'The date-time-like value was not preserved as a string');
+        Assert.AreEqual('System.String', TempJSONBuffer."Value Type", 'The string value type is incorrect');
     end;
 
     [Test]
@@ -247,8 +448,6 @@ codeunit 139210 "JSON Buffer Tests"
     procedure FormatJSONDateTimeWithSeconds()
     var
         TempJSONBuffer: Record "JSON Buffer" temporary;
-        DateTime: DotNet DateTime;
-        CultureInfo: DotNet CultureInfo;
         DateTimeString: Text;
         PropertyValue: Text;
     begin
@@ -256,17 +455,30 @@ codeunit 139210 "JSON Buffer Tests"
         LibraryLowerPermissions.SetO365Basic();
 
         // [WHEN] A JSON string containing a DateTime with seconds and milliseconds is read
-        DateTimeString := DateTime.UtcNow.ToString('yyyy-MM-ddTHH:mm:ss.fff', CultureInfo.InvariantCulture);
-
-        // For unknown reasons, the DateTime.UtcNow.ToString method call above does not always return a string with seconds and milliseconds.
-        if not DateTimeString.Contains('.') then
-            DateTimeString := '2025-12-31T23:59:59.999';
-
+        DateTimeString := '2025-12-31T23:59:59.999';
         TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', DateTimeString));
 
         // [THEN] JSON Buffer contains formatted DateTime with seconds and milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.IsTrue(PropertyValue.Contains('.'), StrSubstNo('DateTime does not contain seconds and milliseconds. DateTimeString: %1, PropertyValue: %2', DateTimeString, PropertyValue));
+        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::Date);
+        Assert.IsTrue(TempJSONBuffer.FindFirst(), 'The ISO DateTime was not recognized');
+        Assert.AreEqual('System.DateTime', TempJSONBuffer."Value Type", 'The DateTime value type is incorrect');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure DateLikeNonDateRemainsString()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        // [SCENARIO] A date-like string is only classified as Date when it is a valid ISO DateTime
+        LibraryLowerPermissions.SetO365Basic();
+
+        TempJSONBuffer.ReadFromText('{"dateOnly":"2025-12-31","invalidDateTime":"2025-13-40T25:61"}');
+
+        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::String);
+        Assert.AreEqual(2, TempJSONBuffer.Count(), 'Date-like strings were classified as DateTime values');
     end;
 
     local procedure VerifyJSONBuffer(var TempJSONBuffer: Record "JSON Buffer" temporary; Depth: Integer; TokenType: Option; Value: Text; ValueType: Text[250]; Path: Text[250])
@@ -287,5 +499,16 @@ codeunit 139210 "JSON Buffer Tests"
         Assert.AreEqual(Path, TempJSONBuffer.Path, 'Incorrect JSON path');
         Assert.IsTrue(TempJSONBuffer.Next() <> 0, 'There are no more elements');
     end;
-}
 
+    local procedure VerifyContiguousEntryNumbers(var TempJSONBuffer: Record "JSON Buffer" temporary)
+    var
+        ExpectedEntryNo: Integer;
+    begin
+        TempJSONBuffer.Reset();
+        if TempJSONBuffer.FindSet() then
+            repeat
+                ExpectedEntryNo += 1;
+                Assert.AreEqual(ExpectedEntryNo, TempJSONBuffer."Entry No.", 'JSON buffer entry numbers are not contiguous');
+            until TempJSONBuffer.Next() = 0;
+    end;
+}

--- a/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
@@ -11,7 +11,9 @@ codeunit 139210 "JSON Buffer Tests"
         LibraryLowerPermissions: Codeunit "Library - Lower Permissions";
         Assert: Codeunit Assert;
         DevMsgNotTemporaryErr: Label 'This function can only be used when the record is temporary.';
+        DateTimeDetailsErr: Label 'DateTime does not contain seconds and milliseconds. DateTimeString: %1, PropertyValue: %2', Comment = '%1 - Source DateTime text, %2 - Parsed JSON Buffer value';
         InvalidJSONErr: Label 'The JSON text is invalid.';
+        JSONVariableTxt: Label '{"Variable":"%1"}', Locked = true, Comment = '%1 - JSON property value';
 
     [Test]
     [Scope('OnPrem')]
@@ -354,7 +356,7 @@ codeunit 139210 "JSON Buffer Tests"
         LongString := 'ABCDEFGHIJKLMOPQRTSTUVWXYZÆØÅ1234567890+´!#¤%&/()=?`,.-;:_@£${[]}<>abcdefghijklmnopqrstuvwxyzæøå½§';
         for i := 1 to 1000 do
             LongString += 'fillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfill';
-        TempJSONBuffer.ReadFromTextStrict(StrSubstNo('{"Variable":"%1"}', LongString));
+        TempJSONBuffer.ReadFromTextStrict(StrSubstNo(JSONVariableTxt, LongString));
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.AreEqual(LongString, PropertyValue, 'Invalid string');
         Assert.IsTrue(FindTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::String), 'The string value was not found');
@@ -450,7 +452,7 @@ codeunit 139210 "JSON Buffer Tests"
 
         // [WHEN] A JSON string containing a DateTime without seconds or milliseconds is read
         DateTimeString := '2025-12-31T23:59';
-        TempJSONBuffer.ReadFromTextStrict(StrSubstNo('{"Variable":"%1"}', DateTimeString));
+        TempJSONBuffer.ReadFromTextStrict(StrSubstNo(JSONVariableTxt, DateTimeString));
 
         // [THEN] JSON Buffer preserves the value as a string without seconds or milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
@@ -472,11 +474,11 @@ codeunit 139210 "JSON Buffer Tests"
 
         // [WHEN] A JSON string containing a DateTime with seconds and milliseconds is read
         DateTimeString := '2025-12-31T23:59:59.999';
-        TempJSONBuffer.ReadFromTextStrict(StrSubstNo('{"Variable":"%1"}', DateTimeString));
+        TempJSONBuffer.ReadFromTextStrict(StrSubstNo(JSONVariableTxt, DateTimeString));
 
         // [THEN] JSON Buffer contains formatted DateTime with seconds and milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
-        Assert.IsTrue(PropertyValue.Contains('.'), StrSubstNo('DateTime does not contain seconds and milliseconds. DateTimeString: %1, PropertyValue: %2', DateTimeString, PropertyValue));
+        Assert.IsTrue(PropertyValue.Contains('.'), StrSubstNo(DateTimeDetailsErr, DateTimeString, PropertyValue));
         Assert.IsTrue(FindTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::Date), 'The ISO DateTime was not recognized');
         Assert.AreEqual('System.DateTime', TempJSONBuffer."Value Type", 'The DateTime value type is incorrect');
     end;

--- a/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
@@ -357,8 +357,7 @@ codeunit 139210 "JSON Buffer Tests"
         TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', LongString));
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.AreEqual(LongString, PropertyValue, 'Invalid string');
-        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::String);
-        TempJSONBuffer.FindFirst();
+        Assert.IsTrue(FindTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::String), 'The string value was not found');
         TempJSONBuffer.CalcFields("Value BLOB");
         Assert.IsTrue(TempJSONBuffer."Value BLOB".HasValue(), 'The long value was not stored in the BLOB');
     end;
@@ -367,7 +366,7 @@ codeunit 139210 "JSON Buffer Tests"
     [Scope('OnPrem')]
     procedure ReadJSONFromBlob()
     var
-        SourceJSONBuffer: Record "JSON Buffer" temporary;
+        TempSourceJSONBuffer: Record "JSON Buffer" temporary;
         TempJSONBuffer: Record "JSON Buffer" temporary;
         BlobFieldRef: FieldRef;
         SourceRecordRef: RecordRef;
@@ -376,12 +375,12 @@ codeunit 139210 "JSON Buffer Tests"
     begin
         // [SCENARIO] JSON Buffer continues to support UTF-8 JSON stored in a BLOB field
         LibraryLowerPermissions.SetO365Basic();
-        SourceJSONBuffer."Entry No." := 1;
-        SourceJSONBuffer."Value BLOB".CreateOutStream(OutStream, TEXTENCODING::UTF8);
+        TempSourceJSONBuffer."Entry No." := 1;
+        TempSourceJSONBuffer."Value BLOB".CreateOutStream(OutStream, TEXTENCODING::UTF8);
         OutStream.WriteText('{"fromBlob":true}');
-        SourceJSONBuffer.Insert();
-        SourceRecordRef.GetTable(SourceJSONBuffer);
-        BlobFieldRef := SourceRecordRef.Field(SourceJSONBuffer.FieldNo("Value BLOB"));
+        TempSourceJSONBuffer.Insert();
+        SourceRecordRef.GetTable(TempSourceJSONBuffer);
+        BlobFieldRef := SourceRecordRef.Field(TempSourceJSONBuffer.FieldNo("Value BLOB"));
 
         TempJSONBuffer.ReadFromBlob(BlobFieldRef);
 
@@ -438,8 +437,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [THEN] JSON Buffer preserves the value as a string without seconds or milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.IsFalse(PropertyValue.Contains('.'), 'DateTime contains seconds and milliseconds');
-        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::String);
-        Assert.IsTrue(TempJSONBuffer.FindFirst(), 'The date-time-like value was not preserved as a string');
+        Assert.IsTrue(FindTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::String), 'The date-time-like value was not preserved as a string');
         Assert.AreEqual('System.String', TempJSONBuffer."Value Type", 'The string value type is incorrect');
     end;
 
@@ -461,8 +459,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [THEN] JSON Buffer contains formatted DateTime with seconds and milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.IsTrue(PropertyValue.Contains('.'), StrSubstNo('DateTime does not contain seconds and milliseconds. DateTimeString: %1, PropertyValue: %2', DateTimeString, PropertyValue));
-        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::Date);
-        Assert.IsTrue(TempJSONBuffer.FindFirst(), 'The ISO DateTime was not recognized');
+        Assert.IsTrue(FindTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::Date), 'The ISO DateTime was not recognized');
         Assert.AreEqual('System.DateTime', TempJSONBuffer."Value Type", 'The DateTime value type is incorrect');
     end;
 
@@ -477,8 +474,7 @@ codeunit 139210 "JSON Buffer Tests"
 
         TempJSONBuffer.ReadFromText('{"dateOnly":"2025-12-31","invalidDateTime":"2025-13-40T25:61"}');
 
-        TempJSONBuffer.SetRange("Token type", TempJSONBuffer."Token type"::String);
-        Assert.AreEqual(2, TempJSONBuffer.Count(), 'Date-like strings were classified as DateTime values');
+        Assert.AreEqual(2, CountTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::String), 'Date-like strings were classified as DateTime values');
     end;
 
     local procedure VerifyJSONBuffer(var TempJSONBuffer: Record "JSON Buffer" temporary; Depth: Integer; TokenType: Option; Value: Text; ValueType: Text[250]; Path: Text[250])
@@ -510,5 +506,28 @@ codeunit 139210 "JSON Buffer Tests"
                 ExpectedEntryNo += 1;
                 Assert.AreEqual(ExpectedEntryNo, TempJSONBuffer."Entry No.", 'JSON buffer entry numbers are not contiguous');
             until TempJSONBuffer.Next() = 0;
+    end;
+
+    local procedure FindTokenType(var TempJSONBuffer: Record "JSON Buffer" temporary; TokenType: Option): Boolean
+    begin
+        TempJSONBuffer.Reset();
+        if TempJSONBuffer.FindSet() then
+            repeat
+                if TempJSONBuffer."Token type" = TokenType then
+                    exit(true);
+            until TempJSONBuffer.Next() = 0;
+    end;
+
+    local procedure CountTokenType(var TempJSONBuffer: Record "JSON Buffer" temporary; TokenType: Option): Integer
+    var
+        TokenCount: Integer;
+    begin
+        TempJSONBuffer.Reset();
+        if TempJSONBuffer.FindSet() then
+            repeat
+                if TempJSONBuffer."Token type" = TokenType then
+                    TokenCount += 1;
+            until TempJSONBuffer.Next() = 0;
+        exit(TokenCount);
     end;
 }

--- a/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JSONBufferTests.Codeunit.al
@@ -11,6 +11,7 @@ codeunit 139210 "JSON Buffer Tests"
         LibraryLowerPermissions: Codeunit "Library - Lower Permissions";
         Assert: Codeunit Assert;
         DevMsgNotTemporaryErr: Label 'This function can only be used when the record is temporary.';
+        InvalidJSONErr: Label 'The JSON text is invalid.';
 
     [Test]
     [Scope('OnPrem')]
@@ -20,10 +21,10 @@ codeunit 139210 "JSON Buffer Tests"
     begin
         // [SCENARIO] Reading empty or whitespace JSON clears the buffer without causing errors
         LibraryLowerPermissions.SetO365Basic();
-        TempJSONBuffer.ReadFromText('{"value":1}');
-        TempJSONBuffer.ReadFromText('');
+        TempJSONBuffer.ReadFromTextStrict('{"value":1}');
+        TempJSONBuffer.ReadFromTextStrict('');
         Assert.RecordIsEmpty(TempJSONBuffer);
-        TempJSONBuffer.ReadFromText('   ');
+        TempJSONBuffer.ReadFromTextStrict('   ');
         Assert.RecordIsEmpty(TempJSONBuffer);
     end;
 
@@ -31,14 +32,13 @@ codeunit 139210 "JSON Buffer Tests"
     [Scope('OnPrem')]
     procedure ReadInvalidJSONStrings()
     var
-        TempJSONBuffer: Record "JSON Buffer" temporary;
     begin
         // [SCENARIO] Reading invalid JSON does produce errors
         LibraryLowerPermissions.SetO365Basic();
-        asserterror TempJSONBuffer.ReadFromText('Test');
-        asserterror TempJSONBuffer.ReadFromText('{Test}');
-        asserterror TempJSONBuffer.ReadFromText('{Test - 5}');
-        asserterror TempJSONBuffer.ReadFromText('true false');
+        AssertStrictReadFails('Test');
+        AssertStrictReadFails('{Test}');
+        AssertStrictReadFails('{Test - 5}');
+        AssertStrictReadFails('true false');
     end;
 
     [Test]
@@ -49,7 +49,7 @@ codeunit 139210 "JSON Buffer Tests"
     begin
         // [SCENARIO] It is only possible to use JSON Buffer as a temporary table
         LibraryLowerPermissions.SetO365Basic();
-        asserterror JSONBuffer.ReadFromText('{Test : 5}');
+        asserterror JSONBuffer.ReadFromTextStrict('{Test : 5}');
         Assert.ExpectedError(DevMsgNotTemporaryErr);
     end;
 
@@ -64,7 +64,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer supports reading arrays
         LibraryLowerPermissions.SetO365Basic();
         // [WHEN] A JSON string containing an array is read
-        TempJSONBuffer.ReadFromText('{"Result":[{"MyVar":"5"},{"OtherVar":"TestValue"}]}');
+        TempJSONBuffer.ReadFromTextStrict('{"Result":[{"MyVar":"5"},{"OtherVar":"TestValue"}]}');
         // [THEN] The structure of the JSON buffer matches that JSON string
         Assert.AreEqual(13, TempJSONBuffer.Count, 'Not all JSON elements were read');
         TempJSONBuffer.FindFirst();
@@ -103,7 +103,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer supports a JSON array at the root
         LibraryLowerPermissions.SetO365Basic();
 
-        TempJSONBuffer.ReadFromText('[1,{"value":"x"},[]]');
+        TempJSONBuffer.ReadFromTextStrict('[1,{"value":"x"},[]]');
 
         Assert.AreEqual(9, TempJSONBuffer.Count(), 'Not all JSON elements were read');
         TempJSONBuffer.FindFirst();
@@ -128,32 +128,32 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer supports each standard JSON scalar at the root
         LibraryLowerPermissions.SetO365Basic();
 
-        TempJSONBuffer.ReadFromText('"root"');
+        TempJSONBuffer.ReadFromTextStrict('"root"');
         Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root string must create one row');
         TempJSONBuffer.FindFirst();
         VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::String, 'root', 'System.String', '');
 
-        TempJSONBuffer.ReadFromText('42');
+        TempJSONBuffer.ReadFromTextStrict('42');
         Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root integer must replace the previous row');
         TempJSONBuffer.FindFirst();
         VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Integer, '42', 'System.Int64', '');
 
-        TempJSONBuffer.ReadFromText('2.5');
+        TempJSONBuffer.ReadFromTextStrict('2.5');
         Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root decimal must replace the previous row');
         TempJSONBuffer.FindFirst();
         VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Decimal, Format(2.5), 'System.Double', '');
 
-        TempJSONBuffer.ReadFromText('true');
+        TempJSONBuffer.ReadFromTextStrict('true');
         Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root Boolean must replace the previous row');
         TempJSONBuffer.FindFirst();
         VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Boolean, 'Yes', 'System.Boolean', '');
 
-        TempJSONBuffer.ReadFromText('false');
+        TempJSONBuffer.ReadFromTextStrict('false');
         Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root Boolean must replace the previous row');
         TempJSONBuffer.FindFirst();
         VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Boolean, 'No', 'System.Boolean', '');
 
-        TempJSONBuffer.ReadFromText('null');
+        TempJSONBuffer.ReadFromTextStrict('null');
         Assert.AreEqual(1, TempJSONBuffer.Count(), 'A root null must replace the previous row');
         TempJSONBuffer.FindFirst();
         VerifyJSONBuffer(TempJSONBuffer, 0, TempJSONBuffer."Token type"::Null, '', '', '');
@@ -168,7 +168,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer preserves object order and native paths through nested and empty containers
         LibraryLowerPermissions.SetO365Basic();
 
-        TempJSONBuffer.ReadFromText('{"z":1,"a.b":{"emptyArray":[],"nested":[{"flag":true}]},"a":null,"emptyObject":{}}');
+        TempJSONBuffer.ReadFromTextStrict('{"z":1,"a.b":{"emptyArray":[],"nested":[{"flag":true}]},"a":null,"emptyObject":{}}');
 
         Assert.AreEqual(22, TempJSONBuffer.Count(), 'Not all JSON elements were read');
         TempJSONBuffer.FindFirst();
@@ -210,7 +210,7 @@ codeunit 139210 "JSON Buffer Tests"
         ExponentValue := 1000;
         Evaluate(LargeIntegerValue, '3000000000');
 
-        TempJSONBuffer.ReadFromText('{"integer":42,"negative":-7,"largeInteger":3000000000,"decimal":2.3,"exponent":1e3}');
+        TempJSONBuffer.ReadFromTextStrict('{"integer":42,"negative":-7,"largeInteger":3000000000,"decimal":2.3,"exponent":1e3}');
 
         Assert.AreEqual(12, TempJSONBuffer.Count(), 'Not all JSON elements were read');
         TempJSONBuffer.FindFirst();
@@ -239,7 +239,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer supports reading variables
         LibraryLowerPermissions.SetO365Basic();
         // [WHEN] A JSON string containing variables is read
-        TempJSONBuffer.ReadFromText('{"test1":"value1","test2":2.3,"test3":"value3"}');
+        TempJSONBuffer.ReadFromTextStrict('{"test1":"value1","test2":2.3,"test3":"value3"}');
         // [THEN] The structure of the JSON buffer matches that JSON string
         Assert.AreEqual(8, TempJSONBuffer.Count, 'Not all JSON elements were read');
         TempJSONBuffer.FindFirst();
@@ -272,7 +272,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer supports reading nested arrays
         LibraryLowerPermissions.SetO365Basic();
         // [WHEN] A JSON string containing two nested arrays is read
-        TempJSONBuffer.ReadFromText(
+        TempJSONBuffer.ReadFromTextStrict(
           '{"Result":[{"MyVar":"5","Result":[{"InnerContent1":"InnerValue1","InnerContent2":"InnerValue2"}]},{"OtherVar":"TestValue"}]}');
 
         // [THEN] We can find these two arrays
@@ -320,7 +320,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] JSON Buffer supports reading consecutive arrays
         LibraryLowerPermissions.SetO365Basic();
         // [WHEN] A JSON string containing two consecutive arrays is read
-        TempJSONBuffer.ReadFromText('{"Array1":[{"Arr1Var":"Arr1Val"}],"Array2":[{"Arr2Var":"Arr2Val"}]}');
+        TempJSONBuffer.ReadFromTextStrict('{"Array1":[{"Arr1Var":"Arr1Val"}],"Array2":[{"Arr2Var":"Arr2Val"}]}');
 
         // [THEN] We can find these two arrays
         Assert.IsTrue(TempJSONBuffer.FindArray(TempArray1JSONBuffer, 'Array1'), 'Could not find array 1');
@@ -354,7 +354,7 @@ codeunit 139210 "JSON Buffer Tests"
         LongString := 'ABCDEFGHIJKLMOPQRTSTUVWXYZÆØÅ1234567890+´!#¤%&/()=?`,.-;:_@£${[]}<>abcdefghijklmnopqrstuvwxyzæøå½§';
         for i := 1 to 1000 do
             LongString += 'fillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfillfill';
-        TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', LongString));
+        TempJSONBuffer.ReadFromTextStrict(StrSubstNo('{"Variable":"%1"}', LongString));
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
         Assert.AreEqual(LongString, PropertyValue, 'Invalid string');
         Assert.IsTrue(FindTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::String), 'The string value was not found');
@@ -382,7 +382,7 @@ codeunit 139210 "JSON Buffer Tests"
         SourceRecordRef.GetTable(TempSourceJSONBuffer);
         BlobFieldRef := SourceRecordRef.Field(TempSourceJSONBuffer.FieldNo("Value BLOB"));
 
-        TempJSONBuffer.ReadFromBlob(BlobFieldRef);
+        TempJSONBuffer.ReadFromBlobStrict(BlobFieldRef);
 
         Assert.AreEqual(4, TempJSONBuffer.Count(), 'Not all JSON elements were read from the BLOB');
         Assert.IsTrue(TempJSONBuffer.GetPropertyValue(PropertyValue, 'fromBlob'), 'The BLOB property was not found');
@@ -392,16 +392,34 @@ codeunit 139210 "JSON Buffer Tests"
     [Test]
     [Scope('OnPrem')]
     procedure RejectJsonNetOnlyInput()
-    var
-        TempJSONBuffer: Record "JSON Buffer" temporary;
     begin
         // [SCENARIO] Native JSON parsing rejects Json.NET extensions that are not standard JSON
         LibraryLowerPermissions.SetO365Basic();
 
-        asserterror TempJSONBuffer.ReadFromText('{"value":1/*comment*/}');
-        asserterror TempJSONBuffer.ReadFromText('new Date(123)');
-        asserterror TempJSONBuffer.ReadFromText('undefined');
+        AssertStrictReadFails('{"value":1/*comment*/}');
+        AssertStrictReadFails('new Date(123)');
+        AssertStrictReadFails('undefined');
     end;
+
+#if not CLEAN30
+    [Test]
+    [Scope('OnPrem')]
+    procedure LegacyReadFromTextAcceptsJsonNetExtensions()
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        LibraryLowerPermissions.SetO365Basic();
+
+#pragma warning disable AL0432
+        TempJSONBuffer.ReadFromText('{"value":1/*comment*/}');
+        Assert.IsFalse(TempJSONBuffer.IsEmpty(), 'The legacy parser rejected a JSON comment.');
+        TempJSONBuffer.ReadFromText('new Date(123)');
+        Assert.IsFalse(TempJSONBuffer.IsEmpty(), 'The legacy parser rejected a Json.NET constructor.');
+        TempJSONBuffer.ReadFromText('undefined');
+        Assert.IsFalse(TempJSONBuffer.IsEmpty(), 'The legacy parser rejected an undefined value.');
+#pragma warning restore AL0432
+    end;
+#endif
 
     [Test]
     [Scope('OnPrem')]
@@ -413,7 +431,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] Comment markers inside a JSON string are ordinary string content
         LibraryLowerPermissions.SetO365Basic();
 
-        TempJSONBuffer.ReadFromText('{"url":"https://example.test/path/*segment*/"}');
+        TempJSONBuffer.ReadFromTextStrict('{"url":"https://example.test/path/*segment*/"}');
 
         Assert.IsTrue(TempJSONBuffer.GetPropertyValue(PropertyValue, 'url'), 'The URL property was not found');
         Assert.AreEqual('https://example.test/path/*segment*/', PropertyValue, 'The URL property value is incorrect');
@@ -432,7 +450,7 @@ codeunit 139210 "JSON Buffer Tests"
 
         // [WHEN] A JSON string containing a DateTime without seconds or milliseconds is read
         DateTimeString := '2025-12-31T23:59';
-        TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', DateTimeString));
+        TempJSONBuffer.ReadFromTextStrict(StrSubstNo('{"Variable":"%1"}', DateTimeString));
 
         // [THEN] JSON Buffer preserves the value as a string without seconds or milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
@@ -454,7 +472,7 @@ codeunit 139210 "JSON Buffer Tests"
 
         // [WHEN] A JSON string containing a DateTime with seconds and milliseconds is read
         DateTimeString := '2025-12-31T23:59:59.999';
-        TempJSONBuffer.ReadFromText(StrSubstNo('{"Variable":"%1"}', DateTimeString));
+        TempJSONBuffer.ReadFromTextStrict(StrSubstNo('{"Variable":"%1"}', DateTimeString));
 
         // [THEN] JSON Buffer contains formatted DateTime with seconds and milliseconds
         TempJSONBuffer.GetPropertyValue(PropertyValue, 'Variable');
@@ -472,7 +490,7 @@ codeunit 139210 "JSON Buffer Tests"
         // [SCENARIO] A date-like string is only classified as Date when it is a valid ISO DateTime
         LibraryLowerPermissions.SetO365Basic();
 
-        TempJSONBuffer.ReadFromText('{"dateOnly":"2025-12-31","invalidDateTime":"2025-13-40T25:61"}');
+        TempJSONBuffer.ReadFromTextStrict('{"dateOnly":"2025-12-31","invalidDateTime":"2025-13-40T25:61"}');
 
         Assert.AreEqual(2, CountTokenType(TempJSONBuffer, TempJSONBuffer."Token type"::String), 'Date-like strings were classified as DateTime values');
     end;
@@ -529,5 +547,13 @@ codeunit 139210 "JSON Buffer Tests"
                     TokenCount += 1;
             until TempJSONBuffer.Next() = 0;
         exit(TokenCount);
+    end;
+
+    local procedure AssertStrictReadFails(JSONText: Text)
+    var
+        TempJSONBuffer: Record "JSON Buffer" temporary;
+    begin
+        asserterror TempJSONBuffer.ReadFromTextStrict(JSONText);
+        Assert.ExpectedError(InvalidJSONErr);
     end;
 }

--- a/src/Layers/W1/Tests/Misc/JsonTextReaderWriterTest.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/JsonTextReaderWriterTest.Codeunit.al
@@ -1,3 +1,4 @@
+#if not CLEAN30
 codeunit 139211 "Json Text Reader/Writer Test"
 {
     Subtype = Test;
@@ -16,7 +17,9 @@ codeunit 139211 "Json Text Reader/Writer Test"
     procedure TestWriter()
     var
         TempJSONBuffer: Record "JSON Buffer" temporary;
+#pragma warning disable AL0432
         JsonTextReaderWriter: Codeunit "Json Text Reader/Writer";
+#pragma warning restore AL0432
         LibraryLowerPermissions: Codeunit "Library - Lower Permissions";
         Json: Text;
     begin
@@ -97,4 +100,4 @@ codeunit 139211 "Json Text Reader/Writer Test"
         end;
     end;
 }
-
+#endif

--- a/src/Layers/W1/Tests/Misc/UTREST.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/UTREST.Codeunit.al
@@ -78,7 +78,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure XmlText2JsonText()
     var
-        JSONMgt: Codeunit System.Text.Json.Json;
+        JSONMgt: Codeunit Json;
         XmlText: Text;
         JsonText: Text;
     begin
@@ -98,7 +98,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure XmlTextWithUTF8BOM2JsonText()
     var
-        JSONMgt: Codeunit System.Text.Json.Json;
+        JSONMgt: Codeunit Json;
         ByteOrderMarkUtf8: Text[1];
         XmlText: Text;
         JsonText: Text;
@@ -120,7 +120,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure JsonText2XmlText()
     var
-        JSONMgt: Codeunit System.Text.Json.Json;
+        JSONMgt: Codeunit Json;
         XmlText: Text;
         JsonText: Text;
     begin

--- a/src/Layers/W1/Tests/Misc/UTREST.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/UTREST.Codeunit.al
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 codeunit 139148 "UT REST"
 {
     Subtype = Test;
@@ -78,7 +80,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure XmlText2JsonText()
     var
-        JSONMgt: Codeunit "JSON Management";
+        JSONMgt: Codeunit Json;
         XmlText: Text;
         JsonText: Text;
     begin
@@ -96,9 +98,31 @@ codeunit 139148 "UT REST"
 
     [Test]
     [Scope('OnPrem')]
+    procedure XmlTextWithUTF8BOM2JsonText()
+    var
+        JSONMgt: Codeunit Json;
+        ByteOrderMarkUtf8: Text[1];
+        XmlText: Text;
+        JsonText: Text;
+    begin
+        // [SCENARIO] XML text with a leading UTF-8 byte order mark is converted to JSON
+
+        // [GIVEN] XML text prefixed with a UTF-8 byte order mark
+        ByteOrderMarkUtf8[1] := 65279;
+        XmlText := ByteOrderMarkUtf8 + MockXMLText();
+
+        // [WHEN] The XML text is converted to JSON
+        JsonText := JSONMgt.XMLTextToJSONText(XmlText);
+
+        // [THEN] The JSON has the expected content
+        VerifyJsonText(JsonText, MockJsonText());
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure JsonText2XmlText()
     var
-        JSONMgt: Codeunit "JSON Management";
+        JSONMgt: Codeunit Json;
         XmlText: Text;
         JsonText: Text;
     begin
@@ -112,6 +136,7 @@ codeunit 139148 "UT REST"
 
         // [THEN] Resulted XML text has appropriate content
         VerifyXMLText(XmlText, MockXMLText());
+        Assert.AreEqual(0, StrPos(XmlText, '<?xml'), InvalidValueErr);
     end;
 
     [Test]
@@ -455,4 +480,3 @@ codeunit 139148 "UT REST"
         Assert.AreEqual(ExpectedXMLText, XMLText, InvalidValueErr);
     end;
 }
-

--- a/src/Layers/W1/Tests/Misc/UTREST.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/UTREST.Codeunit.al
@@ -1,5 +1,3 @@
-using System.Text.Json;
-
 codeunit 139148 "UT REST"
 {
     Subtype = Test;
@@ -80,7 +78,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure XmlText2JsonText()
     var
-        JSONMgt: Codeunit Json;
+        JSONMgt: Codeunit System.Text.Json.Json;
         XmlText: Text;
         JsonText: Text;
     begin
@@ -100,7 +98,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure XmlTextWithUTF8BOM2JsonText()
     var
-        JSONMgt: Codeunit Json;
+        JSONMgt: Codeunit System.Text.Json.Json;
         ByteOrderMarkUtf8: Text[1];
         XmlText: Text;
         JsonText: Text;
@@ -122,7 +120,7 @@ codeunit 139148 "UT REST"
     [Scope('OnPrem')]
     procedure JsonText2XmlText()
     var
-        JSONMgt: Codeunit Json;
+        JSONMgt: Codeunit System.Text.Json.Json;
         XmlText: Text;
         JsonText: Text;
     begin

--- a/src/Layers/W1/Tests/TestLibraries/APIWebhookSendingEvents.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/APIWebhookSendingEvents.Codeunit.al
@@ -105,11 +105,11 @@ codeunit 135090 "API Webhook Sending Events"
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"API Webhook Notification Send", 'OnBeforeSendNotification', '', false, false)]
     local procedure HandleOnBeforeSendNotification(NotificationUrl: Text; Payload: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphMgtGeneralTools: Codeunit "Graph Mgt - General Tools";
-        ValueJArray: DotNet JArray;
-        PayloadJObject: DotNet JObject;
-        ValueJObject: DotNet JObject;
+        ValueJArray: JsonArray;
+        PayloadJObject: JsonObject;
+        ValueJObject: JsonObject;
+        JsonToken: JsonToken;
         ExpectedSubscriptionID: Text;
         ExpectedChangeType: Text;
         ExpectedNotificationUrl: Text;
@@ -125,19 +125,17 @@ codeunit 135090 "API Webhook Sending Events"
         ExpectedEntityCount := LibraryVariableStorage.DequeueInteger();
         Assert.AreEqual(ExpectedNotificationUrl, NotificationUrl, 'Incorrect notification URL');
 
-        JSONManagement.InitializeObject(Payload);
-        JSONManagement.GetJSONObject(PayloadJObject);
-        JSONManagement.GetArrayPropertyValueFromJObjectByName(PayloadJObject, 'value', ValueJArray);
+        PayloadJObject.ReadFrom(Payload);
+        ValueJArray := PayloadJObject.GetArray('value');
         ActualEntityCount := ValueJArray.Count();
         Assert.AreEqual(ExpectedEntityCount, ActualEntityCount, 'Invalid number of entities');
-
-        JSONManagement.InitializeCollectionFromJArray(ValueJArray);
 
         for I := 0 to ActualEntityCount - 1 do begin
             ExpectedSubscriptionID := LibraryVariableStorage.DequeueText();
             ExpectedChangeType := LibraryVariableStorage.DequeueText();
             ExpectedResourceUrl := LibraryVariableStorage.DequeueText();
-            JSONManagement.GetJObjectFromCollectionByIndex(ValueJObject, I);
+            ValueJArray.Get(I, JsonToken);
+            ValueJObject := JsonToken.AsObject();
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(ValueJObject, 'subscriptionId', ActualSubscriptionID);
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(ValueJObject, 'changeType', ActualChangeType);
             GraphMgtGeneralTools.GetMandatoryStringPropertyFromJObject(ValueJObject, 'resource', ActualResourceUrl);
@@ -268,4 +266,3 @@ codeunit 135090 "API Webhook Sending Events"
             until JobQueueEntry.Next() = 0;
     end;
 }
-

--- a/src/Layers/W1/Tests/TestLibraries/LibraryGraphDocumentTools.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryGraphDocumentTools.Codeunit.al
@@ -323,10 +323,10 @@ codeunit 130619 "Library - Graph Document Tools"
         LibraryGraphMgt.GetObjectIDFromJSON(JSONResponse, 'totalTaxAmount', totalTaxAmountTxt);
         LibraryGraphMgt.GetObjectIDFromJSON(JSONResponse, 'totalAmountIncludingTax', totalAmountIncludingTaxTxt);
 
-        Evaluate(discountAmount, discountAmountTxt);
-        Evaluate(totalAmountExcludingTax, totalAmountExcludingTaxTxt);
-        Evaluate(totalTaxAmount, totalTaxAmountTxt);
-        Evaluate(totalAmountIncludingTax, totalAmountIncludingTaxTxt);
+        Evaluate(discountAmount, discountAmountTxt, 9);
+        Evaluate(totalAmountExcludingTax, totalAmountExcludingTaxTxt, 9);
+        Evaluate(totalTaxAmount, totalTaxAmountTxt, 9);
+        Evaluate(totalAmountIncludingTax, totalAmountIncludingTaxTxt, 9);
 
         Assert.AreEqual(
           ExpectedOrderDiscountType, SalesHeader."Invoice Discount Calculation", 'Wrong Invoice Discount type on the header');
@@ -361,10 +361,10 @@ codeunit 130619 "Library - Graph Document Tools"
         LibraryGraphMgt.GetObjectIDFromJSON(JSONResponse, 'totalTaxAmount', totalTaxAmountTxt);
         LibraryGraphMgt.GetObjectIDFromJSON(JSONResponse, 'totalAmountIncludingTax', totalAmountIncludingTaxTxt);
 
-        Evaluate(discountAmount, discountAmountTxt);
-        Evaluate(totalAmountExcludingTax, totalAmountExcludingTaxTxt);
-        Evaluate(totalTaxAmount, totalTaxAmountTxt);
-        Evaluate(totalAmountIncludingTax, totalAmountIncludingTaxTxt);
+        Evaluate(discountAmount, discountAmountTxt, 9);
+        Evaluate(totalAmountExcludingTax, totalAmountExcludingTaxTxt, 9);
+        Evaluate(totalTaxAmount, totalTaxAmountTxt, 9);
+        Evaluate(totalAmountIncludingTax, totalAmountIncludingTaxTxt, 9);
 
         Assert.AreEqual(
           ExpectedOrderDiscountType, PurchaseHeader."Invoice Discount Calculation", 'Wrong Invoice Discount type on the header');
@@ -380,13 +380,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifyCustomerBillingAddress(Customer: Record Customer; SalesHeader: Record "Sales Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'billingPostalAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'billingPostalAddress', JSONAddressValue),
           'Could not find the billingPostalAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'billingPostalAddress should not be blank in ' + ResponseText);
 
@@ -404,13 +402,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifySalesDocumentSellToAddress(Customer: Record Customer; SalesHeader: Record "Sales Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'sellingPostalAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'sellingPostalAddress', JSONAddressValue),
           'Could not find the sellingPostalAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'sellingPostalAddress should not be blank in ' + ResponseText);
 
@@ -432,13 +428,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifySalesDocumentBillToAddress(Customer: Record Customer; SalesHeader: Record "Sales Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'billingPostalAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'billingPostalAddress', JSONAddressValue),
           'Could not find the billingPostalAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'billingPostalAddress should not be blank in ' + ResponseText);
 
@@ -460,13 +454,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifySalesDocumentShipToAddress(Customer: Record Customer; SalesHeader: Record "Sales Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'shippingPostalAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'shippingPostalAddress', JSONAddressValue),
           'Could not find the shippingPostalAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'shippingPostalAddress should not be blank in ' + ResponseText);
 
@@ -488,13 +480,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifyPurchaseDocumentBuyFromAddress(Vendor: Record Vendor; PurchaseHeader: Record "Purchase Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'buyFromAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'buyFromAddress', JSONAddressValue),
           'Could not find the buyFromAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'buyFromAddress should not be blank in ' + ResponseText);
 
@@ -516,13 +506,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifyPurchaseDocumentPayToAddress(Vendor: Record Vendor; PurchaseHeader: Record "Purchase Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'payToAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'payToAddress', JSONAddressValue),
           'Could not find the payToAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'payToAddress should not be blank in ' + ResponseText);
 
@@ -544,13 +532,11 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifyPurchaseDocumentShipToAddress(Vendor: Record Vendor; PurchaseHeader: Record "Purchase Header"; ResponseText: Text; EmptyData: Boolean; PartiallyEmptyData: Boolean)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         JSONAddressValue: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'shipToAddress', JSONAddressValue),
+        JObject.ReadFrom(ResponseText);
+        Assert.IsTrue(TryGetJsonText(JObject, 'shipToAddress', JSONAddressValue),
           'Could not find the shipToAddress property in' + ResponseText);
         Assert.AreNotEqual('', JSONAddressValue, 'shipToAddress should not be blank in ' + ResponseText);
 
@@ -643,41 +629,34 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifySalesObjectTxtDescription(SalesLine: Record "Sales Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JObjectTxt);
         VerifySalesObjectDescription(SalesLine, JsonObject);
     end;
 
     [Scope('OnPrem')]
     procedure VerifySalesObjectTxtDescriptionWithoutComplexTypes(SalesLine: Record "Sales Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JObjectTxt);
         VerifySalesObjectTypeAndSequence(SalesLine, JsonObject);
     end;
 
     [Scope('OnPrem')]
-    procedure VerifySalesObjectDescription(var SalesLine: Record "Sales Line"; var JObject: DotNet JObject)
+    procedure VerifySalesObjectDescription(var SalesLine: Record "Sales Line"; var JObject: JsonObject)
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphMgtComplexTypes: Codeunit "Graph Mgt - Complex Types";
         objectDetailsTxt: Text;
         No: Code[20];
         Description: Text[50];
         Name: Text[100];
     begin
-        JSONManagement.InitializeObjectFromJObject(JObject);
-
         VerifySalesObjectTypeAndSequence(SalesLine, JObject);
 
         Assert.IsTrue(
-          JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, LineDetailsFieldNameTxt, objectDetailsTxt),
+          TryGetJsonText(JObject, LineDetailsFieldNameTxt, objectDetailsTxt),
           'Could not find ' + LineDetailsFieldNameTxt);
 
         case SalesLine.Type of
@@ -691,17 +670,16 @@ codeunit 130619 "Library - Graph Document Tools"
         end;
     end;
 
-    local procedure VerifySalesObjectTypeAndSequence(SalesLine: Record "Sales Line"; JObject: Dotnet JObject)
+    local procedure VerifySalesObjectTypeAndSequence(SalesLine: Record "Sales Line"; JObject: JsonObject)
     var
         SalesInvoiceLineAggregate: Record "Sales Invoice Line Aggregate";
-        JSONManagement: Codeunit "JSON Management";
         sequenceTxt: Text;
         objectTypeTxt: Text;
         xmlConvert: DotNet XmlConvert;
     begin
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'sequence', sequenceTxt), 'Could not find sequence');
+        Assert.IsTrue(TryGetJsonText(JObject, 'sequence', sequenceTxt), 'Could not find sequence');
         Assert.IsTrue(
-          JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, LineTypeFieldNameTxt, objectTypeTxt),
+          TryGetJsonText(JObject, LineTypeFieldNameTxt, objectTypeTxt),
           'Could not find ' + LineTypeFieldNameTxt);
 
         SalesInvoiceLineAggregate."API Type" := SalesLine.Type;
@@ -712,41 +690,34 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifyPurchaseObjectTxtDescription(PurchaseLine: Record "Purchase Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JObjectTxt);
         VerifyPurchaseObjectDescription(PurchaseLine, JsonObject);
     end;
 
     [Scope('OnPrem')]
     procedure VerifyPurchaseObjectTxtDescriptionWithoutComplexType(PurchaseLine: Record "Purchase Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JObjectTxt);
         VerifyPurchaseObjectTypeAndSequence(PurchaseLine, JsonObject);
     end;
 
     [Scope('OnPrem')]
-    procedure VerifyPurchaseObjectDescription(var PurchaseLine: Record "Purchase Line"; var JObject: DotNet JObject)
+    procedure VerifyPurchaseObjectDescription(var PurchaseLine: Record "Purchase Line"; var JObject: JsonObject)
     var
-        JSONManagement: Codeunit "JSON Management";
         GraphMgtComplexTypes: Codeunit "Graph Mgt - Complex Types";
         objectDetailsTxt: Text;
         No: Code[20];
         Description: Text[50];
         Name: Text[100];
     begin
-        JSONManagement.InitializeObjectFromJObject(JObject);
-
         VerifyPurchaseObjectTypeAndSequence(PurchaseLine, JObject);
 
         Assert.IsTrue(
-          JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, LineDetailsFieldNameTxt, objectDetailsTxt),
+          TryGetJsonText(JObject, LineDetailsFieldNameTxt, objectDetailsTxt),
           'Could not find ' + LineDetailsFieldNameTxt);
 
         case PurchaseLine.Type of
@@ -760,17 +731,16 @@ codeunit 130619 "Library - Graph Document Tools"
         end;
     end;
 
-    local procedure VerifyPurchaseObjectTypeAndSequence(PurchaseLine: Record "Purchase Line"; JObject: Dotnet JObject)
+    local procedure VerifyPurchaseObjectTypeAndSequence(PurchaseLine: Record "Purchase Line"; JObject: JsonObject)
     var
         PurchInvLineAggregate: Record "Purch. Inv. Line Aggregate";
-        JSONManagement: Codeunit "JSON Management";
         sequenceTxt: Text;
         objectTypeTxt: Text;
         xmlConvert: DotNet XmlConvert;
     begin
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'sequence', sequenceTxt), 'Could not find sequence');
+        Assert.IsTrue(TryGetJsonText(JObject, 'sequence', sequenceTxt), 'Could not find sequence');
         Assert.IsTrue(
-          JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, LineTypeFieldNameTxt, objectTypeTxt),
+          TryGetJsonText(JObject, LineTypeFieldNameTxt, objectTypeTxt),
           'Could not find ' + LineTypeFieldNameTxt);
         PurchInvLineAggregate."API Type" := PurchaseLine.Type;
         Assert.AreEqual(xmlConvert.DecodeName(objectTypeTxt), Format(PurchInvLineAggregate."API Type"), 'Wrong value for the API Type');
@@ -780,27 +750,23 @@ codeunit 130619 "Library - Graph Document Tools"
     [Scope('OnPrem')]
     procedure VerifySalesIdsSetFromTxt(SalesLine: Record "Sales Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JObjectTxt);
         VerifySalesIdsSet(SalesLine, JsonObject);
     end;
 
     [Scope('OnPrem')]
     procedure VerifyPurchaseIdsSetFromTxt(PurchaseLine: Record "Purchase Line"; JObjectTxt: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JObjectTxt);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(JObjectTxt);
         VerifyPurchaseIdsSet(PurchaseLine, JsonObject);
     end;
 
     [Scope('OnPrem')]
-    procedure VerifySalesIdsSet(var SalesLine: Record "Sales Line"; var JObject: DotNet JObject)
+    procedure VerifySalesIdsSet(var SalesLine: Record "Sales Line"; var JObject: JsonObject)
     var
         Item: Record Item;
         GLAccount: Record "G/L Account";
@@ -835,7 +801,7 @@ codeunit 130619 "Library - Graph Document Tools"
     end;
 
     [Scope('OnPrem')]
-    procedure VerifyPurchaseIdsSet(var PurchaseLine: Record "Purchase Line"; var JObject: DotNet JObject)
+    procedure VerifyPurchaseIdsSet(var PurchaseLine: Record "Purchase Line"; var JObject: JsonObject)
     var
         Item: Record Item;
         GLAccount: Record "G/L Account";
@@ -870,29 +836,39 @@ codeunit 130619 "Library - Graph Document Tools"
     end;
 
     [Scope('OnPrem')]
-    procedure VerifyIdsSet(var JObject: DotNet JObject; var ItemId: Text; var AccountId: Text)
-    var
-        JSONManagement: Codeunit "JSON Management";
+    procedure VerifyIdsSet(var JObject: JsonObject; var ItemId: Text; var AccountId: Text)
     begin
-        JSONManagement.InitializeObjectFromJObject(JObject);
-
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'itemId', ItemId), 'Could not find itemId');
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'accountId', AccountId), 'Could not find accountId');
+        Assert.IsTrue(TryGetJsonText(JObject, 'itemId', ItemId), 'Could not find itemId');
+        Assert.IsTrue(TryGetJsonText(JObject, 'accountId', AccountId), 'Could not find accountId');
     end;
 
     [Scope('OnPrem')]
     procedure VerifyValidDiscountAmount(ResponseText: Text; ExpectedDiscountAmount: Decimal)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        JsonText: Text;
         ActualInvoiceDiscountAmount: Decimal;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JsonObject);
+        JsonObject.ReadFrom(ResponseText);
         Assert.IsTrue(
-          JSONManagement.GetDecimalPropertyValueFromJObjectByName(JsonObject, DiscountAmountFieldTxt, ActualInvoiceDiscountAmount),
+          TryGetJsonText(JsonObject, DiscountAmountFieldTxt, JsonText) and Evaluate(ActualInvoiceDiscountAmount, JsonText, 9),
           'Could not find the invoice discount amount in the response');
         Assert.AreEqual(ExpectedDiscountAmount, ActualInvoiceDiscountAmount, 'Invoice discount amount was not set');
     end;
-}
 
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit(true);
+            Value := JsonToken.AsValue().AsText();
+        end else
+            JsonToken.WriteTo(Value);
+        exit(true);
+    end;
+}

--- a/src/Layers/W1/Tests/TestLibraries/LibraryGraphMgt.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryGraphMgt.Codeunit.al
@@ -14,6 +14,7 @@ codeunit 130618 "Library - Graph Mgt"
         UnexpectedResponseCodeErr: Label 'Response code %1 (%2) differs from the expected %3.', Comment = '%1 - Actual response code number, %2 - Actual response code, %3 - Expected response code number';
         FailedRequestErr: Label '%1 request failed. Response code is %2 (%3). %4', Comment = '%1 - request method, %2 - response code number, %3 - response code, %4 - error message';
         FailedRequestWithUnexpectedResponseCodeErr: Label '%1 request failed. Response code is %2 (%3), expected code is %4. %5', Comment = '%1 - request method, %2 - response code number, %3 - response code, %4 - expected response code, %5 - error message';
+        AtLeastItemsReturnedErr: Label 'At least %1 item(s) should be returned', Comment = '%1 - Minimum number of items';
 
     procedure InitializeObject(JsonText: Text)
     begin
@@ -588,7 +589,7 @@ codeunit 130618 "Library - Graph Mgt"
         ObjectCollection := JSONObject.GetArray(PropertyName);
 
         Assert.IsTrue(
-          ObjectCollection.Count() >= ObjectNumber, StrSubstNo('At least %1 item(s) should be returned', ObjectNumber));
+          ObjectCollection.Count() >= ObjectNumber, StrSubstNo(AtLeastItemsReturnedErr, ObjectNumber));
         if not ObjectCollection.Get(ObjectNumber - 1, JsonToken) then
             exit(false);
         JsonToken.WriteTo(ObjectJSON);

--- a/src/Layers/W1/Tests/TestLibraries/LibraryGraphMgt.Codeunit.al
+++ b/src/Layers/W1/Tests/TestLibraries/LibraryGraphMgt.Codeunit.al
@@ -7,11 +7,62 @@ codeunit 130618 "Library - Graph Mgt"
 
     var
         Assert: Codeunit Assert;
+        JsonRootToken: JsonToken;
+        JsonSelectedToken: JsonToken;
         IncorrectValueErr: Label 'Incorrect value found in JSON for %1 property.', Comment = '%1 - Name of property';
         GraphCollectionMgtItem: Codeunit "Graph Collection Mgt - Item";
         UnexpectedResponseCodeErr: Label 'Response code %1 (%2) differs from the expected %3.', Comment = '%1 - Actual response code number, %2 - Actual response code, %3 - Expected response code number';
         FailedRequestErr: Label '%1 request failed. Response code is %2 (%3). %4', Comment = '%1 - request method, %2 - response code number, %3 - response code, %4 - error message';
         FailedRequestWithUnexpectedResponseCodeErr: Label '%1 request failed. Response code is %2 (%3), expected code is %4. %5', Comment = '%1 - request method, %2 - response code number, %3 - response code, %4 - expected response code, %5 - error message';
+
+    procedure InitializeObject(JsonText: Text)
+    begin
+        Clear(JsonRootToken);
+        Clear(JsonSelectedToken);
+        if JsonText <> '' then begin
+            JsonRootToken.ReadFrom(JsonText);
+            JsonSelectedToken := JsonRootToken;
+        end;
+    end;
+
+    procedure SelectTokenFromRoot(Path: Text): Boolean
+    begin
+        Clear(JsonSelectedToken);
+        exit(JsonRootToken.SelectToken(Path, JsonSelectedToken));
+    end;
+
+    procedure SelectItemFromRoot(Path: Text; Index: Integer): Boolean
+    var
+        CollectionToken: JsonToken;
+    begin
+        if not JsonRootToken.SelectToken(Path, CollectionToken) or not CollectionToken.IsArray() then
+            exit(false);
+        exit(CollectionToken.AsArray().Get(Index, JsonSelectedToken));
+    end;
+
+    procedure GetValue(Path: Text): Text
+    var
+        ValueToken: JsonToken;
+        JsonText: Text;
+    begin
+        if not JsonSelectedToken.SelectToken(Path, ValueToken) then
+            exit('');
+        if ValueToken.IsValue() then begin
+            if ValueToken.AsValue().IsNull() or ValueToken.AsValue().IsUndefined() then
+                exit('');
+            exit(GetJsonValueText(ValueToken));
+        end;
+        ValueToken.WriteTo(JsonText);
+        exit(JsonText);
+    end;
+
+    procedure GetCount(): Integer
+    begin
+        if JsonSelectedToken.IsObject() then
+            exit(JsonSelectedToken.AsObject().Keys().Count());
+        if JsonSelectedToken.IsArray() then
+            exit(JsonSelectedToken.AsArray().Count());
+    end;
 
     procedure EnsureWebServiceExist(ServiceNameTxt: Text[240]; PageNumber: Integer)
     var
@@ -395,57 +446,76 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure GetETagFromJSON(JSONTxt: Text; var ETagValue: Text): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
-        exit(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, '@odata.etag', ETagValue));
+        JObject.ReadFrom(JSONTxt);
+        exit(TryGetJsonText(JObject, '@odata.etag', ETagValue));
     end;
 
     procedure AddPropertytoJSON(JSONTxt: Text; PropertyName: Text; PropertyValue: Variant): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        BooleanValue: Boolean;
+        DecimalValue: Decimal;
+        IntegerValue: Integer;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JsonObject);
-
-        JSONManagement.AddJPropertyToJObject(JsonObject, PropertyName, PropertyValue);
-        exit(JSONManagement.WriteObjectToString());
+        if JSONTxt <> '' then
+            JsonObject.ReadFrom(JSONTxt);
+        case true of
+            PropertyValue.IsInteger:
+                begin
+                    IntegerValue := PropertyValue;
+                    JsonObject.Add(PropertyName, IntegerValue);
+                end;
+            PropertyValue.IsDecimal:
+                begin
+                    DecimalValue := PropertyValue;
+                    JsonObject.Add(PropertyName, DecimalValue);
+                end;
+            PropertyValue.IsBoolean:
+                begin
+                    BooleanValue := PropertyValue;
+                    JsonObject.Add(PropertyName, BooleanValue);
+                end;
+            else
+                JsonObject.Add(PropertyName, Format(PropertyValue, 0, 9));
+        end;
+        JsonObject.WriteTo(JSONTxt);
+        exit(JSONTxt);
     end;
 
     procedure AddComplexTypetoJSON(JSONTxt: Text; ComplexTypeName: Text; ComplexTypeValue: Text): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonObject: JsonObject;
+        ComplexJsonToken: JsonToken;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JsonObject);
-
-        JSONManagement.AddJObjectToJObject(JsonObject, ComplexTypeName, ComplexTypeValue);
-        exit(JSONManagement.WriteObjectToString());
+        if JSONTxt <> '' then
+            JsonObject.ReadFrom(JSONTxt);
+        ComplexJsonToken.ReadFrom(ComplexTypeValue);
+        JsonObject.Add(ComplexTypeName, ComplexJsonToken);
+        JsonObject.WriteTo(JSONTxt);
+        exit(JSONTxt);
     end;
 
     procedure AddObjectToCollectionJSON(JSONTxt: Text; ObjectJSONTxt: Text): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JSONObject: DotNet JObject;
+        JsonArray: JsonArray;
+        JSONObject: JsonObject;
     begin
-        JSONManagement.InitializeCollection(JSONTxt);
-        JSONManagement.InitializeObject(ObjectJSONTxt);
-        JSONManagement.GetJSONObject(JSONObject);
-        JSONManagement.AddJObjectToCollection(JSONObject);
-        exit(JSONManagement.WriteCollectionToString());
+        if JSONTxt <> '' then
+            JsonArray.ReadFrom(JSONTxt);
+        JSONObject.ReadFrom(ObjectJSONTxt);
+        JsonArray.Add(JSONObject);
+        JsonArray.WriteTo(JSONTxt);
+        exit(JSONTxt);
     end;
 
     [Scope('OnPrem')]
-    procedure AssertPropertyInJsonObject(JObject: DotNet JObject; PropertyName: Text; ExpectedValue: Text)
+    procedure AssertPropertyInJsonObject(JObject: JsonObject; PropertyName: Text; ExpectedValue: Text)
     var
-        JsonMgt: Codeunit "JSON Management";
         PropertyValue: Text;
     begin
-        JsonMgt.GetStringPropertyValueFromJObjectByName(JObject, PropertyName, PropertyValue);
+        TryGetJsonText(JObject, PropertyName, PropertyValue);
         Assert.AreEqual(ExpectedValue, PropertyValue, StrSubstNo(IncorrectValueErr, PropertyName));
     end;
 
@@ -473,45 +543,33 @@ codeunit 130618 "Library - Graph Mgt"
     [Scope('OnPrem')]
     procedure GetPropertyValueFromJSON(JSON: Text; PropertyName: Text; var PropertyValue: Text): Boolean
     var
-        JsonMgt: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
-        PropertyValueVar: Variant;
+        JsonObject: JsonObject;
     begin
-        JsonMgt.InitializeObject(JSON);
-        JsonMgt.GetJSONObject(JsonObject);
-        if JsonMgt.GetPropertyValueByName(PropertyName, PropertyValueVar) = false then
-            exit(false);
-        PropertyValue := Format(PropertyValueVar);
-        exit(true);
+        JsonObject.ReadFrom(JSON);
+        exit(TryGetJsonText(JsonObject, PropertyName, PropertyValue));
     end;
 
     [Scope('OnPrem')]
-    procedure GetComplexPropertyFromJSON(JSON: Text; PropertyName: Text; var JObject: DotNet JObject)
+    procedure GetComplexPropertyFromJSON(JSON: Text; PropertyName: Text; var JObject: JsonObject)
     var
-        JsonMgt: Codeunit "JSON Management";
-        ParentObject: DotNet JObject;
-        ComplexText: Text;
+        ParentObject: JsonObject;
+        JsonToken: JsonToken;
     begin
-        JsonMgt.InitializeObject(JSON);
-        JsonMgt.GetJSONObject(ParentObject);
-
-        JsonMgt.GetStringPropertyValueFromJObjectByName(ParentObject, PropertyName, ComplexText);
-        JsonMgt.InitializeObject(ComplexText);
-        JsonMgt.GetJSONObject(JObject);
+        ParentObject.ReadFrom(JSON);
+        ParentObject.Get(PropertyName, JsonToken);
+        JObject := JsonToken.AsObject();
     end;
 
     [Scope('OnPrem')]
     procedure GetComplexPropertyTxtFromJSON(JSON: Text; PropertyName: Text; var ComplexText: Text): Boolean
     var
-        JsonMgt: Codeunit "JSON Management";
-        ParentObject: DotNet JObject;
-        ComplexTxtVar: Variant;
+        ParentObject: JsonObject;
+        JsonToken: JsonToken;
     begin
-        JsonMgt.InitializeObject(JSON);
-        JsonMgt.GetJSONObject(ParentObject);
-        if JsonMgt.GetStringPropertyValueFromJObjectByName(ParentObject, PropertyName, ComplexTxtVar) = false then
+        ParentObject.ReadFrom(JSON);
+        if not ParentObject.Get(PropertyName, JsonToken) then
             exit(false);
-        ComplexText := Format(ComplexTxtVar);
+        JsonToken.WriteTo(ComplexText);
         exit(true);
     end;
 
@@ -522,49 +580,40 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure GetObjectFromJSONResponseByName(ResponseText: Text; PropertyName: Text; var ObjectJSON: Text; ObjectNumber: Integer): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
-        JSONObject: DotNet JObject;
-        JObject: DotNet JObject;
-        ObjectCollectionTxt: Text;
+        JSONObject: JsonObject;
+        ObjectCollection: JsonArray;
+        JsonToken: JsonToken;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JSONObject);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JSONObject, PropertyName, ObjectCollectionTxt);
-        Clear(JSONManagement);
-        JSONManagement.InitializeCollection(ObjectCollectionTxt);
+        JSONObject.ReadFrom(ResponseText);
+        ObjectCollection := JSONObject.GetArray(PropertyName);
 
         Assert.IsTrue(
-          JSONManagement.GetCollectionCount() >= ObjectNumber, StrSubstNo('At least %1 item(s) should be returned', ObjectNumber));
-        if not JSONManagement.GetJObjectFromCollectionByIndex(JObject, ObjectNumber - 1) then
+          ObjectCollection.Count() >= ObjectNumber, StrSubstNo('At least %1 item(s) should be returned', ObjectNumber));
+        if not ObjectCollection.Get(ObjectNumber - 1, JsonToken) then
             exit(false);
-        ObjectJSON := JObject.ToString();
+        JsonToken.WriteTo(ObjectJSON);
         exit(true);
     end;
 
     procedure GetObjectsFromJSONResponse(ResponseText: Text; ObjectIDFieldName: Text; ObjectID1: Text; ObjectID2: Text; var ObjectJSON1: Text; var ObjectJSON2: Text): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
-        JSONObject: DotNet JObject;
-        JObject: DotNet JObject;
+        JSONObject: JsonObject;
+        ObjectCollection: JsonArray;
+        JsonToken: JsonToken;
         ObjectJSON: Text;
         CurrentObjectID: Text;
         I: Integer;
         ObjectID1Found: Boolean;
         ObjectID2Found: Boolean;
-        ObjectCollectionTxt: Text;
     begin
-        JSONManagement.InitializeObject(ResponseText);
-        JSONManagement.GetJSONObject(JSONObject);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JSONObject, 'value', ObjectCollectionTxt);
+        JSONObject.ReadFrom(ResponseText);
+        ObjectCollection := JSONObject.GetArray('value');
 
-        Clear(JSONManagement);
-        JSONManagement.InitializeCollection(ObjectCollectionTxt);
-
-        Assert.IsTrue(JSONManagement.GetCollectionCount() >= 2, 'At least 2 items should be returned');
-        for I := 0 to JSONManagement.GetCollectionCount() - 1 do begin
-            if not JSONManagement.GetJObjectFromCollectionByIndex(JObject, I) then
+        Assert.IsTrue(ObjectCollection.Count() >= 2, 'At least 2 items should be returned');
+        for I := 0 to ObjectCollection.Count() - 1 do begin
+            if not ObjectCollection.Get(I, JsonToken) then
                 exit(false);
-            ObjectJSON := JObject.ToString();
+            JsonToken.WriteTo(ObjectJSON);
             if GetObjectIDFromJSON(ObjectJSON, ObjectIDFieldName, CurrentObjectID) then begin
                 if CurrentObjectID = ObjectID1 then begin
                     ObjectID1Found := true;
@@ -587,55 +636,48 @@ codeunit 130618 "Library - Graph Mgt"
     [TryFunction]
     procedure GetErrorFromJSONResponse(ResponseText: Text; var ErrorCode: Text; var ErrorMessage: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
         GetComplexPropertyFromJSON(ResponseText, 'error', JObject);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'code', ErrorCode);
-        JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'message', ErrorMessage);
+        TryGetJsonText(JObject, 'code', ErrorCode);
+        TryGetJsonText(JObject, 'message', ErrorMessage);
     end;
 
     procedure GetObjectIDFromJSON(JSONTxt: Text; ObjectIDFieldName: Text; var ObjectIDValue: Text): Boolean
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
-        exit(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, ObjectIDFieldName, ObjectIDValue));
+        JObject.ReadFrom(JSONTxt);
+        exit(TryGetJsonText(JObject, ObjectIDFieldName, ObjectIDValue));
     end;
 
     [Scope('OnPrem')]
     procedure GetCollectionCountFromJSON(JSON: Text): Integer
     var
-        JsonMgt: Codeunit "JSON Management";
-        JsonObject: DotNet JObject;
+        JsonArray: JsonArray;
     begin
-        JsonMgt.InitializeCollection(JSON);
-        JsonMgt.GetJSONObject(JsonObject);
-        exit(JsonMgt.GetCollectionCount());
+        JsonArray.ReadFrom(JSON);
+        exit(JsonArray.Count());
     end;
 
     procedure GetObjectFromCollectionByIndex(JSON: Text; Index: Integer): Text
     var
-        JSONManagement: Codeunit "JSON Management";
-        JSONObject: DotNet JObject;
-        RetrievedJSONObject: DotNet JObject;
+        JsonArray: JsonArray;
+        RetrievedJsonToken: JsonToken;
     begin
-        JSONManagement.InitializeCollection(JSON);
-        JSONManagement.GetJSONObject(JSONObject);
+        JsonArray.ReadFrom(JSON);
         Assert.IsTrue(
-          JSONManagement.GetJObjectFromCollectionByIndex(RetrievedJSONObject, Index),
+          JsonArray.Get(Index, RetrievedJsonToken),
           'Could not find object number: ' + Format(Index));
 
-        JSONManagement.InitializeObjectFromJObject(RetrievedJSONObject);
-        exit(JSONManagement.WriteObjectToString());
+        RetrievedJsonToken.WriteTo(JSON);
+        exit(JSON);
     end;
 
     procedure VerifyAddressProperties(JSON: Text; ExpectedLine1: Text; ExpectedLine2: Text; ExpectedCity: Text; ExpectedState: Text; ExpectedCountryCode: Text; ExpectedPostCode: Text)
     var
         GraphCollectionMgtContact: Codeunit "Graph Collection Mgt - Contact";
-        AddressObject: DotNet JObject;
+        AddressObject: JsonObject;
     begin
         GetComplexPropertyFromJSON(JSON, 'address', AddressObject);
         AssertPropertyInJsonObject(AddressObject, 'street', GraphCollectionMgtContact.ConcatenateStreet(ExpectedLine1, ExpectedLine2));
@@ -647,7 +689,7 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure VerifyError(JSON: Text; ExpectedCode: Text; ExpectedMessage: Text)
     var
-        ErrorObject: DotNet JObject;
+        ErrorObject: JsonObject;
     begin
         GetComplexPropertyFromJSON(JSON, 'error', ErrorObject);
         AssertPropertyInJsonObject(ErrorObject, 'code', ExpectedCode);
@@ -661,15 +703,13 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure VerifyIDFieldInJson(JSONTxt: Text; IDFieldName: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         IdValue: Text;
         BlankGuid: Guid;
         IDGuid: Guid;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, IDFieldName, IdValue),
+        JObject.ReadFrom(JSONTxt);
+        Assert.IsTrue(TryGetJsonText(JObject, IDFieldName, IdValue),
           'Could not find the ' + IDFieldName + ' property in' + JSONTxt);
         Assert.AreNotEqual('', IdValue, IDFieldName + ' should not be blank in ' + JSONTxt);
         Assert.IsTrue(Evaluate(IDGuid, IdValue), 'Id is not a guid');
@@ -678,13 +718,11 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure VerifyIDFieldInJsonWithoutIntegrationRecord(JSONTxt: Text; IDFieldName: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         IdValue: Text;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, IDFieldName, IdValue),
+        JObject.ReadFrom(JSONTxt);
+        Assert.IsTrue(TryGetJsonText(JObject, IDFieldName, IdValue),
           'Could not find the ' + IDFieldName + ' property in' + JSONTxt);
         Assert.AreNotEqual('', IdValue, IDFieldName + ' should not be blank in ' + JSONTxt);
     end;
@@ -692,27 +730,27 @@ codeunit 130618 "Library - Graph Mgt"
     procedure VerifyUoMInJson(JSONTxt: Text; UnitofMeasureCode: Code[10]; ItemIdentifierTxt: Text)
     var
         Item: Record Item;
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
+        UnitOfMeasureObject: JsonObject;
+        JsonToken: JsonToken;
         ItemIdValue: Text;
         JSONUoMValue: Text;
         UnitCodeValue: Text;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, ItemIdentifierTxt, ItemIdValue),
+        JObject.ReadFrom(JSONTxt);
+        Assert.IsTrue(TryGetJsonText(JObject, ItemIdentifierTxt, ItemIdValue),
           'Could not find the ItemId property in' + JSONTxt);
 
         Assert.AreNotEqual('', ItemIdValue, 'ItemId should not be blank in ' + JSONTxt);
 
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, 'baseUnitOfMeasure', JSONUoMValue),
+        Assert.IsTrue(JObject.Get('baseUnitOfMeasure', JsonToken) and JsonToken.IsObject(),
           'Could not find the BaseUnitOfMeasure property in' + JSONTxt);
+        JsonToken.WriteTo(JSONUoMValue);
         Assert.AreNotEqual('', JSONUoMValue, 'BaseUnitOfMeasure should not be blank in ' + JSONTxt);
 
-        JSONManagement.InitializeObject(JSONUoMValue);
-        JSONManagement.GetJSONObject(JObject);
+        UnitOfMeasureObject := JsonToken.AsObject();
         Assert.IsTrue(
-          JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitCodeValue),
+          TryGetJsonText(UnitOfMeasureObject, GraphCollectionMgtItem.UOMComplexTypeUnitCode(), UnitCodeValue),
           'Could not find the Unit Code property in' + JSONTxt);
 
         Assert.AreEqual(UnitofMeasureCode, UnitCodeValue, 'Incorrect UoM in JSON');
@@ -724,14 +762,12 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure VerifyGUIDFieldInJson(JSONTxt: Text; GUIDFieldName: Text; ExpectedValue: Guid)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
         StringValue: Text;
         ActualValue: Guid;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
-        Assert.IsTrue(JSONManagement.GetStringPropertyValueFromJObjectByName(JObject, GUIDFieldName, StringValue),
+        JObject.ReadFrom(JSONTxt);
+        Assert.IsTrue(TryGetJsonText(JObject, GUIDFieldName, StringValue),
           'Could not find the ' + GUIDFieldName + ' property in' + JSONTxt);
         Assert.IsTrue(Evaluate(ActualValue, StringValue), 'Property value ' + StringValue + ' is not guid');
         Assert.AreEqual(ActualValue, ExpectedValue,
@@ -740,12 +776,40 @@ codeunit 130618 "Library - Graph Mgt"
 
     procedure VerifyPropertyInJSON(JSONTxt: Text; FieldName: Text; FieldValue: Text)
     var
-        JSONManagement: Codeunit "JSON Management";
-        JObject: DotNet JObject;
+        JObject: JsonObject;
     begin
-        JSONManagement.InitializeObject(JSONTxt);
-        JSONManagement.GetJSONObject(JObject);
+        JObject.ReadFrom(JSONTxt);
         AssertPropertyInJsonObject(JObject, FieldName, FieldValue);
+    end;
+
+    local procedure TryGetJsonText(JsonObject: JsonObject; PropertyName: Text; var Value: Text): Boolean
+    var
+        JsonToken: JsonToken;
+    begin
+        Clear(Value);
+        if not JsonObject.Get(PropertyName, JsonToken) then
+            exit(false);
+        if JsonToken.IsValue() then begin
+            if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+                exit(true);
+            Value := GetJsonValueText(JsonToken);
+        end else
+            JsonToken.WriteTo(Value);
+        exit(true);
+    end;
+
+    local procedure GetJsonValueText(JsonToken: JsonToken): Text
+    var
+        SerializedValue: Text;
+    begin
+        JsonToken.WriteTo(SerializedValue);
+        case SerializedValue of
+            'true':
+                exit('True');
+            'false':
+                exit('False');
+        end;
+        exit(JsonToken.AsValue().AsText());
     end;
 
     procedure StripBrackets(StringWithBrackets: Text): Text
@@ -833,4 +897,3 @@ codeunit 130618 "Library - Graph Mgt"
     begin
     end;
 }
-

--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -978,9 +978,11 @@ dotnet
         {
         }
 
+#if not CLEAN30
         type("Newtonsoft.Json.JsonTextWriter"; "JsonTextWriter")
         {
         }
+#endif
 
         type("Newtonsoft.Json.Linq.JArray"; "JArray")
         {
@@ -998,9 +1000,11 @@ dotnet
         {
         }
 
+#if not CLEAN30
         type("Newtonsoft.Json.Linq.JValue"; "JValue")
         {
         }
+#endif
     }
 
     assembly("Microsoft.Dynamics.Nav.PluralizationService")

--- a/src/System Application/App/DotNet Aliases/src/dotnet.al
+++ b/src/System Application/App/DotNet Aliases/src/dotnet.al
@@ -974,16 +974,14 @@ dotnet
         {
         }
 
+#if not CLEAN30
         type("Newtonsoft.Json.JsonTextReader"; "JsonTextReader")
         {
         }
 
-#if not CLEAN30
         type("Newtonsoft.Json.JsonTextWriter"; "JsonTextWriter")
         {
         }
-#endif
-
         type("Newtonsoft.Json.Linq.JArray"; "JArray")
         {
         }
@@ -999,8 +997,6 @@ dotnet
         type("Newtonsoft.Json.Linq.JToken"; "JToken")
         {
         }
-
-#if not CLEAN30
         type("Newtonsoft.Json.Linq.JValue"; "JValue")
         {
         }

--- a/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
+++ b/src/System Application/App/Extension Management/src/ExtensionMarketplace.Codeunit.al
@@ -33,7 +33,6 @@ codeunit 2501 "Extension Marketplace"
 
     var
         HttpWebRequest: DotNet HttpWebRequest;
-        GlobalPropertyValue: Text;
         ParseFailureErr: Label 'Failed to extract ''%1'' property from JSON object.', Comment = 'JSON parsing error. %1=target property name';
         TelemetryBodyTxt: Label '{"acquisitionResult":"%1", "detail":"%2"}', Comment = '%1=AppSource operation result option, %2=details describing the context or reason for the result', Locked = true;
         ParseApplicationIdErr: Label 'Failed to extract ''%1'' token from Application Id.', Comment = '%1=Name of token that we expected   ';
@@ -49,39 +48,16 @@ codeunit 2501 "Extension Marketplace"
         OperationResult: Option UserNotAuthorized,DeploymentFailedDueToPackage,DeploymentFailed,Successful,UserCancel,UserTimeOut;
         AppDoesntNeedSetupMsg: Label 'Your app is installed and ready to use.';
 
-    local procedure GetValue(JObject: DotNet JObject; Property: Text; ThrowError: Boolean): Text
-    begin
-        // Helper for extracting a property value out of a JObject
-        if TryGetValue(JObject, Property) then
-            exit(GlobalPropertyValue);
-
-        if ThrowError then
-            Error(ParseFailureErr, Property);
-
-        exit('');
-    end;
-
-    [TryFunction]
-    local procedure TryGetValue(JObject: DotNet JObject; Property: Text)
+    procedure GetTelementryUrlFromData(JObject: JsonObject): Text
     var
-        StringComparison: DotNet StringComparison;
-        JToken: DotNet JToken;
+        DataObject: JsonObject;
+        JsonToken: JsonToken;
     begin
-        // Helper to 'safely' extract the value of a JProperty. Ignores case and 'catches' exceptions
-        JToken := JObject.GetValue(Property, StringComparison.OrdinalIgnoreCase);
-        GlobalPropertyValue := JToken.ToString();
-    end;
-
-    procedure GetTelementryUrlFromData(JObject: DotNet JObject): Text
-    var
-        TempObject: DotNet JObject;
-    begin
-        // Extracts the telemetryUrl property, out of the data object, return by the AppSource site
-        // NOTE: the temp object is needed here. While JObject.Parse looks like a static call
-        // to the JObject type, it will in fact reload and modify the underlying referenced object
-        // as well as return the result of a 'parse'
-        TempObject := TempObject.Parse(GetValue(JObject, 'data', false));
-        exit(GetValue(TempObject, 'responseUrl', false));
+        if not TryGetValue(JObject, 'data', JsonToken) or not JsonToken.IsObject() then
+            exit('');
+        DataObject := JsonToken.AsObject();
+        if TryGetValue(DataObject, 'responseUrl', JsonToken) and JsonToken.IsValue() then
+            exit(GetJsonTokenText(JsonToken));
     end;
 
     [TryFunction]
@@ -453,19 +429,42 @@ codeunit 2501 "Extension Marketplace"
         exit(false);
     end;
 
-    procedure GetMessageType(JObject: DotNet JObject): Text;
+    procedure GetMessageType(JObject: JsonObject): Text
+    var
+        JsonToken: JsonToken;
     begin
-        // Extracts the 'msgType' property from the
-        exit(GetValue(JObject, 'msgType', true));
+        if not TryGetValue(JObject, 'msgType', JsonToken) or not JsonToken.IsValue() then
+            Error(ParseFailureErr, 'msgType');
+        exit(GetJsonTokenText(JsonToken));
     end;
 
-    procedure GetApplicationIdFromData(JObject: DotNet JObject): Text;
+    procedure GetApplicationIdFromData(JObject: JsonObject): Text
     var
-        TempObject: DotNet JObject;
+        DataObject: JsonObject;
+        JsonToken: JsonToken;
     begin
-        // Extracts the applicationId property out of the data object return by the SPZA site
-        TempObject := TempObject.Parse(GetValue(JObject, 'data', true));
-        exit(GetValue(TempObject, 'applicationId', true));
+        if not TryGetValue(JObject, 'data', JsonToken) or not JsonToken.IsObject() then
+            Error(ParseFailureErr, 'data');
+        DataObject := JsonToken.AsObject();
+        if not TryGetValue(DataObject, 'applicationId', JsonToken) or not JsonToken.IsValue() then
+            Error(ParseFailureErr, 'applicationId');
+        exit(GetJsonTokenText(JsonToken));
+    end;
+
+    local procedure GetJsonTokenText(JsonToken: JsonToken): Text
+    begin
+        if JsonToken.AsValue().IsNull() or JsonToken.AsValue().IsUndefined() then
+            exit('');
+        exit(JsonToken.AsValue().AsText());
+    end;
+
+    local procedure TryGetValue(JObject: JsonObject; Property: Text; var JsonToken: JsonToken): Boolean
+    var
+        PropertyName: Text;
+    begin
+        foreach PropertyName in JObject.Keys() do
+            if LowerCase(PropertyName) = LowerCase(Property) then
+                exit(JObject.Get(PropertyName, JsonToken));
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Action Triggers", InvokeExtensionInstallation, '', false, false)]

--- a/src/System Application/App/Json/src/Json.Codeunit.al
+++ b/src/System Application/App/Json/src/Json.Codeunit.al
@@ -233,4 +233,20 @@ codeunit 5460 Json
         exit(JsonImpl.ReplaceJObjectInCollection(Index, Value));
     end;
 
+    /// <summary>
+    /// Converts XML text to JSON text.
+    /// </summary>
+    procedure XMLTextToJSONText(Xml: Text): Text
+    begin
+        exit(JsonImpl.XMLTextToJSONText(Xml));
+    end;
+
+    /// <summary>
+    /// Converts JSON text to XML text with the specified document element name.
+    /// </summary>
+    procedure JSONTextToXMLText(Json: Text; DocumentElementName: Text): Text
+    begin
+        exit(JsonImpl.JSONTextToXMLText(Json, DocumentElementName));
+    end;
+
 }

--- a/src/System Application/App/Json/src/Json.Codeunit.al
+++ b/src/System Application/App/Json/src/Json.Codeunit.al
@@ -114,15 +114,29 @@ codeunit 5460 Json
         exit(JsonImpl.GetValueAndSetToRecFieldNo(RecordRef, PropertyPath, FieldNo));
     end;
 
+#if not CLEAN30
     /// <summary>
     /// Gets the value at the specified property name in the JSON object.
     /// </summary>
     /// <param name="PropertyName">The property name</param>
-    /// <param name="Value">The value</param>
+    /// <param name="Value">The DotNet JSON token value.</param>
     /// <returns>True if the value is returned; otherwise, false</returns>
+    [Obsolete('Use GetNativePropertyValueByName to retrieve native AL JSON and scalar values.', '30.0')]
     procedure GetPropertyValueByName(PropertyName: Text; var Value: Variant): Boolean
     begin
         exit(JsonImpl.GetPropertyValueFromJObjectByName(PropertyName, Value));
+    end;
+#endif
+
+    /// <summary>
+    /// Gets the native AL value at the specified property name in the JSON object.
+    /// </summary>
+    /// <param name="PropertyName">The property name.</param>
+    /// <param name="Value">The AL scalar, JsonObject, or JsonArray value. JSON null clears the variant.</param>
+    /// <returns>True if the property exists; otherwise, false.</returns>
+    procedure GetNativePropertyValueByName(PropertyName: Text; var Value: Variant): Boolean
+    begin
+        exit(JsonImpl.GetNativePropertyValueFromJObjectByName(PropertyName, Value));
     end;
 
     /// <summary>
@@ -236,6 +250,8 @@ codeunit 5460 Json
     /// <summary>
     /// Converts XML text to JSON text.
     /// </summary>
+    /// <param name="Xml">The XML document text to convert.</param>
+    /// <returns>The JSON representation produced with Json.NET XmlNodeConverter semantics.</returns>
     procedure XMLTextToJSONText(Xml: Text): Text
     begin
         exit(JsonImpl.XMLTextToJSONText(Xml));
@@ -244,6 +260,9 @@ codeunit 5460 Json
     /// <summary>
     /// Converts JSON text to XML text with the specified document element name.
     /// </summary>
+    /// <param name="Json">The JSON text to convert.</param>
+    /// <param name="DocumentElementName">The name of the XML document element.</param>
+    /// <returns>The converted XML document text.</returns>
     procedure JSONTextToXMLText(Json: Text; DocumentElementName: Text): Text
     begin
         exit(JsonImpl.JSONTextToXMLText(Json, DocumentElementName));

--- a/src/System Application/App/Json/src/JsonImpl.Codeunit.al
+++ b/src/System Application/App/Json/src/JsonImpl.Codeunit.al
@@ -214,12 +214,39 @@ codeunit 5461 "Json Impl."
 
         if JsonObjectState.Get(PropertyName, OldJsonToken) then begin
             OldJsonToken.WriteTo(OldValueText);
-            JsonObjectState.Replace(PropertyName, NewJsonToken);
-            exit(OldValueText <> NewValueText);
+            if OldValueText = NewValueText then
+                exit(false);
+            ReplaceJsonPropertyPreservingOrder(PropertyName, NewJsonToken);
+            exit(true);
         end;
 
         JsonObjectState.Add(PropertyName, NewJsonToken);
         exit(true);
+    end;
+
+    local procedure ReplaceJsonPropertyPreservingOrder(PropertyName: Text; NewJsonToken: JsonToken)
+    var
+        RebuiltJsonObject: JsonObject;
+        PropertyJsonToken: JsonToken;
+        PropertyNames: List of [Text];
+        CurrentPropertyName: Text;
+    begin
+        PropertyNames := JsonObjectState.Keys();
+        foreach CurrentPropertyName in PropertyNames do
+            if CurrentPropertyName = PropertyName then
+                RebuiltJsonObject.Add(CurrentPropertyName, NewJsonToken.Clone())
+            else begin
+                JsonObjectState.Get(CurrentPropertyName, PropertyJsonToken);
+                RebuiltJsonObject.Add(CurrentPropertyName, PropertyJsonToken.Clone());
+            end;
+
+        foreach CurrentPropertyName in PropertyNames do
+            JsonObjectState.Remove(CurrentPropertyName);
+
+        foreach CurrentPropertyName in PropertyNames do begin
+            RebuiltJsonObject.Get(CurrentPropertyName, PropertyJsonToken);
+            JsonObjectState.Add(CurrentPropertyName, PropertyJsonToken.Clone());
+        end;
     end;
 
     procedure AddJObjectToCollection(JSONString: Text): Boolean

--- a/src/System Application/App/Json/src/JsonImpl.Codeunit.al
+++ b/src/System Application/App/Json/src/JsonImpl.Codeunit.al
@@ -17,8 +17,10 @@ codeunit 5461 "Json Impl."
 
     var
         SourceWarningLength: Integer;
-        JsonArrayDotNet: DotNet JArray;
-        JsonObjectDotNet: DotNet JObject;
+        JsonArrayState: JsonArray;
+        JsonObjectState: JsonObject;
+        InvalidJsonArrayErr: Label 'The value is not a valid JSON array.';
+        InvalidJsonObjectErr: Label 'The value is not a valid JSON object.';
         LogLimitWarningTxt: Label 'The JSON input length (%1) exceeds the maximum suggested length (%2) for JSON processing.', Locked = true;
 
     internal procedure EmitLengthWarning(SourceLength: Integer; tag: Text; FormatString: Text)
@@ -31,69 +33,72 @@ codeunit 5461 "Json Impl."
     end;
 
     procedure InitializeCollectionFromString(JSONString: Text)
+    var
+        NewJsonArray: JsonArray;
     begin
-        Clear(JsonArrayDotNet);
         if JSONString <> '' then begin
             EmitLengthWarning(StrLen(JSONString), '0000QNC', LogLimitWarningTxt);
-            JsonArrayDotNet := JsonArrayDotNet.Parse(JSONString)
-        end else
-            InitializeEmptyCollection();
+            if not NewJsonArray.ReadFrom(JSONString) then
+                Error(InvalidJsonArrayErr);
+        end;
+        JsonArrayState := NewJsonArray;
     end;
 
     procedure InitializeObjectFromString(JSONString: Text)
     begin
-        Clear(JsonObjectDotNet);
-        if JSONString <> '' then begin
+        if JSONString <> '' then
             EmitLengthWarning(StrLen(JSONString), '0000QND', LogLimitWarningTxt);
-            JsonObjectDotNet := JsonObjectDotNet.Parse(JSONString)
-        end else
-            InitializeEmptyObject();
+        SetObjectStateFromString(JSONString);
     end;
 
     procedure GetCollectionCount(): Integer
     begin
-        exit(JsonArrayDotNet.Count);
+        exit(JsonArrayState.Count());
     end;
 
     procedure GetCollectionAsText() Value: Text
     begin
-        GetCollection().WriteTo(Value);
+        JsonArrayState.WriteTo(Value);
     end;
 
     procedure GetCollectionAsText(Indentation: Boolean) Value: Text
     var
-        JsonConvert: DotNet JsonConvert;
-        Formatting: DotNet Formatting;
+        JsonTextBuilder: TextBuilder;
     begin
-        Value := GetCollectionAsText();
+        if not Indentation then
+            exit(GetCollectionAsText());
 
-        if Indentation then begin
-            JsonArrayDotNet := JsonArrayDotNet.Parse(Value);
-            Value := JsonConvert.SerializeObject(JsonArrayDotNet, Formatting.Indented)
-        end;
+        AppendJsonArray(JsonArrayState, 0, JsonTextBuilder);
+        exit(JsonTextBuilder.ToText());
     end;
 
-    procedure GetCollection() JArray: JsonArray
+    procedure GetCollection() JsonArray: JsonArray
+    var
+        JsonText: Text;
     begin
-        JArray.ReadFrom(JsonArrayDotNet.ToString());
+        JsonArrayState.WriteTo(JsonText);
+        JsonArray.ReadFrom(JsonText);
     end;
 
     procedure GetObjectAsText() Value: Text
     begin
-        GetObject().WriteTo(Value);
+        JsonObjectState.WriteTo(Value);
     end;
 
-    procedure GetObject() JObject: JsonObject
+    procedure GetObject() JsonObject: JsonObject
+    var
+        JsonText: Text;
     begin
-        JObject.ReadFrom(JsonObjectDotNet.ToString());
+        JsonObjectState.WriteTo(JsonText);
+        JsonObject.ReadFrom(JsonText);
     end;
 
     procedure GetObjectFromCollectionByIndex(Index: Integer; var JsonObjectTxt: Text): Boolean
     begin
-        if not GetJObjectFromCollectionByIndex(Index) then
+        if not SelectObjectFromCollection(Index) then
             exit(false);
 
-        JsonObjectTxt := JsonObjectDotNet.ToString();
+        JsonObjectState.WriteTo(JsonObjectTxt);
         exit(true);
     end;
 
@@ -101,174 +106,289 @@ codeunit 5461 "Json Impl."
     var
         FieldRef: FieldRef;
     begin
-        if IsNull(JsonObjectDotNet) then
-            exit(false);
-
         FieldRef := RecordRef.Field(FieldNo);
         exit(GetPropertyValueFromJObjectByPathSetToFieldRef(PropertyPath, FieldRef));
     end;
 
-    procedure GetPropertyValueFromJObjectByName(propertyName: Text; var value: Variant): Boolean
+    procedure GetPropertyValueFromJObjectByName(PropertyName: Text; var Value: Variant): Boolean
     var
-        JPropertyDotNet: DotNet JProperty;
-        JTokenDotNet: DotNet JToken;
+        JsonToken: JsonToken;
     begin
-        Clear(value);
-        if JsonObjectDotNet.TryGetValue(propertyName, JTokenDotNet) then begin
-            JPropertyDotNet := JsonObjectDotNet.Property(propertyName);
-            value := JPropertyDotNet.Value;
-            exit(true);
-        end;
-        exit(false);
+        Clear(Value);
+        if not JsonObjectState.Get(PropertyName, JsonToken) then
+            exit(false);
+
+        JsonTokenToVariant(JsonToken, Value);
+        exit(true);
     end;
 
-    procedure GetStringPropertyValueFromJObjectByName(propertyName: Text; var value: Text): Boolean
+    procedure GetStringPropertyValueFromJObjectByName(PropertyName: Text; var Value: Text): Boolean
     var
-        VariantValue: Variant;
+        JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
-        Clear(value);
-        if GetPropertyValueFromJObjectByName(propertyName, VariantValue) then begin
-            value := Format(VariantValue);
+        Clear(Value);
+        if not JsonObjectState.Get(PropertyName, JsonToken) then
+            exit(false);
+        if not JsonToken.IsValue() then begin
+            JsonToken.WriteTo(Value);
             exit(true);
         end;
-        exit(false);
-    end;
 
-    procedure GetEnumPropertyValueFromJObjectByName(propertyName: Text; var value: Option): Boolean
-    var
-        StringValue: Text;
-    begin
-        if GetStringPropertyValueFromJObjectByName(propertyName, StringValue) then begin
-            Evaluate(value, StringValue, 0);
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
             exit(true);
-        end;
-        exit(false);
+
+        Value := GetJsonValueAsText(JsonToken);
+        exit(true);
     end;
 
-    procedure GetBoolPropertyValueFromJObjectByName(propertyName: Text; var value: Boolean): Boolean
+    procedure GetEnumPropertyValueFromJObjectByName(PropertyName: Text; var Value: Option): Boolean
     var
-        StringValue: Text;
+        JsonToken: JsonToken;
     begin
-        if GetStringPropertyValueFromJObjectByName(propertyName, StringValue) then begin
-            Evaluate(value, StringValue, 2);
-            exit(true);
-        end;
-        exit(false);
+        if not GetJsonValueByName(PropertyName, JsonToken) then
+            exit(false);
+
+        Evaluate(Value, JsonToken.AsValue().AsText(), 0);
+        exit(true);
     end;
 
-    procedure GetDecimalPropertyValueFromJObjectByName(propertyName: Text; var value: Decimal): Boolean
+    procedure GetBoolPropertyValueFromJObjectByName(PropertyName: Text; var Value: Boolean): Boolean
     var
-        StringValue: Text;
+        JsonToken: JsonToken;
     begin
-        if GetStringPropertyValueFromJObjectByName(propertyName, StringValue) then begin
-            Evaluate(value, StringValue);
-            exit(true);
-        end;
-        exit(false);
+        Clear(Value);
+        if not GetJsonValueByName(PropertyName, JsonToken) then
+            exit(false);
+
+        Value := JsonToken.AsValue().AsBoolean();
+        exit(true);
     end;
 
-    procedure GetIntegerPropertyValueFromJObjectByName(propertyName: Text; var value: Integer): Boolean
+    procedure GetDecimalPropertyValueFromJObjectByName(PropertyName: Text; var Value: Decimal): Boolean
     var
-        StringValue: Text;
+        JsonToken: JsonToken;
     begin
-        if GetStringPropertyValueFromJObjectByName(propertyName, StringValue) then begin
-            Evaluate(value, StringValue);
-            exit(true);
-        end;
-        exit(false);
+        Clear(Value);
+        if not GetJsonValueByName(PropertyName, JsonToken) then
+            exit(false);
+
+        Value := JsonToken.AsValue().AsDecimal();
+        exit(true);
     end;
 
-    procedure GetGuidPropertyValueFromJObjectByName(propertyName: Text; var value: Guid): Boolean
+    procedure GetIntegerPropertyValueFromJObjectByName(PropertyName: Text; var Value: Integer): Boolean
     var
-        StringValue: Text;
+        JsonToken: JsonToken;
     begin
-        if GetStringPropertyValueFromJObjectByName(propertyName, StringValue) then begin
-            Evaluate(value, StringValue);
-            exit(true);
-        end;
-        exit(false);
+        Clear(Value);
+        if not GetJsonValueByName(PropertyName, JsonToken) then
+            exit(false);
+
+        Value := JsonToken.AsValue().AsInteger();
+        exit(true);
     end;
 
-    procedure ReplaceOrAddJPropertyInJObject(propertyName: Text; value: Variant): Boolean
+    procedure GetGuidPropertyValueFromJObjectByName(PropertyName: Text; var Value: Guid): Boolean
     var
-        JPropertyDotNet: DotNet JProperty;
-        OldPropertyDotNet: DotNet JProperty;
-        OldValue: Variant;
+        JsonToken: JsonToken;
     begin
-        JPropertyDotNet := JsonObjectDotNet.Property(propertyName);
-        if not IsNull(JPropertyDotNet) then begin
-            OldPropertyDotNet := JsonObjectDotNet.Property(propertyName);
-            OldValue := OldPropertyDotNet.Value;
-            JPropertyDotNet.Replace(JPropertyDotNet.JProperty(propertyName, value));
-            exit(Format(OldValue) <> Format(value));
+        Clear(Value);
+        if not GetJsonValueByName(PropertyName, JsonToken) then
+            exit(false);
+
+        Evaluate(Value, JsonToken.AsValue().AsText());
+        exit(true);
+    end;
+
+    procedure ReplaceOrAddJPropertyInJObject(PropertyName: Text; Value: Variant): Boolean
+    var
+        NewJsonToken: JsonToken;
+        OldJsonToken: JsonToken;
+        NewValueText: Text;
+        OldValueText: Text;
+    begin
+        CreateJsonTokenFromVariant(Value, NewJsonToken);
+        NewJsonToken.WriteTo(NewValueText);
+
+        if JsonObjectState.Get(PropertyName, OldJsonToken) then begin
+            OldJsonToken.WriteTo(OldValueText);
+            JsonObjectState.Replace(PropertyName, NewJsonToken);
+            exit(OldValueText <> NewValueText);
         end;
 
-        AddJPropertyToJObject(propertyName, value);
+        JsonObjectState.Add(PropertyName, NewJsonToken);
         exit(true);
     end;
 
     procedure AddJObjectToCollection(JSONString: Text): Boolean
     begin
-        if JSONString <> '' then
-            JsonObjectDotNet := JsonObjectDotNet.Parse(JSONString)
-        else
-            InitializeEmptyObject();
-
+        SetObjectStateFromString(JSONString);
         AddJObjectToCollection();
         exit(true);
     end;
 
     procedure RemoveJObjectFromCollection(Index: Integer): Boolean
     begin
-        if (GetCollectionCount() = 0) or (GetCollectionCount() <= Index) then
+        if not IsValidCollectionIndex(Index) then
             exit(false);
 
-        JsonArrayDotNet.RemoveAt(Index);
+        JsonArrayState.RemoveAt(Index);
         exit(true);
     end;
 
     procedure ReplaceJObjectInCollection(Index: Integer; JSONString: Text): Boolean
     begin
-        if not GetJObjectFromCollectionByIndex(Index) then
+        if not SelectObjectFromCollection(Index) then
             exit(false);
 
-        if JSONString <> '' then
-            JsonObjectDotNet := JsonObjectDotNet.Parse(JSONString)
-        else
-            InitializeEmptyObject();
-
-        JsonArrayDotNet.RemoveAt(Index);
-        JsonArrayDotNet.Insert(Index, JsonObjectDotNet);
+        SetObjectStateFromString(JSONString);
+        JsonArrayState.Set(Index, JsonObjectState);
         exit(true);
     end;
 
-    local procedure GetJObjectFromCollectionByIndex(Index: Integer): Boolean
+    local procedure SelectObjectFromCollection(Index: Integer): Boolean
+    var
+        JsonToken: JsonToken;
     begin
-        if (GetCollectionCount() = 0) or (GetCollectionCount() <= Index) then
+        if not IsValidCollectionIndex(Index) then
+            exit(false);
+        if not JsonArrayState.Get(Index, JsonToken) then
+            exit(false);
+        if not JsonToken.IsObject() then
             exit(false);
 
-        JsonObjectDotNet := JsonArrayDotNet.Item(Index);
-        exit(not IsNull(JsonObjectDotNet))
+        JsonObjectState := JsonToken.AsObject();
+        exit(true);
     end;
 
-    local procedure GetPropertyValueFromJObjectByPathSetToFieldRef(propertyPath: Text; var FieldRef: FieldRef): Boolean
+    local procedure IsValidCollectionIndex(Index: Integer): Boolean
+    begin
+        exit((Index >= 0) and (Index < JsonArrayState.Count()));
+    end;
+
+    local procedure GetJsonValueByName(PropertyName: Text; var JsonToken: JsonToken): Boolean
+    var
+        JsonValue: JsonValue;
+    begin
+        if not JsonObjectState.Get(PropertyName, JsonToken) then
+            exit(false);
+        if not JsonToken.IsValue() then
+            exit(false);
+
+        JsonValue := JsonToken.AsValue();
+        exit(not JsonValue.IsNull() and not JsonValue.IsUndefined());
+    end;
+
+    local procedure JsonTokenToVariant(JsonToken: JsonToken; var Value: Variant)
+    var
+        BigIntegerValue: BigInteger;
+        BooleanValue: Boolean;
+        DecimalValue: Decimal;
+        IntegerValue: Integer;
+        JsonArrayValue: JsonArray;
+        JsonObjectValue: JsonObject;
+        JsonValue: JsonValue;
+        SerializedValue: Text;
+        TextValue: Text;
+    begin
+        Clear(Value);
+        case true of
+            JsonToken.IsObject():
+                begin
+                    JsonObjectValue := JsonToken.AsObject();
+                    Value := JsonObjectValue;
+                end;
+            JsonToken.IsArray():
+                begin
+                    JsonArrayValue := JsonToken.AsArray();
+                    Value := JsonArrayValue;
+                end;
+            JsonToken.IsValue():
+                begin
+                    JsonValue := JsonToken.AsValue();
+                    if JsonValue.IsNull() or JsonValue.IsUndefined() then
+                        exit;
+
+                    JsonToken.WriteTo(SerializedValue);
+                    if SerializedValue.StartsWith('"') then begin
+                        TextValue := JsonValue.AsText();
+                        Value := TextValue;
+                    end else
+                        if (SerializedValue = 'true') or (SerializedValue = 'false') then begin
+                            BooleanValue := JsonValue.AsBoolean();
+                            Value := BooleanValue;
+                        end else
+                            if (StrPos(SerializedValue, '.') = 0) and (StrPos(LowerCase(SerializedValue), 'e') = 0) and TryGetJsonInteger(JsonValue, IntegerValue) then
+                                Value := IntegerValue
+                            else
+                                if (StrPos(SerializedValue, '.') = 0) and (StrPos(LowerCase(SerializedValue), 'e') = 0) and TryGetJsonBigInteger(JsonValue, BigIntegerValue) then
+                                    Value := BigIntegerValue
+                                else
+                                    if TryGetJsonDecimal(JsonValue, DecimalValue) then
+                                        Value := DecimalValue
+                                    else begin
+                                        TextValue := SerializedValue;
+                                        Value := TextValue;
+                                    end;
+                end;
+        end;
+    end;
+
+    local procedure GetJsonValueAsText(JsonToken: JsonToken): Text
+    var
+        SerializedValue: Text;
+    begin
+        JsonToken.WriteTo(SerializedValue);
+        case SerializedValue of
+            'true':
+                exit('True');
+            'false':
+                exit('False');
+        end;
+        exit(JsonToken.AsValue().AsText());
+    end;
+
+    [TryFunction]
+    local procedure TryGetJsonInteger(JsonValue: JsonValue; var IntegerValue: Integer)
+    begin
+        IntegerValue := JsonValue.AsInteger();
+    end;
+
+    [TryFunction]
+    local procedure TryGetJsonBigInteger(JsonValue: JsonValue; var BigIntegerValue: BigInteger)
+    begin
+        BigIntegerValue := JsonValue.AsBigInteger();
+    end;
+
+    [TryFunction]
+    local procedure TryGetJsonDecimal(JsonValue: JsonValue; var DecimalValue: Decimal)
+    begin
+        DecimalValue := JsonValue.AsDecimal();
+    end;
+
+    local procedure GetPropertyValueFromJObjectByPathSetToFieldRef(PropertyPath: Text; var FieldRef: FieldRef): Boolean
     var
         RecID: RecordId;
-        Value: Variant;
+        Value: Text;
         IntVar: Integer;
         DecimalVal: Decimal;
         GuidVal: Guid;
         DateVal: Date;
         BoolVal, Success : Boolean;
-        JPropertyDotNet: DotNet JProperty;
+        JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
-        Success := false;
-        JPropertyDotNet := JsonObjectDotNet.SelectToken(propertyPath);
-
-        if IsNull(JPropertyDotNet) then
+        if not JsonObjectState.SelectToken(PropertyPath, JsonToken) then
+            exit(false);
+        if not JsonToken.IsValue() then
             exit(false);
 
-        Value := Format(JPropertyDotNet.Value, 0, 9);
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(false);
+        Value := JsonValue.AsText();
 
         case FieldRef.Type of
             FieldType::Integer,
@@ -399,45 +519,208 @@ codeunit 5461 "Json Impl."
         until Counter = Number;
     end;
 
-    local procedure AddJPropertyToJObject(propertyName: Text; value: Variant)
+    local procedure CreateJsonTokenFromVariant(Value: Variant; var JsonToken: JsonToken)
     var
-        JObjectDotNet: DotNet JObject;
-        JPropertyDotNet: DotNet JProperty;
+        JsonObject: JsonObject;
+    begin
+        AddJPropertyToJObject(JsonObject, 'value', Value);
+        JsonObject.Get('value', JsonToken);
+    end;
+
+    local procedure AddJPropertyToJObject(var JsonObject: JsonObject; PropertyName: Text; Value: Variant)
+    var
+        JsonArrayValue: JsonArray;
+        JsonObjectValue: JsonObject;
+        BooleanValue: Boolean;
+        DecimalValue: Decimal;
+        IntegerValue: Integer;
         ValueText: Text;
     begin
         case true of
-            value.IsDotNet:
+            Value.IsJsonObject():
                 begin
-                    JObjectDotNet := value;
-                    JsonObjectDotNet.Add(propertyName, JObjectDotNet);
+                    JsonObjectValue := Value;
+                    JsonObject.Add(PropertyName, JsonObjectValue);
                 end;
-            value.IsInteger,
-            value.IsDecimal,
-            value.IsBoolean:
+            Value.IsJsonArray():
                 begin
-                    JPropertyDotNet := JPropertyDotNet.JProperty(propertyName, value);
-                    JsonObjectDotNet.Add(JPropertyDotNet);
+                    JsonArrayValue := Value;
+                    JsonObject.Add(PropertyName, JsonArrayValue);
+                end;
+            Value.IsInteger():
+                begin
+                    IntegerValue := Value;
+                    JsonObject.Add(PropertyName, IntegerValue);
+                end;
+            Value.IsDecimal():
+                begin
+                    DecimalValue := Value;
+                    JsonObject.Add(PropertyName, DecimalValue);
+                end;
+            Value.IsBoolean():
+                begin
+                    BooleanValue := Value;
+                    JsonObject.Add(PropertyName, BooleanValue);
                 end;
             else begin
-                ValueText := Format(value, 0, 9);
-                JPropertyDotNet := JPropertyDotNet.JProperty(propertyName, ValueText);
-                JsonObjectDotNet.Add(JPropertyDotNet);
+                ValueText := Format(Value, 0, 9);
+                JsonObject.Add(PropertyName, ValueText);
             end;
         end;
     end;
 
     local procedure AddJObjectToCollection()
+    var
+        JsonObjectClone: JsonObject;
+        JsonText: Text;
     begin
-        JsonArrayDotNet.Add(JsonObjectDotNet.DeepClone());
+        JsonObjectState.WriteTo(JsonText);
+        JsonObjectClone.ReadFrom(JsonText);
+        JsonArrayState.Add(JsonObjectClone);
     end;
 
-    local procedure InitializeEmptyCollection()
+    local procedure SetObjectStateFromString(JSONString: Text)
+    var
+        NewJsonObject: JsonObject;
     begin
-        JsonArrayDotNet := JsonArrayDotNet.JArray();
+        if JSONString <> '' then
+            if not NewJsonObject.ReadFrom(JSONString) then
+                Error(InvalidJsonObjectErr);
+        JsonObjectState := NewJsonObject;
     end;
 
-    local procedure InitializeEmptyObject()
+    local procedure AppendJsonToken(JsonToken: JsonToken; IndentationLevel: Integer; var JsonTextBuilder: TextBuilder)
+    var
+        ScalarText: Text;
     begin
-        JsonObjectDotNet := JsonObjectDotNet.JObject();
+        case true of
+            JsonToken.IsObject():
+                AppendJsonObject(JsonToken.AsObject(), IndentationLevel, JsonTextBuilder);
+            JsonToken.IsArray():
+                AppendJsonArray(JsonToken.AsArray(), IndentationLevel, JsonTextBuilder);
+            else begin
+                JsonToken.WriteTo(ScalarText);
+                JsonTextBuilder.Append(ScalarText);
+            end;
+        end;
     end;
+
+    local procedure AppendJsonObject(JsonObject: JsonObject; IndentationLevel: Integer; var JsonTextBuilder: TextBuilder)
+    var
+        JsonToken: JsonToken;
+        PropertyNames: List of [Text];
+        PropertyName: Text;
+        PropertyIndex: Integer;
+    begin
+        PropertyNames := JsonObject.Keys();
+        if PropertyNames.Count() = 0 then begin
+            JsonTextBuilder.Append('{}');
+            exit;
+        end;
+
+        JsonTextBuilder.Append('{');
+        JsonTextBuilder.Append(GetCRLF());
+        foreach PropertyName in PropertyNames do begin
+            PropertyIndex += 1;
+            AppendIndentation(IndentationLevel + 1, JsonTextBuilder);
+            JsonTextBuilder.Append(SerializeJsonString(PropertyName));
+            JsonTextBuilder.Append(': ');
+            JsonObject.Get(PropertyName, JsonToken);
+            AppendJsonToken(JsonToken, IndentationLevel + 1, JsonTextBuilder);
+            if PropertyIndex < PropertyNames.Count() then
+                JsonTextBuilder.Append(',');
+            JsonTextBuilder.Append(GetCRLF());
+        end;
+        AppendIndentation(IndentationLevel, JsonTextBuilder);
+        JsonTextBuilder.Append('}');
+    end;
+
+    local procedure AppendJsonArray(JsonArray: JsonArray; IndentationLevel: Integer; var JsonTextBuilder: TextBuilder)
+    var
+        JsonToken: JsonToken;
+        Index: Integer;
+    begin
+        if JsonArray.Count() = 0 then begin
+            JsonTextBuilder.Append('[]');
+            exit;
+        end;
+
+        JsonTextBuilder.Append('[');
+        JsonTextBuilder.Append(GetCRLF());
+        for Index := 0 to JsonArray.Count() - 1 do begin
+            AppendIndentation(IndentationLevel + 1, JsonTextBuilder);
+            JsonArray.Get(Index, JsonToken);
+            AppendJsonToken(JsonToken, IndentationLevel + 1, JsonTextBuilder);
+            if Index < JsonArray.Count() - 1 then
+                JsonTextBuilder.Append(',');
+            JsonTextBuilder.Append(GetCRLF());
+        end;
+        AppendIndentation(IndentationLevel, JsonTextBuilder);
+        JsonTextBuilder.Append(']');
+    end;
+
+    local procedure AppendIndentation(IndentationLevel: Integer; var JsonTextBuilder: TextBuilder)
+    begin
+        if IndentationLevel > 0 then
+            JsonTextBuilder.Append(PadStr('', IndentationLevel * 2, ' '));
+    end;
+
+    local procedure SerializeJsonString(Value: Text) SerializedValue: Text
+    var
+        JsonArray: JsonArray;
+    begin
+        JsonArray.Add(Value);
+        JsonArray.WriteTo(SerializedValue);
+        exit(CopyStr(SerializedValue, 2, StrLen(SerializedValue) - 2));
+    end;
+
+    local procedure GetCRLF() CRLF: Text[2]
+    begin
+        CRLF[1] := 13;
+        CRLF[2] := 10;
+    end;
+
+    // XML-JSON compatibility region: native AL has no XmlNodeConverter-equivalent mapping.
+    procedure XMLTextToJSONText(Xml: Text) Json: Text
+    var
+        JsonConvert: DotNet JsonConvert;
+        JsonFormatting: DotNet Formatting;
+        DotNetXmlDocument: DotNet XmlDocument;
+        DtdProcessing: DotNet DtdProcessing;
+        StringReader: DotNet StringReader;
+        XmlReaderSettings: DotNet XmlReaderSettings;
+        XmlTextReader: DotNet XmlTextReader;
+    begin
+        ClearUTF8BOMSymbols(Xml);
+        DotNetXmlDocument := DotNetXmlDocument.XmlDocument();
+        StringReader := StringReader.StringReader(Xml);
+        XmlReaderSettings := XmlReaderSettings.XmlReaderSettings();
+        XmlReaderSettings.DtdProcessing := DtdProcessing.Prohibit;
+        XmlTextReader := XmlTextReader.Create(StringReader, XmlReaderSettings);
+        DotNetXmlDocument.Load(XmlTextReader);
+        XmlTextReader.Close();
+        StringReader.Close();
+        Json := JsonConvert.SerializeXmlNode(DotNetXmlDocument.DocumentElement, JsonFormatting.Indented, true);
+    end;
+
+    procedure JSONTextToXMLText(Json: Text; DocumentElementName: Text) Xml: Text
+    var
+        JsonConvert: DotNet JsonConvert;
+        DotNetXmlDocument: DotNet XmlDocument;
+    begin
+        DotNetXmlDocument := JsonConvert.DeserializeXmlNode(Json, DocumentElementName);
+        Xml := DotNetXmlDocument.DocumentElement.OuterXml();
+    end;
+
+    local procedure ClearUTF8BOMSymbols(var Xml: Text)
+    var
+        ByteOrderMarkUtf8: Char;
+    begin
+        ByteOrderMarkUtf8 := 65279;
+        if Xml = '' then
+            exit;
+        if Xml[1] = ByteOrderMarkUtf8 then
+            Xml := DelStr(Xml, 1, 1);
+    end;
+    // End XML-JSON compatibility region.
 }

--- a/src/System Application/App/Json/src/JsonImpl.Codeunit.al
+++ b/src/System Application/App/Json/src/JsonImpl.Codeunit.al
@@ -73,11 +73,8 @@ codeunit 5461 "Json Impl."
     end;
 
     procedure GetCollection() JsonArray: JsonArray
-    var
-        JsonText: Text;
     begin
-        JsonArrayState.WriteTo(JsonText);
-        JsonArray.ReadFrom(JsonText);
+        exit(JsonArrayState.Clone().AsArray());
     end;
 
     procedure GetObjectAsText() Value: Text
@@ -86,11 +83,8 @@ codeunit 5461 "Json Impl."
     end;
 
     procedure GetObject() JsonObject: JsonObject
-    var
-        JsonText: Text;
     begin
-        JsonObjectState.WriteTo(JsonText);
-        JsonObject.ReadFrom(JsonText);
+        exit(JsonObjectState.Clone().AsObject());
     end;
 
     procedure GetObjectFromCollectionByIndex(Index: Integer; var JsonObjectTxt: Text): Boolean
@@ -110,7 +104,25 @@ codeunit 5461 "Json Impl."
         exit(GetPropertyValueFromJObjectByPathSetToFieldRef(PropertyPath, FieldRef));
     end;
 
+#if not CLEAN30
     procedure GetPropertyValueFromJObjectByName(PropertyName: Text; var Value: Variant): Boolean
+    var
+        JTokenDotNet: DotNet JToken;
+        JsonToken: JsonToken;
+        JsonText: Text;
+    begin
+        Clear(Value);
+        if not JsonObjectState.Get(PropertyName, JsonToken) then
+            exit(false);
+
+        JsonToken.WriteTo(JsonText);
+        JTokenDotNet := JTokenDotNet.Parse(JsonText);
+        Value := JTokenDotNet;
+        exit(true);
+    end;
+#endif
+
+    procedure GetNativePropertyValueFromJObjectByName(PropertyName: Text; var Value: Variant): Boolean
     var
         JsonToken: JsonToken;
     begin
@@ -597,13 +609,8 @@ codeunit 5461 "Json Impl."
     end;
 
     local procedure AddJObjectToCollection()
-    var
-        JsonObjectClone: JsonObject;
-        JsonText: Text;
     begin
-        JsonObjectState.WriteTo(JsonText);
-        JsonObjectClone.ReadFrom(JsonText);
-        JsonArrayState.Add(JsonObjectClone);
+        JsonArrayState.Add(JsonObjectState.Clone().AsObject());
     end;
 
     local procedure SetObjectStateFromString(JSONString: Text)

--- a/src/System Application/App/Json/src/JsonImpl.Codeunit.al
+++ b/src/System Application/App/Json/src/JsonImpl.Codeunit.al
@@ -158,59 +158,84 @@ codeunit 5461 "Json Impl."
     procedure GetEnumPropertyValueFromJObjectByName(PropertyName: Text; var Value: Option): Boolean
     var
         JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
         if not GetJsonValueByName(PropertyName, JsonToken) then
             exit(false);
 
-        Evaluate(Value, JsonToken.AsValue().AsText(), 0);
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(true);
+
+        Evaluate(Value, JsonValue.AsText(), 0);
         exit(true);
     end;
 
     procedure GetBoolPropertyValueFromJObjectByName(PropertyName: Text; var Value: Boolean): Boolean
     var
         JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
         Clear(Value);
         if not GetJsonValueByName(PropertyName, JsonToken) then
             exit(false);
 
-        Value := JsonToken.AsValue().AsBoolean();
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(true);
+
+        Value := JsonValue.AsBoolean();
         exit(true);
     end;
 
     procedure GetDecimalPropertyValueFromJObjectByName(PropertyName: Text; var Value: Decimal): Boolean
     var
         JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
         Clear(Value);
         if not GetJsonValueByName(PropertyName, JsonToken) then
             exit(false);
 
-        Value := JsonToken.AsValue().AsDecimal();
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(true);
+
+        Value := JsonValue.AsDecimal();
         exit(true);
     end;
 
     procedure GetIntegerPropertyValueFromJObjectByName(PropertyName: Text; var Value: Integer): Boolean
     var
         JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
         Clear(Value);
         if not GetJsonValueByName(PropertyName, JsonToken) then
             exit(false);
 
-        Value := JsonToken.AsValue().AsInteger();
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(true);
+
+        Value := JsonValue.AsInteger();
         exit(true);
     end;
 
     procedure GetGuidPropertyValueFromJObjectByName(PropertyName: Text; var Value: Guid): Boolean
     var
         JsonToken: JsonToken;
+        JsonValue: JsonValue;
     begin
         Clear(Value);
         if not GetJsonValueByName(PropertyName, JsonToken) then
             exit(false);
 
-        Evaluate(Value, JsonToken.AsValue().AsText());
+        JsonValue := JsonToken.AsValue();
+        if JsonValue.IsNull() or JsonValue.IsUndefined() then
+            exit(true);
+
+        Evaluate(Value, JsonValue.AsText());
         exit(true);
     end;
 
@@ -308,16 +333,13 @@ codeunit 5461 "Json Impl."
     end;
 
     local procedure GetJsonValueByName(PropertyName: Text; var JsonToken: JsonToken): Boolean
-    var
-        JsonValue: JsonValue;
     begin
         if not JsonObjectState.Get(PropertyName, JsonToken) then
             exit(false);
         if not JsonToken.IsValue() then
             exit(false);
 
-        JsonValue := JsonToken.AsValue();
-        exit(not JsonValue.IsNull() and not JsonValue.IsUndefined());
+        exit(true);
     end;
 
     local procedure JsonTokenToVariant(JsonToken: JsonToken; var Value: Variant)
@@ -425,9 +447,8 @@ codeunit 5461 "Json Impl."
             exit(false);
 
         JsonValue := JsonToken.AsValue();
-        if JsonValue.IsNull() or JsonValue.IsUndefined() then
-            exit(false);
-        Value := JsonValue.AsText();
+        if not (JsonValue.IsNull() or JsonValue.IsUndefined()) then
+            Value := JsonValue.AsText();
 
         case FieldRef.Type of
             FieldType::Integer,
@@ -568,14 +589,41 @@ codeunit 5461 "Json Impl."
 
     local procedure AddJPropertyToJObject(var JsonObject: JsonObject; PropertyName: Text; Value: Variant)
     var
+#if not CLEAN30
+        JTokenDotNet: DotNet JToken;
+        JsonFormatting: DotNet Formatting;
+        JsonText: Text;
+#endif
+        BigIntegerValue: BigInteger;
         JsonArrayValue: JsonArray;
         JsonObjectValue: JsonObject;
+        JsonTokenValue: JsonToken;
+        JsonValueValue: JsonValue;
         BooleanValue: Boolean;
         DecimalValue: Decimal;
         IntegerValue: Integer;
         ValueText: Text;
     begin
         case true of
+#if not CLEAN30
+            Value.IsDotNet:
+                begin
+                    JTokenDotNet := Value;
+                    JsonText := JTokenDotNet.ToString(JsonFormatting.None);
+                    JsonTokenValue.ReadFrom(JsonText);
+                    JsonObject.Add(PropertyName, JsonTokenValue);
+                end;
+#endif
+            Value.IsJsonToken():
+                begin
+                    JsonTokenValue := Value;
+                    JsonObject.Add(PropertyName, JsonTokenValue);
+                end;
+            Value.IsJsonValue():
+                begin
+                    JsonValueValue := Value;
+                    JsonObject.Add(PropertyName, JsonValueValue.AsToken());
+                end;
             Value.IsJsonObject():
                 begin
                     JsonObjectValue := Value;
@@ -585,6 +633,11 @@ codeunit 5461 "Json Impl."
                 begin
                     JsonArrayValue := Value;
                     JsonObject.Add(PropertyName, JsonArrayValue);
+                end;
+            Value.IsBigInteger():
+                begin
+                    BigIntegerValue := Value;
+                    JsonObject.Add(PropertyName, BigIntegerValue);
                 end;
             Value.IsInteger():
                 begin

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Security.AccessControl;
 using System.TestLibraries.Utilities;
 using System.Text.Json;
+using System.Utilities;
 
 codeunit 139910 "Json Test"
 {

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -759,13 +759,13 @@ codeunit 139910 "Json Test"
         SourcePrinter: Record Printer;
         TableInformation: Record "Table Information";
         Json: Codeunit "Json";
-        FieldsJsonObject: JsonObject;
-        RootJsonObject: JsonObject;
-        BlobInStream: InStream;
+        ExpectedRecordId: RecordId;
         RecordRef: RecordRef;
         ExpectedDate: Date;
         ExpectedGuid: Guid;
-        ExpectedRecordId: RecordId;
+        BlobInStream: InStream;
+        FieldsJsonObject: JsonObject;
+        RootJsonObject: JsonObject;
         BlobText: Text;
         JsonText: Text;
         LongText: Text;

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -8,7 +8,6 @@ namespace System.Test.Text.Json;
 using System.Device;
 using System.Environment;
 using System.Environment.Configuration;
-using System.Reflection;
 using System.Security.AccessControl;
 using System.TestLibraries.Utilities;
 using System.Text.Json;

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -754,8 +754,7 @@ codeunit 139910 "Json Test"
     procedure TestGetValueAndSetToSupportedFieldTypes()
     var
         AccessControl: Record "Access Control";
-        ObjectMetadata: Record Object;
-        Profile: Record Profile;
+        DateRecord: Record Date;
         RecordLink: Record "Record Link";
         SourcePrinter: Record Printer;
         TableInformation: Record "Table Information";
@@ -817,23 +816,20 @@ codeunit 139910 "Json Test"
         Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.decimal', TableInformation.FieldNo("Record Size")), 'Decimal path was not assigned.');
         RecordRef.SetTable(TableInformation);
 
-        RecordRef.GetTable(ObjectMetadata);
-        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.date', ObjectMetadata.FieldNo(Date)), 'Date path was not assigned.');
-        RecordRef.SetTable(ObjectMetadata);
+        RecordRef.GetTable(DateRecord);
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.date', DateRecord.FieldNo("Period Start")), 'Date path was not assigned.');
+        RecordRef.SetTable(DateRecord);
 
         RecordRef.GetTable(AccessControl);
         Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.guid', AccessControl.FieldNo("User Security ID")), 'GUID path was not assigned.');
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.code', AccessControl.FieldNo("Role ID")), 'Code path was not assigned.');
         RecordRef.SetTable(AccessControl);
-
-        RecordRef.GetTable(Profile);
-        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.code', Profile.FieldNo("Profile ID")), 'Code path was not assigned.');
-        RecordRef.SetTable(Profile);
 
         // [THEN] Decimal, Date, GUID, and Code conversions are correct
         Assert.AreEqual(12.5, TableInformation."Record Size", 'Decimal field value is incorrect.');
-        Assert.AreEqual(ExpectedDate, ObjectMetadata.Date, 'Date field value is incorrect.');
+        Assert.AreEqual(ExpectedDate, DateRecord."Period Start", 'Date field value is incorrect.');
         Assert.AreEqual(ExpectedGuid, AccessControl."User Security ID", 'GUID field value is incorrect.');
-        Assert.AreEqual('LOWERCASE', Profile."Profile ID", 'Code field value is incorrect.');
+        Assert.AreEqual('LOWERCASE', AccessControl."Role ID", 'Code field value is incorrect.');
     end;
 
     [Test]

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -136,8 +136,11 @@ codeunit 139910 "Json Test"
         Json.InitializeObject('{"object":{"id":1},"array":[1,2]}');
         Assert.IsTrue(Json.GetPropertyValueByName('object', Value), 'The object property was not found.');
         Assert.IsTrue(Value.IsDotNet, 'The legacy object property must return a DotNet JSON token.');
+        Assert.IsTrue(Json.ReplaceOrAddJPropertyInJObject('objectCopy', Value), 'The legacy object token was not added.');
         Assert.IsTrue(Json.GetPropertyValueByName('array', Value), 'The array property was not found.');
         Assert.IsTrue(Value.IsDotNet, 'The legacy array property must return a DotNet JSON token.');
+        Assert.IsTrue(Json.ReplaceOrAddJPropertyInJObject('arrayCopy', Value), 'The legacy array token was not added.');
+        Assert.AreEqual('{"object":{"id":1},"array":[1,2],"objectCopy":{"id":1},"arrayCopy":[1,2]}', Json.GetObjectAsText(), 'Legacy DotNet tokens changed JSON shape when added.');
 #pragma warning restore AL0432
     end;
 #endif
@@ -481,6 +484,8 @@ codeunit 139910 "Json Test"
 
         // [THEN] Both native states contain empty JSON containers
         Assert.AreEqual('{}', Json.GetObjectAsText(), 'Empty object initialization did not create an empty object.');
+        Assert.AreEqual('[]', Json.GetCollectionAsText(), 'Empty collection initialization did not create an empty collection.');
+        Assert.AreEqual(0, Json.GetCollectionCount(), 'Empty collection initialization did not clear the collection.');
     end;
 
     [Test]
@@ -659,15 +664,18 @@ codeunit 139910 "Json Test"
     var
         Json: Codeunit "Json";
         ArrayValue: JsonArray;
+        JsonObjectValue: JsonObject;
+        JsonTokenValue: JsonToken;
         ObjectValue: JsonObject;
         Value: Variant;
+        BigIntegerValue: BigInteger;
         BooleanValue: Boolean;
         DecimalValue: Decimal;
         IntegerValue: Integer;
         TextValue: Text;
     begin
         // [GIVEN] JSON properties of each native JSON shape
-        Json.InitializeObject('{"text":"value","integer":42,"decimal":12.5,"boolean":true,"null":null,"object":{"id":1},"array":[1,2]}');
+        Json.InitializeObject('{"text":"value","integer":42,"bigInteger":3000000000,"decimal":12.5,"boolean":true,"null":null,"object":{"id":1},"array":[1,2]}');
 
         // [WHEN] Scalar values are requested as variants
         Assert.IsTrue(Json.GetNativePropertyValueByName('text', Value), 'Text property was not found.');
@@ -679,6 +687,15 @@ codeunit 139910 "Json Test"
         Assert.IsTrue(Value.IsInteger(), 'Integer JSON value was not returned as AL Integer.');
         IntegerValue := Value;
         Assert.AreEqual(42, IntegerValue, 'Integer variant value is incorrect.');
+
+        Assert.IsTrue(Json.GetNativePropertyValueByName('bigInteger', Value), 'BigInteger property was not found.');
+        Assert.IsTrue(Value.IsBigInteger(), 'Large integer JSON value was not returned as AL BigInteger.');
+        BigIntegerValue := Value;
+        Assert.AreEqual(3000000000L, BigIntegerValue, 'BigInteger variant value is incorrect.');
+        Assert.IsTrue(Json.ReplaceOrAddJPropertyInJObject('bigIntegerCopy', Value), 'BigInteger variant was not added.');
+        JsonObjectValue := Json.GetObject();
+        Assert.IsTrue(JsonObjectValue.Get('bigIntegerCopy', JsonTokenValue), 'BigInteger copy was not found.');
+        Assert.AreEqual(BigIntegerValue, JsonTokenValue.AsValue().AsBigInteger(), 'BigInteger variant was converted to a JSON string.');
 
         Assert.IsTrue(Json.GetNativePropertyValueByName('decimal', Value), 'Decimal property was not found.');
         Assert.IsTrue(Value.IsDecimal(), 'Decimal JSON value was not returned as AL Decimal.');
@@ -734,7 +751,8 @@ codeunit 139910 "Json Test"
         TextValue := 'not cleared';
         Assert.IsTrue(Json.GetStringPropertyValueByName('null', TextValue), 'String getter did not recognize an existing null property.');
         Assert.AreEqual('', TextValue, 'String getter did not return an empty value for JSON null.');
-        Assert.IsFalse(Json.GetIntegerPropertyValueFromJObjectByName('null', IntegerValue), 'Typed getter accepted JSON null.');
+        Assert.IsTrue(Json.GetIntegerPropertyValueFromJObjectByName('null', IntegerValue), 'Typed getter did not recognize an existing null property.');
+        Assert.AreEqual(0, IntegerValue, 'Typed null did not clear the output value.');
         Assert.IsFalse(Json.GetStringPropertyValueByName('missing', TextValue), 'String getter accepted a missing property.');
     end;
 
@@ -876,11 +894,11 @@ codeunit 139910 "Json Test"
         RecordRef.GetTable(Printer);
         Json.InitializeObject('{"nested":{"null":null}}');
 
-        // [THEN] Null and missing paths return false without changing the field
-        Assert.IsFalse(Json.GetValueAndSetToRecFieldNo(RecordRef, 'nested.null', Printer.FieldNo(ID)), 'A null path was assigned to a field.');
+        // [THEN] Null clears compatible fields, while a missing path does not change the field
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'nested.null', Printer.FieldNo(ID)), 'A null path did not clear the field.');
         Assert.IsFalse(Json.GetValueAndSetToRecFieldNo(RecordRef, 'nested.missing', Printer.FieldNo(ID)), 'A missing path was assigned to a field.');
         RecordRef.SetTable(Printer);
-        Assert.AreEqual('unchanged', Printer.ID, 'A null or missing path changed the target field.');
+        Assert.AreEqual('', Printer.ID, 'A null path did not clear the target field.');
     end;
 
     [Test]

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -559,6 +559,20 @@ codeunit 139910 "Json Test"
     end;
 
     [Test]
+    procedure TestSelectedCollectionObjectReplacementPreservesOrder()
+    var
+        Json: Codeunit "Json";
+        SelectedObjectText: Text;
+    begin
+        Json.InitializeCollection('[{"id":"one","name":"first"},{"id":"two"}]');
+        Assert.IsTrue(Json.GetObjectFromCollectionByIndex(0, SelectedObjectText), 'The collection object was not selected.');
+
+        Json.ReplaceOrAddJPropertyInJObject('id', 'replacement');
+
+        Assert.AreEqual('[{"id":"replacement","name":"first"},{"id":"two"}]', Json.GetCollectionAsText(), 'Selected object replacement changed property order or collection state.');
+    end;
+
+    [Test]
     procedure TestReplacedCollectionObjectRemainsSelected()
     var
         Json: Codeunit "Json";

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -6,6 +6,10 @@
 namespace System.Test.Text.Json;
 
 using System.Device;
+using System.Environment;
+using System.Environment.Configuration;
+using System.Reflection;
+using System.Security.AccessControl;
 using System.TestLibraries.Utilities;
 using System.Text.Json;
 
@@ -150,6 +154,20 @@ codeunit 139910 "Json Test"
     end;
 
     [Test]
+    procedure TestGetStringPropertyValuePreservesBooleanCasing()
+    var
+        Json: Codeunit "Json";
+        Value: Text;
+    begin
+        Json.InitializeObject('{"boolean":true,"text":"true"}');
+
+        Assert.IsTrue(Json.GetStringPropertyValueByName('boolean', Value), 'Boolean property was not found.');
+        Assert.AreEqual('True', Value, 'Boolean JSON value was not formatted compatibly.');
+        Assert.IsTrue(Json.GetStringPropertyValueByName('text', Value), 'Text property was not found.');
+        Assert.AreEqual('true', Value, 'Text JSON value was changed while normalizing Boolean values.');
+    end;
+
+    [Test]
     procedure TestGetIntegerPropertyValueFromJObjectByName()
     var
         Json: Codeunit "Json";
@@ -201,6 +219,24 @@ codeunit 139910 "Json Test"
 
         // [THEN] The retrieved value matches the expected value
         Assert.AreEqual(123.45, Value, 'The retrieved value does not match the expected value.');
+    end;
+
+    [Test]
+    procedure TestGetGuidPropertyValueFromJObjectByName()
+    var
+        Json: Codeunit "Json";
+        ExpectedValue: Guid;
+        Value: Guid;
+    begin
+        // [GIVEN] A JSON object with a GUID value
+        ExpectedValue := CreateGuid();
+        Json.InitializeObject('{"id":"' + Format(ExpectedValue) + '"}');
+
+        // [WHEN] Retrieve the GUID from the JSON object
+        Assert.IsTrue(Json.GetGuidPropertyValueFromJObjectByName('id', Value), 'The GUID property was not found.');
+
+        // [THEN] The retrieved value matches the expected value
+        Assert.AreEqual(ExpectedValue, Value, 'The retrieved GUID value does not match the expected value.');
     end;
 
     [Test]
@@ -291,6 +327,52 @@ codeunit 139910 "Json Test"
     end;
 
     [Test]
+    procedure TestXMLTextToJSONTextWithUTF8BOM()
+    var
+        Json: Codeunit "Json";
+        JsonObject: JsonObject;
+        JsonToken: JsonToken;
+        ByteOrderMarkUtf8: Text[1];
+        JsonText: Text;
+        XmlText: Text;
+    begin
+        // [GIVEN] XML text prefixed with a UTF-8 byte order mark
+        ByteOrderMarkUtf8[1] := 65279;
+        XmlText := ByteOrderMarkUtf8 + '<root><value>test</value></root>';
+
+        // [WHEN] The XML text is converted to JSON
+        JsonText := Json.XMLTextToJSONText(XmlText);
+
+        // [THEN] The JSON contains the XML document element content
+        Assert.IsTrue(JsonObject.ReadFrom(JsonText), 'The XML text was not converted to valid JSON.');
+        Assert.IsTrue(JsonObject.Get('value', JsonToken), 'The converted JSON does not contain the expected value.');
+        Assert.IsTrue(JsonToken.IsValue(), 'The converted JSON value has an unexpected type.');
+        Assert.AreEqual('test', JsonToken.AsValue().AsText(), 'The converted JSON value is incorrect.');
+    end;
+
+    [Test]
+    procedure TestXMLTextToJSONTextRejectsDTD()
+    var
+        Json: Codeunit "Json";
+    begin
+        asserterror Json.XMLTextToJSONText('<!DOCTYPE root [<!ENTITY value "test">]><root>&value;</root>');
+    end;
+
+    [Test]
+    procedure TestJSONTextToXMLTextWithoutDeclaration()
+    var
+        Json: Codeunit "Json";
+        XmlText: Text;
+    begin
+        // [WHEN] JSON text is converted to XML
+        XmlText := Json.JSONTextToXMLText('{"value":"test"}', 'root');
+
+        // [THEN] The XML contains only the document element, without an XML declaration
+        Assert.AreEqual('<root><value>test</value></root>', XmlText, 'The converted XML is incorrect.');
+        Assert.AreEqual(0, StrPos(XmlText, '<?xml'), 'The converted XML must not contain an XML declaration.');
+    end;
+
+    [Test]
     procedure TestReplaceOrAddJPropertyInJObject()
     var
         Json: Codeunit "Json";
@@ -372,5 +454,455 @@ codeunit 139910 "Json Test"
 
         // [THEN] The removed value matches the expected value
         Assert.AreEqual('[{"id":"ABC123"},{"id":"DYK484"}]', JsonArrayText, 'The removed value does not match the expected value.');
+    end;
+
+    [Test]
+    procedure TestEmptyInitialization()
+    var
+        Json: Codeunit "Json";
+    begin
+        // [WHEN] Empty object and collection text are initialized
+        Json.InitializeObject('');
+        Json.InitializeCollection('');
+
+        // [THEN] Both native states contain empty JSON containers
+        Assert.AreEqual('{}', Json.GetObjectAsText(), 'Empty object initialization did not create an empty object.');
+    end;
+
+    [Test]
+    procedure TestInvalidJsonInputRaisesError()
+    var
+        Json: Codeunit "Json";
+    begin
+        asserterror Json.InitializeCollection('not json');
+        asserterror Json.InitializeObject('not json');
+
+        Json.InitializeCollection('[]');
+        asserterror Json.AddJObjectToCollection('not json');
+        Assert.AreEqual('[]', Json.GetCollectionAsText(), 'Invalid object input changed the collection.');
+        Assert.AreEqual('[]', Json.GetCollectionAsText(true), 'Invalid object input changed the indented collection.');
+        Assert.AreEqual(0, Json.GetCollectionCount(), 'Invalid object input changed the collection count.');
+
+        Json.InitializeCollection('[{}]');
+        asserterror Json.ReplaceJObjectInCollection(0, 'not json');
+        Assert.AreEqual('[{}]', Json.GetCollectionAsText(), 'Invalid replacement input changed the collection.');
+        Assert.AreEqual(1, Json.GetCollectionCount(), 'Invalid replacement input changed the collection count.');
+    end;
+
+    [Test]
+    procedure TestObjectAndCollectionStateAreIndependent()
+    var
+        Json: Codeunit "Json";
+        SelectedObjectText: Text;
+    begin
+        // [GIVEN] Independently initialized object and collection states
+        Json.InitializeObject('{"objectState":"first"}');
+        Json.InitializeCollection('[{"collectionState":"kept"}]');
+
+        // [THEN] Initializing the collection did not replace object state
+        Assert.AreEqual('{"objectState":"first"}', Json.GetObjectAsText(), 'Collection initialization changed object state.');
+
+        // [WHEN] Object state is initialized again
+        Json.InitializeObject('{"objectState":"second"}');
+
+        // [THEN] Collection state is unchanged
+        Assert.AreEqual('[{"collectionState":"kept"}]', Json.GetCollectionAsText(), 'Object initialization changed collection state.');
+
+        // [GIVEN] Object state refers to an item in the current collection
+        Assert.IsTrue(Json.GetObjectFromCollectionByIndex(0, SelectedObjectText), 'The collection object was not selected.');
+
+        // [WHEN] Collection state is initialized again
+        Json.InitializeCollection('[{"collectionState":"replacement"}]');
+
+        // [THEN] The previously selected object remains valid and independent of the new collection
+        Assert.AreEqual('{"collectionState":"kept"}', Json.GetObjectAsText(), 'Collection reinitialization changed the selected object state.');
+        Assert.AreEqual('[{"collectionState":"replacement"}]', Json.GetCollectionAsText(), 'Collection reinitialization produced unexpected state.');
+    end;
+
+    [Test]
+    procedure TestInvalidCollectionIndexesAreSafe()
+    var
+        Json: Codeunit "Json";
+        JsonObjectText: Text;
+    begin
+        // [GIVEN] A collection with one object
+        Json.InitializeCollection('[{"id":"one"}]');
+        JsonObjectText := 'unchanged';
+
+        // [WHEN] Negative and out-of-range indexes are used
+        // [THEN] Operations fail without changing collection state or the output parameter
+        Assert.IsFalse(Json.GetObjectFromCollectionByIndex(-1, JsonObjectText), 'A negative index was accepted.');
+        Assert.AreEqual('unchanged', JsonObjectText, 'A failed selection changed the output value.');
+        Assert.IsFalse(Json.GetObjectFromCollectionByIndex(1, JsonObjectText), 'An out-of-range index was accepted.');
+        Assert.IsFalse(Json.RemoveJObjectFromCollection(-1), 'A negative remove index was accepted.');
+        Assert.IsFalse(Json.RemoveJObjectFromCollection(1), 'An out-of-range remove index was accepted.');
+        Assert.IsFalse(Json.ReplaceJObjectInCollection(-1, '{"id":"replacement"}'), 'A negative replace index was accepted.');
+        Assert.IsFalse(Json.ReplaceJObjectInCollection(1, '{"id":"replacement"}'), 'An out-of-range replace index was accepted.');
+        Assert.AreEqual('[{"id":"one"}]', Json.GetCollectionAsText(), 'An invalid index changed collection state.');
+    end;
+
+    [Test]
+    procedure TestSelectedCollectionObjectMutatesCollectionState()
+    var
+        Json: Codeunit "Json";
+        SelectedObjectText: Text;
+    begin
+        // [GIVEN] The first collection object is selected
+        Json.InitializeCollection('[{"id":"one"},{"id":"two"}]');
+        Assert.IsTrue(Json.GetObjectFromCollectionByIndex(0, SelectedObjectText), 'The collection object was not selected.');
+
+        // [WHEN] Object state is changed
+        Json.ReplaceOrAddJPropertyInJObject('selected', true);
+
+        // [THEN] Object state still refers to the selected collection item
+        Assert.AreEqual('[{"id":"one","selected":true},{"id":"two"}]', Json.GetCollectionAsText(), 'Selected object mutation was not reflected in collection state.');
+    end;
+
+    [Test]
+    procedure TestReplacedCollectionObjectRemainsSelected()
+    var
+        Json: Codeunit "Json";
+    begin
+        // [GIVEN] A collection object is replaced
+        Json.InitializeCollection('[{"id":"one"}]');
+        Assert.IsTrue(Json.ReplaceJObjectInCollection(0, '{"id":"replacement"}'), 'The collection object was not replaced.');
+
+        // [WHEN] Object state is changed after replacement
+        Json.ReplaceOrAddJPropertyInJObject('selected', true);
+
+        // [THEN] Object state refers to the replacement in the collection
+        Assert.AreEqual('[{"id":"replacement","selected":true}]', Json.GetCollectionAsText(), 'Replacement did not remain selected as object state.');
+    end;
+
+    [Test]
+    procedure TestGetCollectionAndObjectReturnDeepClones()
+    var
+        Json: Codeunit "Json";
+        DetachedArray: JsonArray;
+        DetachedObject: JsonObject;
+        NestedObject: JsonObject;
+        JsonToken: JsonToken;
+    begin
+        // [GIVEN] Object and collection states containing nested objects
+        Json.InitializeCollection('[{"nested":{"value":1}}]');
+        Json.InitializeObject('{"nested":{"value":1}}');
+
+        // [WHEN] Nested values in the returned native containers are changed
+        DetachedArray := Json.GetCollection();
+        DetachedArray.Get(0, JsonToken);
+        DetachedObject := JsonToken.AsObject();
+        DetachedObject.Get('nested', JsonToken);
+        NestedObject := JsonToken.AsObject();
+        NestedObject.Replace('value', 2);
+
+        DetachedObject := Json.GetObject();
+        DetachedObject.Get('nested', JsonToken);
+        NestedObject := JsonToken.AsObject();
+        NestedObject.Replace('value', 2);
+
+        // [THEN] Persistent states are detached even for nested values
+        Assert.AreEqual('[{"nested":{"value":1}}]', Json.GetCollectionAsText(), 'GetCollection returned an alias instead of a deep clone.');
+        Assert.AreEqual('{"nested":{"value":1}}', Json.GetObjectAsText(), 'GetObject returned an alias instead of a deep clone.');
+    end;
+
+    [Test]
+    procedure TestAddJObjectToCollectionDeepClonesObjectState()
+    var
+        Json: Codeunit "Json";
+    begin
+        // [GIVEN] An object is added to an empty collection
+        Json.InitializeCollection('');
+        Json.AddJObjectToCollection('{"nested":{"value":1}}');
+
+        // [WHEN] The source object state is changed after the add
+        Json.ReplaceOrAddJPropertyInJObject('sourceOnly', true);
+
+        // [THEN] The collection contains a detached deep clone
+        Assert.AreEqual('[{"nested":{"value":1}}]', Json.GetCollectionAsText(), 'AddJObjectToCollection retained an alias to object state.');
+        Assert.AreEqual('{"nested":{"value":1},"sourceOnly":true}', Json.GetObjectAsText(), 'Object state did not retain the source object.');
+    end;
+
+    [Test]
+    procedure TestVariantPropertyTypes()
+    var
+        Json: Codeunit "Json";
+        ArrayValue: JsonArray;
+        ObjectValue: JsonObject;
+        Value: Variant;
+        BooleanValue: Boolean;
+        DecimalValue: Decimal;
+        IntegerValue: Integer;
+        TextValue: Text;
+    begin
+        // [GIVEN] JSON properties of each native JSON shape
+        Json.InitializeObject('{"text":"value","integer":42,"decimal":12.5,"boolean":true,"null":null,"object":{"id":1},"array":[1,2]}');
+
+        // [WHEN] Scalar values are requested as variants
+        Assert.IsTrue(Json.GetPropertyValueByName('text', Value), 'Text property was not found.');
+        Assert.IsTrue(Value.IsText(), 'Text JSON value was not returned as AL Text.');
+        TextValue := Value;
+        Assert.AreEqual('value', TextValue, 'Text variant value is incorrect.');
+
+        Assert.IsTrue(Json.GetPropertyValueByName('integer', Value), 'Integer property was not found.');
+        Assert.IsTrue(Value.IsInteger(), 'Integer JSON value was not returned as AL Integer.');
+        IntegerValue := Value;
+        Assert.AreEqual(42, IntegerValue, 'Integer variant value is incorrect.');
+
+        Assert.IsTrue(Json.GetPropertyValueByName('decimal', Value), 'Decimal property was not found.');
+        Assert.IsTrue(Value.IsDecimal(), 'Decimal JSON value was not returned as AL Decimal.');
+        DecimalValue := Value;
+        Assert.AreEqual(12.5, DecimalValue, 'Decimal variant value is incorrect.');
+
+        Assert.IsTrue(Json.GetPropertyValueByName('boolean', Value), 'Boolean property was not found.');
+        Assert.IsTrue(Value.IsBoolean(), 'Boolean JSON value was not returned as AL Boolean.');
+        BooleanValue := Value;
+        Assert.IsTrue(BooleanValue, 'Boolean variant value is incorrect.');
+
+        // [THEN] Native object and array values are carried directly by Variant
+        Assert.IsTrue(Json.GetPropertyValueByName('object', Value), 'Object property was not found.');
+        Assert.IsTrue(Value.IsJsonObject(), 'Object JSON value was not returned as a native JsonObject.');
+        ObjectValue := Value;
+        ObjectValue.WriteTo(TextValue);
+        Assert.AreEqual('{"id":1}', TextValue, 'Object variant value is incorrect.');
+
+        Assert.IsTrue(Json.GetPropertyValueByName('array', Value), 'Array property was not found.');
+        Assert.IsTrue(Value.IsJsonArray(), 'Array JSON value was not returned as a native JsonArray.');
+        ArrayValue := Value;
+        ArrayValue.WriteTo(TextValue);
+        Assert.AreEqual('[1,2]', TextValue, 'Array variant value is incorrect.');
+    end;
+
+    [Test]
+    procedure TestNullAndMissingProperties()
+    var
+        Json: Codeunit "Json";
+        Value: Variant;
+        TextValue: Text;
+        IntegerValue: Integer;
+    begin
+        // [GIVEN] An object containing a JSON null
+        Json.InitializeObject('{"null":null}');
+
+        // [WHEN] The null property is requested
+        Value := 'not cleared';
+        Assert.IsTrue(Json.GetPropertyValueByName('null', Value), 'An existing null property was reported as missing.');
+
+        // [THEN] JSON null is represented by a cleared Variant
+        Assert.AreEqual('', Format(Value), 'JSON null did not clear the Variant value.');
+        Assert.IsFalse(Value.IsText(), 'JSON null was incorrectly returned as text.');
+
+        // [WHEN] A missing property is requested
+        Value := 'not cleared';
+
+        // [THEN] The call returns false and still clears the output Variant
+        Assert.IsFalse(Json.GetPropertyValueByName('missing', Value), 'A missing property was reported as present.');
+        Assert.AreEqual('', Format(Value), 'A missing property did not clear the Variant value.');
+
+        // [THEN] String null is empty, while a typed null is rejected
+        TextValue := 'not cleared';
+        Assert.IsTrue(Json.GetStringPropertyValueByName('null', TextValue), 'String getter did not recognize an existing null property.');
+        Assert.AreEqual('', TextValue, 'String getter did not return an empty value for JSON null.');
+        Assert.IsFalse(Json.GetIntegerPropertyValueFromJObjectByName('null', IntegerValue), 'Typed getter accepted JSON null.');
+        Assert.IsFalse(Json.GetStringPropertyValueByName('missing', TextValue), 'String getter accepted a missing property.');
+    end;
+
+    [Test]
+    procedure TestAddPropertyPreservesNativeScalarDispatch()
+    var
+        Json: Codeunit "Json";
+        JsonArrayValue: JsonArray;
+        JsonObjectValue: JsonObject;
+        ExpectedDate: Date;
+    begin
+        // [GIVEN] An empty JSON object
+        Json.InitializeObject('');
+        ExpectedDate := DMY2Date(9, 9, 2026);
+        JsonArrayValue.ReadFrom('[1,2]');
+        JsonObjectValue.ReadFrom('{"id":1}');
+
+        // [WHEN] Native JSON containers, scalar values, and another AL value are added
+        Json.ReplaceOrAddJPropertyInJObject('object', JsonObjectValue);
+        Json.ReplaceOrAddJPropertyInJObject('array', JsonArrayValue);
+        Json.ReplaceOrAddJPropertyInJObject('integer', 7);
+        Json.ReplaceOrAddJPropertyInJObject('decimal', 12.5);
+        Json.ReplaceOrAddJPropertyInJObject('boolean', true);
+        Json.ReplaceOrAddJPropertyInJObject('date', ExpectedDate);
+
+        // [THEN] JSON containers and scalar types are preserved, and other AL values use format 9 text
+        Assert.AreEqual('{"object":{"id":1},"array":[1,2],"integer":7,"decimal":12.5,"boolean":true,"date":"2026-09-09"}', Json.GetObjectAsText(), 'Property dispatch produced unexpected JSON types.');
+    end;
+
+    [Test]
+    procedure TestReplaceOrAddReturnValue()
+    var
+        Json: Codeunit "Json";
+    begin
+        // [GIVEN] An object with existing scalar properties
+        Json.InitializeObject('{"text":"same","integer":1}');
+
+        // [THEN] Equal replacements return false
+        Assert.IsFalse(Json.ReplaceOrAddJPropertyInJObject('text', 'same'), 'An equal text replacement was reported as changed.');
+        Assert.IsFalse(Json.ReplaceOrAddJPropertyInJObject('integer', 1), 'An equal integer replacement was reported as changed.');
+
+        // [THEN] Changed replacements and additions return true
+        Assert.IsTrue(Json.ReplaceOrAddJPropertyInJObject('integer', 2), 'A changed replacement was not reported.');
+        Assert.IsTrue(Json.ReplaceOrAddJPropertyInJObject('added', false), 'A new property was not reported.');
+        Assert.AreEqual('{"text":"same","integer":2,"added":false}', Json.GetObjectAsText(), 'Replacement or addition produced unexpected JSON.');
+    end;
+
+    [Test]
+    procedure TestGetValueAndSetToSupportedFieldTypes()
+    var
+        AccessControl: Record "Access Control";
+        ObjectMetadata: Record Object;
+        Profile: Record Profile;
+        RecordLink: Record "Record Link";
+        SourcePrinter: Record Printer;
+        TableInformation: Record "Table Information";
+        Json: Codeunit "Json";
+        FieldsJsonObject: JsonObject;
+        RootJsonObject: JsonObject;
+        BlobInStream: InStream;
+        RecordRef: RecordRef;
+        ExpectedDate: Date;
+        ExpectedGuid: Guid;
+        ExpectedRecordId: RecordId;
+        BlobText: Text;
+        JsonText: Text;
+        LongText: Text;
+    begin
+        // [GIVEN] JSON values for every documented field type available on existing records
+        ExpectedDate := DMY2Date(9, 9, 2026);
+        ExpectedGuid := CreateGuid();
+        SourcePrinter.ID := 'JSON-RECORD-ID';
+        ExpectedRecordId := SourcePrinter.RecordId();
+        LongText := PadStr('', 300, 'X');
+
+        FieldsJsonObject.Add('integer', 42);
+        FieldsJsonObject.Add('decimal', 12.5);
+        FieldsJsonObject.Add('date', ExpectedDate);
+        FieldsJsonObject.Add('boolean', true);
+        FieldsJsonObject.Add('guid', Format(ExpectedGuid));
+        FieldsJsonObject.Add('text', LongText);
+        FieldsJsonObject.Add('code', 'lowercase');
+        FieldsJsonObject.Add('option', 1);
+        FieldsJsonObject.Add('blob', 'SGVsbG8=');
+        FieldsJsonObject.Add('recordId', Format(ExpectedRecordId));
+        RootJsonObject.Add('fields', FieldsJsonObject);
+        RootJsonObject.WriteTo(JsonText);
+        Json.InitializeObject(JsonText);
+
+        // [WHEN] Paths are assigned to Integer, Text, Boolean, Option, BLOB, and RecordID fields
+        RecordRef.GetTable(RecordLink);
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.integer', RecordLink.FieldNo("Link ID")), 'Integer path was not assigned.');
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.text', RecordLink.FieldNo(Description)), 'Text path was not assigned.');
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.boolean', RecordLink.FieldNo(Notify)), 'Boolean path was not assigned.');
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.option', RecordLink.FieldNo(Type)), 'Option path was not assigned.');
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.blob', RecordLink.FieldNo(Note)), 'BLOB path was not assigned.');
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.recordId', RecordLink.FieldNo("Record ID")), 'RecordID path was not assigned.');
+        RecordRef.SetTable(RecordLink);
+
+        // [THEN] The fields contain converted values, including text truncation and decoded Base64
+        Assert.AreEqual(42, RecordLink."Link ID", 'Integer field value is incorrect.');
+        Assert.AreEqual(250, StrLen(RecordLink.Description), 'Text field value was not truncated to the field length.');
+        Assert.IsTrue(RecordLink.Notify, 'Boolean field value is incorrect.');
+        Assert.AreEqual(RecordLink.Type::Note, RecordLink.Type, 'Option field value is incorrect.');
+        Assert.AreEqual(Format(ExpectedRecordId), Format(RecordLink."Record ID"), 'RecordID field value is incorrect.');
+        RecordLink.Note.CreateInStream(BlobInStream);
+        BlobInStream.ReadText(BlobText);
+        Assert.AreEqual('Hello', BlobText, 'BLOB field value was not decoded from Base64.');
+
+        // [WHEN] The remaining documented field types are assigned on existing platform records
+        RecordRef.GetTable(TableInformation);
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.decimal', TableInformation.FieldNo("Record Size")), 'Decimal path was not assigned.');
+        RecordRef.SetTable(TableInformation);
+
+        RecordRef.GetTable(ObjectMetadata);
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.date', ObjectMetadata.FieldNo(Date)), 'Date path was not assigned.');
+        RecordRef.SetTable(ObjectMetadata);
+
+        RecordRef.GetTable(AccessControl);
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.guid', AccessControl.FieldNo("User Security ID")), 'GUID path was not assigned.');
+        RecordRef.SetTable(AccessControl);
+
+        RecordRef.GetTable(Profile);
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'fields.code', Profile.FieldNo("Profile ID")), 'Code path was not assigned.');
+        RecordRef.SetTable(Profile);
+
+        // [THEN] Decimal, Date, GUID, and Code conversions are correct
+        Assert.AreEqual(12.5, TableInformation."Record Size", 'Decimal field value is incorrect.');
+        Assert.AreEqual(ExpectedDate, ObjectMetadata.Date, 'Date field value is incorrect.');
+        Assert.AreEqual(ExpectedGuid, AccessControl."User Security ID", 'GUID field value is incorrect.');
+        Assert.AreEqual('LOWERCASE', Profile."Profile ID", 'Code field value is incorrect.');
+    end;
+
+    [Test]
+    procedure TestGetValueAndSetToRecFieldNoHandlesNullAndMissingPaths()
+    var
+        Printer: Record Printer;
+        Json: Codeunit "Json";
+        RecordRef: RecordRef;
+    begin
+        // [GIVEN] A record value and an object with a null property
+        Printer.ID := 'unchanged';
+        RecordRef.GetTable(Printer);
+        Json.InitializeObject('{"nested":{"null":null}}');
+
+        // [THEN] Null and missing paths return false without changing the field
+        Assert.IsFalse(Json.GetValueAndSetToRecFieldNo(RecordRef, 'nested.null', Printer.FieldNo(ID)), 'A null path was assigned to a field.');
+        Assert.IsFalse(Json.GetValueAndSetToRecFieldNo(RecordRef, 'nested.missing', Printer.FieldNo(ID)), 'A missing path was assigned to a field.');
+        RecordRef.SetTable(Printer);
+        Assert.AreEqual('unchanged', Printer.ID, 'A null or missing path changed the target field.');
+    end;
+
+    [Test]
+    procedure TestGetValueAndSetToRecFieldNoSelectsArrayPath()
+    var
+        Printer: Record Printer;
+        Json: Codeunit "Json";
+        RecordRef: RecordRef;
+    begin
+        // [GIVEN] A nested array path
+        Json.InitializeObject('{"items":[{"name":"selected"}]}');
+        RecordRef.GetTable(Printer);
+
+        // [WHEN] The array item path is assigned
+        Assert.IsTrue(Json.GetValueAndSetToRecFieldNo(RecordRef, 'items[0].name', Printer.FieldNo(Name)), 'Array path was not selected.');
+        RecordRef.SetTable(Printer);
+
+        // [THEN] The selected value is assigned
+        Assert.AreEqual('selected', Printer.Name, 'Array path selected an unexpected value.');
+    end;
+
+    [Test]
+    procedure TestGetCollectionAsTextIndentedGoldenOutput()
+    var
+        Json: Codeunit "Json";
+        CRLF: Text[2];
+        ExpectedText: Text;
+    begin
+        // [GIVEN] Nested JSON with empty containers and escaped property/value text
+        Json.InitializeCollection('[{"quoted\"key":"quote\" slash\\ line\r\n","nested":{"emptyObject":{},"emptyArray":[],"values":[1,true,null]}}]');
+        CRLF[1] := 13;
+        CRLF[2] := 10;
+        ExpectedText :=
+            '[' + CRLF +
+            '  {' + CRLF +
+            '    "quoted\"key": "quote\" slash\\ line\r\n",' + CRLF +
+            '    "nested": {' + CRLF +
+            '      "emptyObject": {},' + CRLF +
+            '      "emptyArray": [],' + CRLF +
+            '      "values": [' + CRLF +
+            '        1,' + CRLF +
+            '        true,' + CRLF +
+            '        null' + CRLF +
+            '      ]' + CRLF +
+            '    }' + CRLF +
+            '  }' + CRLF +
+            ']';
+
+        // [WHEN] The collection is formatted with indentation
+        // [THEN] Output exactly matches JsonConvert-compatible indentation and CRLF placement
+        Assert.AreEqual(ExpectedText, Json.GetCollectionAsText(true), 'Indented JSON output does not match the expected golden text.');
     end;
 }

--- a/src/System Application/Test/Json/src/JsonTest.Codeunit.al
+++ b/src/System Application/Test/Json/src/JsonTest.Codeunit.al
@@ -19,6 +19,8 @@ codeunit 139910 "Json Test"
 
     var
         Assert: Codeunit "Library Assert";
+        InvalidJsonArrayErr: Label 'The value is not a valid JSON array.';
+        InvalidJsonObjectErr: Label 'The value is not a valid JSON object.';
 
     [Test]
     procedure TestGetCollectionCount()
@@ -111,6 +113,7 @@ codeunit 139910 "Json Test"
         Assert.AreEqual('Test Name', Printer.Name, 'The Name field was not set correctly.');
     end;
 
+#if not CLEAN30
     [Test]
     procedure TestGetPropertyValueByName()
     var
@@ -123,11 +126,21 @@ codeunit 139910 "Json Test"
         Json.InitializeObject(JsonObjectText);
 
         // [WHEN] Retrieve a value from the JSON object
+#pragma warning disable AL0432
         Json.GetPropertyValueByName('id', Value);
 
         // [THEN] The retrieved value matches the expected value
+        Assert.IsTrue(Value.IsDotNet, 'The legacy property getter must return a DotNet JSON token.');
         Assert.AreEqual('ABC123', Format(Value), 'The retrieved value does not match the expected value.');
+
+        Json.InitializeObject('{"object":{"id":1},"array":[1,2]}');
+        Assert.IsTrue(Json.GetPropertyValueByName('object', Value), 'The object property was not found.');
+        Assert.IsTrue(Value.IsDotNet, 'The legacy object property must return a DotNet JSON token.');
+        Assert.IsTrue(Json.GetPropertyValueByName('array', Value), 'The array property was not found.');
+        Assert.IsTrue(Value.IsDotNet, 'The legacy array property must return a DotNet JSON token.');
+#pragma warning restore AL0432
     end;
+#endif
 
     [Test]
     procedure TestGetStringPropertyValueByName()
@@ -356,6 +369,7 @@ codeunit 139910 "Json Test"
         Json: Codeunit "Json";
     begin
         asserterror Json.XMLTextToJSONText('<!DOCTYPE root [<!ENTITY value "test">]><root>&value;</root>');
+        Assert.ExpectedError('DTD');
     end;
 
     [Test]
@@ -475,16 +489,20 @@ codeunit 139910 "Json Test"
         Json: Codeunit "Json";
     begin
         asserterror Json.InitializeCollection('not json');
+        Assert.ExpectedError(InvalidJsonArrayErr);
         asserterror Json.InitializeObject('not json');
+        Assert.ExpectedError(InvalidJsonObjectErr);
 
         Json.InitializeCollection('[]');
         asserterror Json.AddJObjectToCollection('not json');
+        Assert.ExpectedError(InvalidJsonObjectErr);
         Assert.AreEqual('[]', Json.GetCollectionAsText(), 'Invalid object input changed the collection.');
         Assert.AreEqual('[]', Json.GetCollectionAsText(true), 'Invalid object input changed the indented collection.');
         Assert.AreEqual(0, Json.GetCollectionCount(), 'Invalid object input changed the collection count.');
 
         Json.InitializeCollection('[{}]');
         asserterror Json.ReplaceJObjectInCollection(0, 'not json');
+        Assert.ExpectedError(InvalidJsonObjectErr);
         Assert.AreEqual('[{}]', Json.GetCollectionAsText(), 'Invalid replacement input changed the collection.');
         Assert.AreEqual(1, Json.GetCollectionCount(), 'Invalid replacement input changed the collection count.');
     end;
@@ -652,34 +670,34 @@ codeunit 139910 "Json Test"
         Json.InitializeObject('{"text":"value","integer":42,"decimal":12.5,"boolean":true,"null":null,"object":{"id":1},"array":[1,2]}');
 
         // [WHEN] Scalar values are requested as variants
-        Assert.IsTrue(Json.GetPropertyValueByName('text', Value), 'Text property was not found.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('text', Value), 'Text property was not found.');
         Assert.IsTrue(Value.IsText(), 'Text JSON value was not returned as AL Text.');
         TextValue := Value;
         Assert.AreEqual('value', TextValue, 'Text variant value is incorrect.');
 
-        Assert.IsTrue(Json.GetPropertyValueByName('integer', Value), 'Integer property was not found.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('integer', Value), 'Integer property was not found.');
         Assert.IsTrue(Value.IsInteger(), 'Integer JSON value was not returned as AL Integer.');
         IntegerValue := Value;
         Assert.AreEqual(42, IntegerValue, 'Integer variant value is incorrect.');
 
-        Assert.IsTrue(Json.GetPropertyValueByName('decimal', Value), 'Decimal property was not found.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('decimal', Value), 'Decimal property was not found.');
         Assert.IsTrue(Value.IsDecimal(), 'Decimal JSON value was not returned as AL Decimal.');
         DecimalValue := Value;
         Assert.AreEqual(12.5, DecimalValue, 'Decimal variant value is incorrect.');
 
-        Assert.IsTrue(Json.GetPropertyValueByName('boolean', Value), 'Boolean property was not found.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('boolean', Value), 'Boolean property was not found.');
         Assert.IsTrue(Value.IsBoolean(), 'Boolean JSON value was not returned as AL Boolean.');
         BooleanValue := Value;
         Assert.IsTrue(BooleanValue, 'Boolean variant value is incorrect.');
 
         // [THEN] Native object and array values are carried directly by Variant
-        Assert.IsTrue(Json.GetPropertyValueByName('object', Value), 'Object property was not found.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('object', Value), 'Object property was not found.');
         Assert.IsTrue(Value.IsJsonObject(), 'Object JSON value was not returned as a native JsonObject.');
         ObjectValue := Value;
         ObjectValue.WriteTo(TextValue);
         Assert.AreEqual('{"id":1}', TextValue, 'Object variant value is incorrect.');
 
-        Assert.IsTrue(Json.GetPropertyValueByName('array', Value), 'Array property was not found.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('array', Value), 'Array property was not found.');
         Assert.IsTrue(Value.IsJsonArray(), 'Array JSON value was not returned as a native JsonArray.');
         ArrayValue := Value;
         ArrayValue.WriteTo(TextValue);
@@ -699,7 +717,7 @@ codeunit 139910 "Json Test"
 
         // [WHEN] The null property is requested
         Value := 'not cleared';
-        Assert.IsTrue(Json.GetPropertyValueByName('null', Value), 'An existing null property was reported as missing.');
+        Assert.IsTrue(Json.GetNativePropertyValueByName('null', Value), 'An existing null property was reported as missing.');
 
         // [THEN] JSON null is represented by a cleared Variant
         Assert.AreEqual('', Format(Value), 'JSON null did not clear the Variant value.');
@@ -709,7 +727,7 @@ codeunit 139910 "Json Test"
         Value := 'not cleared';
 
         // [THEN] The call returns false and still clears the output Variant
-        Assert.IsFalse(Json.GetPropertyValueByName('missing', Value), 'A missing property was reported as present.');
+        Assert.IsFalse(Json.GetNativePropertyValueByName('missing', Value), 'A missing property was reported as present.');
         Assert.AreEqual('', Format(Value), 'A missing property did not clear the Variant value.');
 
         // [THEN] String null is empty, while a typed null is rejected


### PR DESCRIPTION
## Why

Codeunits 5459 `JSON Management` and 1234 `Json Text Reader/Writer` expose legacy Newtonsoft/.NET-based JSON handling throughout Base Application and dependent apps. This change migrates first-party callers to native AL JSON types and establishes the compatibility lifecycle needed to remove the legacy helpers under `CLEAN30`.

## What changed

- Migrated production, test, and test-library callers to `JsonObject`, `JsonArray`, `JsonToken`, and `JsonValue`.
- Reworked the System Application `Json` implementation to use native AL JSON state, parsing, mutation, path selection, cloning, field conversion, and formatting.
- Replaced Power Automate environment-response parsing with native AL JSON and added focused parser coverage.
- Added strict native JSON Buffer parsing while preserving the existing permissive Json.NET-backed `ReadFromText` and `ReadFromBlob` APIs as obsolete compatibility surfaces until `CLEAN30`.
- Preserved the legacy DotNet Variant shape of public `Json.GetPropertyValueByName` until `CLEAN30` and added `GetNativePropertyValueByName` for native AL values.
- Marked codeunits 5459 and 1234 as pending obsolete and wrapped them with `CLEAN30`.
- Kept compatibility overloads only for public production APIs and the externally subscribable Workflow event; removed legacy signatures directly from internal and test-only objects.
- Excluded `JsonTextReader`, `JsonTextWriter`, `JObject`, `JArray`, `JToken`, `JProperty`, and `JValue` aliases from `CLEAN30` builds after removing their clean-build consumers.

## Compatibility boundary

Normal builds retain public DotNet compatibility surfaces, including the original `Json.GetPropertyValueByName` and permissive JSON Buffer readers. Their native replacements are available immediately and the legacy procedures are pending obsolete for 30.0. `CLEAN30` removes the legacy APIs, the two helper codeunits, their remaining compatibility calls, and the native-replaceable Newtonsoft aliases together.

Newtonsoft remains only for capabilities without a direct native AL replacement:

- XML-to-JSON and JSON-to-XML conversion using Json.NET `XmlNodeConverter` semantics.
- Business Chart and Generic Chart serialization of CLR chart models.
- Performance Profiler deserialization into the CLR `CpuProfile` model.

This PR does not change those payload formats or CLR domain models.

## Tests

- Expanded System Application Json characterization for invalid input, legacy/native Variant shapes, state independence, clone behavior, property order, field conversions, indentation, BOM, DTD rejection, and XML declaration behavior.
- Added Power Automate environment parsing coverage for provisioning-state casing, defaults, null/missing properties, and malformed responses.
- Expanded JSON Buffer coverage for legacy Json.NET extensions, strict native root objects/arrays/scalars, paths, depth, standard scalar types, BLOB input, long Unicode text, and malformed input.
- Added focused blank-dimension round-trip coverage for Graph complex types.
- Added or updated focused coverage for Pagero file-part errors.
- Migrated affected API, Graph, Power BI, Sustainability, Image Analysis, Hybrid, and localized tests to native JSON types.

Fixes [AB#649586](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649586)











