### PR TITLE
[Expense Agent tests] Fix action-result assertions for runtime compilation

### DIFF
--- a/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
@@ -759,7 +759,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.ApproveTravelRequest(ActionContext, ApproverExpenseUser."No.");
 
         // [THEN] The request is approved with its audit fields and a linked report.
-        Assert.AreEqual(WebServiceActionResultCode::Updated, ActionContext.GetResultCode(), TravelRequestActionResultMsg);
+        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Approved, SpendRequest.Status, 'The travel request should be approved through the page action.');
         Assert.AreEqual(UserSecurityId(), SpendRequest."Approved/Rejected by User ID", 'The approving user should be recorded.');
@@ -789,7 +789,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.SubmitTravelRequest(ActionContext, ExpenseUser."No.");
 
         // [THEN] The request is released with its submission audit fields.
-        Assert.AreEqual(WebServiceActionResultCode::Updated, ActionContext.GetResultCode(), TravelRequestActionResultMsg);
+        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Released, SpendRequest.Status, 'The travel request should be released through the page action.');
         Assert.AreEqual(ExpenseUser."No.", SpendRequest."Submitted By Expense User No.", 'The submitting expense user should be recorded.');
@@ -898,7 +898,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.RejectTravelRequest(ActionContext, ApproverExpenseUser."No.", RejectReason);
 
         // [THEN] The action returns Updated and the request records the rejection details.
-        Assert.AreEqual(WebServiceActionResultCode::Updated, ActionContext.GetResultCode(), TravelRequestActionResultMsg);
+        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Rejected, SpendRequest.Status, TravelRequestRejectedMsg);
         Assert.AreEqual(UserSecurityId(), SpendRequest."Approved/Rejected by User ID", TravelRequestRejectionUserMsg);

--- a/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/test/src/SpendRequestTest.Codeunit.al
@@ -759,7 +759,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.ApproveTravelRequest(ActionContext, ApproverExpenseUser."No.");
 
         // [THEN] The request is approved with its audit fields and a linked report.
-        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
+        Assert.AreEqual(Format(WebServiceActionResultCode::Updated), Format(ActionContext.GetResultCode()), TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Approved, SpendRequest.Status, 'The travel request should be approved through the page action.');
         Assert.AreEqual(UserSecurityId(), SpendRequest."Approved/Rejected by User ID", 'The approving user should be recorded.');
@@ -789,7 +789,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.SubmitTravelRequest(ActionContext, ExpenseUser."No.");
 
         // [THEN] The request is released with its submission audit fields.
-        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
+        Assert.AreEqual(Format(WebServiceActionResultCode::Updated), Format(ActionContext.GetResultCode()), TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Released, SpendRequest.Status, 'The travel request should be released through the page action.');
         Assert.AreEqual(ExpenseUser."No.", SpendRequest."Submitted By Expense User No.", 'The submitting expense user should be recorded.');
@@ -898,7 +898,7 @@ codeunit 148339 "Spend Request Test"
         TravelRequestsAPI.RejectTravelRequest(ActionContext, ApproverExpenseUser."No.", RejectReason);
 
         // [THEN] The action returns Updated and the request records the rejection details.
-        Assert.IsTrue(ActionContext.GetResultCode() = WebServiceActionResultCode::Updated, TravelRequestActionResultMsg);
+        Assert.AreEqual(Format(WebServiceActionResultCode::Updated), Format(ActionContext.GetResultCode()), TravelRequestActionResultMsg);
         SpendRequest.Get(SpendRequest."No.");
         Assert.AreEqual(SpendRequest.Status::Rejected, SpendRequest.Status, TravelRequestRejectedMsg);
         Assert.AreEqual(UserSecurityId(), SpendRequest."Approved/Rejected by User ID", TravelRequestRejectionUserMsg);


### PR DESCRIPTION
## Summary

[AB#646383](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646383)

Fix runtime compilation of CU 148339 `Spend Request Test`. Three existing page-action tests pass the built-in `WebServiceActionResultCode` to `Assert.AreEqual`, which requires an unsupported Variant conversion in generated C#.

Compare `Format(WebServiceActionResultCode::Updated)` with `Format(ActionContext.GetResultCode())` using `Assert.AreEqual`. Preserve the existing error message and all fixture, audit-field, and report assertions. Both sides are formatted in the same context; no localized text or numeric result value is hardcoded.

Affected tests:
- `ApproveTravelRequestPageAction`
- `SubmitTravelRequestPageAction`
- `RejectTravelRequestPageAction`

## Evidence and validation

W1 Default, Integration and Uncategorized in [run 34472110108](https://github.com/microsoft/BCApps/actions/runs/34472110108) fail with CS1503: `WebServiceActionResultCode` cannot convert to `NavValue`. Test discovery compiles this codeunit before category/isolation filtering.

The assertion code was introduced by #11007 and is unchanged in the tested main revision. This PR changes exactly three lines in one AL test file. Source-equivalence checks and `git diff --check` pass.

**The compilation fix is runtime-verified.** [Standalone CI](https://github.com/microsoft/BCApps/actions/runs/34532211672) and [auth-branch CI](https://github.com/microsoft/BCApps/actions/runs/34532226875) each passed all 46 build jobs. All three repaired tests passed in every available Integration artifact: 22 standalone countries and 21 auth countries, including W1.

Both overall workflows remain **failed**. Twelve other Expense tests fail on both branches (six permission tests and six deletion/date/filter tests), with additional infrastructure failures. Auth-only CZ/DK failures are being investigated in the harness. These failures are not suppressed or fixed in this three-line prerequisite. No local NST result is claimed.

The first attempt (`a4ed3c3f18`) used direct equality, which CI rejected with AL0175. Corrected head `86497ab769` instead uses Format's intrinsic conversion. Read-only compiler inspection traced the supported conversion before the successful compilation and target-method execution above. The unsupported equality is no longer present.

## Relationship to API authentication work

This is a separately reviewable prerequisite for #10085, not an authentication or production-behavior change. The corrected head `86497ab769` is included in its head `b05ed58024` to unblock validation; once this prerequisite is merged into main, these three lines no longer belong to that PR's diff.

No tests are disabled or enabled. No workflow filters, NAV selectors, authentication code, or native-stack ordering change. This draft targets main independently; it is not another business-fix layer in stack #11232.

