### PR TITLE
Fix E-Doc. Item Charge Mapping codeunit ID

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/EDocItemChargeMapping.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/EDocItemChargeMapping.Codeunit.al
@@ -9,7 +9,7 @@ using Microsoft.Inventory.Item;
 using Microsoft.Inventory.Ledger;
 using Microsoft.Sales.History;
 
-codeunit 6532 "E-Doc. Item Charge Mapping"
+codeunit 6246 "E-Doc. Item Charge Mapping"
 {
     Permissions =
         tabledata "Item Charge" = r,


### PR DESCRIPTION
## Why

The E-Doc. Item Charge Mapping codeunit uses an incorrect object ID. It must use the assigned codeunit ID 6246.

## Summary

- **Updated** the E-Doc. Item Charge Mapping codeunit ID from 6532 to 6246.

Fixes
[AB#641600](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/641600)


