### PR TITLE
[CZ tests] Make advance-payment posting fixtures self-contained

### DIFF
--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/LibraryPurchAdvancesCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/LibraryPurchAdvancesCZZ.Codeunit.al
@@ -228,7 +228,7 @@ codeunit 148008 "Library - Purch. Advances CZZ"
         VATPostingSetup: Record "VAT Posting Setup";
     begin
         LibraryERM.FindVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT");
-        LibraryERM.FindGeneralPostingSetup(GeneralPostingSetup);
+        LibraryERM.FindGeneralPostingSetupInvtBase(GeneralPostingSetup);
         LibraryERM.CreateGLAccount(GLAccount);
         GLAccount.Validate("Gen. Posting Type", GLAccount."Gen. Posting Type"::Purchase);
         GLAccount.Validate("Gen. Bus. Posting Group", GeneralPostingSetup."Gen. Bus. Posting Group");

--- a/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/LibrarySalesAdvancesCZZ.Codeunit.al
+++ b/src/Apps/CZ/AdvancePaymentsLocalization/test/Src/LibrarySalesAdvancesCZZ.Codeunit.al
@@ -231,7 +231,7 @@ codeunit 148009 "Library - Sales Advances CZZ"
         VATPostingSetup: Record "VAT Posting Setup";
     begin
         LibraryERM.FindVATPostingSetup(VATPostingSetup, VATPostingSetup."VAT Calculation Type"::"Normal VAT");
-        LibraryERM.FindGeneralPostingSetup(GeneralPostingSetup);
+        LibraryERM.FindGeneralPostingSetupInvtBase(GeneralPostingSetup);
         LibraryERM.CreateGLAccount(GLAccount);
         GLAccount.Validate("Gen. Posting Type", GLAccount."Gen. Posting Type"::Sale);
         GLAccount.Validate("Gen. Bus. Posting Group", GeneralPostingSetup."Gen. Bus. Posting Group");


### PR DESCRIPTION
## Summary

[AB#646383](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/646383)

Make the Czech advance-payment test libraries create their own general posting fixture when a suitable one is absent.

In the purchase and sales libraries' `CreateGLAccount`, replace `LibraryERM.FindGeneralPostingSetup` with the existing `LibraryERM.FindGeneralPostingSetupInvtBase`. That helper reuses a suitable setup or creates posting groups and configured G/L accounts through existing test-library routines.

Exactly two test-library lines change. No production posting logic, test-runner isolation, test exclusions, NAV selectors, or company configuration changes.

## Evidence and validation

Before this fix, fourteen existing blocked/privacy customer/vendor scenarios in CUs 148108 and 148109 failed before their business assertions because no nonblank General Posting Setup pair existed. The failure persisted in [run 34569356813](https://github.com/microsoft/BCApps/actions/runs/34569356813/job/103189263603) after discovery was isolated from the primary fixture.

The predecessor CZ test suite creates posting setups. Source inspection shows the baseline's extra Disabled pass can leave runner 130451 selected for subsequent calls; the auth harness uses ordinary Codeunit isolation (130450), which must not depend on another suite's writes. Exact baseline CZ suite-state snapshots were not captured, so the full state transition is not claimed proved.

The fixture fix removes the unconditional dependency on existing data regardless of that runner-history explanation. The chosen find-or-create helper is already used by the inventory test library and is present in the Czech Application Test Library.

Source-equivalence and whitespace checks passed: only the two helper calls changed. **All fourteen formerly failing scenarios now pass** in [combined auth CI, CZ Default](https://github.com/microsoft/BCApps/actions/runs/34592175490/job/103264073977), on head `25916aeb85`. The lane still fails six separate Expense permission tests, not these advance-payment scenarios.

[Standalone CI](https://github.com/microsoft/BCApps/actions/runs/34590822856) **passed on attempt 2** at 2026-09-11T19:28:34Z after the AU timing-test retry. That retry was not initiated by this assistant. [Combined auth CI](https://github.com/microsoft/BCApps/actions/runs/34592175490) remains failed on the 12 known Expense methods, not these fourteen Czech scenarios. No local NST result is claimed.

## Relationship to API authentication work

This independently reviewable test-fixture prerequisite targets main. Its commit `9b196da5f3` is included in #10085 at `b85fcfbac6` to validate under the corrected isolation behavior. It is not folded into the authentication provider or the production application.

The separately tracked CU 148339 compilation prerequisite is #11340. The auth branch includes that prerequisite; this two-line PR does not duplicate it. Coverage review recorded no Expense cases in the standalone typed artifacts, so its green workflow is not evidence that the broader auth run's Expense failures are fixed.

