### PR TITLE
[Main]- RSPackContentEvaluation

### DIFF
--- a/src/Layers/AT/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/AT/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/AU/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/AU/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/BE/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/BE/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/CA/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/CA/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -197,14 +197,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/DE/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/DE/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/DK/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/DK/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/ES/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/ES/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/FI/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/FI/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/GB/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/GB/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -149,14 +149,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/IS/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/IS/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/IT/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/IT/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/MX/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/MX/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/NO/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/NO/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/NZ/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/NZ/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/SE/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/SE/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/US/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/US/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -197,14 +197,14 @@
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',

--- a/src/Layers/W1/Tests/Misc/RSPackContentEvaluation.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/RSPackContentEvaluation.Codeunit.al
@@ -150,14 +150,14 @@ codeunit 138400 "RS Pack Content - Evaluation"
         Initialize();
 
         TempXMLBuffer.Load(FileManagement.CombinePath(
-            ApplicationPath, '../../App/Demotool/Pictures/MachineLearning/itemsales.xml'));
+            ApplicationPath, '../../App/BCApps/src/DemoTool/Pictures/MachineLearning/itemsales.xml'));
 
-        Item.SetRange("Assembly BOM", false);
         Evaluate(Periods, TempXMLBuffer.GetAttributeValueAsText('Periods'));
         TempXMLBuffer.FindChildElements(TempXMLBuffer);
         TempXMLBuffer.FindSet();
-        Assert.RecordCount(TempXMLBuffer, Item.Count);
         repeat
+            Item.Get(TempXMLBuffer.GetAttributeValueAsText('item'));
+            Item.TestField("Assembly BOM", false);
             TempXMLBuffer.FindChildElements(TempXMLBufferPeriods);
             Assert.AreEqual(Periods, TempXMLBufferPeriods.Count,
               StrSubstNo('Item %1 does not have %2 periods',


### PR DESCRIPTION
Workitem [Bug 641038](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/641038): [all-e]Re-enable BC tests disabled due to BCApps submodule migration (hardcoded GDL/DemoTool paths)

Fixes [AB#641038](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641038)

