### PR TITLE
[Master] - Bug 648681: [Expense Agent] Fix Expense Agent KPI report-line drill-down filter

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/KPI/EAKPIEntries.Page.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/KPI/EAKPIEntries.Page.al
@@ -37,6 +37,15 @@ page 7075 "EA KPI Entries"
                         Rec.OpenCard();
                     end;
                 }
+                field("Line No."; Rec."Line No.")
+                {
+                    ToolTip = 'Specifies the line number of the record, for expense report lines.';
+
+                    trigger OnDrillDown()
+                    begin
+                        Rec.OpenCard();
+                    end;
+                }
                 field(CreatedByExpUserId; Rec."Created By Exp. User Id")
                 {
                     Visible = false;

--- a/src/Apps/W1/ExpenseAgent/app/src/KPI/EAKPIEntry.Table.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/KPI/EAKPIEntry.Table.al
@@ -110,6 +110,8 @@ table 6951 "EA KPI Entry"
             Rec."Record Type"::"Expense Report Line":
                 begin
                     if ExpenseReportLine.Get(Rec."No.", Rec."Line No.") then begin
+                        ExpenseReportLine.SetRange("Document No.", Rec."No.");
+                        ExpenseReportLine.SetRange("Line No.", Rec."Line No.");
                         Page.Run(Page::"Expense Report Lines", ExpenseReportLine);
                         exit;
                     end;


### PR DESCRIPTION
Fixes [AB#648681](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648681)

### Problem

The Expense Agent KPI report-line drill-down opened the Expense Report Lines page without filtering it to the selected KPI entry, so unrelated report lines were shown.

### Changes

- Filtered the Expense Report Line record by Document No. and Line No. before opening the page.
- Exposed Line No. on the Expense Agent Entries page so report-line entries can be distinguished.

### Validation

- Manually traced the drill-down path.
- Verified that the record passed to Page.Run carries the expected filters.

