### PR TITLE
Slice 641293: [Expense Agent] Expense Locations and Per-diem rules in configuration - added check for existing country

### DIFF
--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseLocations.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseLocations.Codeunit.al
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.ExpenseAgent;
+using Microsoft.Foundation.Address;
 
 codeunit 7124 "Create Expense Locations"
 {
@@ -801,9 +802,14 @@ codeunit 7124 "Create Expense Locations"
 
 
     internal procedure InsertExpenseLocation(var ExpenseLocation: Record "Expense Location"; Code: Code[20]; Description: Text[100]; CountryRegionCode: Code[10]; City: Text[30]; County: Text[30])
+    var
+        CountryRegion: Record "Country/Region";
     begin
         if ExpenseLocation.Get(Code) then
             exit;
+        if CountryRegionCode <> '' then
+            if not CountryRegion.Get(CountryRegionCode) then
+                exit;
         ExpenseLocation.Validate("No.", Code);
         ExpenseLocation.Validate(Description, Description);
         ExpenseLocation.Validate("Country/Region Code", CountryRegionCode);

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseRuleConditions.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseRuleConditions.Codeunit.al
@@ -280,11 +280,15 @@ codeunit 7126 "Create Expense Rule Conditions"
 
     internal procedure InsertExpenseRuleCondition(var ExpenseRuleCondition: Record "Expense Rule Condition"; ExpenseCategoryCode: Code[20]; ExpenseLocationCode: Code[20]; EffectiveDate: Date; LineNo: Integer; ConditionType: Enum "Expense Rule Condition Type"; Value: Decimal)
     var
+        ExpenseLocation: Record "Expense Location";
         IsHandled: Boolean;
     begin
         CreateExpenseCategories.OnBeforeAddRuleConditionSeed(ExpenseRuleCondition, ExpenseCategoryCode, ExpenseLocationCode, ConditionType, Value, IsHandled);
         if IsHandled then
             exit;
+        if ExpenseLocationCode <> '' then
+            if not ExpenseLocation.Get(ExpenseLocationCode) then
+                exit;
         if ExpenseRuleCondition.Get(ExpenseCategoryCode, ExpenseLocationCode, EffectiveDate, LineNo) then
             exit;
         ExpenseRuleCondition."Expense Category Code" := ExpenseCategoryCode;

--- a/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseRuleHeaders.Codeunit.al
+++ b/src/Apps/W1/ExpenseAgent/app/src/Setup/Codeunits/CreateExpenseRuleHeaders.Codeunit.al
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 // ------------------------------------------------------------------------------------------------
 namespace Microsoft.ExpenseAgent;
+using Microsoft.Finance.Currency;
 
 codeunit 7128 "Create Expense Rule Headers"
 {
@@ -282,6 +283,8 @@ codeunit 7128 "Create Expense Rule Headers"
     local procedure InsertExpenseRuleHeader(var ExpenseRuleHeader: Record "Expense Rule Header"; ExpenseCategoryCode: Code[20]; ExpenseLocationCode: Code[20]; EffectiveDate: Date; JustificationRequired: Enum "Expense Justification"; RequiredSpecificMerchant: Boolean; SpecificMerchantName: Text[100]; CurrencyCode: Code[10]; UnitOfMeasureCode: Code[10])
     var
         ExistingCategory: Record "Expense Category";
+        ExpenseLocation: Record "Expense Location";
+        Currency: Record Currency;
         IsHandled: Boolean;
     begin
         // prevent inserting invalid data
@@ -293,6 +296,12 @@ codeunit 7128 "Create Expense Rule Headers"
         CreateExpenseCategories.OnBeforeAddRuleSeed(ExpenseRuleHeader, ExpenseCategoryCode, ExpenseLocationCode, CurrencyCode, JustificationRequired, IsHandled);
         if IsHandled then
             exit;
+        if ExpenseLocationCode <> '' then
+            if not ExpenseLocation.Get(ExpenseLocationCode) then
+                exit;
+        if CurrencyCode <> '' then
+            if not Currency.Get(CurrencyCode) then
+                exit;
         if ExpenseRuleHeader.Get(ExpenseCategoryCode, ExpenseLocationCode, EffectiveDate) then
             exit;
         ExpenseRuleHeader."Expense Category Code" := ExpenseCategoryCode;


### PR DESCRIPTION
Skip creation for setup for non-existing country- and currency codes (customer databases may have less data than our demo data)

Fixes [AB#641293](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641293)



