### PR TITLE
[master] Report 400 (Remittance Advice) Does Not Include Applied Vendor Refund Entries Resulting in Incorrect Total Calculation

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Payments/ExportRemitAdvicePEPPOL30.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Payments/ExportRemitAdvicePEPPOL30.Codeunit.al
@@ -295,7 +295,7 @@ codeunit 37208 "Export Remit. Advice PEPPOL30"
             this.AddCacElement(this.RootNode, 'RemittanceAdviceLine', LineNode);
             this.AddCbcElement(LineNode, 'ID', Format(SeqNo), ChildNode);
 
-            if LineBuffer."Applied Doc. Type" = LineBuffer."Applied Doc. Type"::"Credit Memo" then
+            if LineBuffer."Applied Doc. Type" in [LineBuffer."Applied Doc. Type"::"Credit Memo", LineBuffer."Applied Doc. Type"::Refund] then
                 this.AddMoneyElement(LineNode, 'CreditLineAmount', LineBuffer."Paid Amount", LineCurrencyCode, ChildNode)
             else
                 this.AddMoneyElement(LineNode, 'DebitLineAmount', LineBuffer."Paid Amount", LineCurrencyCode, ChildNode);

--- a/src/Apps/W1/PEPPOL/App/src/Payments/ExportRemitAdvicePEPPOL30.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Payments/ExportRemitAdvicePEPPOL30.Codeunit.al
@@ -307,7 +307,7 @@ codeunit 37208 "Export Remit. Advice PEPPOL30"
                 this.AddCbcElement(LineNode, 'Note', StrSubstNo(this.PmtDiscountNoteMsg, this.FormatAmount(LineBuffer."Pmt. Discount Amount")), ChildNode);
 
             this.AddCacElement(LineNode, 'BillingReference', BillingRefNode);
-            if LineBuffer."Applied Doc. Type" = LineBuffer."Applied Doc. Type"::"Credit Memo" then
+            if LineBuffer."Applied Doc. Type" in [LineBuffer."Applied Doc. Type"::"Credit Memo", LineBuffer."Applied Doc. Type"::Refund] then
                 this.AddCacElement(BillingRefNode, 'CreditNoteDocumentReference', DocRefNode)
             else
                 this.AddCacElement(BillingRefNode, 'InvoiceDocumentReference', DocRefNode);

--- a/src/Apps/W1/PEPPOL/App/src/Payments/RemitAdviceBufferMgt.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Payments/RemitAdviceBufferMgt.Codeunit.al
@@ -267,19 +267,25 @@ codeunit 37207 "Remit. Advice Buffer Mgt."
                 DetailedVendLedgEntry.Reset();
                 DetailedVendLedgEntry.SetRange("Vendor Ledger Entry No.", AppliedVendLedgEntry."Entry No.");
                 DetailedVendLedgEntry.SetRange("Entry Type", DetailedVendLedgEntry."Entry Type"::Application);
-                DetailedVendLedgEntry.SetRange("Document Type", DetailedVendLedgEntry."Document Type"::Payment);
-                DetailedVendLedgEntry.SetRange("Document No.", PaymentVendLedgEntry."Document No.");
+                if AppliedVendLedgEntry."Document Type" = AppliedVendLedgEntry."Document Type"::Refund then begin
+                    DetailedVendLedgEntry.SetRange("Document Type", DetailedVendLedgEntry."Document Type"::Refund);
+                    DetailedVendLedgEntry.SetRange("Document No.", AppliedVendLedgEntry."Document No.");
+                end else begin
+                    DetailedVendLedgEntry.SetRange("Document Type", DetailedVendLedgEntry."Document Type"::Payment);
+                    DetailedVendLedgEntry.SetRange("Document No.", PaymentVendLedgEntry."Document No.");
+                end;
                 DetailedVendLedgEntry.SetRange(Unapplied, false);
                 if not DetailedVendLedgEntry.IsEmpty() then begin
                     DetailedVendLedgEntry.CalcSums(Amount, "Remaining Pmt. Disc. Possible");
                     LineAmount := DetailedVendLedgEntry.Amount;
 
                     LineDiscount := 0;
-                    if AppliedVendLedgEntry."Currency Code" <> '' then begin
-                        if IsDiscountAppliedToPayment(AppliedVendLedgEntry."Entry No.", PaymentVendLedgEntry."Document No.") then
-                            LineDiscount := DetailedVendLedgEntry."Remaining Pmt. Disc. Possible";
-                    end else
-                        LineDiscount := CurrExchRate.ExchangeAmtFCYToFCY(AppliedVendLedgEntry."Posting Date", '', AppliedVendLedgEntry."Currency Code", AppliedVendLedgEntry."Pmt. Disc. Rcd.(LCY)");
+                    if AppliedVendLedgEntry."Document Type" <> AppliedVendLedgEntry."Document Type"::Refund then
+                        if AppliedVendLedgEntry."Currency Code" <> '' then begin
+                            if IsDiscountAppliedToPayment(AppliedVendLedgEntry."Entry No.", PaymentVendLedgEntry."Document No.") then
+                                LineDiscount := DetailedVendLedgEntry."Remaining Pmt. Disc. Possible";
+                        end else
+                            LineDiscount := CurrExchRate.ExchangeAmtFCYToFCY(AppliedVendLedgEntry."Posting Date", '', AppliedVendLedgEntry."Currency Code", AppliedVendLedgEntry."Pmt. Disc. Rcd.(LCY)");
 
                     LineNo += 1;
                     TempBuffer.Init();
@@ -297,7 +303,11 @@ codeunit 37207 "Remit. Advice Buffer Mgt."
                     TempBuffer."Vendor Ledger Entry No." := AppliedVendLedgEntry."Entry No.";
                     TempBuffer.Insert();
 
-                    TotalPaid += TempBuffer."Paid Amount";
+                    // A refund reduces the payment total, mirroring report 400's "Amount -= LineAmount"
+                    if AppliedVendLedgEntry."Document Type" = AppliedVendLedgEntry."Document Type"::Refund then
+                        TotalPaid -= TempBuffer."Paid Amount"
+                    else
+                        TotalPaid += TempBuffer."Paid Amount";
                     TotalDiscount += TempBuffer."Pmt. Discount Amount";
 
                     // Applied credit-memo cross-applications (report 400 lines 231-249)
@@ -357,6 +367,7 @@ codeunit 37207 "Remit. Advice Buffer Mgt."
     var
         DetailedVendLedgEntry1: Record "Detailed Vendor Ledg. Entry";
         DetailedVendLedgEntry2: Record "Detailed Vendor Ledg. Entry";
+        RefundVendLedgEntry: Record "Vendor Ledger Entry";
         EntryNo: Integer;
     begin
         AppliedVendLedgEntry.Reset();
@@ -406,6 +417,16 @@ codeunit 37207 "Remit. Advice Buffer Mgt."
                         AppliedVendLedgEntry.Mark(true);
                 end;
             until DetailedVendLedgEntry1.Next() = 0;
+
+        RefundVendLedgEntry.SetRange("Vendor No.", PaymentVendLedgEntry."Vendor No.");
+        RefundVendLedgEntry.SetRange("Document No.", PaymentVendLedgEntry."Document No.");
+        RefundVendLedgEntry.SetRange("Document Type", RefundVendLedgEntry."Document Type"::Refund);
+        if RefundVendLedgEntry.FindSet() then
+            repeat
+                AppliedVendLedgEntry.SetRange("Entry No.", RefundVendLedgEntry."Entry No.");
+                if AppliedVendLedgEntry.FindFirst() then
+                    AppliedVendLedgEntry.Mark(true);
+            until RefundVendLedgEntry.Next() = 0;
 
         AppliedVendLedgEntry.SetCurrentKey("Entry No.");
         AppliedVendLedgEntry.SetRange("Entry No.");

--- a/src/Layers/W1/BaseApp/Purchases/Reports/RemittanceAdviceEntries.Report.al
+++ b/src/Layers/W1/BaseApp/Purchases/Reports/RemittanceAdviceEntries.Report.al
@@ -256,26 +256,37 @@ report 400 "Remittance Advice - Entries"
                     CalcFields(Amount, "Remaining Amount");
                     DtldVendLedgEntry.SetRange("Vendor Ledger Entry No.", "Entry No.");
                     DtldVendLedgEntry.SetRange("Entry Type", DtldVendLedgEntry."Entry Type"::Application);
-                    DtldVendLedgEntry.SetRange("Document Type", DtldVendLedgEntry."Document Type"::Payment);
-                    DtldVendLedgEntry.SetRange("Document No.", "Vendor Ledger Entry"."Document No.");
+                    if "Document Type" = "Document Type"::Refund then begin
+                        DtldVendLedgEntry.SetRange("Document Type", DtldVendLedgEntry."Document Type"::Refund);
+                        DtldVendLedgEntry.SetRange("Document No.", "Document No.");
+                    end else begin
+                        DtldVendLedgEntry.SetRange("Document Type", DtldVendLedgEntry."Document Type"::Payment);
+                        DtldVendLedgEntry.SetRange("Document No.", "Vendor Ledger Entry"."Document No.");
+                    end;
                     DtldVendLedgEntry.SetRange(Unapplied, false);
                     if DtldVendLedgEntry.IsEmpty() then
                         CurrReport.Skip();
                     DtldVendLedgEntry.CalcSums(Amount, "Remaining Pmt. Disc. Possible");
                     LineAmount := DtldVendLedgEntry.Amount;
 
-                    if "Currency Code" <> '' then begin
-                        if IsDiscountAppliedToPayment("Vendor Ledger Entry"."Entry No.", "Vendor Ledger Entry"."Document No.") then
-                            LineDiscount := DtldVendLedgEntry."Remaining Pmt. Disc. Possible"
-                    end else
-                        LineDiscount := CurrExchRate.ExchangeAmtFCYToFCY("Posting Date", '', "Currency Code", "Pmt. Disc. Rcd.(LCY)");
+                    Clear(LineDiscount);
+                    if "Document Type" <> "Document Type"::Refund then
+                        if "Currency Code" <> '' then begin
+                            if IsDiscountAppliedToPayment("Vendor Ledger Entry"."Entry No.", "Vendor Ledger Entry"."Document No.") then
+                                LineDiscount := DtldVendLedgEntry."Remaining Pmt. Disc. Possible"
+                        end else
+                            LineDiscount := CurrExchRate.ExchangeAmtFCYToFCY("Posting Date", '', "Currency Code", "Pmt. Disc. Rcd.(LCY)");
 
                     "Vendor Ledger Entry".Amount += LineDiscount;
+                    if "Document Type" = "Document Type"::Refund then
+                        "Vendor Ledger Entry".Amount -= LineAmount;
 
                     LAmountWDiscCur := -LineAmount - LineDiscount;
                 end;
 
                 trigger OnPreDataItem()
+                var
+                    RefundVendLedgEntry: Record "Vendor Ledger Entry";
                 begin
                     CreateVendLedgEntry := "Vendor Ledger Entry";
                     FindApplnEntriesDtldtLedgEntry();
@@ -293,6 +304,15 @@ report 400 "Remittance Advice - Entries"
                         repeat
                             Mark(true);
                         until Next() = 0;
+
+                    RefundVendLedgEntry.SetRange("Vendor No.", CreateVendLedgEntry."Vendor No.");
+                    RefundVendLedgEntry.SetRange("Document No.", CreateVendLedgEntry."Document No.");
+                    RefundVendLedgEntry.SetRange("Document Type", RefundVendLedgEntry."Document Type"::Refund);
+                    if RefundVendLedgEntry.FindSet() then
+                        repeat
+                            "Entry No." := RefundVendLedgEntry."Entry No.";
+                            Mark(true);
+                        until RefundVendLedgEntry.Next() = 0;
 
                     SetCurrentKey("Entry No.");
                     SetRange("Closed by Entry No.");

--- a/src/Layers/W1/Tests/Report/RemittanceREPCheckUT.Codeunit.al
+++ b/src/Layers/W1/Tests/Report/RemittanceREPCheckUT.Codeunit.al
@@ -15,6 +15,10 @@ codeunit 133771 "Remittance REP Check UT"
         LibraryReportDataset: Codeunit "Library - Report Dataset";
         LibraryERM: Codeunit "Library - ERM";
         Assert: Codeunit Assert;
+        EntryNoElementTok: Label 'EntryNo_VendLedgEntry2', Locked = true;
+        DocTypeElementTok: Label 'DocType_VendLedgEntry2', Locked = true;
+        LineAmountElementTok: Label 'LAmountWDiscCur', Locked = true;
+        TotalAmountElementTok: Label 'Amount_VendLedgEntry', Locked = true;
 
     [Test]
     [HandlerFunctions('RemittanceAdviceJournalRequestPageHandler')]
@@ -189,6 +193,46 @@ codeunit 133771 "Remittance REP Check UT"
         VerifyPayedDocumentsAndPartiallyPaid(VendorLedgerEntry, GenJournalLine);
     end;
 
+    [Test]
+    [HandlerFunctions('RemittanceAdviceEntriesRequestPageHandler')]
+    [TransactionModel(TransactionModel::AutoRollback)]
+    procedure RefundSharingPaymentDocShownOnRemittanceAdviceEntries()
+    var
+        DetailedVendorLedgEntry: Record "Detailed Vendor Ledg. Entry";
+        PaymentVendorLedgerEntry: Record "Vendor Ledger Entry";
+        RefundVendorLedgerEntry: Record "Vendor Ledger Entry";
+        VendorNo: Code[20];
+        DocumentNo: Code[20];
+        RefundAmount: Decimal;
+    begin
+        // [FEATURE] [Report] [Remittance Advice - Entries] [AI test 0.4]
+        // [SCENARIO] A vendor refund sharing the payment's document is rendered as a line on Report 400 - Remittance Advice - Entries
+        Initialize();
+
+        // [GIVEN] Payment and Refund for the same vendor sharing DocumentNo .
+        VendorNo := CreateVendor();
+        DocumentNo := LibraryUTUtility.GetNewCode();
+        CreatePaymentAndRefundWithDocumentNo(PaymentVendorLedgerEntry, RefundVendorLedgerEntry, VendorNo, DocumentNo);
+
+        // [GIVEN] Refund has an applied refund detailed entry.
+        RefundAmount :=
+          CreateDetailedVendorLedgerEntry(
+            RefundVendorLedgerEntry, RefundVendorLedgerEntry."Entry No.", DetailedVendorLedgEntry."Entry Type"::Application,
+            DetailedVendorLedgEntry."Document Type"::Refund, 1);
+
+        // [WHEN] Run report Remittance Advice - Entries filtered on payment.
+        LibraryVariableStorage.Enqueue(PaymentVendorLedgerEntry."Entry No.");
+        REPORT.Run(REPORT::"Remittance Advice - Entries");
+
+        // [THEN] Verify that the Refund is displayed as a transaction line on the report with the refund amount.
+        LibraryReportDataset.LoadDataSetFile();
+        LibraryReportDataset.AssertElementWithValueExists(EntryNoElementTok, RefundVendorLedgerEntry."Entry No.");
+        LibraryReportDataset.AssertElementWithValueExists(DocTypeElementTok, Format(RefundVendorLedgerEntry."Document Type"));
+        LibraryReportDataset.AssertElementWithValueExists(LineAmountElementTok, -RefundAmount);
+        LibraryReportDataset.AssertElementWithValueExists(TotalAmountElementTok, -RefundAmount);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     begin
         LibraryVariableStorage.Clear();
@@ -342,6 +386,16 @@ codeunit 133771 "Remittance REP Check UT"
               'AppliedVendLedgEntryTempRemainingAmt', -(VendorLedgerEntry."Remaining Amount" - VendorLedgerEntry."Amount to Apply"));
             LibraryReportDataset.AssertElementWithValueExists('AppliedVendLedgEntryTempDocType', Format(VendorLedgerEntry."Document Type"));
         until VendorLedgerEntry.Next() = 0;
+    end;
+
+    local procedure CreatePaymentAndRefundWithDocumentNo(var PaymentVendorLedgerEntry: Record "Vendor Ledger Entry"; var RefundVendorLedgerEntry: Record "Vendor Ledger Entry"; VendorNo: Code[20]; DocumentNo: Code[20])
+    begin
+        CreateVendorLedgerEntry(PaymentVendorLedgerEntry, '', VendorNo, PaymentVendorLedgerEntry."Document Type"::Payment);  // Blank value for Applies To ID.
+        PaymentVendorLedgerEntry."Document No." := DocumentNo;
+        PaymentVendorLedgerEntry.Modify();
+        CreateVendorLedgerEntry(RefundVendorLedgerEntry, '', VendorNo, RefundVendorLedgerEntry."Document Type"::Refund);  // Blank value for Applies To ID.
+        RefundVendorLedgerEntry."Document No." := DocumentNo;
+        RefundVendorLedgerEntry.Modify();
     end;
 
     [RequestPageHandler]


### PR DESCRIPTION
**Issue:** A vendor refund sharing a payment's document number isn't shown as a line on Report 400, so the listed lines don't match the printed total (389 vs 390).

**Cause:** The report only surfaced entries from the payment's own application chain, missing refunds applied through a separate chain — while the total still counted them.

**Solution:** Mark refunds sharing the payment's Vendor No. + Document No. so they render as lines, skip payment-discount logic for refunds, and adjust the total by `-= LineAmount` so lines reconcile with the total.

Workitem: [Bug 648309](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648309): [master] [All-E] Report 400 (Remittance Advice) Does Not Include Applied Vendor Refund Entries Resulting in Incorrect Total Calculation

Fixes [AB#648309](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648309)






