### PR TITLE
Re-enable AutoAcceptICGenJnlTransactionUT: add Report 511 handler

### DIFF
--- a/src/Layers/W1/Tests/ERM/ERMIntercompanyIII.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMIntercompanyIII.Codeunit.al
@@ -2265,6 +2265,7 @@ codeunit 134154 "ERM Intercompany III"
     end;
 
     [Test]
+    [HandlerFunctions('RequestPageHandler')]
     procedure AutoAcceptICGenJnlTransactionUT()
     var
         ICSetup: Record "IC Setup";


### PR DESCRIPTION
## What & why

Fixes test failure regression from PR #9038. When Page 615 licensing tier changed to IsBasicOnlyEnabled, Report 511 now runs during IC Accept flow and commits mid-test, causing Gen. Journal Line assertion to fail.

Solution adds RequestPageHandler to test, ensuring Report 511's request page is properly handled. Test isolation restored without modifying IC flow logic.

Fixes [AB#642679](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642679)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

## Risk & compatibility

None. Test-only change using existing handler pattern. No IC flow modifications, no public API changes, no data impact.

