### PR TITLE
Ignore generated AL tooling files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,6 +320,12 @@ TestResults.xml
 #Build files
 *.al.bak
 
+# AL code review output
+.bc-review/
+
+# A view metadata for W1 and country-specific layers
+src/Layers/*/.view/*
+
 # Jupyter Notebook
 *.ipynb_checkpoints
 *.ipynb


### PR DESCRIPTION
## Why

AL code review and layered-view tooling generate local metadata and report files that appear as untracked changes and clutter the working tree.

## What changed

- Ignore generated `.bc-review/` output.
- Ignore `layered_view_files.json` for every layer directory, including `W1` and country codes such as `GB` and `DK`.

## Validation

Verified the ignore rule with `W1`, `GB`, and `DK` layer paths and confirmed no generated files remain visible in `git status`.

Fixes [AB#649853](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649853)
