### PR TITLE
[28.5] Restore German PEPPOL sales validation

### DIFF
--- a/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationEvents.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationEvents.Codeunit.al
@@ -1,0 +1,30 @@
+// ------------------------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// ------------------------------------------------------------------------------------------------
+namespace Microsoft.Peppol;
+
+using Microsoft.Foundation.Company;
+using Microsoft.Sales.Customer;
+using Microsoft.Sales.Document;
+
+codeunit 37224 "PEPPOL30 Sales Val. Events"
+{
+    InherentEntitlements = X;
+    InherentPermissions = X;
+
+    [IntegrationEvent(false, false)]
+    internal procedure OnCheckSalesDocumentOnBeforeCheckCustomerVATRegNo(SalesHeader: Record "Sales Header"; Customer: Record Customer; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    internal procedure OnCheckSalesDocumentOnBeforeCheckYourReference(SalesHeader: Record "Sales Header"; var IsHandled: Boolean)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    internal procedure OnAfterCheckSalesDocument(SalesHeader: Record "Sales Header"; CompanyInfo: Record "Company Information")
+    begin
+    end;
+}

--- a/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Sales/PEPPOL30SalesValidationImpl.Codeunit.al
@@ -42,6 +42,8 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
         Customer: Record Customer;
         GLSetup: Record "General Ledger Setup";
         ResponsibilityCenter: Record "Responsibility Center";
+        PEPPOL30SalesValEvents: Codeunit "PEPPOL30 Sales Val. Events";
+        IsHandled: Boolean;
     begin
         CompanyInfo.Get();
         GLSetup.Get();
@@ -75,11 +77,14 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
         SalesHeader.TestField("Bill-to Country/Region Code");
         CheckCountryRegionCode(SalesHeader."Bill-to Country/Region Code");
 
-        if (SalesHeader."Document Type" in [SalesHeader."Document Type"::Invoice, SalesHeader."Document Type"::Order, SalesHeader."Document Type"::"Credit Memo"]) and
-           Customer.Get(SalesHeader."Bill-to Customer No.")
-        then
-            if (Customer.GLN + Customer."VAT Registration No.") = '' then
-                Error(MissingCustGLNOrVATRegNoErr, Customer."No.");
+        IsHandled := false;
+        PEPPOL30SalesValEvents.OnCheckSalesDocumentOnBeforeCheckCustomerVATRegNo(SalesHeader, Customer, IsHandled);
+        if not IsHandled then
+            if (SalesHeader."Document Type" in [SalesHeader."Document Type"::Invoice, SalesHeader."Document Type"::Order, SalesHeader."Document Type"::"Credit Memo"]) and
+               Customer.Get(SalesHeader."Bill-to Customer No.")
+            then
+                if (Customer.GLN + Customer."VAT Registration No.") = '' then
+                    Error(MissingCustGLNOrVATRegNoErr, Customer."No.");
 
         if SalesHeader."Document Type" = SalesHeader."Document Type"::"Credit Memo" then
             if SalesHeader."Applies-to Doc. Type" = SalesHeader."Applies-to Doc. Type"::Invoice then
@@ -88,7 +93,10 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
         if SalesHeader."Document Type" in [SalesHeader."Document Type"::Invoice, SalesHeader."Document Type"::Order] then
             SalesHeader.TestField("Shipment Date");
 
-        SalesHeader.TestField("Your Reference");
+        IsHandled := false;
+        PEPPOL30SalesValEvents.OnCheckSalesDocumentOnBeforeCheckYourReference(SalesHeader, IsHandled);
+        if not IsHandled then
+            SalesHeader.TestField("Your Reference");
 
         CheckShipToAddress(SalesHeader);
         SalesHeader.TestField("Due Date");
@@ -97,6 +105,8 @@ codeunit 37203 "PEPPOL30 Sales Validation Impl"
             CompanyInfo.TestField("Bank Account No.");
         CompanyInfo.TestField("Bank Branch No.");
         CompanyInfo.TestField("SWIFT Code");
+
+        PEPPOL30SalesValEvents.OnAfterCheckSalesDocument(SalesHeader, CompanyInfo);
     end;
 
     procedure CheckSalesDocumentLines(SalesHeader: Record "Sales Header")

--- a/src/Apps/W1/PEPPOL/Test/src/PEPPOLBISBillingTests.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/Test/src/PEPPOLBISBillingTests.Codeunit.al
@@ -1547,6 +1547,79 @@ codeunit 139236 "PEPPOL BIS BillingTests"
         VerifyTaxTotalAmounts(0, VatPer, 0, 0);
     end;
 
+    [Test]
+    procedure ValidateSalesDocumentRequiresCustomerIdentifier()
+    var
+        Customer: Record Customer;
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PEPPOL30SalesValidation: Codeunit "PEPPOL30 Sales Validation";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO] Generic PEPPOL validation requires a customer GLN or VAT registration no.
+        Initialize();
+
+        // [GIVEN] Sales Invoice "SI" without customer GLN or VAT registration no.
+        Customer.Get(CreateCustomerWithAddressAndVATRegNo());
+        Customer.GLN := '';
+        Customer."VAT Registration No." := '';
+        Customer.Modify(true);
+        CreateSalesDoc(SalesHeader, SalesLine, Customer."No.", "Sales Document Type"::Invoice, '');
+
+        // [WHEN] CU 37216 validates the sales invoice without German binding
+        asserterror PEPPOL30SalesValidation.ValidateDocument(SalesHeader);
+
+        // [THEN] Customer GLN or VAT Registration No. is required
+        Assert.ExpectedError('You must specify either GLN or VAT Registration No. for Customer');
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    procedure ValidateSalesDocumentRequiresYourReference()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PEPPOL30SalesValidation: Codeunit "PEPPOL30 Sales Validation";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO] Generic PEPPOL validation requires Your Reference
+        Initialize();
+
+        // [GIVEN] Otherwise valid Sales Invoice "SI" without Your Reference
+        CreateSalesDoc(SalesHeader, SalesLine, CreateCustomerWithAddressAndVATRegNo(), "Sales Document Type"::Invoice, '');
+        SalesHeader.Validate("Your Reference", '');
+        SalesHeader.Modify(true);
+
+        // [WHEN] CU 37216 validates the sales invoice without German binding
+        asserterror PEPPOL30SalesValidation.ValidateDocument(SalesHeader);
+
+        // [THEN] Your Reference is required
+        Assert.ExpectedError(SalesHeader.FieldCaption("Your Reference"));
+        Assert.ExpectedErrorCode('Dialog');
+    end;
+
+    [Test]
+    procedure ValidateSalesDocumentDoesNotRequireSellToEmail()
+    var
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        PEPPOL30SalesValidation: Codeunit "PEPPOL30 Sales Validation";
+    begin
+        // [FEATURE] [AI test 0.4]
+        // [SCENARIO] Generic PEPPOL validation permits blank Sell-to E-Mail
+        Initialize();
+
+        // [GIVEN] Otherwise valid Sales Invoice "SI" without Sell-to E-Mail
+        CreateSalesDoc(SalesHeader, SalesLine, CreateCustomerWithAddressAndVATRegNo(), "Sales Document Type"::Invoice, '');
+        SalesHeader.Validate("Sell-to E-Mail", '');
+        SalesHeader.Modify(true);
+
+        // [WHEN] CU 37216 validates the sales invoice without German binding
+        PEPPOL30SalesValidation.ValidateDocument(SalesHeader);
+
+        // [THEN] The sales invoice passes validation
+    end;
+
     local procedure Initialize()
     var
         CompanyInfo: Record "Company Information";


### PR DESCRIPTION
## Why

XRechnung and ZUGFeRD no longer receive the German PEPPOL sales-validation deviations after E-Document validation moved to the standalone PEPPOL app. Routing-number documents are therefore rejected by generic customer and reference checks, while the German Sell-to E-Mail requirement is no longer applied.

## Summary

- **Added** stateless sales-validation extension events at the customer identifier, Your Reference, and completed-header checkpoints.
- **Restored** German routing, buyer-reference, and e-mail behavior without changing persisted setup or generic validation.
- **Added** generic PEPPOL regression coverage for customer identifiers, Your Reference, and Sell-to E-Mail isolation.