### PR TITLE
[29.0][InterCompany][SII] Setup and telemetry enhancements

### DIFF
--- a/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIISetup.Table.al
+++ b/src/Layers/ES/BaseApp/Local/SII/EServices/EDocument/SIISetup.Table.al
@@ -233,7 +233,10 @@ table 10751 "SII Setup"
     var
         FeatureTelemetry: Codeunit "Feature Telemetry";
         CannotEnableWithoutCertificateErr: Label 'The setup cannot be enabled without a valid certificate.';
-        InvalidEndpointUrlErr: Label 'The endpoint URL %1 is not on the allow-list for this feature.', Comment = '%1 = the URL entered by the user';
+        InvalidEndpointUrlErr: Label 'The endpoint host %1 is not on the allow-list for this feature.', Comment = '%1 = the rejected host';
+        EndpointUrlRejectedAuditTxt: Label 'A SII endpoint URL was rejected during validation. Host: %1.', Locked = true, Comment = '%1 = the rejected host';
+        EndpointUrlRejectedTelemetryTxt: Label 'A SII endpoint URL was rejected during validation.', Locked = true;
+        UnparsableHostTok: Label '(unparsable host)', Locked = true;
         EndpointFieldChangedTxt: Label 'SII endpoint field "%1" was changed.', Locked = true, Comment = '%1 - endpoint field caption';
         SecurityAuditCertificateCodeChangedTxt: Label 'SII Certificate Code was changed from %1 to %2.', Locked = true, Comment = '%1 - old certificate code, %2 - new certificate code';
         SiiTxt: Label 'https://www2.agenciatributaria.gob.es/static_files/common/internet/dep/aplicaciones/es/aeat/ssii/fact/ws/SuministroInformacion.xsd', Locked = true;
@@ -259,9 +262,22 @@ table 10751 "SII Setup"
     end;
 
     procedure ValidateEndpointUrl(Url: Text)
+    var
+        TelemetryDimensions: Dictionary of [Text, Text];
+        Host: Text;
     begin
-        if not IsAllowedEndpointUrl(Url) then
-            Error(InvalidEndpointUrlErr, Url);
+        if IsAllowedEndpointUrl(Url) then
+            exit;
+
+        Host := GetHostFromUrl(Url);
+        Session.LogSecurityAudit(
+            SIIFeatureNameTok, SecurityOperationResult::Failure,
+            StrSubstNo(EndpointUrlRejectedAuditTxt, Host),
+            AuditCategory::ApplicationManagement);
+        TelemetryDimensions.Add('Category', SIIFeatureNameTok);
+        TelemetryDimensions.Add('Host', Host);
+        Session.LogMessage('0000VCA', EndpointUrlRejectedTelemetryTxt, Verbosity::Warning, DataClassification::SystemMetadata, TelemetryScope::All, TelemetryDimensions);
+        Error(InvalidEndpointUrlErr, Host);
     end;
 
     procedure IsAllowedEndpointUrl(Url: Text): Boolean
@@ -289,6 +305,20 @@ table 10751 "SII Setup"
             if (Host = Suffix) or Host.EndsWith('.' + Suffix) then
                 exit(true);
         exit(false);
+    end;
+
+    local procedure GetHostFromUrl(Url: Text): Text
+    var
+        Uri: Codeunit Uri;
+        Host: Text;
+    begin
+        if not Uri.IsWellFormedUriString(Url, Enum::UriKind::Absolute) then
+            exit(UnparsableHostTok);
+        Uri.Init(Url);
+        Host := LowerCase(Uri.GetHost());
+        if Host = '' then
+            exit(UnparsableHostTok);
+        exit(Host);
     end;
 
     local procedure ValidateAndAuditEndpointUrlChange(EndpointFieldCaption: Text; OldUrl: Text; NewUrl: Text)

--- a/src/Layers/ES/Tests/Local/SIIEndpointUrlValidation.Codeunit.al
+++ b/src/Layers/ES/Tests/Local/SIIEndpointUrlValidation.Codeunit.al
@@ -10,7 +10,6 @@ codeunit 147595 "SII Endpoint Url Validation"
 
     var
         Assert: Codeunit Assert;
-        InvalidEndpointUrlErr: Label 'The endpoint URL %1 is not on the allow-list for this feature.', Comment = '%1 = the URL entered by the user';
 
     [Test]
     [Scope('OnPrem')]
@@ -46,7 +45,8 @@ codeunit 147595 "SII Endpoint Url Validation"
         // [SCENARIO 636975] Non-HTTPS URLs are rejected.
         NonHttpsUrl := 'http://www1.agenciatributaria.gob.es/wlpl/SSII-FACT/ws/fe/SiiFactFEV1SOAP';
         asserterror SIISetup.ValidateEndpointUrl(NonHttpsUrl);
-        Assert.ExpectedError(StrSubstNo(InvalidEndpointUrlErr, NonHttpsUrl));
+        Assert.ExpectedError('is not on the allow-list for this feature');
+        Assert.ExpectedError('www1.agenciatributaria.gob.es');
     end;
 
     [Test]
@@ -60,7 +60,8 @@ codeunit 147595 "SII Endpoint Url Validation"
         // [SCENARIO 636975] Malformed URLs are rejected.
         MalformedUrl := 'not a url';
         asserterror SIISetup.ValidateEndpointUrl(MalformedUrl);
-        Assert.ExpectedError(StrSubstNo(InvalidEndpointUrlErr, MalformedUrl));
+        Assert.ExpectedError('is not on the allow-list for this feature');
+        Assert.ExpectedError('(unparsable host)');
     end;
 
     [Test]

--- a/src/Layers/RU/Tests/ERM/ERMIntercompany.Codeunit.al
+++ b/src/Layers/RU/Tests/ERM/ERMIntercompany.Codeunit.al
@@ -1126,6 +1126,109 @@ codeunit 134151 "ERM Intercompany"
 
     [Test]
     [Scope('OnPrem')]
+    procedure TrustedCrossIntercompanyDestinationUrlIsAllowed()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+    begin
+        // [FEATURE] [AI test 0.4]
+        Assert.IsTrue(
+            CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics.com/v2.0/tenant/environment/api/v2.0/companies', '.dynamics.com'),
+            'The trusted Business Central API URL must be allowed.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure UntrustedCrossIntercompanyDestinationUrlsAreBlocked()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+    begin
+        // [FEATURE] [AI test 0.4]
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('http://api.businesscentral.dynamics.com/v2.0/companies', '.dynamics.com'), 'A non-HTTPS URL must be rejected.');
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics.com.example.com/v2.0/companies', '.dynamics.com'), 'A look-alike host must be rejected.');
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('', '.dynamics.com'), 'A blank URL must be rejected.');
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('not-a-valid-uri', '.dynamics.com'), 'A malformed URL must be rejected.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TrustedCrossIntercompanyTokenEndpointIsAllowed()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.microsoftonline.com/' + Format(CreateGuid(), 0, 4) + '/oauth2/v2.0/token';
+
+        Assert.AreEqual(TokenEndpoint, CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/'), 'The trusted Microsoft Entra token endpoint must be returned unchanged.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TrustedCrossIntercompanyTokenEndpointAllowsDomainTenant()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/token';
+
+        Assert.AreEqual(TokenEndpoint, CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/'), 'A domain-based tenant identifier must be accepted.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure UntrustedCrossIntercompanyTokenEndpointsAreBlocked()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+
+        TokenEndpoint := 'https://login.microsoftonline.com.example.com/' + Format(CreateGuid(), 0, 4) + '/oauth2/v2.0/token';
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+
+        // An empty tenant segment must be rejected (verifies the tenant identifier extraction boundary).
+        TokenEndpoint := 'https://login.microsoftonline.com//oauth2/v2.0/token';
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CrossIntercompanyDestinationUrlPpeHostIsValidated()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+    begin
+        // [FEATURE] [AI test 0.4]
+        Assert.IsTrue(
+            CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics-tie.com/v2.0/tenant/environment/api/v2.0/companies', '.dynamics-tie.com'),
+            'The trusted PPE Business Central API URL must be allowed.');
+        Assert.IsFalse(
+            CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics-tie.com.example.com/v2.0/companies', '.dynamics-tie.com'),
+            'A look-alike PPE host must be rejected.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CrossIntercompanyTokenEndpointPpeAuthorityIsValidated()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.windows-ppe.net/' + Format(CreateGuid(), 0, 4) + '/oauth2/v2.0/token';
+        Assert.AreEqual(TokenEndpoint, CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.windows-ppe.net/'), 'The trusted PPE token endpoint must be returned unchanged.');
+
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority('https://login.windows-ppe.net/common/oauth2/v2.0/token', 'https://login.windows-ppe.net/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure PostICJournalLineWithInboxTypeFileLocation()
     var
         ICPartner: Record "IC Partner";

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/CrossIntercompPartnerSetup.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/CrossIntercompPartnerSetup.Page.al
@@ -7,7 +7,6 @@ namespace Microsoft.Intercompany.DataExchange;
 using Microsoft.Intercompany.Partner;
 using Microsoft.Intercompany.Setup;
 using System.Environment;
-using System.Utilities;
 
 /// <summary>
 /// Wizard page for setting up cross-environment intercompany partner connections.
@@ -121,6 +120,8 @@ page 561 "CrossIntercomp. Partner Setup"
 
                         trigger OnValidate()
                         begin
+                            if (PartnerSaaSConnectionUrl <> '') and not ValidateDynamicsUrl(PartnerSaaSConnectionUrl) then
+                                Error(UntrustedConnectionUrlErr);
                             NextEnabled := CheckIfSaaSConnectionDetailsAreFilled();
                         end;
                     }
@@ -205,6 +206,8 @@ page 561 "CrossIntercomp. Partner Setup"
                         ExtendedDatatype = URL;
                         Caption = 'Redirect URL';
                         ToolTip = 'Specifies the OAuth 2.0 redirect URL of the Microsoft Entra authentication application. In most scenarios this will be: https://businesscentral.dynamics.com/OAuthLanding.htm .';
+                        // The connector always uses the environment's default redirect URL, so this field is hidden to avoid promising configurable behavior.
+                        Visible = false;
                         trigger OnValidate()
                         begin
                             NextEnabled := CheckIfSaaSConnectionDetailsAreFilled();
@@ -348,7 +351,7 @@ page 561 "CrossIntercomp. Partner Setup"
         NotSetUpQst: Label 'The setup for the connection to the intercompany partner''s environment isn''t complete. If you leave this guide, your settings will be deleted.\\Are you sure you want to exit?';
         LearnMoreTok: Label 'Privacy and Cookies';
         PrivacyLinkTxt: Label 'https://go.microsoft.com/fwlink/?linkid=521839';
-        UrlNotDynamicsErr: Label 'The URL provided is not in the dynamics.com domain.';
+        UntrustedConnectionUrlErr: Label 'The connection URL must be a trusted Business Central API URL.';
 
 
     local procedure LoadSaaSDataForCurrentCompany()
@@ -485,24 +488,12 @@ page 561 "CrossIntercomp. Partner Setup"
 
     internal procedure ValidateDynamicsUrl(Url: Text): Boolean
     var
-        UrlHelper: Codeunit "URL Helper";
-        UnexpectedDomain: Boolean;
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
     begin
         if Url = '' then
             exit(true);
 
-        if not Url.StartsWith('https://') then
-            exit(false);
-
-        if UrlHelper.IsPPE() then
-            UnexpectedDomain := StrPos(LowerCase(Url), '.dynamics-tie.com') = 0;
-
-        if UrlHelper.IsPROD() then
-            UnexpectedDomain := StrPos(LowerCase(Url), '.dynamics.com') = 0;
-
-        if not UnexpectedDomain then
-            exit(true);
-        Error(UrlNotDynamicsErr);
+        exit(CrossIntercompanyConnector.IsDestinationUrlTrusted(Url));
     end;
     #endregion
 }

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/CrossIntercompanyConnector.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/CrossIntercompanyConnector.Codeunit.al
@@ -8,6 +8,7 @@ using Microsoft.Finance.GeneralLedger.Setup;
 using Microsoft.Intercompany.Partner;
 using System.Environment;
 using System.Security.Authentication;
+using System.Utilities;
 
 /// <summary>
 /// Manages secure API connections and data exchange between intercompany partners across different environments.
@@ -33,6 +34,12 @@ codeunit 560 "CrossIntercompany Connector"
         V1VersionTok: Label 'v1.0', Locked = true;
         GeneralAPIsPathTok: Label 'v2.0/companies', Locked = true;
         BCResourceURLScopeTok: Label 'https://api.businesscentral.dynamics.com/.default', Locked = true;
+        DynamicsProdHostSuffixTok: Label '.dynamics.com', Locked = true;
+        DynamicsPPEHostSuffixTok: Label '.dynamics-tie.com', Locked = true;
+        EntraAuthorityPrefixTok: Label 'https://login.microsoftonline.com/', Locked = true;
+        EntraPPEAuthorityPrefixTok: Label 'https://login.windows-ppe.net/', Locked = true;
+        OAuthTokenEndpointSuffixTok: Label '/oauth2/v2.0/token', Locked = true;
+        TenantDomainPatternTok: Label '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$', Locked = true;
         ExpandedTok: Label 'bufferIntercompanyInboxTransactions,bufferIntercompanyInboxJournalLines,bufferIntercompanyInboxPurchaseHeaders,bufferIntercompanyInboxPurchaseLines,bufferIntercompanyInboxSalesHeaders,bufferIntercompanyInboxSalesLines,bufferIntercompanyInOutJournalLineDimensions,bufferIntercompanyDocumentDimensions,bufferIntercompanyCommentLines', Locked = true;
 
         NonSaaSEnvironmentErr: Label 'This functionality is only available in online environments.';
@@ -50,6 +57,14 @@ codeunit 560 "CrossIntercompany Connector"
         SuccessConnectingToPartnerMsg: Label 'Successfully connected, the partner %1 is available to be used with intercompany.', Comment = '%1 = IC Partner Code';
         PartnerMissingICSetupErr: Label 'Partner %1 has not completed the information required to use intercompany.', Comment = '%1 = IC Partner Code';
         MissalignmentBetweenNamesErr: Label 'The partner''s company name %1 does not match the name you are introducing for partner %2.', Comment = '%1 = Partner''s Company Name, %2 = IC Partner Name';
+        InvalidDestinationUrlErr: Label 'The intercompany connection URL must use the trusted Business Central API host.';
+        InvalidDestinationUrlSecurityAuditTxt: Label 'An invalid destination URL was rejected for a cross-environment intercompany connection. Host: %1.', Locked = true, Comment = '%1 = the rejected host';
+        InvalidDestinationUrlTelemetryTxt: Label 'A cross-environment intercompany destination URL failed trusted-host validation.', Locked = true;
+        InvalidTokenEndpointErr: Label 'The token endpoint must identify a Microsoft Entra tenant on the trusted authority.';
+        InvalidTokenEndpointSecurityAuditTxt: Label 'An invalid OAuth token endpoint was rejected for a cross-environment intercompany connection. Host: %1.', Locked = true, Comment = '%1 = the rejected host';
+        InvalidTokenEndpointTelemetryTxt: Label 'A cross-environment intercompany OAuth token endpoint failed trusted-authority validation.', Locked = true;
+        CrossIntercompanyServiceNameTxt: Label 'Cross-environment Intercompany', Locked = true;
+        UnparsableHostTok: Label '(unparsable host)', Locked = true;
 
     internal procedure TestICPartnerSetup(var TempICPartner: Record "IC Partner" temporary): Boolean
     var
@@ -258,6 +273,7 @@ codeunit 560 "CrossIntercompany Connector"
         HttpRequestMessage: HttpRequestMessage;
         HttpResponseMessage: HttpResponseMessage;
     begin
+        ValidateDestinationUrl(Uri);
         HttpRequestMessage.Method(Method);
         HttpRequestMessage.SetRequestUri(Uri);
         PrepareHeaders(HttpRequestMessage, ICPartner);
@@ -369,13 +385,136 @@ codeunit 560 "CrossIntercompany Connector"
 
         ClientId := ICPartner.GetSecret(ICPartner."Client Id Key").Unwrap();
         ClientSecret := ICPartner.GetSecret(ICPartner."Client Secret Key");
-        TokenEndpoint := ICPartner.GetSecret(ICPartner."Token Endpoint Key").Unwrap();
-        RedirectURL := ICPartner.GetSecret(ICPartner."Redirect URL Key").Unwrap();
+        TokenEndpoint := GetValidatedTokenEndpoint(ICPartner.GetSecret(ICPartner."Token Endpoint Key").Unwrap());
+        OAuth2.GetDefaultRedirectUrl(RedirectURL);
         Scopes.Add(BCResourceURLScopeTok);
 
         OAuth2.AcquireTokenWithClientCredentials(ClientId, ClientSecret, TokenEndpoint, RedirectURL, Scopes, BearerAccessToken);
 
         exit(BearerAccessToken);
+    end;
+
+    local procedure ValidateDestinationUrl(DestinationUrl: Text): Boolean
+    begin
+        if not IsDestinationUrlTrusted(DestinationUrl) then
+            RejectInvalidDestinationUrl(GetHostFromUrl(DestinationUrl));
+
+        exit(true);
+    end;
+
+    internal procedure IsDestinationUrlTrusted(DestinationUrl: Text): Boolean
+    var
+        UrlHelper: Codeunit "Url Helper";
+    begin
+        if UrlHelper.IsPPE() then
+            exit(IsDestinationUrlAllowed(DestinationUrl, DynamicsPPEHostSuffixTok));
+        if UrlHelper.IsPROD() then
+            exit(IsDestinationUrlAllowed(DestinationUrl, DynamicsProdHostSuffixTok));
+        exit(false);
+    end;
+
+    internal procedure IsDestinationUrlAllowed(DestinationUrl: Text; ExpectedHostSuffix: Text): Boolean
+    var
+        Uri: Codeunit Uri;
+    begin
+        if not Uri.IsWellFormedUriString(DestinationUrl, Enum::UriKind::Absolute) then
+            exit(false);
+
+        Uri.Init(DestinationUrl);
+        if LowerCase(Uri.GetScheme()) <> 'https' then
+            exit(false);
+        if Uri.GetPort() <> 443 then
+            exit(false);
+
+        // Allow any Dynamics host (including Embed ISV subdomains) under the environment's trusted domain.
+        exit(LowerCase(Uri.GetHost()).EndsWith(ExpectedHostSuffix));
+    end;
+
+    local procedure RejectInvalidDestinationUrl(Host: Text)
+    var
+        TelemetryDimensions: Dictionary of [Text, Text];
+    begin
+        TelemetryDimensions.Add('Category', CrossIntercompanyTok);
+        TelemetryDimensions.Add('Host', Host);
+        Session.LogMessage('0000VC7', InvalidDestinationUrlTelemetryTxt, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, TelemetryDimensions);
+        Session.LogSecurityAudit(
+            CrossIntercompanyServiceNameTxt, SecurityOperationResult::Failure,
+            StrSubstNo(InvalidDestinationUrlSecurityAuditTxt, Host), AuditCategory::ApplicationManagement);
+        Error(InvalidDestinationUrlErr);
+    end;
+
+    local procedure GetValidatedTokenEndpoint(ConfiguredTokenEndpoint: Text): Text
+    var
+        UrlHelper: Codeunit "Url Helper";
+        AuthorityPrefix: Text;
+    begin
+        if UrlHelper.IsPPE() then
+            AuthorityPrefix := EntraPPEAuthorityPrefixTok
+        else
+            if UrlHelper.IsPROD() then
+                AuthorityPrefix := EntraAuthorityPrefixTok
+            else
+                RejectInvalidTokenEndpoint(GetHostFromUrl(ConfiguredTokenEndpoint));
+
+        exit(GetValidatedTokenEndpointForAuthority(ConfiguredTokenEndpoint, AuthorityPrefix));
+    end;
+
+    internal procedure GetValidatedTokenEndpointForAuthority(ConfiguredTokenEndpoint: Text; AuthorityPrefix: Text): Text
+    var
+        TenantIdText: Text;
+    begin
+        if not LowerCase(ConfiguredTokenEndpoint).StartsWith(AuthorityPrefix) or
+           not LowerCase(ConfiguredTokenEndpoint).EndsWith(OAuthTokenEndpointSuffixTok)
+        then
+            RejectInvalidTokenEndpoint(GetHostFromUrl(ConfiguredTokenEndpoint));
+
+        TenantIdText := CopyStr(ConfiguredTokenEndpoint, StrLen(AuthorityPrefix) + 1, StrLen(ConfiguredTokenEndpoint) - StrLen(AuthorityPrefix) - StrLen(OAuthTokenEndpointSuffixTok));
+        if not IsValidTenantIdentifier(TenantIdText) then
+            RejectInvalidTokenEndpoint(GetHostFromUrl(ConfiguredTokenEndpoint));
+
+        exit(ConfiguredTokenEndpoint);
+    end;
+
+    local procedure IsValidTenantIdentifier(TenantIdentifier: Text): Boolean
+    var
+        Regex: Codeunit Regex;
+        TenantId: Guid;
+    begin
+        if TenantIdentifier = '' then
+            exit(false);
+
+        // A tenant is identified either by its GUID or by a verified Entra domain name (for example, contoso.onmicrosoft.com).
+        if Evaluate(TenantId, TenantIdentifier) then
+            exit(true);
+
+        exit(Regex.IsMatch(LowerCase(TenantIdentifier), TenantDomainPatternTok));
+    end;
+
+    local procedure RejectInvalidTokenEndpoint(Host: Text)
+    var
+        TelemetryDimensions: Dictionary of [Text, Text];
+    begin
+        TelemetryDimensions.Add('Category', CrossIntercompanyTok);
+        TelemetryDimensions.Add('Host', Host);
+        Session.LogMessage('0000VC8', InvalidTokenEndpointTelemetryTxt, Verbosity::Error, DataClassification::SystemMetadata, TelemetryScope::All, TelemetryDimensions);
+        Session.LogSecurityAudit(
+            CrossIntercompanyServiceNameTxt, SecurityOperationResult::Failure,
+            StrSubstNo(InvalidTokenEndpointSecurityAuditTxt, Host), AuditCategory::ApplicationManagement);
+        Error(InvalidTokenEndpointErr);
+    end;
+
+    local procedure GetHostFromUrl(Url: Text): Text
+    var
+        Uri: Codeunit Uri;
+        Host: Text;
+    begin
+        if not Uri.IsValidUri(Url) then
+            exit(UnparsableHostTok);
+        Uri.Init(Url);
+        Host := LowerCase(Uri.GetHost());
+        if Host = '' then
+            exit(UnparsableHostTok);
+        exit(Host);
     end;
 
     #region Auxiliar methods

--- a/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/CrossIntercompanyModifySetup.Page.al
+++ b/src/Layers/W1/BaseApp/Finance/Intercompany/DataExchange/CrossIntercompanyModifySetup.Page.al
@@ -81,6 +81,8 @@ page 565 "CrossIntercompany Modify Setup"
                     ApplicationArea = Intercompany;
                     Importance = Additional;
                     ToolTip = 'Specifies the OAuth 2.0 redirect URL of the Microsoft Entra authentication application.';
+                    // The connector always uses the environment's default redirect URL, so this field is hidden to avoid promising configurable behavior.
+                    Visible = false;
                 }
             }
         }

--- a/src/Layers/W1/Tests/ERM/ERMIntercompany.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMIntercompany.Codeunit.al
@@ -1126,6 +1126,109 @@ codeunit 134151 "ERM Intercompany"
 
     [Test]
     [Scope('OnPrem')]
+    procedure TrustedCrossIntercompanyDestinationUrlIsAllowed()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+    begin
+        // [FEATURE] [AI test 0.4]
+        Assert.IsTrue(
+            CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics.com/v2.0/tenant/environment/api/v2.0/companies', '.dynamics.com'),
+            'The trusted Business Central API URL must be allowed.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure UntrustedCrossIntercompanyDestinationUrlsAreBlocked()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+    begin
+        // [FEATURE] [AI test 0.4]
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('http://api.businesscentral.dynamics.com/v2.0/companies', '.dynamics.com'), 'A non-HTTPS URL must be rejected.');
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics.com.example.com/v2.0/companies', '.dynamics.com'), 'A look-alike host must be rejected.');
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('', '.dynamics.com'), 'A blank URL must be rejected.');
+        Assert.IsFalse(CrossIntercompanyConnector.IsDestinationUrlAllowed('not-a-valid-uri', '.dynamics.com'), 'A malformed URL must be rejected.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TrustedCrossIntercompanyTokenEndpointIsAllowed()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.microsoftonline.com/' + Format(CreateGuid(), 0, 4) + '/oauth2/v2.0/token';
+
+        Assert.AreEqual(TokenEndpoint, CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/'), 'The trusted Microsoft Entra token endpoint must be returned unchanged.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure TrustedCrossIntercompanyTokenEndpointAllowsDomainTenant()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/token';
+
+        Assert.AreEqual(TokenEndpoint, CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/'), 'A domain-based tenant identifier must be accepted.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure UntrustedCrossIntercompanyTokenEndpointsAreBlocked()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+
+        TokenEndpoint := 'https://login.microsoftonline.com.example.com/' + Format(CreateGuid(), 0, 4) + '/oauth2/v2.0/token';
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+
+        // An empty tenant segment must be rejected (verifies the tenant identifier extraction boundary).
+        TokenEndpoint := 'https://login.microsoftonline.com//oauth2/v2.0/token';
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.microsoftonline.com/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CrossIntercompanyDestinationUrlPpeHostIsValidated()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+    begin
+        // [FEATURE] [AI test 0.4]
+        Assert.IsTrue(
+            CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics-tie.com/v2.0/tenant/environment/api/v2.0/companies', '.dynamics-tie.com'),
+            'The trusted PPE Business Central API URL must be allowed.');
+        Assert.IsFalse(
+            CrossIntercompanyConnector.IsDestinationUrlAllowed('https://api.businesscentral.dynamics-tie.com.example.com/v2.0/companies', '.dynamics-tie.com'),
+            'A look-alike PPE host must be rejected.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure CrossIntercompanyTokenEndpointPpeAuthorityIsValidated()
+    var
+        CrossIntercompanyConnector: Codeunit "CrossIntercompany Connector";
+        TokenEndpoint: Text;
+    begin
+        // [FEATURE] [AI test 0.4]
+        TokenEndpoint := 'https://login.windows-ppe.net/' + Format(CreateGuid(), 0, 4) + '/oauth2/v2.0/token';
+        Assert.AreEqual(TokenEndpoint, CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority(TokenEndpoint, 'https://login.windows-ppe.net/'), 'The trusted PPE token endpoint must be returned unchanged.');
+
+        asserterror CrossIntercompanyConnector.GetValidatedTokenEndpointForAuthority('https://login.windows-ppe.net/common/oauth2/v2.0/token', 'https://login.windows-ppe.net/');
+        Assert.ExpectedError('The token endpoint must identify a Microsoft Entra tenant on the trusted authority.');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure PostICJournalLineWithInboxTypeFileLocation()
     var
         ICPartner: Record "IC Partner";


### PR DESCRIPTION
[29.0][InterCompany][SII] Setup and telemetry enhancements

Backports only the Intercompany (CrossIntercompany connector/pages + ERM tests) and SII (Spain) parts of #11016 to releases/29.0.

<!--
Thanks for contributing to BCApps!

A few things before you hit "Create pull request":
- Your PR must link to an approved issue. New here? See CONTRIBUTING.md.
- You must have built and run your change yourself. CI is a safety net, not a substitute.
- If you used AI or an agent to write this PR, you are still the author. Read the diff,
  build it, and try it before requesting review.

Contributing guide:    https://github.com/microsoft/BCApps/blob/main/CONTRIBUTING.md
Local dev environment: https://github.com/microsoft/BCApps/blob/main/LOCAL_DEV_ENV.md
-->

## What & why

<!-- A few sentences: what does this change do, and what problem does it solve? -->

## Linked work

<!-- Required: link an approved GitHub issue using "Fixes #<number>".
     Microsoft contributors: also link the ADO work item with "AB#<number>" if you have one. -->

Fixes [AB#649993](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649993) and [AB#650209](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650209)

## How I validated this

- [X] I read the full diff and it contains only changes I intended.
- [ ] I built the affected app(s) locally with no new analyzer warnings.
- [ ] I ran the change in Business Central and confirmed it behaves as expected.
- [X] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome** *(required — be specific: scenarios, commands, screenshots for UI changes)*
Added automated tests
<!-- Example:
- Ran the new "Post and Send" action on a sales invoice in a fresh container; document posted and email queued (see screenshot).
- New unit tests in MyFeatureTest.Codeunit.al pass locally; full module test suite green.
- No tests added because change is comment-only / refactor with existing coverage. -->

## Risk & compatibility

<!-- Anything reviewers should watch for: breaking changes, upgrade/data impact, permissions,
     telemetry, feature flags, follow-up work. Write "None" if there's nothing to call out. -->







