### PR TITLE
[29.0] - Bug 649843: Composite layout stress-test fixes, part resolution source and status action captions

### DIFF
--- a/src/Layers/W1/BaseApp/Foundation/Reporting/NewReportThemeHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/NewReportThemeHeaderFooter.Page.al
@@ -35,6 +35,13 @@ page 9668 "New Report Theme Header/Footer"
                 Caption = 'Description';
                 ToolTip = 'Specifies a description for the new theme or header/footer.';
             }
+            field(CreateEmptyLayoutField; CreateEmptyLayout)
+            {
+                ApplicationArea = Basic, Suite;
+                Caption = 'Create a Blank Layout';
+                Visible = IsHeaderFooter and not EditMode;
+                ToolTip = 'Specifies whether to create a blank header/footer that you can export and edit, instead of uploading a file.';
+            }
         }
     }
 
@@ -50,6 +57,8 @@ page 9668 "New Report Theme Header/Footer"
             DialogCaption := NewThemeCaptionLbl
         else
             DialogCaption := NewHeaderFooterCaptionLbl;
+
+        IsHeaderFooter := NewSubtype = Enum::"Report Layout Subtype"::HeaderFooter;
     end;
 
     internal procedure GetPartName(): Text[250]
@@ -60,6 +69,11 @@ page 9668 "New Report Theme Header/Footer"
     internal procedure GetPartDescription(): Text[250]
     begin
         exit(PartDescription);
+    end;
+
+    internal procedure GetCreateEmptyLayout(): Boolean
+    begin
+        exit(CreateEmptyLayout);
     end;
 
     /// <summary>
@@ -76,8 +90,10 @@ page 9668 "New Report Theme Header/Footer"
     var
         PartName: Text[250];
         PartDescription: Text[250];
+        CreateEmptyLayout: Boolean;
         DialogCaption: Text;
         EditMode: Boolean;
+        IsHeaderFooter: Boolean;
         NewThemeCaptionLbl: Label 'New Theme';
         NewHeaderFooterCaptionLbl: Label 'New Header/Footer';
         EditDescriptionCaptionLbl: Label 'Edit Description';

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutSelection.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutSelection.Page.al
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.Foundation.Reporting;
 
+using Microsoft.Shared.Report;
 using System.Environment;
 using System.Environment.Configuration;
 using System.Reflection;
@@ -557,6 +558,9 @@ page 9652 "Report Layout Selection"
 
     local procedure ShowResolvedLayoutParts()
     var
+        DefaultReportLayoutList: Record "Report Layout List";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+        LayoutKey: Text;
         HeaderDisplay: Text;
         HeaderSource: Text;
         ThemeDisplay: Text;
@@ -565,9 +569,15 @@ page 9652 "Report Layout Selection"
         if Rec."Report ID" = 0 then
             Error(SelectReportFirstErr);
 
-        // Walk the same Tenant Report Layout Cfg precedence the platform uses at render time, so the message reflects
-        // the parts that will actually apply — including report, company and global defaults — not only a layout-level row.
-        LookupHelper.GetResolvedPartDisplays(Rec."Report ID", '', HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
+        ReportLayoutsImpl.SetSelectedCompany(SelectedCompany);
+        if ReportLayoutsImpl.GetDefaultReportLayoutSelection(Rec."Report ID", DefaultReportLayoutList) then
+            LayoutKey := LookupHelper.CompositeLayoutKey(DefaultReportLayoutList);
+
+        if LayoutKey <> '' then
+            LookupHelper.GetResolvedPartDisplays(Rec."Report ID", LayoutKey, HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource)
+        else
+            LookupHelper.GetReportLevelPartDisplays(Rec."Report ID", HeaderDisplay, HeaderSource, ThemeDisplay, ThemeSource);
+
         Message(ShowLayoutPartsMsg, FormatPartDisplay(HeaderDisplay, HeaderSource), FormatPartDisplay(ThemeDisplay, ThemeSource));
     end;
 

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayouts.page.al
@@ -498,7 +498,7 @@ page 9660 "Report Layouts"
             action(SetApproved)
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Set Approved';
+                Caption = 'Set as Approved';
                 ToolTip = 'Mark the selected layouts as approved. Only approved layouts are available for selection on report request pages.';
                 Image = Approve;
                 Enabled = CanModifyStatus;
@@ -512,7 +512,7 @@ page 9660 "Report Layouts"
             action(SetDraft)
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Set Draft';
+                Caption = 'Set as Draft';
                 ToolTip = 'Mark the selected layouts as draft. Draft layouts are not available for selection on report request pages.';
                 Image = OpenWorksheet;
                 Enabled = CanModifyStatus;
@@ -526,7 +526,7 @@ page 9660 "Report Layouts"
             action(SetPendingApproval)
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Set Pending Approval';
+                Caption = 'Set as Pending Approval';
                 ToolTip = 'Mark the selected layouts as pending approval. Pending layouts are not available for selection on report request pages.';
                 Image = AddWatch;
                 Enabled = CanModifyStatus;
@@ -540,7 +540,7 @@ page 9660 "Report Layouts"
             action(SetRetired)
             {
                 ApplicationArea = Basic, Suite;
-                Caption = 'Set Retired';
+                Caption = 'Set as Retired';
                 ToolTip = 'Mark the selected layouts as retired. Retired layouts are not available for selection on report request pages.';
                 Image = Archive;
                 Enabled = CanModifyStatus;

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportLayoutsImpl.codeunit.al
@@ -7,6 +7,7 @@ namespace Microsoft.Shared.Report;
 using Microsoft.EServices.EDocument;
 using Microsoft.Foundation.Reporting;
 using System;
+using System.Environment;
 using System.Environment.Configuration;
 using System.IO;
 using System.Reflection;
@@ -22,7 +23,8 @@ codeunit 9660 "Report Layouts Impl."
     Access = Internal;
     Permissions = tabledata "Tenant Report Layout" = rimd,
                   tabledata "Tenant Report Layout Selection" = rimd,
-                  tabledata "Tenant Report Layout Override" = rimd;
+                  tabledata "Tenant Report Layout Override" = rimd,
+                  tabledata Company = r;
 
     var
         TenantReportLayoutSelection: Record "Tenant Report Layout Selection";
@@ -45,6 +47,11 @@ codeunit 9660 "Report Layouts Impl."
         CannotUpdateLayoutTxt: Label 'The Layout could not be updated for export. The exported file will contain the original layout.';
         LayoutAlreadyExistsErr: Label 'A layout named "%1" already exists.', Comment = '%1 = Layout Name';
         MixedScopeErr: Label 'The selected layouts have different scopes. Some apply to all companies and some only to the current company. Select layouts of a single scope and try again.';
+        EmptyLayoutFileErr: Label 'The file "%1" is empty. Choose a file that contains a layout and try again.', Comment = '%1 = File Name';
+        EmptyGeneratedLayoutErr: Label 'A blank layout could not be generated for this report. Clear the blank layout option and choose a layout file instead.';
+        CannotChangeStatusOfDefaultErr: Label 'You cannot set "%1" to %2 while it is the default layout for report "%3". Select another default layout first.', Comment = '%1 = Layout Name, %2 = New Status, %3 = Report Name';
+        CannotChangeStatusOfDefaultInCompanyErr: Label 'You cannot set "%1" to %2 because it is the default layout for report "%3" in company "%4", and the status applies to all companies. Select another default layout in that company first.', Comment = '%1 = Layout Name, %2 = New Status, %3 = Report Name, %4 = Company Name';
+        DefaultFallbackTxt: Label '"%1" is the layout that report "%2" falls back to, and it is no longer approved. The report keeps using it until you select another default layout.', Comment = '%1 = Layout Name, %2 = Report Name';
 
     internal procedure SetSelectedCompany(NewCompanyName: Text)
     begin
@@ -81,6 +88,85 @@ codeunit 9660 "Report Layouts Impl."
             exit(true);
         end;
         exit(false);
+    end;
+
+    local procedure ErrorIfLayoutIsDefault(ReportLayoutList: Record "Report Layout List"; NewStatus: Enum "Report Layout Status")
+    var
+        TenantReportLayoutSelectionLocal: Record "Tenant Report Layout Selection";
+    begin
+        if NewStatus = Enum::"Report Layout Status"::Approved then
+            exit;
+
+        // A default that is already unapproved loses nothing by moving between the other statuses, and blocking
+        // that would strand it outside the approval flow with Approved as its only reachable status.
+        if ReportLayoutList."Layout Status" <> Enum::"Report Layout Status"::Approved then
+            exit;
+
+        // One read covers the common case, where the layout is nobody's explicit default.
+        TenantReportLayoutSelectionLocal.SetRange("Report ID", ReportLayoutList."Report ID");
+        TenantReportLayoutSelectionLocal.SetRange("User ID", EmptyGuid);
+        TenantReportLayoutSelectionLocal.SetRange("Layout Name", ReportLayoutList."Name");
+        TenantReportLayoutSelectionLocal.SetRange("App ID", ReportLayoutList."Application ID");
+        if not TenantReportLayoutSelectionLocal.FindSet() then
+            exit;
+
+        repeat
+            if TenantReportLayoutSelectionLocal."Company Name" = OverrideCompany() then
+                Error(CannotChangeStatusOfDefaultErr, ReportLayoutList.Caption, Format(NewStatus), ReportLayoutList."Report Name");
+        until TenantReportLayoutSelectionLocal.Next() = 0;
+
+        // A company-scoped override moves the status in this company only, so no other company can be left behind.
+        if not StatusChangeIsGlobalScope(ReportLayoutList) then
+            exit;
+
+        TenantReportLayoutSelectionLocal.FindSet();
+        repeat
+            if OtherCompanyLosesItsDefault(ReportLayoutList, TenantReportLayoutSelectionLocal."Company Name") then
+                Error(CannotChangeStatusOfDefaultInCompanyErr, ReportLayoutList.Caption, Format(NewStatus), ReportLayoutList."Report Name", TenantReportLayoutSelectionLocal."Company Name");
+        until TenantReportLayoutSelectionLocal.Next() = 0;
+    end;
+
+    /// <summary>
+    /// Tells whether a global status change would leave the given company with an unapproved default layout.
+    /// </summary>
+    local procedure OtherCompanyLosesItsDefault(ReportLayoutList: Record "Report Layout List"; SelectionCompanyName: Text[30]): Boolean
+    var
+        Company: Record Company;
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+    begin
+        if SelectionCompanyName = OverrideCompany() then
+            exit(false);
+
+        // A selection row can outlive the company it names. Naming a company the user cannot open would block the
+        // status change with no way to act on the message.
+        if not Company.Get(SelectionCompanyName) then
+            exit(false);
+
+        // That company keeps its own status for this layout, so the global write never reaches it.
+        if TenantReportLayoutOverride.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", ReportLayoutList."Runtime Package ID", SelectionCompanyName) then
+            if TenantReportLayoutOverride."Override Layout Status" then
+                exit(false);
+
+        exit(true);
+    end;
+
+    /// <summary>
+    /// Tells whether a status change on this layout applies to every company. An extension-installed layout is
+    /// company-scoped only while an "Override Layout Status" row exists for the current company; a user-defined
+    /// layout is company-scoped only when the layout itself belongs to a single company.
+    /// </summary>
+    local procedure StatusChangeIsGlobalScope(ReportLayoutList: Record "Report Layout List"): Boolean
+    var
+        TenantReportLayout: Record "Tenant Report Layout";
+    begin
+        if not ReportLayoutList."User Defined" then
+            exit(LayoutStatusIsGlobalScope(ReportLayoutList));
+
+        // No layout row means SetLayoutStatus will not change anything, so nothing can be left behind either.
+        if not TenantReportLayout.Get(ReportLayoutList."Report ID", ReportLayoutList."Name", EmptyGuid) then
+            exit(false);
+
+        exit(TenantReportLayout."Company Name" = '');
     end;
 
     local procedure LayoutStatusIsGlobalScope(ReportLayoutList: Record "Report Layout List"): Boolean
@@ -152,12 +238,18 @@ codeunit 9660 "Report Layouts Impl."
         UpdateCount: Integer;
         HasGlobalScope: Boolean;
         HasCompanyScope: Boolean;
+        FallbackMessages: List of [Text];
     begin
         if not ReportLayoutList.FindSet() then
             exit(0);
 
         // First pass: classify scope. User-defined layouts update in place and do not affect it.
         repeat
+            ErrorIfLayoutIsDefault(ReportLayoutList, NewStatus);
+
+            if IsMetadataDefaultLayout(ReportLayoutList, NewStatus) then
+                FallbackMessages.Add(StrSubstNo(DefaultFallbackTxt, ReportLayoutList.Caption, ReportLayoutList."Report Name"));
+
             if not ReportLayoutList."User Defined" then
                 if LayoutStatusIsGlobalScope(ReportLayoutList) then
                     HasGlobalScope := true
@@ -178,8 +270,42 @@ codeunit 9660 "Report Layouts Impl."
             CustomDimensions.Add('NewStatus', Format(NewStatus));
             CustomDimensions.Add('UpdateCount', Format(UpdateCount));
             Log('0000RTN', 'Report layout status changed by user', CustomDimensions);
+
+            NotifyDefaultFallback(FallbackMessages);
         end;
         exit(UpdateCount);
+    end;
+
+    local procedure NotifyDefaultFallback(FallbackMessages: List of [Text])
+    var
+        FallbackNotification: Notification;
+        FallbackMessage: Text;
+    begin
+        foreach FallbackMessage in FallbackMessages do begin
+            Clear(FallbackNotification);
+            FallbackNotification.Message(FallbackMessage);
+            FallbackNotification.Scope(NotificationScope::LocalScope);
+            FallbackNotification.Send();
+        end;
+    end;
+
+    local procedure IsMetadataDefaultLayout(ReportLayoutList: Record "Report Layout List"; NewStatus: Enum "Report Layout Status"): Boolean
+    var
+        TenantReportLayoutSelectionLocal: Record "Tenant Report Layout Selection";
+        DefaultReportLayoutList: Record "Report Layout List";
+    begin
+        if NewStatus = Enum::"Report Layout Status"::Approved then
+            exit(false);
+
+        if TenantReportLayoutSelectionLocal.Get(ReportLayoutList."Report ID", OverrideCompany(), EmptyGuid) then
+            exit(false);
+
+        if not GetDefaultReportLayoutSelection(ReportLayoutList."Report ID", DefaultReportLayoutList) then
+            exit(false);
+
+        if DefaultReportLayoutList.Name <> ReportLayoutList.Name then
+            exit(false);
+        exit(DefaultReportLayoutList."Application ID" = ReportLayoutList."Application ID");
     end;
 
     internal procedure RunCustomReport(SelectedReportLayoutList: Record "Report Layout List")
@@ -312,7 +438,7 @@ codeunit 9660 "Report Layouts Impl."
         TenantReportLayoutSelection.Init();
         DefaultReportLayoutList.Init();
 
-        if TenantReportLayoutSelection.Get(ReportId, SelectedCompany, EmptyGuid) then begin
+        if TenantReportLayoutSelection.Get(ReportId, OverrideCompany(), EmptyGuid) then begin
             // Filter Default Report Layout List by the layout name and application id and report id
             DefaultReportLayoutList.SetRange("Name", TenantReportLayoutSelection."Layout Name");
             DefaultReportLayoutList.SetRange("Application ID", TenantReportLayoutSelection."App ID");
@@ -381,11 +507,17 @@ codeunit 9660 "Report Layouts Impl."
     end;
 
     internal procedure InsertNewLayout(ReportID: Integer; LayoutName: Text[250]; LayoutDescription: Text[250]; LayoutFormat: Option; LayoutIsGlobal: Boolean; CreateEmptyLayout: Boolean; ExcelSheetConfiguration: Enum "Excel Sheet Configuration"; LayoutSubtype: Enum "Report Layout Subtype"; var ReturnReportID: Integer; var ReturnLayoutName: Text)
+    begin
+        InsertNewLayout(ReportID, LayoutName, LayoutDescription, LayoutFormat, LayoutIsGlobal, CreateEmptyLayout, ExcelSheetConfiguration, LayoutSubtype, false, ReturnReportID, ReturnLayoutName);
+    end;
+
+    internal procedure InsertNewLayout(ReportID: Integer; LayoutName: Text[250]; LayoutDescription: Text[250]; LayoutFormat: Option; LayoutIsGlobal: Boolean; CreateEmptyLayout: Boolean; ExcelSheetConfiguration: Enum "Excel Sheet Configuration"; LayoutSubtype: Enum "Report Layout Subtype"; ReplaceExisting: Boolean; var ReturnReportID: Integer; var ReturnLayoutName: Text)
     var
         TenantReportLayout: Record "Tenant Report Layout";
         FileManagement: Codeunit "File Management";
         DocumentReportManagement: Codeunit "Document Report Mgt.";
         TempBlob: Codeunit "Temp Blob";
+        UploadedBlob: Codeunit "Temp Blob";
         FileFilterTxt: Text;
         DialogCaption: Text;
         NVInStream: InStream;
@@ -403,6 +535,10 @@ codeunit 9660 "Report Layouts Impl."
             Message(EmptyLayoutNameTxt);
             exit;
         end;
+
+        if not ReplaceExisting then
+            if TenantReportLayout.Get(ReportID, LayoutName, EmptyGuid) then
+                Error(LayoutAlreadyExistsErr, LayoutName);
 
         TenantReportLayout.Init();
         TenantReportLayout."Report ID" := ReportID;
@@ -453,6 +589,9 @@ codeunit 9660 "Report Layouts Impl."
                     end;
             end;
 
+            if EmptyLayoutCreated then
+                if TempBlob.Length() = 0 then
+                    Error(EmptyGeneratedLayoutErr);
         end;
 
         if (not EmptyLayoutCreated) then begin
@@ -510,11 +649,16 @@ codeunit 9660 "Report Layouts Impl."
             // Custom layouts files are treated as unknown streams and don't need validation.
             if TenantReportLayout."Layout Format" <> TenantReportLayout."Layout Format"::Custom then
                 FileManagement.ValidateFileExtension(UploadFileName, FileFilterTxt);
+
+            CopyStream(UploadedBlob.CreateOutStream(), NVInStream);
+            if UploadedBlob.Length() = 0 then
+                Error(EmptyLayoutFileErr, UploadFileName);
+            NVInStream := UploadedBlob.CreateInStream();
         end;
 
-        // If the current layout is being replaced using the ReplaceLayout action
-        if TenantReportLayout.Get(TenantReportLayout."Report ID", TenantReportLayout."Name", TenantReportLayout."App ID") then
-            TenantReportLayout.Delete(true);
+        if ReplaceExisting then
+            if TenantReportLayout.Get(TenantReportLayout."Report ID", TenantReportLayout."Name", TenantReportLayout."App ID") then
+                TenantReportLayout.Delete(true);
 
         TenantReportLayout."Layout".ImportStream(NVInStream, TenantReportLayout."Description");
         TenantReportLayout."MIME Type" := CreateLayoutMime(UploadFileName);
@@ -564,7 +708,7 @@ codeunit 9660 "Report Layouts Impl."
         TenantReportLayout."Name" := LayoutName;
 
         if TenantReportLayout.Get(ReportID, LayoutName, TenantReportLayout."App ID") then begin
-            InsertNewLayout(ReportID, LayoutName, LayoutDescription, LayoutFormat, TenantReportLayout."Company Name" = '', false, TenantReportLayout.ExcelLayoutMultipleDataSheets, TenantReportLayout."Layout Subtype", ReturnReportID, ReturnLayoutName);
+            InsertNewLayout(ReportID, LayoutName, LayoutDescription, LayoutFormat, TenantReportLayout."Company Name" = '', false, TenantReportLayout.ExcelLayoutMultipleDataSheets, TenantReportLayout."Layout Subtype", true, ReturnReportID, ReturnLayoutName);
 
             InitReportLayoutDimensions(TenantReportLayout, CustomDimensions);
             AddReportLayoutDimensionsDescription(LayoutDescription, CustomDimensions);

--- a/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
+++ b/src/Layers/W1/BaseApp/Foundation/Reporting/ReportThemeandHeaderFooter.Page.al
@@ -179,7 +179,7 @@ page 9666 "Report Theme and Header/Footer"
                 action(SetApproved)
                 {
                     ApplicationArea = Basic, Suite;
-                    Caption = 'Set Approved';
+                    Caption = 'Set as Approved';
                     Image = Approve;
                     Scope = Repeater;
                     ToolTip = 'Approve the selected parts so they can be assigned as report defaults.';
@@ -192,7 +192,7 @@ page 9666 "Report Theme and Header/Footer"
                 action(SetDraft)
                 {
                     ApplicationArea = Basic, Suite;
-                    Caption = 'Set Draft';
+                    Caption = 'Set as Draft';
                     Image = OpenWorksheet;
                     Scope = Repeater;
                     ToolTip = 'Move the selected parts back to Draft. Draft parts cannot be assigned as report defaults.';
@@ -205,7 +205,7 @@ page 9666 "Report Theme and Header/Footer"
                 action(SetPendingApproval)
                 {
                     ApplicationArea = Basic, Suite;
-                    Caption = 'Set Pending Approval';
+                    Caption = 'Set as Pending Approval';
                     Image = AddWatch;
                     Scope = Repeater;
                     ToolTip = 'Mark the selected parts as pending approval.';
@@ -218,7 +218,7 @@ page 9666 "Report Theme and Header/Footer"
                 action(SetRetired)
                 {
                     ApplicationArea = Basic, Suite;
-                    Caption = 'Set Retired';
+                    Caption = 'Set as Retired';
                     Image = Archive;
                     Scope = Repeater;
                     ToolTip = 'Retire the selected parts so they are no longer offered for assignment.';
@@ -291,7 +291,7 @@ page 9666 "Report Theme and Header/Footer"
             NewPartDialog.GetPartDescription(),
             Rec."Layout Format"::Word,
             true,
-            false,
+            NewPartDialog.GetCreateEmptyLayout(),
             ExcelSheetConfiguration,
             Subtype,
             ReturnReportID,

--- a/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al
@@ -23,6 +23,9 @@ codeunit 134619 "Composite Layout Tests"
         CompanySourceTok: Label 'Company', Locked = true;
         GlobalDefaultSourceTok: Label 'Global default', Locked = true;
         DocumentReportExperienceTok: Label 'DocumentReportExperience', Locked = true;
+        ExtensionLayoutTok: Label 'MYLAYOUT', Locked = true;
+        ActingCompanyTok: Label 'Layout Status Test Co', Locked = true;
+        MissingCompanyTok: Label 'Removed Test Company', Locked = true;
         TestReportID: Integer;
         BodyReportID: Integer;
         PartsReportID: Integer;
@@ -929,6 +932,220 @@ codeunit 134619 "Composite Layout Tests"
         RestoreDocumentReportExperience();
     end;
 
+    [Test]
+    [HandlerFunctions('PartInfoMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ShowLayoutPartsReportsAReportDefaultAssignment()
+    var
+        ActualMessage: Text;
+    begin
+        // [SCENARIO 648842] Show layout parts on the Report Layout Selection page reports a report-level assignment
+        // with the 'Report default' source, resolved through the layout the report actually uses.
+        Initialize();
+        EnableDocumentReportExperience();
+
+        // [GIVEN] A report-level assignment (this report, all layouts) and no layout-scoped assignment.
+        InsertCfg(BodyReportID, '', '', CreatePart('SelectionRepHF', Enum::"Report Layout Subtype"::HeaderFooter), CreatePart('SelectionRepTheme', Enum::"Report Layout Subtype"::Theme));
+
+        // [WHEN] Invoking Show layout parts for that report.
+        InvokeShowLayoutParts(BodyReportID);
+
+        // [THEN] Both parts are reported as coming from the report default.
+        ActualMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage('SelectionRepHF (from ' + ReportDefaultSourceTok + ')', ActualMessage);
+        Assert.ExpectedMessage('SelectionRepTheme (from ' + ReportDefaultSourceTok + ')', ActualMessage);
+        LibraryVariableStorage.AssertEmpty();
+
+        RestoreDocumentReportExperience();
+    end;
+
+    [Test]
+    [HandlerFunctions('PartInfoMessageHandler')]
+    [Scope('OnPrem')]
+    procedure ShowLayoutPartsPrefersTheAssignmentOnTheDefaultLayout()
+    var
+        ActualMessage: Text;
+        BodyKey: Text;
+    begin
+        // [SCENARIO 648842] When the default layout of the report carries its own header/footer assignment, Show
+        // layout parts reports that assignment - not the report-level one it would otherwise fall back to. Before
+        // the fix the action always resolved with an empty layout name, so the layout-scoped row was never seen.
+        Initialize();
+        EnableDocumentReportExperience();
+
+        // [GIVEN] A layout that is the default for the report, with a header assigned on the layout itself, and a
+        // different header assigned at the report level.
+        BodyKey := CreateLayoutOnReport(BodyReportID, 'SelectionBody', Enum::"Report Layout Subtype"::Body);
+        SetDefaultLayout(BodyReportID, 'SelectionBody');
+        InsertCfg(BodyReportID, '', '', CreatePart('LosingRepHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
+        InsertCfg(BodyReportID, BodyKey, '', CreatePart('WinningLayoutHF', Enum::"Report Layout Subtype"::HeaderFooter), '');
+
+        // [WHEN] Invoking Show layout parts for that report.
+        InvokeShowLayoutParts(BodyReportID);
+
+        // [THEN] The assignment on the default layout wins and is reported as 'This layout'.
+        ActualMessage := LibraryVariableStorage.DequeueText();
+        Assert.ExpectedMessage('WinningLayoutHF (from ' + ThisLayoutSourceTok + ')', ActualMessage);
+        Assert.AreEqual(0, StrPos(ActualMessage, 'LosingRepHF'), 'The report-level assignment must not win over the one on the default layout.');
+        LibraryVariableStorage.AssertEmpty();
+
+        RestoreDocumentReportExperience();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure StatusOfTheDefaultLayoutCannotBeChanged()
+    begin
+        // [SCENARIO 649379] A layout that is the default for the report in this company cannot be moved out of
+        // Approved, because that would leave the report with an unapproved default.
+        Initialize();
+
+        // [GIVEN] An approved layout that is the default for the report in this company.
+        CreateLayoutOnReport(BodyReportID, 'CurrentDefaultBody', Enum::"Report Layout Subtype"::Body);
+        SetLayoutStatusTo(BodyReportID, 'CurrentDefaultBody', Enum::"Report Layout Status"::Approved);
+        SetDefaultLayout(BodyReportID, 'CurrentDefaultBody');
+
+        // [WHEN] Setting its status to Draft.
+        asserterror SetLayoutStatusBatchAs(ThisCompany(), BodyReportID, 'CurrentDefaultBody', Enum::"Report Layout Status"::Draft);
+
+        // [THEN] The status change is refused and the message names the layout.
+        Assert.ExpectedError('while it is the default layout');
+        Assert.ExpectedError('CurrentDefaultBody');
+
+        ClearDefaultLayoutSelections();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure StatusChangeIgnoresADefaultLeftBehindByADeletedCompany()
+    var
+        UpdateCount: Integer;
+    begin
+        // [SCENARIO 649379] A selection row can outlive the company it names. Treating one as a blocker would
+        // strand the layout, with an error telling the user to choose another default in a company they cannot open.
+        Initialize();
+
+        // [GIVEN] An approved global layout recorded as the default for a company that does not exist.
+        CreateLayoutOnReport(BodyReportID, 'StaleDefaultBody', Enum::"Report Layout Subtype"::Body);
+        SetLayoutStatusTo(BodyReportID, 'StaleDefaultBody', Enum::"Report Layout Status"::Approved);
+        SelectDefaultLayoutInCompany(BodyReportID, 'StaleDefaultBody', MissingCompanyTok);
+
+        // [WHEN] Setting its status to Draft.
+        UpdateCount := SetLayoutStatusBatchAs(ThisCompany(), BodyReportID, 'StaleDefaultBody', Enum::"Report Layout Status"::Draft);
+
+        // [THEN] The stale row is ignored and the status change goes through.
+        Assert.AreEqual(1, UpdateCount, 'A default left behind by a deleted company should not block the change.');
+
+        ClearDefaultLayoutSelections();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure StatusOfADefaultThatIsAlreadyUnapprovedCanStillChange()
+    var
+        UpdateCount: Integer;
+    begin
+        // [SCENARIO 649379] The guard protects an approved default. One that is already unapproved loses nothing
+        // by moving between the other statuses, so the approval flow must stay open to it.
+        Initialize();
+
+        // [GIVEN] A draft layout that is the default for the report.
+        CreateLayoutOnReport(BodyReportID, 'DraftDefaultBody', Enum::"Report Layout Subtype"::Body);
+        SetLayoutStatusTo(BodyReportID, 'DraftDefaultBody', Enum::"Report Layout Status"::Draft);
+        SetDefaultLayout(BodyReportID, 'DraftDefaultBody');
+
+        // [WHEN] Moving it on to Pending Approval.
+        UpdateCount := SetLayoutStatusBatchAs(ThisCompany(), BodyReportID, 'DraftDefaultBody', Enum::"Report Layout Status"::"Pending Approval");
+
+        // [THEN] The status change goes through.
+        Assert.AreEqual(1, UpdateCount, 'An already unapproved default should still be able to change status.');
+
+        ClearDefaultLayoutSelections();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure StatusOfALayoutThatIsDefaultInAnotherCompanyCannotBeChanged()
+    begin
+        // [SCENARIO 649379] The status of a global layout is written once for every company, so a default selected
+        // in another company has to be checked too - otherwise that company is left with exactly the unapproved
+        // default this guard exists to prevent.
+        Initialize();
+
+        // [GIVEN] An approved global layout that is the default in this company.
+        CreateLayoutOnReport(BodyReportID, 'OtherCompanyDefaultBody', Enum::"Report Layout Subtype"::Body);
+        SetLayoutStatusTo(BodyReportID, 'OtherCompanyDefaultBody', Enum::"Report Layout Status"::Approved);
+        SelectDefaultLayoutInCompany(BodyReportID, 'OtherCompanyDefaultBody', ThisCompany());
+
+        // [WHEN] Setting its status to Draft while the action runs as a different company.
+        // The roles are the way round they are so the test does not depend on how many companies the test database
+        // has: the action runs as a company that holds no default, which leaves this company - a real one, which is
+        // what the guard requires before it treats a company as affected - playing the other company.
+        asserterror SetLayoutStatusBatchAs(ActingCompanyTok, BodyReportID, 'OtherCompanyDefaultBody', Enum::"Report Layout Status"::Draft);
+
+        // [THEN] The status change is refused and the message names the company that would lose its default.
+        Assert.ExpectedError('the status applies to all companies');
+        Assert.ExpectedError(CompanyName());
+
+        ClearDefaultLayoutSelections();
+    end;
+
+    [Test]
+    [HandlerFunctions('FallbackNotificationHandler')]
+    [Scope('OnPrem')]
+    procedure CompanyScopedStatusChangeIgnoresADefaultInAnotherCompany()
+    var
+        UpdateCount: Integer;
+    begin
+        // [SCENARIO 649379] A layout whose status is overridden per company changes in this company only, so a
+        // default selected in another company is untouched by it and must not block the change.
+        Initialize();
+
+        // [GIVEN] An extension-installed layout whose status is overridden for the company the action runs as,
+        // and which is the default in another company.
+        SeedCompanyScopedStatusOverride(BodyReportID, ExtensionLayoutTok, ActingCompanyTok);
+        SelectDefaultLayoutInCompany(BodyReportID, ExtensionLayoutTok, ThisCompany());
+
+        // [WHEN] Setting its status to Draft.
+        UpdateCount := SetLayoutStatusBatchAs(ActingCompanyTok, BodyReportID, ExtensionLayoutTok, Enum::"Report Layout Status"::Draft);
+
+        // [THEN] The change goes through, because it only applies to this company.
+        Assert.AreEqual(1, UpdateCount, 'The company-scoped status change should be applied.');
+
+        // [THEN] This company is told that the report now falls back to a layout that is no longer approved.
+        Assert.ExpectedMessage(ExtensionLayoutTok, LibraryVariableStorage.DequeueText());
+        LibraryVariableStorage.AssertEmpty();
+
+        ClearDefaultLayoutSelections();
+    end;
+
+    [Test]
+    [HandlerFunctions('FallbackNotificationHandler')]
+    [Scope('OnPrem')]
+    procedure StatusChangeIsAllowedWhenTheOtherCompanyKeepsItsOwnStatus()
+    var
+        UpdateCount: Integer;
+    begin
+        // [SCENARIO 649379] A company that keeps its own status for the layout is not reached by a global status
+        // write, so its default must not block the change either.
+        Initialize();
+
+        // [GIVEN] An extension-installed layout that another company has as its default and overrides the status of.
+        SeedCompanyScopedStatusOverride(BodyReportID, ExtensionLayoutTok, ThisCompany());
+        SelectDefaultLayoutInCompany(BodyReportID, ExtensionLayoutTok, ThisCompany());
+
+        // [WHEN] Setting its status to Draft, acting as a company that keeps no status of its own, so the change
+        // applies to all companies.
+        UpdateCount := SetLayoutStatusBatchAs(ActingCompanyTok, BodyReportID, ExtensionLayoutTok, Enum::"Report Layout Status"::Draft);
+
+        // [THEN] The change goes through, and this company is told about the fallback.
+        Assert.AreEqual(1, UpdateCount, 'The global status change should be applied.');
+        Assert.ExpectedMessage(ExtensionLayoutTok, LibraryVariableStorage.DequeueText());
+        LibraryVariableStorage.AssertEmpty();
+
+        ClearDefaultLayoutSelections();
+    end;
+
     local procedure ReportLayoutsNewLayout()
     var
         ReportLayoutsPage: TestPage "Report Layouts";
@@ -1038,6 +1255,12 @@ codeunit 134619 "Composite Layout Tests"
         LibraryVariableStorage.Enqueue(Message);
     end;
 
+    [SendNotificationHandler]
+    procedure FallbackNotificationHandler(var FallbackNotification: Notification): Boolean
+    begin
+        LibraryVariableStorage.Enqueue(FallbackNotification.Message);
+    end;
+
     local procedure Initialize()
     var
         TenantReportLayoutCfg: Record "Tenant Report Layout Cfg";
@@ -1058,6 +1281,7 @@ codeunit 134619 "Composite Layout Tests"
         TenantReportLayoutCfg.DeleteAll(true);
         TenantReportLayoutCfg.SetRange("Report ID", BodyReportID);
         TenantReportLayoutCfg.DeleteAll(true);
+        ClearDefaultLayoutSelections();
         ClearTestReportLayouts();
         ClearWildcardCfg('');                                                                     // global default: report 0, all companies
         ClearWildcardCfg(CopyStr(CompanyName(), 1, MaxStrLen(TenantReportLayoutCfg."Company Name"))); // company default: report 0, this company
@@ -1130,6 +1354,114 @@ codeunit 134619 "Composite Layout Tests"
         else
             FeatureKey.Enabled := FeatureKey.Enabled::None;
         FeatureKey.Modify();
+    end;
+
+    local procedure InvokeShowLayoutParts(ReportID: Integer)
+    var
+        ReportLayoutSelectionPage: TestPage "Report Layout Selection";
+    begin
+        ReportLayoutSelectionPage.OpenEdit();
+        ReportLayoutSelectionPage.Filter.SetFilter("Report ID", Format(ReportID));
+        Assert.IsTrue(ReportLayoutSelectionPage.First(), 'The report should be listed on the Report Layout Selection page.');
+        ReportLayoutSelectionPage.ShowLayoutParts.Invoke();
+        ReportLayoutSelectionPage.Close();
+    end;
+
+    local procedure SetLayoutStatusTo(ReportID: Integer; LayoutName: Text; NewStatus: Enum "Report Layout Status")
+    var
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+    begin
+        FindLayout(ReportID, LayoutName, ReportLayoutList);
+        ReportLayoutsImpl.SetSelectedCompany(CompanyName());
+        ReportLayoutsImpl.SetLayoutStatus(ReportLayoutList, NewStatus);
+    end;
+
+    local procedure SetLayoutStatusBatchAs(ActingCompany: Text[30]; ReportID: Integer; LayoutName: Text; NewStatus: Enum "Report Layout Status"): Integer
+    var
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+    begin
+        // SetSelectedCompany is what decides the company the status change runs in, the same way the pages set it.
+        ReportLayoutList.SetRange("Report ID", ReportID);
+        ReportLayoutList.SetRange(Name, CopyStr(LayoutName, 1, 250));
+        ReportLayoutsImpl.SetSelectedCompany(ActingCompany);
+        exit(ReportLayoutsImpl.SetLayoutStatusBatch(ReportLayoutList, NewStatus));
+    end;
+
+    local procedure ThisCompany(): Text[30]
+    begin
+        exit(CopyStr(CompanyName(), 1, 30));
+    end;
+
+    local procedure SetDefaultLayout(ReportID: Integer; LayoutName: Text)
+    var
+        ReportLayoutList: Record "Report Layout List";
+        ReportLayoutsImpl: Codeunit "Report Layouts Impl.";
+    begin
+        FindLayout(ReportID, LayoutName, ReportLayoutList);
+        ReportLayoutsImpl.SetSelectedCompany(CompanyName());
+        ReportLayoutsImpl.SetDefaultReportLayoutSelection(ReportLayoutList, false);
+    end;
+
+    local procedure SelectDefaultLayoutInCompany(ReportID: Integer; LayoutName: Text; CompanyToSelectIn: Text[30])
+    var
+        ReportLayoutList: Record "Report Layout List";
+        TenantReportLayoutSelection: Record "Tenant Report Layout Selection";
+        EmptyGuid: Guid;
+    begin
+        // Writes the same row the Report Layout Selection page writes when a default is picked, but for another
+        // company. The guard reads this table, so no second company has to be created for it to be exercised.
+        FindLayout(ReportID, LayoutName, ReportLayoutList);
+
+        TenantReportLayoutSelection."Report ID" := ReportID;
+        TenantReportLayoutSelection."Company Name" := CompanyToSelectIn;
+        TenantReportLayoutSelection."User ID" := EmptyGuid;
+        TenantReportLayoutSelection."Layout Name" := ReportLayoutList.Name;
+        TenantReportLayoutSelection."App ID" := ReportLayoutList."Application ID";
+        if not TenantReportLayoutSelection.Insert(true) then
+            TenantReportLayoutSelection.Modify(true);
+    end;
+
+    local procedure SeedCompanyScopedStatusOverride(ReportID: Integer; LayoutName: Text; OverrideCompanyName: Text[30])
+    var
+        ReportLayoutList: Record "Report Layout List";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+    begin
+        // An "Override Layout Status" row is what makes the status of an extension-installed layout company-scoped;
+        // the UI no longer writes one, so the test seeds it the way an older version or a vendor install codeunit would.
+        FindLayout(ReportID, LayoutName, ReportLayoutList);
+
+        if not TenantReportLayoutOverride.Get(ReportID, ReportLayoutList.Name, ReportLayoutList."Runtime Package ID", OverrideCompanyName) then begin
+            TenantReportLayoutOverride.Init();
+            TenantReportLayoutOverride."Report ID" := ReportID;
+            TenantReportLayoutOverride.Name := ReportLayoutList.Name;
+            TenantReportLayoutOverride."Runtime Package ID" := ReportLayoutList."Runtime Package ID";
+            TenantReportLayoutOverride."Company Name" := OverrideCompanyName;
+            TenantReportLayoutOverride.Insert(true);
+        end;
+
+        TenantReportLayoutOverride."Layout Status" := Enum::"Report Layout Status"::Approved;
+        TenantReportLayoutOverride."Override Layout Status" := true;
+        TenantReportLayoutOverride.Modify(true);
+    end;
+
+    local procedure ClearDefaultLayoutSelections()
+    var
+        ReportLayoutSelection: Record "Report Layout Selection";
+        TenantReportLayoutSelection: Record "Tenant Report Layout Selection";
+        TenantReportLayoutOverride: Record "Tenant Report Layout Override";
+    begin
+        // Default selections and status overrides are keyed by company, so clear every company's rows for the test
+        // report - the suite runs in a non-isolated bucket and the cross-company tests write rows for other companies.
+        TenantReportLayoutSelection.SetRange("Report ID", BodyReportID);
+        TenantReportLayoutSelection.DeleteAll();
+
+        TenantReportLayoutOverride.SetRange("Report ID", BodyReportID);
+        TenantReportLayoutOverride.DeleteAll();
+
+        ReportLayoutSelection.SetRange("Report ID", BodyReportID);
+        ReportLayoutSelection.DeleteAll();
     end;
 
     local procedure CreatePart(PartName: Text; Subtype: Enum "Report Layout Subtype"): Text


### PR DESCRIPTION
Fixes [AB#649843](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649843)

### Problem

Three defects in the composite layout feature, found by stress testing, plus one gap the same testing exposed. All present in `releases/29.0`:

- A duplicate part name silently overwrote an existing layout, because `InsertNewLayout` ended with an unconditional `Get` + `Delete(true)` of a same-named layout. Parts created from Report Theme and Header/Footer never reached the name check in the New Layout dialog.
- A layout could be moved out of Approved while a report was using it as its chosen default, and a non-approved layout could be made the default.
- An empty upload produced a platform message about an empty `InStream` object instead of a usable error.
- Header/footer parts could not be created blank, so the only way to a new part was exporting an existing one and stripping it.
- `Show layout parts` passed a blank layout name to `GetResolvedPartDisplays`, so it reported the report-default rows as `This layout` and never consulted a layout-scoped assignment. The message could contradict the Report Layout FactBox for the same layout.
- The status actions read `Set Approved` / `Set Draft` / `Set Pending Approval` / `Set Retired`.

### Changes

- `InsertNewLayout` takes a `ReplaceExisting` intent: New rejects a taken name before the file dialog opens, Replace still overwrites (after a successful upload) and carries the layout's status forward.
- `SetLayoutStatus` refuses to take a chosen default out of Approved, and reports the metadata-default fallback case instead of blocking it; the default-selection path validates that a layout is approved, from both routes.
- Uploads are buffered through a `Temp Blob` so an empty file is rejected with its own error, on the generated path too.
- `NewWordLayout` injects the report's `WordXmlPart` so a blank header/footer part can be created, exported and returned with Replace.
- `Show layout parts` resolves the report's effective layout through `GetDefaultReportLayoutSelection` and passes that layout's `CompositeLayoutKey`.
- Status action captions become `Set as ...` on both pages that expose them.

### Backport

Backport of #11211 to `releases/29.0`.

Cherry-picked commit(s):

- 4979d3868b5a06d31d3345479b7a955fecbca571

Covers Bug 649379, Bug 648842 and Bug 647373 — main squashed all three into the one commit above.

The five Base Application files applied unchanged (verified line by line against the main commit). One conflict, in `src/Layers/W1/Tests/Report/CompositeLayoutTests.Codeunit.al`: `releases/29.0` does not have the shipped-parts seeding tests, because codeunit `"Composite Report Parts Mgt."` only exists in main, so the file here is ~557 lines shorter and the conflict was main-only context rather than a real overlap. The commit's 332 added test lines (3 labels, 8 tests, 1 notification handler, 1 cleanup call, 8 helpers) were applied to the `29.0` version of the file and verified byte-identical to the main commit's additions; none of them reference main-only objects. No hand edits beyond placement.

### Validation

- [x] Diff reviewed against the main commit: 520 insertions, 18 deletions, same as main.
- [x] No main-only dependencies in the backported test code.
- [x] Built locally against 29.0 symbols: Base Application and Tests-Report both compile with **0 errors**, and the warning set is identical to a pristine `releases/29.0` build (647 in Base Application, 13 in Tests-Report — no new, none removed).

Build detail: `alc` 18.0.41.7630 from the enlistment (`Run/ALDevEnv/bin`), platform symbols `System 29.0.54137.0`, System Application and Business Foundation 29.0 from the local package cache. Tests-Report was compiled against the Base Application produced from this branch, not the shipped one.

### Risk & compatibility

Same intended behavioural changes as #11211: a duplicate part name is an error rather than a silent overwrite; a chosen default layout cannot be taken out of Approved in one step (a report's built-in fallback layout still can, with a message); a non-approved layout cannot be made the default; batch status changes are validated before anything is written. No schema, permission or telemetry changes.

