### PR TITLE
[demo] [test] Export and import requested delivery dates in PEPPOL orders

### DIFF
--- a/src/Apps/W1/EDocument/App/src/Processing/Import/Sales/EDocSalesDocHelper.Codeunit.al
+++ b/src/Apps/W1/EDocument/App/src/Processing/Import/Sales/EDocSalesDocHelper.Codeunit.al
@@ -40,6 +40,8 @@ codeunit 6427 "E-Doc. Sales Doc. Helper"
         SalesLine."Variant Code" := EDocSalesLine."[BC] Variant Code";
         SalesLine.Type := EDocSalesLine."[BC] Sales Line Type";
         SalesLine.Validate("No.", EDocSalesLine."[BC] Sales Line No.");
+        if EDocSalesLine."Requested Delivery Date" <> 0D then
+            SalesLine.Validate("Requested Delivery Date", EDocSalesLine."Requested Delivery Date");
         if (SalesLine.Type = SalesLine.Type::"G/L Account") and HasTotalDiscount then
             SalesLine.Validate("Allow Invoice Disc.", true);
         SalesLine.Description := EDocSalesLine.Description;

--- a/src/Apps/W1/EDocument/Test/src/Processing/EDocProcessTest.Codeunit.al
+++ b/src/Apps/W1/EDocument/Test/src/Processing/EDocProcessTest.Codeunit.al
@@ -1363,6 +1363,65 @@ codeunit 139883 "E-Doc Process Test"
     end;
 
     [Test]
+    procedure FinishDraftSalesOrder_AppliesRequestedDeliveryDates()
+    var
+        EDocument: Record "E-Document";
+        EDocSalesHeader: Record "E-Document Sales Header";
+        EDocSalesLine: Record "E-Document Sales Line";
+        TempEDocImportParameters: Record "E-Doc. Import Parameters";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        Item: Record Item;
+        EDocImport: Codeunit "E-Doc. Import";
+        EDocumentProcessing: Codeunit "E-Document Processing";
+        HeaderRequestedDeliveryDate: Date;
+        LineRequestedDeliveryDate: Date;
+    begin
+        // [SCENARIO] Requested delivery dates from a PEPPOL Order are applied to the Sales Order before BC calculates line dates.
+        Initialize(Enum::"Service Integration"::"Mock");
+        HeaderRequestedDeliveryDate := DMY2Date(15, 2, 2026);
+        LineRequestedDeliveryDate := DMY2Date(20, 2, 2026);
+
+        // [GIVEN] A PEPPOL Order with a header requested delivery date and a different date on its first line
+        TempEDocImportParameters."Step to Run" := "Import E-Document Steps"::"Read into Draft";
+        LibraryEDoc.CreateInboundPEPPOLDocumentToState(EDocument, EDocumentService, 'peppol/peppol-order-standard.xml', TempEDocImportParameters);
+        EDocument.Get(EDocument."Entry No");
+
+        LibraryEDoc.GetGenericItem(Item);
+        EDocSalesHeader.GetFromEDocument(EDocument);
+        EDocSalesHeader."[BC] Customer No." := Customer."No.";
+        EDocSalesHeader.Modify();
+        EDocSalesLine.SetRange("E-Document Entry No.", EDocument."Entry No");
+        if EDocSalesLine.FindSet() then
+            repeat
+                EDocSalesLine."[BC] Sales Line Type" := "Sales Line Type"::Item;
+                EDocSalesLine."[BC] Sales Line No." := Item."No.";
+                EDocSalesLine.Modify();
+            until EDocSalesLine.Next() = 0;
+
+        EDocument."Document Type" := "E-Document Type"::"Sales Order";
+        EDocument.Modify();
+        EDocumentProcessing.ModifyEDocumentProcessingStatus(EDocument, "Import E-Doc. Proc. Status"::"Draft Ready");
+
+        // [WHEN] The draft is applied to a Sales Order
+        TempEDocImportParameters."Step to Run" := "Import E-Document Steps"::"Finish draft";
+        EDocImport.ProcessIncomingEDocument(EDocument, TempEDocImportParameters);
+        EDocument.Get(EDocument."Entry No");
+
+        // [THEN] The header date is applied before lines and the first line date overrides it
+        SalesHeader.Get(EDocument."Document Record ID");
+        Assert.AreEqual(HeaderRequestedDeliveryDate, SalesHeader."Requested Delivery Date", 'The header Requested Delivery Date should match the PEPPOL Order.');
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.FindSet();
+        VerifySalesLineDates(SalesLine, LineRequestedDeliveryDate);
+
+        // [THEN] A line without its own date inherits the header date
+        SalesLine.Next();
+        VerifySalesLineDates(SalesLine, HeaderRequestedDeliveryDate);
+    end;
+
+    [Test]
     procedure FinishDraftSalesOrder_CanBeUndone()
     var
         EDocument: Record "E-Document";
@@ -1498,6 +1557,14 @@ codeunit 139883 "E-Doc Process Test"
         // [Cleanup]
         ExistingSalesHeader.Get(ExistingSalesHeader."Document Type"::Order, 'EDOC-DUP-SO-001');
         ExistingSalesHeader.Delete();
+    end;
+
+    local procedure VerifySalesLineDates(SalesLine: Record "Sales Line"; ExpectedRequestedDeliveryDate: Date)
+    begin
+        Assert.AreEqual(ExpectedRequestedDeliveryDate, SalesLine."Requested Delivery Date", 'The line Requested Delivery Date is incorrect.');
+        Assert.AreEqual(ExpectedRequestedDeliveryDate, SalesLine."Planned Delivery Date", 'The line Planned Delivery Date is incorrect.');
+        Assert.AreEqual(ExpectedRequestedDeliveryDate, SalesLine."Planned Shipment Date", 'The line Planned Shipment Date is incorrect.');
+        Assert.AreEqual(ExpectedRequestedDeliveryDate, SalesLine."Shipment Date", 'The line Shipment Date is incorrect.');
     end;
 
     #endregion

--- a/src/Apps/W1/PEPPOL/App/src/Purchases/ExportPurchaseOrderPEPPOL30.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/App/src/Purchases/ExportPurchaseOrderPEPPOL30.Codeunit.al
@@ -260,6 +260,7 @@ codeunit 37202 "Export Purchase Order PEPPOL30"
         this.AddNonEmptyNode(AddressNode, 'CountrySubentity', CountrySubentity, CbcNamespaceTok, ChildNode);
         this.XMLDOMManagement.AddElement(AddressNode, 'Country', '', CacNamespaceTok, CountryNode);
         this.XMLDOMManagement.AddElement(CountryNode, 'IdentificationCode', IdentificationCode, CbcNamespaceTok, ChildNode);
+        this.AddRequestedDeliveryPeriod(DeliveryNode, PurchaseHeader."Requested Receipt Date");
     end;
 
     local procedure AddPaymentTerms(PurchaseHeader: Record "Purchase Header")
@@ -368,6 +369,7 @@ codeunit 37202 "Export Purchase Order PEPPOL30"
         this.XMLDOMManagement.AddAttribute(ChildNode, 'unitCode', UnitCode);
         this.XMLDOMManagement.AddElement(LineItemNode, 'LineExtensionAmount', InvoiceLineExtensionAmount, CbcNamespaceTok, ChildNode);
         this.XMLDOMManagement.AddAttribute(ChildNode, 'currencyID', InvLinePriceAmountCurrencyID);
+        this.AddRequestedDelivery(PurchaseLine, LineItemNode);
         this.XMLDOMManagement.AddElement(LineItemNode, 'Price', '', CacNamespaceTok, PriceNode);
         this.XMLDOMManagement.AddElement(PriceNode, 'PriceAmount', InvoiceLinePriceAmount, CbcNamespaceTok, ChildNode);
         this.XMLDOMManagement.AddAttribute(ChildNode, 'currencyID', InvLinePriceAmountCurrencyID);
@@ -390,6 +392,32 @@ codeunit 37202 "Export Purchase Order PEPPOL30"
         this.XMLDOMManagement.AddElement(ClassifiedTaxCategoryNode, 'Percent', InvoiceLineTaxPercent, CbcNamespaceTok, ChildNode);
         this.XMLDOMManagement.AddElement(ClassifiedTaxCategoryNode, 'TaxScheme', '', CacNamespaceTok, TaxSchemeNode);
         this.XMLDOMManagement.AddElement(TaxSchemeNode, 'ID', ClassifiedTaxCategorySchemeID, CbcNamespaceTok, ChildNode);
+    end;
+
+    local procedure AddRequestedDelivery(PurchaseLine: Record "Purchase Line"; LineItemNode: XmlNode)
+    var
+        DeliveryNode: XmlNode;
+    begin
+        if PurchaseLine."Requested Receipt Date" = 0D then
+            exit;
+
+        this.XMLDOMManagement.AddElement(LineItemNode, 'Delivery', '', CacNamespaceTok, DeliveryNode);
+        this.AddRequestedDeliveryPeriod(DeliveryNode, PurchaseLine."Requested Receipt Date");
+    end;
+
+    local procedure AddRequestedDeliveryPeriod(DeliveryNode: XmlNode; RequestedReceiptDate: Date)
+    var
+        RequestedDeliveryPeriodNode: XmlNode;
+        ChildNode: XmlNode;
+        RequestedReceiptDateText: Text;
+    begin
+        if RequestedReceiptDate = 0D then
+            exit;
+
+        RequestedReceiptDateText := Format(RequestedReceiptDate, 0, 9);
+        this.XMLDOMManagement.AddElement(DeliveryNode, 'RequestedDeliveryPeriod', '', CacNamespaceTok, RequestedDeliveryPeriodNode);
+        this.XMLDOMManagement.AddElement(RequestedDeliveryPeriodNode, 'StartDate', RequestedReceiptDateText, CbcNamespaceTok, ChildNode);
+        this.XMLDOMManagement.AddElement(RequestedDeliveryPeriodNode, 'EndDate', RequestedReceiptDateText, CbcNamespaceTok, ChildNode);
     end;
 
     local procedure AddPartyTaxScheme(PartyNode: XmlNode)

--- a/src/Apps/W1/PEPPOL/Test/src/PEPPOLBISBillingTests.Codeunit.al
+++ b/src/Apps/W1/PEPPOL/Test/src/PEPPOLBISBillingTests.Codeunit.al
@@ -16,6 +16,8 @@ using Microsoft.Foundation.Enums;
 using Microsoft.Foundation.Reporting;
 using Microsoft.Inventory.Item;
 using Microsoft.Peppol;
+using Microsoft.Purchases.Document;
+using Microsoft.Purchases.Setup;
 using Microsoft.Sales.Customer;
 using Microsoft.Sales.Document;
 using Microsoft.Sales.History;
@@ -43,6 +45,7 @@ codeunit 139236 "PEPPOL BIS BillingTests"
     var
         LibraryService: Codeunit "Library - Service";
         LibraryInventory: Codeunit "Library - Inventory";
+        LibraryPurchase: Codeunit "Library - Purchase";
         LibrarySales: Codeunit "Library - Sales";
         LibraryERM: Codeunit "Library - ERM";
         LibraryRandom: Codeunit "Library - Random";
@@ -56,6 +59,67 @@ codeunit 139236 "PEPPOL BIS BillingTests"
         WrongFileNameErr: Label 'File name should be: %1', Comment = '%1 - Client File Name';
         InvoiceNamespaceTxt: Label 'urn:oasis:names:specification:ubl:schema:xsd:Invoice-2', Locked = true;
         CreditNoteNamespaceTxt: Label 'urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2', Locked = true;
+        OrderNamespaceTxt: Label 'urn:oasis:names:specification:ubl:schema:xsd:Order-2', Locked = true;
+
+    [Test]
+    procedure ExportPurchaseOrderRequestedReceiptDates()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TempBlob: Codeunit "Temp Blob";
+        HeaderRequestedReceiptDate: Date;
+        LineRequestedReceiptDate: Date;
+    begin
+        // [FEATURE] [Order] [Delivery Date]
+        // [SCENARIO] Requested receipt dates are exported as PEPPOL requested delivery periods
+        Initialize();
+
+        // [GIVEN] A purchase order with different requested receipt dates on the header and line
+        HeaderRequestedReceiptDate := WorkDate() + 1;
+        LineRequestedReceiptDate := WorkDate() + 2;
+        CreatePurchaseOrder(PurchaseHeader, PurchaseLine);
+        PurchaseHeader.Validate("Requested Receipt Date", HeaderRequestedReceiptDate);
+        PurchaseHeader.Modify(true);
+        PurchaseLine.Validate("Requested Receipt Date", LineRequestedReceiptDate);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase order is exported to PEPPOL XML
+        ExportPurchaseOrderToBlob(PurchaseHeader, TempBlob);
+
+        // [THEN] Each date is exported as both the start and end of its requested delivery period
+        InitXPathXMLReader(TempBlob, OrderNamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('/*/cac:Delivery/cac:RequestedDeliveryPeriod/cbc:StartDate', Format(HeaderRequestedReceiptDate, 0, 9));
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('/*/cac:Delivery/cac:RequestedDeliveryPeriod/cbc:EndDate', Format(HeaderRequestedReceiptDate, 0, 9));
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//cac:OrderLine/cac:LineItem/cac:Delivery/cac:RequestedDeliveryPeriod/cbc:StartDate', Format(LineRequestedReceiptDate, 0, 9));
+        LibraryXPathXMLReader.VerifyNodeValueByXPath('//cac:OrderLine/cac:LineItem/cac:Delivery/cac:RequestedDeliveryPeriod/cbc:EndDate', Format(LineRequestedReceiptDate, 0, 9));
+    end;
+
+    [Test]
+    procedure ExportPurchaseOrderWithoutRequestedReceiptDates()
+    var
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        TempBlob: Codeunit "Temp Blob";
+    begin
+        // [FEATURE] [Order] [Delivery Date]
+        // [SCENARIO] Blank requested receipt dates do not create requested delivery periods
+        Initialize();
+
+        // [GIVEN] A purchase order without requested receipt dates
+        CreatePurchaseOrder(PurchaseHeader, PurchaseLine);
+        PurchaseHeader.Validate("Requested Receipt Date", 0D);
+        PurchaseHeader.Modify(true);
+        PurchaseLine.Validate("Requested Receipt Date", 0D);
+        PurchaseLine.Modify(true);
+
+        // [WHEN] The purchase order is exported to PEPPOL XML
+        ExportPurchaseOrderToBlob(PurchaseHeader, TempBlob);
+
+        // [THEN] No requested delivery period is exported at header or line level
+        InitXPathXMLReader(TempBlob, OrderNamespaceTxt);
+        LibraryXPathXMLReader.VerifyNodeAbsence('/*/cac:Delivery/cac:RequestedDeliveryPeriod');
+        LibraryXPathXMLReader.VerifyNodeAbsence('//cac:OrderLine/cac:LineItem/cac:Delivery/cac:RequestedDeliveryPeriod');
+    end;
 
     [Test]
     [Scope('OnPrem')]
@@ -1632,18 +1696,35 @@ codeunit 139236 "PEPPOL BIS BillingTests"
             LibraryERMCountryData.CreateVATData();
             LibraryERMCountryData.UpdateGeneralLedgerSetup();
             LibraryERMCountryData.UpdateGeneralPostingSetup();
+            LibraryERMCountryData.UpdatePurchasesPayablesSetup();
             LibraryERMCountryData.UpdateSalesReceivablesSetup();
             LibraryERMCountryData.UpdateLocalData();
             UpdateElectronicDocumentFormatSetup();
             LibraryService.SetupServiceMgtNoSeries();
             LibrarySetupStorage.Save(DATABASE::"Company Information");
             LibrarySetupStorage.Save(DATABASE::"General Ledger Setup");
+            LibrarySetupStorage.Save(DATABASE::"Purchases & Payables Setup");
 
             IsInitialized := true;
             LibraryTestInitialize.OnAfterTestSuiteInitialize(Codeunit::"PEPPOL BIS BillingTests");
         end;
 
         ConfigureVATPostingSetup();
+    end;
+
+    local procedure CreatePurchaseOrder(var PurchaseHeader: Record "Purchase Header"; var PurchaseLine: Record "Purchase Line")
+    begin
+        LibraryPurchase.CreatePurchHeader(PurchaseHeader, PurchaseHeader."Document Type"::Order, LibraryPurchase.CreateVendorNo());
+        LibraryPurchase.CreatePurchaseLine(PurchaseLine, PurchaseHeader, PurchaseLine.Type::Item, LibraryInventory.CreateItemNo(), 1);
+    end;
+
+    local procedure ExportPurchaseOrderToBlob(PurchaseHeader: Record "Purchase Header"; var TempBlob: Codeunit "Temp Blob")
+    var
+        ExportPurchaseOrderPEPPOL30: Codeunit "Export Purchase Order PEPPOL30";
+    begin
+        ExportPurchaseOrderPEPPOL30.SetFormat(Enum::"PEPPOL 3.0 Purchase"::"PEPPOL 3.0 - Purchase");
+        ExportPurchaseOrderPEPPOL30.Run(PurchaseHeader);
+        ExportPurchaseOrderPEPPOL30.GetPurchaseOrderXML(TempBlob);
     end;
 
     local procedure AddCustPEPPOLIdentifier(CustNo: Code[20])


### PR DESCRIPTION
## Why

PEPPOL orders need to communicate the buyer's requested dates at header and line level and apply them when creating the seller's Sales Order.

## Summary

- **Added** header requested delivery periods using the purchase order's Requested Receipt Date
- **Added** line requested delivery periods using each purchase line's Requested Receipt Date
- **Omitted** requested delivery period elements when the corresponding date is blank
- **Covered** populated and blank header and line dates with PEPPOL XML integration tests
- **Applied** the imported header Requested Delivery Date before creating Sales Order lines
- **Applied** explicit line Requested Delivery Dates through validation so BC calculates planned delivery, planned shipment, and shipment dates
- **Covered** explicit line dates and header-date inheritance with a Sales Order integration test

