### PR TITLE
[Main]- Reminder Automation Tests.TestReminderAutomationLogsInteractionWithIssuedReminderNumber fails (IT + CZ)

### DIFF
--- a/src/Layers/IT/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
+++ b/src/Layers/IT/Tests/ERM-Finance/ReminderAutomationTests.Codeunit.al
@@ -1071,7 +1071,7 @@ codeunit 134979 "Reminder Automation Tests"
         Assert.AreEqual(1, TempBlobList.Count(), NoOfAttachmentsSameErr);
     end;
 
-    [HandlerFunctions('ConfirmHandler,NewReminderActionModalPageHandler,CreateRemindersSetupModalPageHandler,IssueRemindersSetupModalPageHandler,SendRemindersSetupLogInteractionModalPageHandler,SelectRemTermsAutomationHandler')]
+    [HandlerFunctions('NewReminderActionModalPageHandler,CreateRemindersSetupModalPageHandler,IssueRemindersSetupModalPageHandler,SendRemindersSetupLogInteractionModalPageHandler,SelectRemTermsAutomationHandler')]
     [Test]
     procedure TestReminderAutomationLogsInteractionWithIssuedReminderNumber()
     var


### PR DESCRIPTION
workitem [Bug 642684](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/642684): [All-e]Test disabled after BCApps uptake: Reminder Automation Tests.TestReminderAutomationLogsInteractionWithIssuedReminderNumber fails (IT + CZ)

Fixes [AB#642684](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/642684)
