### PR TITLE
Honor explicit 0% discounts in Sales and Purchase price lists

### DIFF
--- a/src/Layers/W1/BaseApp/Pricing/Calculation/PriceCalculationV16.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Pricing/Calculation/PriceCalculationV16.Codeunit.al
@@ -243,6 +243,7 @@ codeunit 7002 "Price Calculation - V16" implements "Price Calculation"
 
     local procedure PickBestLine(AmountType: Enum "Price Amount Type"; PriceListLine: Record "Price List Line"; var BestPriceListLine: Record "Price List Line"; var FoundBestLine: Boolean)
     var
+        DiscountIsDeclared: Boolean;
         IsHandled: Boolean;
     begin
         IsHandled := false;
@@ -250,11 +251,15 @@ codeunit 7002 "Price Calculation - V16" implements "Price Calculation"
         if IsHandled then
             exit;
 
+        DiscountIsDeclared :=
+            (PriceListLine."Amount Type" = PriceListLine."Amount Type"::Discount) or (PriceListLine."Line Discount %" > 0);
         if IsImprovedLine(PriceListLine, BestPriceListLine) or not IsDegradedLine(PriceListLine, BestPriceListLine) then begin
             if IsImprovedLine(PriceListLine, BestPriceListLine) and not IsDegradedLine(PriceListLine, BestPriceListLine) then
-                if (AmountType <> AmountType::Discount) or (PriceListLine."Line Discount %" > 0) then
+                if (AmountType <> AmountType::Discount) or DiscountIsDeclared then
                     Clear(BestPriceListLine);
-            if IsBetterLine(PriceListLine, AmountType, BestPriceListLine) then begin
+            if IsBetterLine(PriceListLine, AmountType, BestPriceListLine) or
+               ((AmountType = AmountType::Discount) and DiscountIsDeclared and not BestPriceListLine.IsRealLine())
+            then begin
                 BestPriceListLine := PriceListLine;
                 FoundBestLine := true;
             end;

--- a/src/Layers/W1/Tests/ERM/TestPriceCalculationV16.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/TestPriceCalculationV16.Codeunit.al
@@ -6245,6 +6245,285 @@ codeunit 134159 "Test Price Calculation - V16"
     end;
 
     [Test]
+    procedure SalesVariantZeroDiscountBeforeGenericDiscount()
+    begin
+        // [FEATURE] [SalesPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] Explicit variant 0% wins before generic 30% in primary-key order; clearing the variant restores 30%.
+        VerifySalesExplicitZeroDiscount(true, false);
+    end;
+
+    [Test]
+    procedure SalesVariantZeroDiscountAfterGenericDiscount()
+    begin
+        // [FEATURE] [SalesPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] Explicit variant 0% wins after generic 30% in primary-key order; clearing the variant restores 30%.
+        VerifySalesExplicitZeroDiscount(false, false);
+    end;
+
+    [Test]
+    procedure PurchVariantZeroDiscountBeforeGenericDiscount()
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] Explicit variant 0% wins before generic 30% in primary-key order; clearing the variant restores 30%.
+        VerifyPurchExplicitZeroDiscount(true, false);
+    end;
+
+    [Test]
+    procedure PurchVariantZeroDiscountAfterGenericDiscount()
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Variant] [Discount]
+        // [SCENARIO 649151] Explicit variant 0% wins after generic 30% in primary-key order; clearing the variant restores 30%.
+        VerifyPurchExplicitZeroDiscount(false, false);
+    end;
+
+    [Test]
+    procedure SalesCurrencyZeroDiscountBeforeGenericDiscount()
+    begin
+        // [FEATURE] [SalesPrice] [Item] [Currency] [Discount]
+        // [SCENARIO 649151] Explicit currency 0% wins before generic 30% in primary-key order without changing the price.
+        VerifySalesExplicitZeroDiscount(true, true);
+    end;
+
+    [Test]
+    procedure SalesCurrencyZeroDiscountAfterGenericDiscount()
+    begin
+        // [FEATURE] [SalesPrice] [Item] [Currency] [Discount]
+        // [SCENARIO 649151] Explicit currency 0% wins after generic 30% in primary-key order without changing the price.
+        VerifySalesExplicitZeroDiscount(false, true);
+    end;
+
+    [Test]
+    procedure PurchCurrencyZeroDiscountBeforeGenericDiscount()
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Currency] [Discount]
+        // [SCENARIO 649151] Explicit currency 0% wins before generic 30% in primary-key order without changing the cost.
+        VerifyPurchExplicitZeroDiscount(true, true);
+    end;
+
+    [Test]
+    procedure PurchCurrencyZeroDiscountAfterGenericDiscount()
+    begin
+        // [FEATURE] [PurchPrice] [Item] [Currency] [Discount]
+        // [SCENARIO 649151] Explicit currency 0% wins after generic 30% in primary-key order without changing the cost.
+        VerifyPurchExplicitZeroDiscount(false, true);
+    end;
+
+    [Test]
+    procedure HighestVariantDiscountWinsBetweenExplicitZeroDiscounts()
+    var
+        TempPriceListLine: Record "Price List Line" temporary;
+        PriceCalculationBufferMgt: Codeunit "Price Calculation Buffer Mgt.";
+        PriceCalculationV16: Codeunit "Price Calculation - V16";
+    begin
+        // [FEATURE] [UT] [Variant] [Discount]
+        // [SCENARIO 649151] Explicit zeros before and after positive discounts at the same specificity do not veto the highest discount.
+        Initialize();
+        MockBuffer("Price Type"::Purchase, '', 1, PriceCalculationBufferMgt);
+
+        // [GIVEN] One list in PK order: variant Discount 0, generic 30, variant 5, variant Any 10, variant Any 0, variant Discount 0.
+        AddDiscountCandidate(TempPriceListLine, 'V', "Price Amount Type"::Discount, 0);
+        AddDiscountCandidate(TempPriceListLine, '', "Price Amount Type"::Discount, 30);
+        AddDiscountCandidate(TempPriceListLine, 'V', "Price Amount Type"::Discount, 5);
+        AddDiscountCandidate(TempPriceListLine, 'V', "Price Amount Type"::Any, 10);
+        AddDiscountCandidate(TempPriceListLine, 'V', "Price Amount Type"::Any, 0);
+        AddDiscountCandidate(TempPriceListLine, 'V', "Price Amount Type"::Discount, 0);
+
+        // [WHEN] The shared production selector calculates the discount.
+        Assert.IsTrue(
+            PriceCalculationV16.CalcBestAmount("Price Amount Type"::Discount, PriceCalculationBufferMgt, TempPriceListLine),
+            'A real discount line must be selected.');
+
+        // [THEN] The highest variant discount wins, including when it is declared on an Any line.
+        TempPriceListLine.TestField("Line No.", 40000);
+        TempPriceListLine.TestField("Line Discount %", 10);
+    end;
+
+    local procedure VerifySalesExplicitZeroDiscount(ZeroDiscountFirst: Boolean; UseCurrency: Boolean)
+    var
+        Customer: Record Customer;
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        PriceListHeader: Record "Price List Header";
+        ZeroDiscountLine: Record "Price List Line";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        SalesLinePrice: Codeunit "Sales Line - Price";
+        CurrencyCode: Code[10];
+    begin
+        Initialize();
+
+        // [GIVEN] A customer-specific list with a separate Price 100, generic Discount 30 and explicit specific Discount 0.
+        LibrarySales.CreateCustomer(Customer);
+        LibraryInventory.CreateItem(Item);
+        if UseCurrency then
+            CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 1, 1)
+        else
+            LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Sale, "Price Source Type"::Customer, Customer."No.");
+        CreateExplicitZeroDiscountPriceList(ZeroDiscountLine, PriceListHeader, Item."No.", ItemVariant.Code, CurrencyCode, ZeroDiscountFirst);
+
+        // [GIVEN] A sales quote with no variant in LCY has price 100 and discount 30%.
+        LibrarySales.CreateSalesHeader(SalesHeader, "Sales Document Type"::Quote, Customer."No.");
+        LibrarySales.CreateSalesLine(SalesLine, SalesHeader, "Sales Line Type"::Item, Item."No.", 1);
+        SalesLine.TestField("Line Discount %", 30);
+        SalesLine.TestField("Unit Price", 100);
+
+        // [WHEN] The variant is selected, or a new quote is created in the specific currency.
+        if UseCurrency then begin
+            Clear(SalesHeader);
+            Clear(SalesLine);
+            LibrarySales.CreateSalesHeader(SalesHeader, "Sales Document Type"::Quote, Customer."No.");
+            SalesHeader.Validate("Currency Code", CurrencyCode);
+            SalesHeader.Modify(true);
+            LibrarySales.CreateSalesLine(SalesLine, SalesHeader, "Sales Line Type"::Item, Item."No.", 1);
+        end else
+            SalesLine.Validate("Variant Code", ItemVariant.Code);
+
+        // [THEN] The explicit zero is selected as a real winner, not an empty fallback, and the price is unchanged.
+        SalesLine.TestField("Line Discount %", 0);
+        SalesLine.TestField("Unit Price", 100);
+        SalesLinePrice.SetLine("Price Type"::Sale, SalesHeader, SalesLine);
+        VerifyExplicitZeroDiscountWinner(SalesLinePrice, ZeroDiscountLine, ZeroDiscountFirst);
+
+        if not UseCurrency then begin
+            // [WHEN] The variant is cleared on the same line.
+            SalesLine.Validate("Variant Code", '');
+            // [THEN] The generic discount returns without changing the price.
+            SalesLine.TestField("Line Discount %", 30);
+            SalesLine.TestField("Unit Price", 100);
+        end;
+    end;
+
+    local procedure VerifyPurchExplicitZeroDiscount(ZeroDiscountFirst: Boolean; UseCurrency: Boolean)
+    var
+        Vendor: Record Vendor;
+        Item: Record Item;
+        ItemVariant: Record "Item Variant";
+        PriceListHeader: Record "Price List Header";
+        ZeroDiscountLine: Record "Price List Line";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        PurchaseLinePrice: Codeunit "Purchase Line - Price";
+        CurrencyCode: Code[10];
+    begin
+        Initialize();
+
+        // [GIVEN] A vendor-specific list with a separate Price 100, generic Discount 30 and explicit specific Discount 0.
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        if UseCurrency then
+            CurrencyCode := LibraryERM.CreateCurrencyWithExchangeRate(WorkDate(), 1, 1)
+        else
+            LibraryInventory.CreateItemVariant(ItemVariant, Item."No.");
+        LibraryPriceCalculation.CreatePriceHeader(PriceListHeader, "Price Type"::Purchase, "Price Source Type"::Vendor, Vendor."No.");
+        CreateExplicitZeroDiscountPriceList(ZeroDiscountLine, PriceListHeader, Item."No.", ItemVariant.Code, CurrencyCode, ZeroDiscountFirst);
+
+        // [GIVEN] A purchase order with no variant in LCY has cost 100 and discount 30%.
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        PurchaseLine.TestField("Line Discount %", 30);
+        PurchaseLine.TestField("Direct Unit Cost", 100);
+
+        // [WHEN] The variant is selected, or a new order is created in the specific currency.
+        if UseCurrency then begin
+            Clear(PurchaseHeader);
+            Clear(PurchaseLine);
+            LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, Vendor."No.");
+            PurchaseHeader.Validate("Currency Code", CurrencyCode);
+            PurchaseHeader.Modify(true);
+            LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, Item."No.", 1);
+        end else
+            PurchaseLine.Validate("Variant Code", ItemVariant.Code);
+
+        // [THEN] The explicit zero is selected as a real winner, not an empty fallback, and the cost is unchanged.
+        PurchaseLine.TestField("Line Discount %", 0);
+        PurchaseLine.TestField("Direct Unit Cost", 100);
+        PurchaseLinePrice.SetLine("Price Type"::Purchase, PurchaseHeader, PurchaseLine);
+        VerifyExplicitZeroDiscountWinner(PurchaseLinePrice, ZeroDiscountLine, ZeroDiscountFirst);
+
+        if not UseCurrency then begin
+            // [WHEN] The variant is cleared on the same line.
+            PurchaseLine.Validate("Variant Code", '');
+            // [THEN] The generic discount returns without changing the cost.
+            PurchaseLine.TestField("Line Discount %", 30);
+            PurchaseLine.TestField("Direct Unit Cost", 100);
+        end;
+    end;
+
+    local procedure CreateExplicitZeroDiscountPriceList(var ZeroDiscountLine: Record "Price List Line"; PriceListHeader: Record "Price List Header"; ItemNo: Code[20]; VariantCode: Code[10]; CurrencyCode: Code[10]; ZeroDiscountFirst: Boolean)
+    var
+        PriceListLine: Record "Price List Line";
+    begin
+        PriceListHeader."Allow Updating Defaults" := true;
+        PriceListHeader.Modify();
+        LibraryPriceCalculation.CreatePriceListLine(PriceListLine, PriceListHeader, "Price Amount Type"::Price, "Price Asset Type"::Item, ItemNo);
+        case PriceListHeader."Price Type" of
+            "Price Type"::Sale:
+                PriceListLine.Validate("Unit Price", 100);
+            "Price Type"::Purchase:
+                PriceListLine.Validate("Direct Unit Cost", 100);
+        end;
+        PriceListLine.Validate("Allow Line Disc.", true);
+        PriceListLine.Status := "Price Status"::Active;
+        PriceListLine.Modify(true);
+
+        // All candidates share one list code; AutoIncrement assigns increasing line numbers, which determine the selector's PK order.
+        if not ZeroDiscountFirst then
+            CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, ItemNo, '', '', 30);
+        CreateActiveItemDiscountLine(ZeroDiscountLine, PriceListHeader, ItemNo, VariantCode, CurrencyCode, 0);
+        if ZeroDiscountFirst then
+            CreateActiveItemDiscountLine(PriceListLine, PriceListHeader, ItemNo, '', '', 30);
+        Assert.AreEqual(ZeroDiscountFirst, ZeroDiscountLine."Line No." < PriceListLine."Line No.", 'Unexpected discount primary-key order.');
+    end;
+
+    local procedure CreateActiveItemDiscountLine(var PriceListLine: Record "Price List Line"; PriceListHeader: Record "Price List Header"; ItemNo: Code[20]; VariantCode: Code[10]; CurrencyCode: Code[10]; DiscountPct: Decimal)
+    begin
+        Clear(PriceListLine);
+        LibraryPriceCalculation.CreatePriceListLine(PriceListLine, PriceListHeader, "Price Amount Type"::Discount, "Price Asset Type"::Item, ItemNo);
+        PriceListLine.Validate("Variant Code", VariantCode);
+        PriceListLine.Validate("Currency Code", CurrencyCode);
+        PriceListLine.Validate("Line Discount %", DiscountPct);
+        PriceListLine.Status := "Price Status"::Active;
+        PriceListLine.Modify(true);
+    end;
+
+    local procedure VerifyExplicitZeroDiscountWinner(LineWithPrice: Interface "Line With Price"; ZeroDiscountLine: Record "Price List Line"; ZeroDiscountFirst: Boolean)
+    var
+        TempPriceListLine: Record "Price List Line" temporary;
+        PriceCalculationBufferMgt: Codeunit "Price Calculation Buffer Mgt.";
+        PriceCalculationV16: Codeunit "Price Calculation - V16";
+    begin
+        Assert.IsTrue(LineWithPrice.CopyToBuffer(PriceCalculationBufferMgt), 'The document line must support price calculation.');
+        Assert.IsTrue(
+            PriceCalculationV16.FindLines("Price Amount Type"::Discount, TempPriceListLine, PriceCalculationBufferMgt, false),
+            'Both discount candidates must be found.');
+        Assert.RecordCount(TempPriceListLine, 2);
+
+        // FindLines resets the temporary buffer to the PK; verify actual candidate order, not just creation order.
+        TempPriceListLine.FindFirst();
+        TempPriceListLine.TestField("Price List Code", ZeroDiscountLine."Price List Code");
+        Assert.AreEqual(ZeroDiscountFirst, TempPriceListLine."Line No." = ZeroDiscountLine."Line No.", 'Unexpected first discount candidate.');
+        TempPriceListLine.FindLast();
+        Assert.AreEqual(not ZeroDiscountFirst, TempPriceListLine."Line No." = ZeroDiscountLine."Line No.", 'Unexpected last discount candidate.');
+
+        Assert.IsTrue(
+            PriceCalculationV16.CalcBestAmount("Price Amount Type"::Discount, PriceCalculationBufferMgt, TempPriceListLine),
+            'The explicit zero must be selected, not replaced with an empty fallback.');
+        TempPriceListLine.TestField("Price List Code", ZeroDiscountLine."Price List Code");
+        TempPriceListLine.TestField("Line No.", ZeroDiscountLine."Line No.");
+        TempPriceListLine.TestField("Amount Type", "Price Amount Type"::Discount);
+        TempPriceListLine.TestField("Line Discount %", 0);
+    end;
+
+    local procedure AddDiscountCandidate(var TempPriceListLine: Record "Price List Line" temporary; VariantCode: Code[10]; AmountType: Enum "Price Amount Type"; DiscountPct: Decimal)
+    begin
+        AddPriceLine(TempPriceListLine, "Price Type"::Purchase, '', VariantCode, 100);
+        TempPriceListLine."Amount Type" := AmountType;
+        TempPriceListLine."Line Discount %" := DiscountPct;
+        TempPriceListLine.Modify();
+    end;
+
+    [Test]
     procedure SalesLineResourceUnitCostWhenWorkTypeBeforeQuantity()
     var
         Customer: Record Customer;


### PR DESCRIPTION
## What & why

**Supersedes draft #11070. Please use this PR for further review; the two PRs are alternatives, not cumulative changes.** This PR retains the same explicit-zero discount behavior, adds an extension-veto correction from review, and expands coverage to twelve BaseApp tests plus two focused Shopify integration tests. The earlier draft is retained for history.

The shared V16 pricing selector cannot select an explicit, more-specific 0% discount over a generic positive discount. This affects both Sales and Purchase price lists, including variant and currency specificity.

Treat a line as declaring a discount when either its amount type is `Discount` or its discount percentage is positive. Use this distinction for the specificity reset in `PickBestLine` and for acceptance of a real candidate when the best line is empty in `IsBetterLine`. Candidate acceptance happens **before `OnAfterIsBetterLine`**, preserving subscribers' ability to veto the result rather than overriding their decision in the caller.

- `Discount` / 0% can win through the existing specificity rules.
- `Price & Discount` (`Any`) / 0% remains incidental and does not erase a genuine discount.
- At equal specificity, the highest eligible discount still wins; explicit zero is not an unconditional veto.
- The price-comparison code, event signatures and outer specificity checks are unchanged.
- Shopify uses this shared selector through its product-price calculator. Two tests verify selling-price and compare-at outputs without changing Shopify production code or making Shopify API calls.

## Linked work

[AB#649151](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/649151)

Microsoft product fix tracked in the ADO work item above; no separate GitHub issue was found. This replaces the implementation proposal in #11070 rather than introducing a second fix for the same work item.

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Full branch Base Application and Tests-ERM builds passed with CodeCop, including the later extension-veto correction: zero errors and no diagnostics on changed lines. Existing warnings on unchanged source remain.
- Full branch Shopify test app built successfully with CodeCop: zero errors, one existing AA0217 warning in an unchanged shipping test, and no diagnostics in the new tests. `git diff --check` passed.
- Local execution used the installed `30.0.54539.0` baseline with only the intended source changes. The current PR selector and the two Shopify tests were published successfully; fresh installed symbols matched every AL source file and build metadata against the verified packages. Schemas/assets, unrelated app state and checked document/price-list/shop data remained unchanged. The local server's missing existing MockTest dependency was supplied and publication completed after an approved restart; no test/source workaround was added to the PR.
- **BaseApp automated:** on 2026-09-11, the author ran the entire codeunit **134159, `Test Price Calculation - V16`**, through AL Test Tool and reported all tests passed. This run included the nine original new tests but **predates the three later extension-veto tests**; it is not runtime evidence for those later tests. No exported result log or exact total count is attached.
- **Shopify automated:** on 2026-09-17, the author confirmed the requested Shopify tests ran successfully in local BC using AL Test Tool, following publication of codeunit **139605, `Shpfy Product Price Calc. Test`**. No exported result log is attached. These tests need no live Shopify store or credentials.
- **Manual, Sales and Purchase:** separate Price 100, generic Discount 30%, and variant-specific Discount 0% rows; the author confirmed the variant/quantity/clear-variant walkthrough worked while preserving price/cost.
- **Manual regression, Sales and Purchase:** changing the variant row to Price & Discount with price/cost 100, discount 0 and Allow Line Disc. enabled preserved the generic 30%; changing it back to Discount restored explicit-zero behavior. The author confirmed both scenarios passed.
- Adversarial review found a Shopify fixture isolation issue: the single-instance calculator can retain a customer from an earlier catalog test. The fixture now resets that context through the existing API before selecting the actual shop. Re-review found no remaining static blocker.
- Broader repository CI remains a separate validation gate; no repository-wide test pass is claimed.

Twelve new tests in codeunit 134159:

| Coverage | Tests |
|---|---|
| Sales variant, both candidate orders | `SalesVariantZeroDiscountBeforeGenericDiscount`, `SalesVariantZeroDiscountAfterGenericDiscount` |
| Purchase variant, both candidate orders | `PurchVariantZeroDiscountBeforeGenericDiscount`, `PurchVariantZeroDiscountAfterGenericDiscount` |
| Sales currency, both candidate orders | `SalesCurrencyZeroDiscountBeforeGenericDiscount`, `SalesCurrencyZeroDiscountAfterGenericDiscount` |
| Purchase currency, both candidate orders | `PurchCurrencyZeroDiscountBeforeGenericDiscount`, `PurchCurrencyZeroDiscountAfterGenericDiscount` |
| Equal-specificity highest discount and incidental-zero preservation | `HighestVariantDiscountWinsBetweenExplicitZeroDiscounts` |
| Extension veto through the complete selector | `OnAfterIsBetterLineCanVetoExplicitZeroDiscount`, `OnAfterIsBetterLineCanVetoPositiveDiscount`, `OnAfterIsBetterLineCanVetoPositiveAnyDiscount` |

The original document tests assert generic 30%, specific 0%, unchanged price/cost 100, actual filtered candidate order and the exact real winning record. Variant cases also assert generic-discount restoration; currency cases use a 1:1 exchange rate. The later veto tests exercise `CalcBestAmount` with a subscriber that rejects a candidate, then prove the same candidate is eligible without the subscriber.

Two new tests in codeunit 139605:

| Test | Expected Shopify outputs for the variant |
|---|---|
| `ExplicitZeroDiscountByVariantInV16` | Discount-only 0% overrides generic 30%: selling price 100, compare-at 0 |
| `IncidentalZeroDiscountByVariantInV16` | Price & Discount / 0% preserves generic 30%: selling price 70, compare-at 100 |

Both call the actual Shopify calculator, check cost 50, and calculate generic → variant → generic. List price 100 differs from item-card price 125 to detect fallback. Reusing output variables checks compare-at clearing, and returning to the generic item checks context leakage. Exhaustive selector permutations remain in BaseApp; existing Shopify compare-at JSON serialization coverage is not duplicated.

Existing regression coverage retained unchanged: `DiscountPreservedWhenSpuriousZeroPctVariantLineExists`, `VariantSpecificDiscountOverridesHigherGenericDiscount`, and `VariantDiscountSelectedWhenSpuriousZeroPctAndRealVariantDiscountExist`.

## Risk & compatibility

- **Intentional behavior change:** eligible, more-specific `Discount` lines with 0% can now override a less-specific positive discount. Configurations containing unintended zero-discount rules should be reviewed; their prevalence is unknown.
- A zero on a combined `Price & Discount` row remains ignored as a discount override. An explicit no-discount exception must use **Defines = Discount**; existing rows are not rewritten.
- Shopify outbound selling/compare-at prices reflect the selected BC discount. Although price-comparison code is unchanged, a different selected discount can affect existing lowest-net-price comparisons when competing price lines differ in discount permission.
- No schema, API-signature or permission changes. No Shopify production changes, return/refund changes, or fix for the separate pre-existing Sales/Purchase cost-field clearing inconsistency.
- Developed with agent assistance; validation distinguishes agent-performed builds/deployment checks from author-performed manual and automated test runs.

