### PR TITLE
Prevent order matching for invoice lines created by Get Receipt Lines

### DIFF
--- a/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
@@ -759,7 +759,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.ApproveTravelRequest(ActionContext, ApproverExpenseUser."No.");
 
         // [THEN] The request is approved with its audit fields and a linked report.
-        Assert.AreEqual(WebServiceActionResultCode::Updated, ActionContext.GetResultCode(), TravelRequestActionResultMsg);
+        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Approved, SpendRequest.Status, 'The travel request should be approved through the page action.');
         Assert.AreEqual(UserSecurityId(), SpendRequest."Approved/Rejected by User ID", 'The approving user should be recorded.');
@@ -789,7 +789,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.SubmitTravelRequest(ActionContext, ExpenseUser."No.");
 
         // [THEN] The request is released with its submission audit fields.
-        Assert.AreEqual(WebServiceActionResultCode::Updated, ActionContext.GetResultCode(), TravelRequestActionResultMsg);
+        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Released, SpendRequest.Status, 'The travel request should be released through the page action.');
         Assert.AreEqual(ExpenseUser."No.", SpendRequest."Submitted By Expense User No.", 'The submitting expense user should be recorded.');
@@ -898,7 +898,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.RejectTravelRequest(ActionContext, ApproverExpenseUser."No.", RejectReason);
 
         // [THEN] The action returns Updated and the request records the rejection details.
-        Assert.AreEqual(WebServiceActionResultCode::Updated, ActionContext.GetResultCode(), TravelRequestActionResultMsg);
+        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Rejected, SpendRequest.Status, TravelRequestRejectedMsg);
         Assert.AreEqual(UserSecurityId(), SpendRequest."Approved/Rejected by User ID", TravelRequestRejectionUserMsg);

--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -345,8 +345,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1198,8 +1200,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1192,8 +1194,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1186,8 +1188,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/FR/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/FR/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1180,8 +1182,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -349,8 +349,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1197,8 +1199,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -339,8 +339,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1193,8 +1195,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1201,8 +1203,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -348,8 +348,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1206,8 +1208,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
@@ -311,6 +311,12 @@ codeunit 5826 "Matched Order Line Mgmt."
         exit(not MatchedOrderLine.IsEmpty());
     end;
 
+    internal procedure CheckLineCanBeMatched(PurchaseLine: Record "Purchase Line")
+    begin
+        if PurchaseLine."Receipt No." <> '' then
+            Error(LineCreatedFromReceiptErr, PurchaseLine."Line No.");
+    end;
+
     internal procedure IsLineMatched(PurchaseLine: Record "Purchase Line"; ShowError: Boolean): Boolean
     begin
         case PurchaseLine."Document Type" of
@@ -699,6 +705,7 @@ codeunit 5826 "Matched Order Line Mgmt."
         PurchaseLines: Page "Purchase Lines";
     begin
         PurchaseLineInvoice.GetBySystemId(DetailedMatchedOrderLine."Document Line SystemId");
+        CheckLineCanBeMatched(PurchaseLineInvoice);
         PurchaseLineOrder.FilterGroup(-1);
         PurchaseLineOrder.SetFilter("Outstanding Quantity", '<>0');
         PurchaseLineOrder.SetFilter("Qty. Rcd. Not Invoiced", '<>0');
@@ -769,6 +776,7 @@ codeunit 5826 "Matched Order Line Mgmt."
         GetReceiptLines: Page "Get Receipt Lines";
     begin
         PurchaseLineInvoice.GetBySystemId(DetailedMatchedOrderLine."Document Line SystemId");
+        CheckLineCanBeMatched(PurchaseLineInvoice);
         PurchRcptLine.FilterGroup(2);
         if IsNullGuid(DetailedMatchedOrderLine."Matched Order Line SystemId") then begin
             PurchRcptLine.SetRange("Buy-from Vendor No.", PurchaseLineInvoice."Buy-from Vendor No.");
@@ -1246,6 +1254,7 @@ codeunit 5826 "Matched Order Line Mgmt."
         PrepaymentNotSupportedErr: Label 'Matched order lines are not supported for prepayment lines. Order No.: %1, Line No.: %2', Comment = '%1 = Order No., %2 = Line No.';
         PurchaseInvoiceLineMatchedErr: Label 'The line is matched to an order line and cannot be modified.';
         PurchaseOrderLineMatchedErr: Label 'The line is matched to an invoice line and cannot be modified.';
+        LineCreatedFromReceiptErr: Label 'Matched order lines are not supported for lines created with the Get Receipt Lines function. Line No.: %1', Comment = '%1 = Line No.';
         InvoiceLineLbl: Label 'Invoice %1 Line %2', Comment = '%1 = Document No., %2 = Line No.';
         OrderLineLbl: Label 'Order %1 Line %2', Comment = '%1 = Document No., %2 = Line No.';
         RcptLineLbl: Label 'Receipt %1 Line %2', Comment = '%1 = Document No., %2 = Line No.';

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1181,8 +1183,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
@@ -4795,7 +4795,7 @@ codeunit 134468 "ERM Matched Order Line Tests"
         PurchaseHeaderInvoice: Record "Purchase Header";
         PurchaseLineInvoice: Record "Purchase Line";
         PurchRcptLine: Record "Purch. Rcpt. Line";
-        DetailedMatchedOrderLine: Record "Detailed Matched Order Line";
+        TempDetailedMatchedOrderLine: Record "Detailed Matched Order Line";
         Item: Record Item;
         Vendor: Record Vendor;
         MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
@@ -4829,11 +4829,11 @@ codeunit 134468 "ERM Matched Order Line Tests"
         PurchaseLineInvoice.SetFilter("Receipt No.", '<>%1', '');
         PurchaseLineInvoice.FindFirst();
 
-        DetailedMatchedOrderLine.Init();
-        DetailedMatchedOrderLine."Document Line SystemId" := PurchaseLineInvoice.SystemId;
+        TempDetailedMatchedOrderLine.Init();
+        TempDetailedMatchedOrderLine."Document Line SystemId" := PurchaseLineInvoice.SystemId;
 
         // [WHEN] Getting order lines for that invoice line
-        asserterror MatchedOrderLineMgmt.GetOrderLines("Matched Order Line Source"::"Purchase Invoice", DetailedMatchedOrderLine);
+        asserterror MatchedOrderLineMgmt.GetOrderLines("Matched Order Line Source"::"Purchase Invoice", TempDetailedMatchedOrderLine);
 
         // [THEN] It is rejected because the combination is not supported
         Assert.ExpectedError('created with the Get Receipt Lines function');

--- a/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
@@ -4737,6 +4737,108 @@ codeunit 134468 "ERM Matched Order Line Tests"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure MatchingRejectedForInvoiceLineCreatedByGetReceiptLines()
+    var
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO] An invoice line created by Get Receipt Lines cannot be opened for order matching.
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 100);
+
+        // [GIVEN] A received purchase order
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        PurchaseLineOrder.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        PurchaseLineOrder.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
+        PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
+        PurchRcptLine.FindFirst();
+
+        // [GIVEN] A purchase invoice line created via Get Receipt Lines (has a Receipt No.)
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
+        PurchGetReceipt.SetPurchHeader(PurchaseHeaderInvoice);
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+
+        PurchaseLineInvoice.SetRange("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.SetRange("Document No.", PurchaseHeaderInvoice."No.");
+        PurchaseLineInvoice.SetFilter("Receipt No.", '<>%1', '');
+        PurchaseLineInvoice.FindFirst();
+
+        // [WHEN] Opening order matching for that invoice line
+        asserterror MatchedOrderLineMgmt.CheckLineCanBeMatched(PurchaseLineInvoice);
+
+        // [THEN] It is rejected because the combination is not supported
+        Assert.ExpectedError('created with the Get Receipt Lines function');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure GetOrderLinesRejectedForInvoiceLineCreatedByGetReceiptLines()
+    var
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        DetailedMatchedOrderLine: Record "Detailed Matched Order Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO] Get Order Lines cannot match order lines to an invoice line created by Get Receipt Lines, even when opened from the header.
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 100);
+
+        // [GIVEN] A received purchase order
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        PurchaseLineOrder.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        PurchaseLineOrder.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
+        PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
+        PurchRcptLine.FindFirst();
+
+        // [GIVEN] A purchase invoice line created via Get Receipt Lines (has a Receipt No.)
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
+        PurchGetReceipt.SetPurchHeader(PurchaseHeaderInvoice);
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+
+        PurchaseLineInvoice.SetRange("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.SetRange("Document No.", PurchaseHeaderInvoice."No.");
+        PurchaseLineInvoice.SetFilter("Receipt No.", '<>%1', '');
+        PurchaseLineInvoice.FindFirst();
+
+        DetailedMatchedOrderLine.Init();
+        DetailedMatchedOrderLine."Document Line SystemId" := PurchaseLineInvoice.SystemId;
+
+        // [WHEN] Getting order lines for that invoice line
+        asserterror MatchedOrderLineMgmt.GetOrderLines("Matched Order Line Source"::"Purchase Invoice", DetailedMatchedOrderLine);
+
+        // [THEN] It is rejected because the combination is not supported
+        Assert.ExpectedError('created with the Get Receipt Lines function');
+    end;
+
     // ============================================================================
     // REGION: Local Helper Functions
     // ============================================================================


### PR DESCRIPTION
Fixes [AB#636138](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/636138)

### Summary
Matched Order Lines could produce inconsistent information when working with very similar purchase orders, because an invoice line created by the **Get Receipt Lines** function (which populates the `Receipt No.` field) could still be opened and matched for order matching. This PR blocks that combination, which is not supported, at both the per-line entry points and the header-opened path.

### Changes
- **`Matched Order Line Mgmt.` codeunit** — Added `CheckLineCanBeMatched`, which raises an error when the purchase invoice line has a non-empty `Receipt No.` (i.e. it originates from Get Receipt Lines). Also called it in `GetOrderLinesForPurchaseInvoice` and `GetPurchaseReceiptLines` so matches cannot be added to a receipt-created line even when the page is opened from the header.
- **`Purch. Invoice Subform` page** — Both entry points that open the Matched Order Lines page for a single line (the `Matched Order Lines` field drill-down and the `Matched Order Lines` action) now call `CheckLineCanBeMatched` before opening the page.
- **`ERM Matched Order Line Tests` codeunit** — Added `MatchingRejectedForInvoiceLineCreatedByGetReceiptLines` (per-line path) and `GetOrderLinesRejectedForInvoiceLineCreatedByGetReceiptLines` (header path), which create an invoice line via Get Receipt Lines and assert that matching is rejected.

### Error message
> Matched order lines are not supported for lines created with the Get Receipt Lines function. Line No.: %1

### Notes
- The guard is enforced at two levels: the per-line page entry points give the user immediate feedback (the page won't open for a receipt-created line), and the `Get Order Lines` / `Get Receipt Lines` functions in the codeunit provide authoritative enforcement, covering the header-opened view where matching isn't tied to a single line.




