### PR TITLE
[SOA] Fix "The Order Promising Setup does not exist." crash when setting quote quantity

### DIFF
--- a/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/ItemSearch/SOAItemSearch.Codeunit.al
@@ -161,7 +161,8 @@ codeunit 4591 "SOA Item Search"
 
         Msg := StrSubstNo(NotificationMsg, Item.Description);
 
-        if SOASetup."Incl. Capable to Promise" then begin
+        // Capable to Promise reads the Order Promising Setup and errors if it is missing, so skip it when the setup is not configured.
+        if SOASetup."Incl. Capable to Promise" and OrderPromisingSetupExists() then begin
             SOAShipmentDateMgt.SetParamenters(Item."No.", SalesLine."Variant Code", SalesLine."Location Code", SalesLine."Unit of Measure Code", SalesLine."Shipment Date", SalesLine.Quantity);
             SOAShipmentDateMgt.Run();
             if SOAShipmentDateMgt.GetEarliestShipmentDate() <= SalesLine."Shipment Date" then
@@ -174,6 +175,13 @@ codeunit 4591 "SOA Item Search"
         QuoteAvailabilityCheckNotification.Message(Msg);
         QuoteAvailabilityCheckNotification.Scope(NotificationScope::LocalScope);
         NotificationLifecycleMgt.SendNotificationWithAdditionalContext(QuoteAvailabilityCheckNotification, SalesLine.RecordId, GetQuoteItemAvailabilityNotificationId());
+    end;
+
+    local procedure OrderPromisingSetupExists(): Boolean
+    var
+        OrderPromisingSetup: Record "Order Promising Setup";
+    begin
+        exit(not OrderPromisingSetup.IsEmpty());
     end;
 
     local procedure GetQuoteItemAvailabilityNotificationId(): Guid

--- a/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
+++ b/src/Apps/W1/SalesOrderAgent/app/src/Setup/SOASetup.Page.al
@@ -8,6 +8,7 @@
 
 namespace Microsoft.Agent.SalesOrderAgent;
 
+using Microsoft.Inventory.Availability;
 using System.Agents;
 using System.AI;
 using System.Email;
@@ -258,6 +259,8 @@ page 4400 "SOA Setup"
                             Editable = OnlyAvailableItemsActive;
                             trigger OnValidate()
                             begin
+                                if Rec."Incl. Capable to Promise" then
+                                    VerifyOrderPromisingSetupExists();
                                 ConfigUpdated();
                             end;
                         }
@@ -688,6 +691,21 @@ page 4400 "SOA Setup"
             TempAgentSetupBuffer.State := TempAgentSetupBuffer.State::Enabled;
     end;
 
+    local procedure VerifyOrderPromisingSetupExists()
+    var
+        OrderPromisingSetup: Record "Order Promising Setup";
+    begin
+        if not OrderPromisingSetup.IsEmpty() then
+            exit;
+
+        // Capable to Promise requires the Order Promising Setup; offer to create it so the agent does not fail later.
+        if Confirm(OrderPromisingSetupMissingQst, false) then
+            Page.RunModal(Page::"Order Promising Setup");
+
+        if OrderPromisingSetup.IsEmpty() then
+            Rec."Incl. Capable to Promise" := false;
+    end;
+
     local procedure EnabledAgentFirstConfig(): Boolean
     begin
         exit((TempAgentSetupBuffer.State = TempAgentSetupBuffer.State::Disabled) and IsFirstConfig() and CheckIsValidConfig());
@@ -868,4 +886,5 @@ page 4400 "SOA Setup"
         InboxFolderIdTok: Label 'inbox', Locked = true;
         NoFolderSelectedInboxWarningQst: Label 'There is no mail folder selected, so the agent will process emails from the inbox (%1 emails since %2). Do you want to continue?', Comment = '%1=email count, %2=start date';
         AgentArchivedNotificationMsg: Label 'This agent is archived, so its settings are read-only. Its tasks and logs remain available for auditing.';
+        OrderPromisingSetupMissingQst: Label 'The Order Promising Setup does not exist and is required to include capable-to-promise items. Do you want to create it now?';
 }


### PR DESCRIPTION
## What & why

The Sales Order Agent could fail with **"The Order Promising Setup does not exist."**
when it entered or updated a quantity on a sales quote line.

`SOA Item Search`'s `OnAfterCheckItemAvailable` subscriber calls
`SOAShipmentDateMgt.Run()` as a bare statement. When **Include capable to promise**
is enabled but the company has no `Order Promising Setup` record,
`Capable to Promise.CalcCapableToPromiseDate` raises that error, and because the
`Run()` return value isn't checked the error propagates to the user. Customers who
don't use order promising hit this, and it was confirmed recurring in telemetry.

This change:
1. **Fixes the crash** — the capable-to-promise calculation is skipped when
   `Order Promising Setup` doesn't exist. The agent still sends the normal
   "inventory is lower than the entered quantity" notification instead of erroring.
   This resolves the crash for agents that are already configured this way.
2. **Prevents the misconfiguration** — enabling the *Include capable to promise*
   toggle on the SOA Setup page now checks for the setup and offers to create it;
   the toggle reverts if the user declines or lacks permission.

Both parts are needed: the affected customers already have the toggle on without the
setup, so the setup-page check alone would not stop their crash — the runtime guard does.

**Changed objects**
- `src/ItemSearch/SOAItemSearch.Codeunit.al` (codeunit 4591) - guard CTP call on
  `OrderPromisingSetupExists()` + helper.
- `src/Setup/SOASetup.Page.al` (page 4400) — `Include capable to promise` `OnValidate`
  confirmation, `VerifyOrderPromisingSetupExists()` helper, prompt label, and
  `using Microsoft.Inventory.Availability`.

## Linked work
Fixes [AB#622246](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/622246)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.

**What I tested and the outcome**

- No AL compiler diagnostics in either changed file.
- Reviewed existing CTP accuracy tests: they set `"Incl. Capable to Promise"` directly
  on the `SOA Setup` record (via `SOATestProcessLibrary`), bypassing the page trigger,
  and run with `Order Promising Setup` present, so neither change affects them.
- Still to do before merge: container repro — enable *Include capable to promise*, remove
  the `Order Promising Setup` record, have the agent create/update a quote line, and confirm
  the availability notification appears with no error; and verify the setup-page prompt
  creates the record / reverts on cancel.

## Risk & compatibility

- Behavior changes **only** when `Order Promising Setup` is missing: the agent now degrades
  gracefully (skips the earliest-ship-date line) instead of erroring. When the setup exists,
  behavior is unchanged.
- New confirmation dialog on the SOA Setup page when enabling the toggle without the setup.
- `Order Promising Setup` is read (`IsEmpty`) from the agent session (codeunit 4591) and the
  admin session (page 4400); both flows already access this table.
- No schema/table changes, no upgrade or data impact, no new permissions, no telemetry changes.







