### PR TITLE
[Master] - Bug 648886: [Sustainability][Value Chain] Transfer Order uses average emissions instead of Specific carbon tracking (lot/serial)

### DIFF
--- a/src/Apps/W1/Sustainability/app/src/Posting/SustainabilityPostMgt.Codeunit.al
+++ b/src/Apps/W1/Sustainability/app/src/Posting/SustainabilityPostMgt.Codeunit.al
@@ -350,14 +350,43 @@ codeunit 6212 "Sustainability Post Mgt"
     var
         TransferInILE: Record "Item Ledger Entry";
         TransferOutILE: Record "Item Ledger Entry";
+        TempItemLedgerEntry: Record "Item Ledger Entry" temporary;
         SustainabilityValueEntry: Record "Sustainability Value Entry";
+        ShowAppliedEntries: Codeunit "Show Applied Entries";
     begin
-        TransferInILE.SetLoadFields("Entry Type", Quantity, "Item Register No.", "Item No.", "Lot No.", "Serial No.");
+        TransferInILE.SetLoadFields("Entry No.", "Entry Type", Quantity, "Order No.", "Order Line No.", "Item Register No.", "Item No.", "Lot No.", "Serial No.");
         if not TransferInILE.Get(ItemLedgerEntryNo) then
             exit;
 
-        if (TransferInILE."Entry Type" <> TransferInILE."Entry Type"::Transfer) or (TransferInILE.Quantity <= 0) then
+        if TransferInILE."Entry Type" <> TransferInILE."Entry Type"::Transfer then
             exit;
+
+        if TransferInILE.Quantity < 0 then begin
+            ShowAppliedEntries.FindAppliedEntries(TransferInILE, TempItemLedgerEntry);
+            if TempItemLedgerEntry.FindSet() then
+                repeat
+                    if (TempItemLedgerEntry."Lot No." = TransferInILE."Lot No.") and
+                       (TempItemLedgerEntry."Serial No." = TransferInILE."Serial No.")
+                    then
+                        GetCO2eAmountAndQuantity(TempItemLedgerEntry."Entry No.", CO2eAmount, CO2eQuantity);
+                until TempItemLedgerEntry.Next() = 0;
+            exit;
+        end;
+
+        if TransferInILE."Order No." <> '' then begin
+            TransferOutILE.SetRange("Order No.", TransferInILE."Order No.");
+            TransferOutILE.SetRange("Order Line No.", TransferInILE."Order Line No.");
+            TransferOutILE.SetRange("Item No.", TransferInILE."Item No.");
+            TransferOutILE.SetRange("Entry Type", TransferOutILE."Entry Type"::Transfer);
+            TransferOutILE.SetFilter(Quantity, '<%1', 0);
+            TransferOutILE.SetFilter("Entry No.", '<%1', TransferInILE."Entry No.");
+            TransferOutILE.SetRange("Lot No.", TransferInILE."Lot No.");
+            TransferOutILE.SetRange("Serial No.", TransferInILE."Serial No.");
+            if TransferOutILE.FindLast() then begin
+                GetCO2eAmountAndQuantity(TransferOutILE."Entry No.", CO2eAmount, CO2eQuantity);
+                exit;
+            end;
+        end;
 
         // Reclassification transfer-in ILEs lack SVEs; resolve from the transfer-out counterpart.
         TransferOutILE.SetRange("Item Register No.", TransferInILE."Item Register No.");

--- a/src/Apps/W1/Sustainability/test/src/SustainabilityPostingTest.Codeunit.al
+++ b/src/Apps/W1/Sustainability/test/src/SustainabilityPostingTest.Codeunit.al
@@ -5,6 +5,7 @@ using Microsoft.Assembly.History;
 using Microsoft.Assembly.Posting;
 using Microsoft.Assembly.Setup;
 using Microsoft.Finance.GeneralLedger.Preview;
+using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Foundation.Address;
 using Microsoft.Foundation.AuditCodes;
 using Microsoft.Foundation.Navigate;
@@ -5664,6 +5665,74 @@ codeunit 148184 "Sustainability Posting Test"
         Assert.AreEqual(BaselineEntryNo + 1, SustainabilityLedgerEntry."Entry No.", EntryNoShouldBeBaselinePlusOneErr);
     end;
 
+    [Test]
+    procedure VerifySpecificCarbonTrackingUsesLotEmissionAfterTransfer()
+    var
+        Item: Record Item;
+        SustainabilityAccount: Record "Sustainability Account";
+        TransferHeader: Record "Transfer Header";
+        TransferLine: Record "Transfer Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        SustainabilityValueEntry: Record "Sustainability Value Entry";
+        ReservationEntry: Record "Reservation Entry";
+        FromLocation: Record Location;
+        ToLocation: Record Location;
+        InTransitLocation: Record Location;
+        LotNo: array[2] of Code[50];
+        AccountCode: Code[20];
+        CategoryCode: Code[20];
+        SubcategoryCode: Code[20];
+        PostedInvoiceNo: Code[20];
+        Index: Integer;
+    begin
+        // [SCENARIO 648886] A Specific item keeps the selected lot's CO2e after transfer when the transfer has no additional emissions.
+        LibrarySustainability.CleanUpBeforeTesting();
+
+        // [GIVEN] Value Chain Tracking is enabled and a lot-tracked Specific item has a default Sustainability Account.
+        LibrarySustainability.UpdateValueChainTrackingInSustainabilitySetup(true);
+        CreateSustainabilityAccount(AccountCode, CategoryCode, SubcategoryCode, LibraryRandom.RandInt(10));
+        SustainabilityAccount.Get(AccountCode);
+        LibraryItemTracking.CreateLotItem(Item);
+        EnsureGeneralPostingSetupForItem(Item);
+        LibrarySustainability.UpdateCarbonTrackingMethod(Item, Item."Carbon Tracking Method"::Specific);
+        Item.Validate("Default Sust. Account", AccountCode);
+        Item.Modify();
+        LibraryWarehouse.CreateTransferLocations(FromLocation, ToLocation, InTransitLocation);
+
+        // [GIVEN] LOT1 has 100 CO2e and LOT2 has 300 CO2e at the source location.
+        LotNo[1] := LibraryUtility.GenerateGUID();
+        LotNo[2] := LibraryUtility.GenerateGUID();
+        LibrarySustainability.PostPositiveAdjustmentWithItemTracking(Item, FromLocation.Code, AccountCode, '', 1, WorkDate(), '', LotNo[1], 100);
+        LibrarySustainability.PostPositiveAdjustmentWithItemTracking(Item, FromLocation.Code, AccountCode, '', 1, WorkDate(), '', LotNo[2], 300);
+
+        // [GIVEN] Both lots are transferred without sustainability emissions on the transfer line.
+        LibraryWarehouse.CreateTransferHeader(TransferHeader, FromLocation.Code, ToLocation.Code, InTransitLocation.Code);
+        LibraryWarehouse.CreateTransferLine(TransferHeader, TransferLine, Item."No.", 2);
+        TransferLine.Validate("Sust. Account No.", '');
+        TransferLine.Validate("CO2e per Unit", 0);
+        TransferLine.Modify();
+        for Index := 1 to ArrayLen(LotNo) do
+            LibraryItemTracking.CreateTransferOrderItemTracking(ReservationEntry, TransferLine, '', LotNo[Index], 1);
+        LibraryWarehouse.PostTransferOrder(TransferHeader, true, true);
+
+        // [WHEN] LOT1 is sold from the destination location.
+        LibrarySales.CreateSalesHeader(SalesHeader, SalesHeader."Document Type"::Order, LibrarySales.CreateCustomerNo());
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, SalesLine.Type::Item, Item."No.", 1);
+        SalesLine.Validate("Location Code", ToLocation.Code);
+        SalesLine.Validate("Sust. Account No.", AccountCode);
+        SalesLine.Modify(true);
+        LibraryItemTracking.CreateSalesOrderItemTracking(ReservationEntry, SalesLine, '', LotNo[1], 1);
+        PostedInvoiceNo := LibrarySales.PostSalesDocument(SalesHeader, true, true);
+
+        // [THEN] The Sustainability Value Entry use LOT1's 100 CO2e per unit, not the 200 CO2e average of both lots.
+        SustainabilityValueEntry.SetRange("Document No.", PostedInvoiceNo);
+        SustainabilityValueEntry.SetRange("Item No.", Item."No.");
+        SustainabilityValueEntry.FindFirst();
+        Assert.AreEqual(100, SustainabilityValueEntry."CO2e per Unit", StrSubstNo(ValueMustBeEqualErr, SustainabilityValueEntry.FieldCaption("CO2e per Unit"), 100, SustainabilityValueEntry.TableCaption()));
+        Assert.AreEqual(-100, SustainabilityValueEntry."CO2e Amount (Actual)", StrSubstNo(ValueMustBeEqualErr, SustainabilityValueEntry.FieldCaption("CO2e Amount (Actual)"), -100, SustainabilityValueEntry.TableCaption()));
+    end;
+
     local procedure CreateUserSetup(var UserSetup: Record "User Setup"; UserID: Code[50])
     begin
         UserSetup.Init();
@@ -6103,6 +6172,29 @@ codeunit 148184 "Sustainability Posting Test"
             ItemJournalLine."Entry Type"::"Positive Adjmt.", Item."No.", Quantity);
 
         LibraryInventory.PostItemJournalLine(ItemJournalTemplate.Name, ItemJournalBatch.Name);
+    end;
+
+    local procedure EnsureGeneralPostingSetupForItem(Item: Record Item)
+    var
+        GeneralPostingSetup: Record "General Posting Setup";
+    begin
+        if Item."Gen. Prod. Posting Group" = '' then
+            exit;
+
+        if not GeneralPostingSetup.Get('', Item."Gen. Prod. Posting Group") then
+            LibraryERM.CreateGeneralPostingSetup(GeneralPostingSetup, '', Item."Gen. Prod. Posting Group");
+
+        if GeneralPostingSetup."Inventory Adjmt. Account" = '' then
+            GeneralPostingSetup.Validate("Inventory Adjmt. Account", LibraryERM.CreateGLAccountNo());
+        if GeneralPostingSetup."Direct Cost Applied Account" = '' then
+            GeneralPostingSetup.Validate("Direct Cost Applied Account", LibraryERM.CreateGLAccountNo());
+        if GeneralPostingSetup."Overhead Applied Account" = '' then
+            GeneralPostingSetup.Validate("Overhead Applied Account", LibraryERM.CreateGLAccountNo());
+        if GeneralPostingSetup."Purchase Variance Account" = '' then
+            GeneralPostingSetup.Validate("Purchase Variance Account", LibraryERM.CreateGLAccountNo());
+        if GeneralPostingSetup."COGS Account" = '' then
+            GeneralPostingSetup.Validate("COGS Account", LibraryERM.CreateGLAccountNo());
+        GeneralPostingSetup.Modify(true);
     end;
 
     local procedure VerifySustainabilityValueEntry(ItemNo: Code[20]; CO2eEmissionExpected: Decimal; CO2eEmissionActual: Decimal)


### PR DESCRIPTION
Fixes [AB#648886](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/648886)

**Issue:** For items using the Specific carbon tracking method, transferring multiple tracked lots or serial numbers with different emissions could cause a later sale to use an average emission instead of the selected tracking value.

**Cause:** A transfer receipt has no Sustainability Value Entry. While resolving its emissions, the posting code follows the matching transfer shipment. The shipment traversal then aggregated all applied source item ledger entries, including other lots or serial numbers from the same transfer.

**Solution:** Restrict the recursive transfer-shipment application traversal to entries with the same Lot No. and Serial No. as the transfer entry. This preserves the specific tracking emission across transfer receipt and subsequent sale.

