### PR TITLE
Obsolete GPT-5.5 chat and add GPT-5.6 Ceres deployments

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAAttachmentMLLM.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Integration/SOAAttachmentMLLM.Codeunit.al
@@ -137,7 +137,7 @@ codeunit 4421 "SOA Attachment MLLM"
         end;
         Prompt := SecretText.SecretStrSubstNo(PromptTemplate, SecurityPrompt);
 
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT55ChatPreview());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT56ChatPreview());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Sales Order Agent");
 
         AOAIChatCompletionParams.SetTemperature(0);
@@ -273,6 +273,6 @@ codeunit 4421 "SOA Attachment MLLM"
 
     local procedure GetMaxTokens(): Integer
     begin
-        exit(50000); // Well within the output token limit of GPT-5.5.
+        exit(50000);
     end;
 }

--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOABroaderItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOABroaderItemSearch.Codeunit.al
@@ -53,7 +53,7 @@ codeunit 4596 "SOA Broader Item Search"
         CompletionAnswer: Text;
     begin
         // Generate OpenAI Completion
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT55ChatLatest());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT56ChatLatest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Sales Order Agent");
 
         AOAIChatCompletionParams.SetMaxTokens(MaxTokens());

--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSelector.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSelector.Codeunit.al
@@ -83,7 +83,7 @@ codeunit 4417 "SOA Item Selector"
         end;
 
         // Configure Azure OpenAI
-        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT55ChatLatest());
+        AzureOpenAI.SetAuthorization(Enum::"AOAI Model Type"::"Chat Completions", AOAIDeployments.GetGPT56ChatLatest());
         AzureOpenAI.SetCopilotCapability(Enum::"Copilot Capability"::"Sales Order Agent");
 
         // Set parameters

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeployments.Codeunit.al
@@ -142,10 +142,12 @@ codeunit 7768 "AOAI Deployments"
         exit(AOAIDeploymentsImpl.GetGPT53ChatPreview(CallerModuleInfo));
     end;
 
+#if not CLEAN30
     /// <summary>
     /// Returns the name of the latest AOAI deployment model of GPT-5.5 chat.
     /// </summary>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT-5.5 chat deployment name is no longer supported from 11 September 2026. Use GetGPT56ChatLatest instead (or GetGPT56ChatPreview for testing upcoming versions).', '30.0')]
     procedure GetGPT55ChatLatest(): Text
     var
         CallerModuleInfo: ModuleInfo;
@@ -157,13 +159,40 @@ codeunit 7768 "AOAI Deployments"
     /// <summary>
     /// Returns the name of the preview AOAI deployment model of GPT-5.5 chat.
     /// </summary>
-    /// <remarks>Use this deployment when the chat messages contain file content parts.</remarks>
+    /// <remarks>Use GetGPT56ChatPreview when the chat messages contain file content parts.</remarks>
     /// <returns>The deployment name.</returns>
+    [Obsolete('GPT-5.5 chat deployment name is no longer supported from 11 September 2026. Use GetGPT56ChatLatest instead (or GetGPT56ChatPreview for testing upcoming versions).', '30.0')]
     procedure GetGPT55ChatPreview(): Text
     var
         CallerModuleInfo: ModuleInfo;
     begin
         NavApp.GetCallerModuleInfo(CallerModuleInfo);
         exit(AOAIDeploymentsImpl.GetGPT55ChatPreview(CallerModuleInfo));
+    end;
+#endif
+
+    /// <summary>
+    /// Returns the name of the latest AOAI deployment model of GPT-5.6 chat.
+    /// </summary>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT56ChatLatest(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT56ChatLatest(CallerModuleInfo));
+    end;
+
+    /// <summary>
+    /// Returns the name of the preview AOAI deployment model of GPT-5.6 chat.
+    /// </summary>
+    /// <remarks>Use this deployment when the chat messages contain file content parts.</remarks>
+    /// <returns>The deployment name.</returns>
+    procedure GetGPT56ChatPreview(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(AOAIDeploymentsImpl.GetGPT56ChatPreview(CallerModuleInfo));
     end;
 }

--- a/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AOAIDeploymentsImpl.Codeunit.al
@@ -26,8 +26,12 @@ codeunit 7769 "AOAI Deployments Impl"
         GPT41MiniPreviewLbl: Label 'gpt-41-mini-preview', Locked = true;
         GPT53ChatLatestLbl: Label 'gpt-53-chat-latest', Locked = true;
         GPT53ChatPreviewLbl: Label 'gpt-53-chat-preview', Locked = true;
+#if not CLEAN30
         GPT55ChatLatestLbl: Label 'gpt-55-chat-latest', Locked = true;
         GPT55ChatPreviewLbl: Label 'gpt-55-chat-preview', Locked = true;
+#endif
+        GPT56ChatLatestLbl: Label 'gpt-56-ceres-latest', Locked = true;
+        GPT56ChatPreviewLbl: Label 'gpt-56-ceres-preview', Locked = true;
         DeprecatedDeployments: Dictionary of [Text, Date];
         DeprecationDatesInitialized: Boolean;
         DeprecationMessageLbl: Label 'We detected usage of the Azure OpenAI deployment "%1". This model is obsoleted starting %2 and the quality of your results might vary after that date. Check out codeunit 7768 AOAI Deployments to find the supported deployments.', Comment = 'Telemetry message where %1 is the name of the deployment and %2 is the date of deprecation';
@@ -83,6 +87,7 @@ codeunit 7769 "AOAI Deployments Impl"
         exit(GetDeploymentName(GPT53ChatPreviewLbl));
     end;
 
+#if not CLEAN30
     procedure GetGPT55ChatLatest(CallerModuleInfo: ModuleInfo): Text
     begin
         exit(GetDeploymentName(GPT55ChatLatestLbl));
@@ -91,6 +96,26 @@ codeunit 7769 "AOAI Deployments Impl"
     procedure GetGPT55ChatPreview(CallerModuleInfo: ModuleInfo): Text
     begin
         exit(GetDeploymentName(GPT55ChatPreviewLbl));
+    end;
+#endif
+
+    procedure GetGPT56ChatLatest(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT56ChatLatestLbl));
+    end;
+
+    procedure GetGPT56ChatPreview(CallerModuleInfo: ModuleInfo): Text
+    begin
+        exit(GetDeploymentName(GPT56ChatPreviewLbl));
+    end;
+
+    procedure IsFileContentSupported(DeploymentName: Text): Boolean
+    begin
+#if not CLEAN30
+        if DeploymentName = GPT55ChatPreviewLbl then
+            exit(true);
+#endif
+        exit(DeploymentName in [GPT41MiniPreviewLbl, GPT56ChatPreviewLbl]);
     end;
 
     // Initializes dictionary of deprecated models
@@ -105,6 +130,10 @@ codeunit 7769 "AOAI Deployments Impl"
         DeprecatedDeployments.Add(GPT4oPreviewLbl, DMY2Date(15, 7, 2025));
         DeprecatedDeployments.Add(GPT4oMiniLatestLbl, DMY2Date(15, 7, 2025));
         DeprecatedDeployments.Add(GPT4oMiniPreviewLbl, DMY2Date(15, 7, 2025));
+#endif
+#if not CLEAN30
+        DeprecatedDeployments.Add(GPT55ChatLatestLbl, DMY2Date(11, 9, 2026));
+        DeprecatedDeployments.Add(GPT55ChatPreviewLbl, DMY2Date(11, 9, 2026));
 #endif
         DeprecationDatesInitialized := true;
     end;

--- a/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatMessagesImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/Chat Completion/AOAIChatMessagesImpl.Codeunit.al
@@ -43,7 +43,7 @@ codeunit 7764 "AOAI Chat Messages Impl"
         TelemetryPrepromptRetrievalErr: Label 'Preprompt failed to be retrieved from Azure Key Vault.', Locked = true;
         TelemetryPostpromptRetrievalErr: Label 'Postprompt failed to be retrieved from Azure Key Vault.', Locked = true;
         WrongTypeErr: Label 'Wrong type when preparing sanitized message variant.', Locked = true;
-        IncompatibleModelErr: Label 'The current message history contains file content which is only compatible with the GPT-4.1 mini preview and GPT-5.5 chat preview deployments.';
+        IncompatibleModelErr: Label 'The current message history contains file content. Use the GPT-4.1 mini preview or GPT-5.6 chat preview deployment.';
 
 
     [NonDebuggable]
@@ -464,7 +464,7 @@ codeunit 7764 "AOAI Chat Messages Impl"
     [NonDebuggable]
     procedure CheckCompatibilityWithModel(Deployment: SecretText)
     var
-        AOAIDeployments: Codeunit "AOAI Deployments";
+        AOAIDeploymentsImpl: Codeunit "AOAI Deployments Impl";
         AOAIUserMessage: Codeunit "AOAI User Message";
         DeploymentName: Text;
         Counter: Integer;
@@ -474,7 +474,7 @@ codeunit 7764 "AOAI Chat Messages Impl"
         for Counter := 1 to HistoryUserMessages.Count() do begin
             HistoryUserMessages.Get(Counter, AOAIUserMessage);
             if AOAIUserMessage.HasFilePart() then
-                if not (DeploymentName in [AOAIDeployments.GetGPT41MiniPreview(), AOAIDeployments.GetGPT55ChatPreview()]) then
+                if not AOAIDeploymentsImpl.IsFileContentSupported(DeploymentName) then
                     Error(IncompatibleModelErr);
         end;
     end;

--- a/src/System Application/Test Library/AI/src/AzureOpenAITestLibrary.Codeunit.al
+++ b/src/System Application/Test Library/AI/src/AzureOpenAITestLibrary.Codeunit.al
@@ -23,6 +23,11 @@ codeunit 132933 "Azure OpenAI Test Library"
         exit(AOAIChatMessages.AssembleTools());
     end;
 
+    procedure CheckAOAIChatMessagesCompatibilityWithModel(var AOAIChatMessages: Codeunit "AOAI Chat Messages"; Deployment: SecretText)
+    begin
+        AOAIChatMessages.CheckCompatibilityWithModel(Deployment);
+    end;
+
     procedure GetAOAIChatCompletionParametersPayload(AOAIChatCompletionParams: Codeunit "AOAI Chat Completion Params"; var Payload: JsonObject)
     begin
         AOAIChatCompletionParams.AddChatCompletionsParametersToPayload(Payload);

--- a/src/System Application/Test/AI/src/AzureOpenAITest.Codeunit.al
+++ b/src/System Application/Test/AI/src/AzureOpenAITest.Codeunit.al
@@ -29,6 +29,30 @@ codeunit 132684 "Azure OpenAI Test"
 #endif
 
     [Test]
+    procedure TestGPT56ChatDeploymentNames()
+    var
+        AOAIDeployments: Codeunit "AOAI Deployments";
+    begin
+        // [SCENARIO] GPT-5.6 chat exposes distinct latest and preview deployment names.
+        LibraryAssert.AreEqual('gpt-56-ceres-latest', AOAIDeployments.GetGPT56ChatLatest(), 'The GPT-5.6 chat latest deployment name should be returned.');
+        LibraryAssert.AreEqual('gpt-56-ceres-preview', AOAIDeployments.GetGPT56ChatPreview(), 'The GPT-5.6 chat preview deployment name should be returned.');
+    end;
+
+#if not CLEAN30
+#pragma warning disable AL0432
+    [Test]
+    procedure TestGPT55ChatDeploymentNames()
+    var
+        AOAIDeployments: Codeunit "AOAI Deployments";
+    begin
+        // [SCENARIO] Obsolete GPT-5.5 chat getters preserve their deployment names for existing callers.
+        LibraryAssert.AreEqual('gpt-55-chat-latest', AOAIDeployments.GetGPT55ChatLatest(), 'The obsolete GPT-5.5 chat latest deployment name should be preserved.');
+        LibraryAssert.AreEqual('gpt-55-chat-preview', AOAIDeployments.GetGPT55ChatPreview(), 'The obsolete GPT-5.5 chat preview deployment name should be preserved.');
+    end;
+#pragma warning restore AL0432
+#endif
+
+    [Test]
     [HandlerFunctions('HandleCopilotNotAvailable')]
     procedure TestIsEnabledRejectPrivacyNotice()
     var
@@ -842,6 +866,73 @@ codeunit 132684 "Azure OpenAI Test"
         LibraryAssert.AreEqual(1, ContentToken.AsArray().Count, 'The second message content should be an array with 1 part');
     end;
 
+
+    [Test]
+    procedure TestChatMessagesFileContentSupportsPreviewModels()
+    var
+        AOAIChatMessages: Codeunit "AOAI Chat Messages";
+        AOAIUserMessage: Codeunit "AOAI User Message";
+        AOAIDeployments: Codeunit "AOAI Deployments";
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+    begin
+        // [SCENARIO] File content is accepted by supported preview deployments, including the obsolete GPT-5.5 chat preview.
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+        AOAIChatMessages.AddUserMessage('Text message');
+        AOAIUserMessage.AddFilePart('Test');
+        AOAIChatMessages.AddUserMessage(AOAIUserMessage);
+
+        // [WHEN] Checking file-content compatibility
+        // [THEN] Supported preview deployments do not raise an error.
+        AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT41MiniPreview());
+        AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT56ChatPreview());
+#if not CLEAN30
+#pragma warning disable AL0432
+        AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT55ChatPreview());
+#pragma warning restore AL0432
+#endif
+    end;
+
+    [Test]
+    procedure TestChatMessagesFileContentRejectsUnsupportedModels()
+    var
+        AOAIChatMessages: Codeunit "AOAI Chat Messages";
+        AOAIUserMessage: Codeunit "AOAI User Message";
+        AOAIDeployments: Codeunit "AOAI Deployments";
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+    begin
+        // [SCENARIO] File content is rejected for deployments that do not support it.
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+        AOAIUserMessage.AddFilePart('Test');
+        AOAIChatMessages.AddUserMessage(AOAIUserMessage);
+
+        // [WHEN] Checking deployments without file-content support
+        // [THEN] The error recommends supported preview deployments.
+        asserterror AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT56ChatLatest());
+        LibraryAssert.ExpectedError('Use the GPT-4.1 mini preview or GPT-5.6 chat preview deployment.');
+        asserterror AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT41MiniLatest());
+        LibraryAssert.ExpectedError('Use the GPT-4.1 mini preview or GPT-5.6 chat preview deployment.');
+        asserterror AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, DeploymentTxt);
+        LibraryAssert.ExpectedError('Use the GPT-4.1 mini preview or GPT-5.6 chat preview deployment.');
+    end;
+
+    [Test]
+    procedure TestChatMessagesTextContentSupportsAllModels()
+    var
+        AOAIChatMessages: Codeunit "AOAI Chat Messages";
+        AOAIUserMessage: Codeunit "AOAI User Message";
+        AOAIDeployments: Codeunit "AOAI Deployments";
+        AzureOpenAITestLibrary: Codeunit "Azure OpenAI Test Library";
+    begin
+        // [SCENARIO] Text-only messages do not impose file-content deployment restrictions.
+        EnvironmentInfoTestLibrary.SetTestabilitySoftwareAsAService(false);
+        AOAIChatMessages.AddUserMessage('Text message');
+        AOAIUserMessage.AddTextPart('Text content part');
+        AOAIChatMessages.AddUserMessage(AOAIUserMessage);
+
+        AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT56ChatLatest());
+        AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, AOAIDeployments.GetGPT56ChatPreview());
+        AzureOpenAITestLibrary.CheckAOAIChatMessagesCompatibilityWithModel(AOAIChatMessages, DeploymentTxt);
+    end;
 
     // [Test] Offline test to validate the flow of calling the Azure OpenAI service with chat messages containing file content.
     procedure OfflineChatCompletionWithFileContent()


### PR DESCRIPTION
<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

GPT-5.5 chat deployments retire on 11 September 2026. This change adds their GPT-5.6 replacements and moves the existing Sales Order Agent callers off the retiring deployments.

- Mark `GetGPT55ChatLatest()` and `GetGPT55ChatPreview()` obsolete in version `30.0`, with matching retirement telemetry and `CLEAN30` guards.
- Add `GetGPT56ChatLatest()` and `GetGPT56ChatPreview()`, returning `gpt-56-ceres-latest` and `gpt-56-ceres-preview`. The public getters retain the Chat naming convention; Ceres is used in the deployment values.
- Support GPT-5.6 preview for file-content messages, retain GPT-5.5 preview compatibility until cleanup, and migrate Sales Order Agent attachment extraction and item-search callers. Compatibility checks compare deployment labels directly so they do not emit retirement telemetry by calling obsolete getters.

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

N/A - No source issue or ADO work item was provided. An approved issue still needs to be linked.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*

<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

- `git diff --check` passed.
- Added five AL tests covering exact GPT-5.6 Ceres deployment names, unchanged obsolete GPT-5.5 names, supported file-content preview models, rejection of unsupported models, and unrestricted text-only messages.
- AL build and runtime tests were not run: Docker and the AL compiler were unavailable on PATH in this environment.

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->

Existing GPT-5.5 getters keep returning their original names until `CLEAN30` removes them; they do not silently redirect callers. Their obsolete messages identify the retirement date and replacement APIs. GPT-5.5 preview remains accepted for file content while those APIs are retained.

Sales Order Agent now selects GPT-5.6 Ceres, so the corresponding deployments must be available in the managed AOAI environment. This PR updates deployment selection, not Azure resource provisioning. No data or schema changes.

