### PR TITLE
[Shopify] Improve shop navigation and background sync guidance

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyBackgroundSyncs.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Codeunits/ShpfyBackgroundSyncs.Codeunit.al
@@ -17,11 +17,12 @@ codeunit 30101 "Shpfy Background Syncs"
 
     var
         SyncDescriptionTxt: Label 'Shopify Sync of %1 for shop(s) %2', Comment = '%1 = Synchronization Tyep, %2 = Synchronization Code';
-        InventorySyncTypeTxt: Label 'Inventory';
         OrderSyncTypeTxt: Label 'Order';
         PayoutsSyncTypeTxt: Label 'Payouts';
         ProductImagesSyncTypeTxt: Label 'Product Images';
-        ProductsSyncTypeTxt: Label 'Products';
+        ProductSyncDescriptionTxt: Label 'Shopify product sync for shop(s) %1', Comment = '%1 = Shopify shop code filter';
+        PriceSyncDescriptionTxt: Label 'Shopify price sync for shop(s) %1', Comment = '%1 = Shopify shop code filter';
+        InventorySyncDescriptionTxt: Label 'Shopify inventory sync for shop(s) %1', Comment = '%1 = Shopify shop code filter';
         JobQueueCategoryLbl: Label 'SHPFY', Locked = true;
         NothingToSyncErr: Label 'You need to add items to Shopify first, do you want to do it now?';
 
@@ -231,7 +232,7 @@ codeunit 30101 "Shpfy Background Syncs"
         Shop.SetRange("Allow Background Syncs", true);
         if not Shop.IsEmpty then begin
             Parameters := StrSubstNo(InventoryParametersTxt, Shop.GetView());
-            EnqueueJobEntry(Report::"Shpfy Sync Stock to Shopify", Parameters, StrSubstNo(SyncDescriptionTxt, InventorySyncTypeTxt, Shop.GetFilter(Code)), true, true);
+            EnqueueJobEntry(Report::"Shpfy Sync Stock to Shopify", Parameters, StrSubstNo(InventorySyncDescriptionTxt, Shop.GetFilter(Code)), true, true);
         end;
         Shop.SetRange("Allow Background Syncs", false);
         if not Shop.IsEmpty then begin
@@ -530,7 +531,7 @@ codeunit 30101 "Shpfy Background Syncs"
             Shop.SetRange("Allow Background Syncs", true);
             if not Shop.IsEmpty() then begin
                 Parameters := StrSubstNo(ProductParmatersTxt, format(false, 0, 9), Shop.GetView(), NumberOfRecords);
-                JobQueueId := EnqueueJobEntry(Report::"Shpfy Sync Products", Parameters, StrSubstNo(SyncDescriptionTxt, ProductsSyncTypeTxt, Shop.GetFilter(Code)), true, false);
+                JobQueueId := EnqueueJobEntry(Report::"Shpfy Sync Products", Parameters, StrSubstNo(ProductSyncDescriptionTxt, Shop.GetFilter(Code)), true, false);
             end;
         end;
 
@@ -554,13 +555,21 @@ codeunit 30101 "Shpfy Background Syncs"
         Shop.SetRange("Allow Background Syncs", true);
         if not Shop.IsEmpty then begin
             Parameters := StrSubstNo(ProductParmatersTxt, format(PricesOnly, 0, 9), Shop.GetView());
-            EnqueueJobEntry(Report::"Shpfy Sync Products", Parameters, StrSubstNo(SyncDescriptionTxt, ProductsSyncTypeTxt, Shop.GetFilter(Code)), true, true);
+            EnqueueJobEntry(Report::"Shpfy Sync Products", Parameters, GetProductSyncDescription(PricesOnly, Shop.GetFilter(Code)), true, true);
         end;
         Shop.SetRange("Allow Background Syncs", false);
         if not Shop.IsEmpty then begin
             Parameters := StrSubstNo(ProductParmatersTxt, format(PricesOnly, 0, 9), Shop.GetView());
-            EnqueueJobEntry(Report::"Shpfy Sync Products", Parameters, StrSubstNo(SyncDescriptionTxt, ProductsSyncTypeTxt, Shop.GetFilter(Code)), false, true);
+            EnqueueJobEntry(Report::"Shpfy Sync Products", Parameters, GetProductSyncDescription(PricesOnly, Shop.GetFilter(Code)), false, true);
         end;
+    end;
+
+    local procedure GetProductSyncDescription(PricesOnly: Boolean; ShopCodeFilter: Text): Text
+    begin
+        if PricesOnly then
+            exit(StrSubstNo(PriceSyncDescriptionTxt, ShopCodeFilter));
+
+        exit(StrSubstNo(ProductSyncDescriptionTxt, ShopCodeFilter));
     end;
 
     /// <summary> 

--- a/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Pages/ShpfyShopCard.Page.al
@@ -845,6 +845,32 @@ page 30101 "Shpfy Shop Card"
                 ToolTip = 'View a list of Shopify Staff Members for the shop.';
                 Visible = Rec."Advanced Shopify Plan";
             }
+            action(PaymentTransactions)
+            {
+                ApplicationArea = All;
+                Caption = 'Payment Transactions';
+                Image = Transactions;
+                Promoted = true;
+                PromotedCategory = Category4;
+                PromotedIsBig = true;
+                PromotedOnly = true;
+                RunObject = page "Shpfy Payment Transactions";
+                RunPageLink = "Shop Code" = field(Code);
+                ToolTip = 'View the Shopify payment transactions for this shop.';
+            }
+            action(Payouts)
+            {
+                ApplicationArea = All;
+                Caption = 'Payouts';
+                Image = PaymentHistory;
+                Promoted = true;
+                PromotedCategory = Category4;
+                PromotedIsBig = true;
+                PromotedOnly = true;
+                RunObject = page "Shpfy Payouts";
+                RunPageLink = "Shop Code" = field(Code);
+                ToolTip = 'View the Shopify payouts for this shop.';
+            }
         }
         area(Processing)
         {

--- a/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
+++ b/src/Apps/W1/Shopify/App/src/Base/Tables/ShpfyShop.Table.al
@@ -396,7 +396,7 @@ table 30102 "Shpfy Shop"
         field(44; "Allow Background Syncs"; Boolean)
         {
             Caption = 'Run Syncs in Background';
-            ToolTip = 'Specifies whether synchronization runs in the background. When enabled, you can continue working while large data sets synchronize. Disable for demos or troubleshooting to see real-time progress and receive detailed error messages.';
+            ToolTip = 'Specifies whether synchronization runs in the background. When enabled, you can continue working while large data sets synchronize. Review the status and errors in Job Queue Log Entries. Disable for demos or troubleshooting to see real-time progress and receive detailed error messages.';
             DataClassification = CustomerContent;
             InitValue = true;
         }

--- a/src/Apps/W1/Shopify/Test/Payments/ShpfyPaymentsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Payments/ShpfyPaymentsTest.Codeunit.al
@@ -249,7 +249,6 @@ codeunit 139566 "Shpfy Payments Test"
     local procedure CreateOtherShop(var OtherShop: Record "Shpfy Shop")
     begin
         OtherShop.Code := CopyStr(Shop.Code + '2', 1, MaxStrLen(OtherShop.Code));
-        OtherShop."Shopify URL" := StrSubstNo('https://%1.myshopify.com', LowerCase(OtherShop.Code));
         OtherShop.Insert(false);
     end;
 

--- a/src/Apps/W1/Shopify/Test/Payments/ShpfyPaymentsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Payments/ShpfyPaymentsTest.Codeunit.al
@@ -247,8 +247,14 @@ codeunit 139566 "Shpfy Payments Test"
     end;
 
     local procedure CreateOtherShop(var OtherShop: Record "Shpfy Shop")
+    var
+        OtherShopCode: Code[20];
     begin
-        OtherShop.Code := CopyStr(Shop.Code + '2', 1, MaxStrLen(OtherShop.Code));
+        OtherShopCode := CopyStr(Shop.Code + '2', 1, MaxStrLen(OtherShop.Code));
+        if OtherShop.Get(OtherShopCode) then
+            exit;
+
+        OtherShop.Code := OtherShopCode;
         OtherShop.Insert(false);
     end;
 

--- a/src/Apps/W1/Shopify/Test/Payments/ShpfyPaymentsTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Payments/ShpfyPaymentsTest.Codeunit.al
@@ -143,6 +143,44 @@ codeunit 139566 "Shpfy Payments Test"
     end;
 
     [Test]
+    [HandlerFunctions('PaymentTransactionsPageHandler')]
+    procedure ShopCardPaymentTransactionsActionFiltersByShop()
+    var
+        OtherShop: Record "Shpfy Shop";
+        ShopCard: TestPage "Shpfy Shop Card";
+    begin
+        Initialize();
+
+        CreateOtherShop(OtherShop);
+        CreatePaymentTransaction(Shop.Code);
+        CreatePaymentTransaction(OtherShop.Code);
+
+        ShopCard.OpenView();
+        ShopCard.GoToRecord(Shop);
+        ShopCard.PaymentTransactions.Invoke();
+        ShopCard.Close();
+    end;
+
+    [Test]
+    [HandlerFunctions('PayoutsPageHandler')]
+    procedure ShopCardPayoutsActionFiltersByShop()
+    var
+        OtherShop: Record "Shpfy Shop";
+        ShopCard: TestPage "Shpfy Shop Card";
+    begin
+        Initialize();
+
+        CreateOtherShop(OtherShop);
+        CreatePayout(Shop.Code);
+        CreatePayout(OtherShop.Code);
+
+        ShopCard.OpenView();
+        ShopCard.GoToRecord(Shop);
+        ShopCard.Payouts.Invoke();
+        ShopCard.Close();
+    end;
+
+    [Test]
     procedure UnitTestImportDispute()
     var
         Dispute: Record "Shpfy Dispute";
@@ -206,6 +244,55 @@ codeunit 139566 "Shpfy Payments Test"
         JPayment.Add('associatedOrder', JAssociatedOrder);
         JPayment.Add('sourceOrderTransactionId', Any.IntegerInRange(10000, 99999));
         exit(JPayment);
+    end;
+
+    local procedure CreateOtherShop(var OtherShop: Record "Shpfy Shop")
+    begin
+        OtherShop.Code := CopyStr(Shop.Code + '2', 1, MaxStrLen(OtherShop.Code));
+        OtherShop."Shopify URL" := StrSubstNo('https://%1.myshopify.com', LowerCase(OtherShop.Code));
+        OtherShop.Insert(false);
+    end;
+
+    local procedure CreatePaymentTransaction(ShopCode: Code[20])
+    var
+        PaymentTransaction: Record "Shpfy Payment Transaction";
+        Id: BigInteger;
+    begin
+        repeat
+            Id := Any.IntegerInRange(1, 999999999);
+        until not PaymentTransaction.Get(Id);
+
+        PaymentTransaction.Id := Id;
+        PaymentTransaction."Shop Code" := ShopCode;
+        PaymentTransaction.Insert(false);
+    end;
+
+    local procedure CreatePayout(ShopCode: Code[20])
+    var
+        Payout: Record "Shpfy Payout";
+        Id: BigInteger;
+    begin
+        repeat
+            Id := Any.IntegerInRange(1, 999999999);
+        until not Payout.Get(Id);
+
+        Payout.Id := Id;
+        Payout."Shop Code" := ShopCode;
+        Payout.Insert(false);
+    end;
+
+    [PageHandler]
+    procedure PaymentTransactionsPageHandler(var PaymentTransactions: TestPage "Shpfy Payment Transactions")
+    begin
+        LibraryAssert.AreEqual(Shop.Code, PaymentTransactions.Filter.GetFilter("Shop Code"), 'Payment transactions should be filtered by Shop Code');
+        LibraryAssert.IsTrue(PaymentTransactions.First(), 'A payment transaction for the selected shop should be shown');
+    end;
+
+    [PageHandler]
+    procedure PayoutsPageHandler(var Payouts: TestPage "Shpfy Payouts")
+    begin
+        LibraryAssert.AreEqual(Shop.Code, Payouts.Filter.GetFilter("Shop Code"), 'Payouts should be filtered by Shop Code');
+        LibraryAssert.IsTrue(Payouts.First(), 'A payout for the selected shop should be shown');
     end;
 
     local procedure GetRandomDispute(Id: BigInteger; var DisputeStatus: Enum "Shpfy Dispute Status"; var FinalizedOn: DateTime): JsonObject


### PR DESCRIPTION
## Summary

Improve Shopify shop navigation and background synchronization guidance.

## Change

- Add shop-filtered Payment Transactions and Payouts actions at the end of the Shopify Shop Card's Related menu.
- Add two-shop automated coverage for both navigation filters.
- Direct users to Job Queue Log Entries when background synchronization is enabled.
- Distinguish product, price, and inventory synchronization job descriptions.

Fixes [AB#649977](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649977)

Fixes [AB#650035](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650035)


