### PR TITLE
[27.2] Prepare Regex for .NET 10

### DIFF
--- a/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
+++ b/src/System Application/App/Regex/src/RegexImpl.Codeunit.al
@@ -327,13 +327,16 @@ codeunit 3961 "Regex Impl."
     procedure Regex(Pattern: Text; var RegexOptions: Record "Regex Options")
     var
         TimeoutDuration: DotNet TimeSpan;
+        MatchTimeoutInMs: BigInteger;
     begin
         DotNetRegexOptions := RegexOptions.GetRegexOptions();
-        if RegexOptions.MatchTimeoutInMs < 1000 then
+        MatchTimeoutInMs := RegexOptions.MatchTimeoutInMs;
+        if MatchTimeoutInMs < 1000 then
             Error(TimeoutTooLowErr);
-        if RegexOptions.MatchTimeoutInMs > 10000 then
+        if MatchTimeoutInMs > 10000 then
             Error(TimeoutTooHighErr);
-        DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromMilliseconds(RegexOptions.MatchTimeoutInMs));
+
+        DotNetRegex := DotNetRegex.Regex(Pattern, DotNetRegexOptions, TimeoutDuration.FromTicks(MatchTimeoutInMs * 10000));
     end;
 
     local procedure CheckIfInstantiated()


### PR DESCRIPTION
## Summary
- use a 64-bit timeout value for Regex construction
- construct the timeout with TimeSpan.FromTicks to avoid the .NET 10 FromMilliseconds overload ambiguity
- backport the final compatibility change to the numbered servicing branch

The change remains compatible with the existing runtime and can be merged before the Platform-Core .NET 10 update.

The BaseApp Iat: BigInteger change is not included because BaseApp source is not present in the BCApps 27.2 release branch.

Fixes [AB#649935](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649935)

