### PR TITLE
[29.X]-[Subcontracting] Purchase Return Order cannot be posted for subcontracting, while Corrective Credit Memo works well

### DIFF
--- a/src/Layers/BE/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/BE/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -3903,6 +3903,71 @@ codeunit 137063 "SCM Manufacturing 7.0"
         Assert.ExpectedTestFieldError(ProductionOrder.FieldCaption("Variant Code"), '');
     end;
 
+    [Test]
+    [HandlerFunctions('PostedPurchaseDocumentLinesPageHandler')]
+    procedure PostPurchaseReturnOrderForSubcontractingWhenLastOperationIsNotSubcontracted()
+    var
+        CapacityUnitOfMeasure: Record "Capacity Unit of Measure";
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+        RequisitionLine: Record "Requisition Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        SubcontractingWorkCenter: Record "Work Center";
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+        WorkCenter: Record "Work Center";
+        OperationNo: Code[10];
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647380] A subcontracting purchase return order can be posted when a later operation is not subcontracted.
+        Initialize();
+
+        // [GIVEN] A released production order whose subcontracting operation is followed by a non-subcontracting operation.
+        OperationNo := Format(10 + LibraryRandom.RandInt(10));
+        CreateSubcontractingSetup(SubcontractingWorkCenter, RoutingHeader, OperationNo);
+        UpdateRoutingStatus(RoutingHeader, RoutingHeader.Status::"Under Development");
+        CreateWorkCenterSetup(WorkCenter, CapacityUnitOfMeasure.Type::Minutes, 160000T, 235959T);
+        CreateRoutingLine(RoutingLine, RoutingHeader, WorkCenter."No.");
+        UpdateRoutingStatus(RoutingHeader, RoutingHeader.Status::Certified);
+        CreateProdItem(Item, RoutingHeader."No.");
+        CreateAndRefreshProdOrder(
+            ProductionOrder, ProductionOrder.Status::Released, Item."No.", LibraryRandom.RandInt(10),
+            ProductionOrder."Source Type"::Item, false);
+
+        // [GIVEN] A subcontracting purchase order created from the subcontracting worksheet is received and invoiced.
+        CalculateSubcontractOrder(RequisitionLine, SubcontractingWorkCenter."No.", ProductionOrder);
+        LibraryPlanning.CarryOutAMSubcontractWksh(RequisitionLine);
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.SetRange("Operation No.", OperationNo);
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [GIVEN] A purchase return order populated from the posted subcontracting invoice.
+        PurchInvLine.SetRange("Order No.", PurchaseHeader."No.");
+        PurchInvLine.FindFirst();
+        LibraryPurchase.CreatePurchHeader(
+            PurchaseHeader, PurchaseHeader."Document Type"::"Return Order", SubcontractingWorkCenter."Subcontractor No.");
+        LibraryVariableStorage.Enqueue(PurchInvLine."Document No.");
+        PurchaseHeader.GetPstdDocLinesToReverse();
+        PurchaseHeader.Validate("Vendor Cr. Memo No.", PurchaseHeader."Buy-from Vendor No.");
+        PurchaseHeader.Modify(true);
+
+        // [WHEN] The purchase return order is shipped and invoiced.
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Posting succeeds.
+        PurchCrMemoHdr.SetRange("Buy-from Vendor No.", PurchaseHeader."Buy-from Vendor No.");
+        Assert.RecordIsNotEmpty(PurchCrMemoHdr);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -6240,6 +6305,14 @@ codeunit 137063 "SCM Manufacturing 7.0"
     begin
         ProdOrderComponents.ItemTrackingLines.Invoke();
         ProdOrderComponents.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure PostedPurchaseDocumentLinesPageHandler(var PostedPurchaseDocumentLines: TestPage "Posted Purchase Document Lines")
+    begin
+        PostedPurchaseDocumentLines.PostedReceiptsBtn.SetValue('Posted Invoices');
+        PostedPurchaseDocumentLines.PostedInvoices.Filter.SetFilter("Document No.", LibraryVariableStorage.DequeueText());
+        PostedPurchaseDocumentLines.OK().Invoke();
     end;
 
     local procedure GetShopCalendarCodeForProductionOrder(ProductionOrder: Record "Production Order"): Code[10]

--- a/src/Layers/IT/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/IT/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -3897,6 +3897,71 @@ codeunit 137063 "SCM Manufacturing 7.0"
         Assert.ExpectedTestFieldError(ProductionOrder.FieldCaption("Variant Code"), '');
     end;
 
+    [Test]
+    [HandlerFunctions('PostedPurchaseDocumentLinesPageHandler')]
+    procedure PostPurchaseReturnOrderForSubcontractingWhenLastOperationIsNotSubcontracted()
+    var
+        CapacityUnitOfMeasure: Record "Capacity Unit of Measure";
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+        RequisitionLine: Record "Requisition Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        SubcontractingWorkCenter: Record "Work Center";
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+        WorkCenter: Record "Work Center";
+        OperationNo: Code[10];
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647380] A subcontracting purchase return order can be posted when a later operation is not subcontracted.
+        Initialize();
+
+        // [GIVEN] A released production order whose subcontracting operation is followed by a non-subcontracting operation.
+        OperationNo := Format(10 + LibraryRandom.RandInt(10));
+        CreateSubcontractingSetup(SubcontractingWorkCenter, RoutingHeader, OperationNo);
+        UpdateRoutingStatus(RoutingHeader, RoutingHeader.Status::"Under Development");
+        CreateWorkCenterSetup(WorkCenter, CapacityUnitOfMeasure.Type::Minutes, 160000T, 235959T);
+        CreateRoutingLine(RoutingLine, RoutingHeader, WorkCenter."No.");
+        UpdateRoutingStatus(RoutingHeader, RoutingHeader.Status::Certified);
+        CreateProdItem(Item, RoutingHeader."No.");
+        CreateAndRefreshProdOrder(
+            ProductionOrder, ProductionOrder.Status::Released, Item."No.", LibraryRandom.RandInt(10),
+            ProductionOrder."Source Type"::Item, false);
+
+        // [GIVEN] A subcontracting purchase order created from the subcontracting worksheet is received and invoiced.
+        CalculateSubcontractOrder(RequisitionLine, SubcontractingWorkCenter."No.", ProductionOrder);
+        LibraryPlanning.CarryOutAMSubcontractWksh(RequisitionLine);
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.SetRange("Operation No.", OperationNo);
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [GIVEN] A purchase return order populated from the posted subcontracting invoice.
+        PurchInvLine.SetRange("Order No.", PurchaseHeader."No.");
+        PurchInvLine.FindFirst();
+        LibraryPurchase.CreatePurchHeader(
+            PurchaseHeader, PurchaseHeader."Document Type"::"Return Order", SubcontractingWorkCenter."Subcontractor No.");
+        LibraryVariableStorage.Enqueue(PurchInvLine."Document No.");
+        PurchaseHeader.GetPstdDocLinesToReverse();
+        PurchaseHeader.Validate("Vendor Cr. Memo No.", PurchaseHeader."Buy-from Vendor No.");
+        PurchaseHeader.Modify(true);
+
+        // [WHEN] The purchase return order is shipped and invoiced.
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Posting succeeds.
+        PurchCrMemoHdr.SetRange("Buy-from Vendor No.", PurchaseHeader."Buy-from Vendor No.");
+        Assert.RecordIsNotEmpty(PurchCrMemoHdr);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -6249,6 +6314,14 @@ codeunit 137063 "SCM Manufacturing 7.0"
     begin
         ProdOrderComponents.ItemTrackingLines.Invoke();
         ProdOrderComponents.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure PostedPurchaseDocumentLinesPageHandler(var PostedPurchaseDocumentLines: TestPage "Posted Purchase Document Lines")
+    begin
+        PostedPurchaseDocumentLines.PostedReceiptsBtn.SetValue('Posted Invoices');
+        PostedPurchaseDocumentLines.PostedInvoices.Filter.SetFilter("Document No.", LibraryVariableStorage.DequeueText());
+        PostedPurchaseDocumentLines.OK().Invoke();
     end;
 
     local procedure GetShopCalendarCodeForProductionOrder(ProductionOrder: Record "Production Order"): Code[10]

--- a/src/Layers/W1/BaseApp/Manufacturing/Purchases/Document/MfgPurchaseDocumentMgt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Manufacturing/Purchases/Document/MfgPurchaseDocumentMgt.Codeunit.al
@@ -74,7 +74,7 @@ codeunit 99000789 "Mfg. Purchase Document Mgt."
     [EventSubscriber(ObjectType::Table, Database::"Purchase Line", 'OnIsSubcontractingCreditMemo', '', true, false)]
     local procedure OnIsSubcontractingCreditMemo(var PurchaseLine: Record "Purchase Line"; var Result: Boolean)
     begin
-        if (PurchaseLine."Document Type" = PurchaseLine."Document Type"::"Credit Memo") and PurchaseLine.IsProdOrder() and
+        if PurchaseLine.IsCreditDocType() and PurchaseLine.IsProdOrder() and
            (PurchaseLine."Operation No." <> '') and (PurchaseLine."Work Center No." <> '') then
             Result := true
         else

--- a/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
+++ b/src/Layers/W1/Tests/SCM-Manufacturing/SCMManufacturing70.Codeunit.al
@@ -3793,6 +3793,71 @@ codeunit 137063 "SCM Manufacturing 7.0"
         Assert.AreEqual(SKURoutingHeader."No.", ProdOrderLine."Routing No.", ProductionRoutingErr);
     end;
 
+    [Test]
+    [HandlerFunctions('PostedPurchaseDocumentLinesPageHandler')]
+    procedure PostPurchaseReturnOrderForSubcontractingWhenLastOperationIsNotSubcontracted()
+    var
+        CapacityUnitOfMeasure: Record "Capacity Unit of Measure";
+        Item: Record Item;
+        ProductionOrder: Record "Production Order";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchInvLine: Record "Purch. Inv. Line";
+        RequisitionLine: Record "Requisition Line";
+        RoutingHeader: Record "Routing Header";
+        RoutingLine: Record "Routing Line";
+        SubcontractingWorkCenter: Record "Work Center";
+        PurchCrMemoHdr: Record "Purch. Cr. Memo Hdr.";
+        WorkCenter: Record "Work Center";
+        OperationNo: Code[10];
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO 647380] A subcontracting purchase return order can be posted when a later operation is not subcontracted.
+        Initialize();
+
+        // [GIVEN] A released production order whose subcontracting operation is followed by a non-subcontracting operation.
+        OperationNo := Format(10 + LibraryRandom.RandInt(10));
+        CreateSubcontractingSetup(SubcontractingWorkCenter, RoutingHeader, OperationNo);
+        UpdateRoutingStatus(RoutingHeader, RoutingHeader.Status::"Under Development");
+        CreateWorkCenterSetup(WorkCenter, CapacityUnitOfMeasure.Type::Minutes, 160000T, 235959T);
+        CreateRoutingLine(RoutingLine, RoutingHeader, WorkCenter."No.");
+        UpdateRoutingStatus(RoutingHeader, RoutingHeader.Status::Certified);
+        CreateProdItem(Item, RoutingHeader."No.");
+        CreateAndRefreshProdOrder(
+            ProductionOrder, ProductionOrder.Status::Released, Item."No.", LibraryRandom.RandInt(10),
+            ProductionOrder."Source Type"::Item, false);
+
+        // [GIVEN] A subcontracting purchase order created from the subcontracting worksheet is received and invoiced.
+        CalculateSubcontractOrder(RequisitionLine, SubcontractingWorkCenter."No.", ProductionOrder);
+        LibraryPlanning.CarryOutAMSubcontractWksh(RequisitionLine);
+        PurchaseLine.SetRange("Document Type", PurchaseLine."Document Type"::Order);
+        PurchaseLine.SetRange("Prod. Order No.", ProductionOrder."No.");
+        PurchaseLine.SetRange("Operation No.", OperationNo);
+        PurchaseLine.FindFirst();
+        PurchaseHeader.Get(PurchaseLine."Document Type", PurchaseLine."Document No.");
+        PurchaseHeader.Validate("Vendor Invoice No.", PurchaseHeader."No.");
+        PurchaseHeader.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [GIVEN] A purchase return order populated from the posted subcontracting invoice.
+        PurchInvLine.SetRange("Order No.", PurchaseHeader."No.");
+        PurchInvLine.FindFirst();
+        LibraryPurchase.CreatePurchHeader(
+            PurchaseHeader, PurchaseHeader."Document Type"::"Return Order", SubcontractingWorkCenter."Subcontractor No.");
+        LibraryVariableStorage.Enqueue(PurchInvLine."Document No.");
+        PurchaseHeader.GetPstdDocLinesToReverse();
+        PurchaseHeader.Validate("Vendor Cr. Memo No.", PurchaseHeader."Buy-from Vendor No.");
+        PurchaseHeader.Modify(true);
+
+        // [WHEN] The purchase return order is shipped and invoiced.
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeader, true, true);
+
+        // [THEN] Posting succeeds.
+        PurchCrMemoHdr.SetRange("Buy-from Vendor No.", PurchaseHeader."Buy-from Vendor No.");
+        Assert.RecordIsNotEmpty(PurchCrMemoHdr);
+        LibraryVariableStorage.AssertEmpty();
+    end;
+
     local procedure Initialize()
     var
         LibraryERMCountryData: Codeunit "Library - ERM Country Data";
@@ -6130,6 +6195,14 @@ codeunit 137063 "SCM Manufacturing 7.0"
     begin
         ProdOrderComponents.ItemTrackingLines.Invoke();
         ProdOrderComponents.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure PostedPurchaseDocumentLinesPageHandler(var PostedPurchaseDocumentLines: TestPage "Posted Purchase Document Lines")
+    begin
+        PostedPurchaseDocumentLines.PostedReceiptsBtn.SetValue('Posted Invoices');
+        PostedPurchaseDocumentLines.PostedInvoices.Filter.SetFilter("Document No.", LibraryVariableStorage.DequeueText());
+        PostedPurchaseDocumentLines.OK().Invoke();
     end;
 
     local procedure GetShopCalendarCodeForProductionOrder(ProductionOrder: Record "Production Order"): Code[10]


### PR DESCRIPTION
Fixes [AB#649809](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649809)









