### PR TITLE
Bug 650055: [29.x] Matched Order Lines functionality could lead to inconsistent information if we deal with very similar Purchase Orders.

### DIFF
--- a/src/Layers/APAC/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/APAC/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -345,8 +345,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1198,8 +1200,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/BE/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/BE/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1192,8 +1194,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/ES/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/ES/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1186,8 +1188,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/FR/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/FR/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1180,8 +1182,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/IT/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/IT/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -349,8 +349,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1197,8 +1199,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/NA/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/NA/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -339,8 +339,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1193,8 +1195,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/NL/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/NL/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1201,8 +1203,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/RU/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/RU/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -348,8 +348,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1206,8 +1208,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
+++ b/src/Layers/W1/BaseApp/Inventory/Tracking/MatchedOrderLineMgmt.Codeunit.al
@@ -311,6 +311,12 @@ codeunit 5826 "Matched Order Line Mgmt."
         exit(not MatchedOrderLine.IsEmpty());
     end;
 
+    internal procedure CheckLineCanBeMatched(PurchaseLine: Record "Purchase Line")
+    begin
+        if PurchaseLine."Receipt No." <> '' then
+            Error(LineCreatedFromReceiptErr, PurchaseLine."Line No.");
+    end;
+
     internal procedure IsLineMatched(PurchaseLine: Record "Purchase Line"; ShowError: Boolean): Boolean
     begin
         case PurchaseLine."Document Type" of
@@ -699,6 +705,7 @@ codeunit 5826 "Matched Order Line Mgmt."
         PurchaseLines: Page "Purchase Lines";
     begin
         PurchaseLineInvoice.GetBySystemId(DetailedMatchedOrderLine."Document Line SystemId");
+        CheckLineCanBeMatched(PurchaseLineInvoice);
         PurchaseLineOrder.FilterGroup(-1);
         PurchaseLineOrder.SetFilter("Outstanding Quantity", '<>0');
         PurchaseLineOrder.SetFilter("Qty. Rcd. Not Invoiced", '<>0');
@@ -769,6 +776,7 @@ codeunit 5826 "Matched Order Line Mgmt."
         GetReceiptLines: Page "Get Receipt Lines";
     begin
         PurchaseLineInvoice.GetBySystemId(DetailedMatchedOrderLine."Document Line SystemId");
+        CheckLineCanBeMatched(PurchaseLineInvoice);
         PurchRcptLine.FilterGroup(2);
         if IsNullGuid(DetailedMatchedOrderLine."Matched Order Line SystemId") then begin
             PurchRcptLine.SetRange("Buy-from Vendor No.", PurchaseLineInvoice."Buy-from Vendor No.");
@@ -1246,6 +1254,7 @@ codeunit 5826 "Matched Order Line Mgmt."
         PrepaymentNotSupportedErr: Label 'Matched order lines are not supported for prepayment lines. Order No.: %1, Line No.: %2', Comment = '%1 = Order No., %2 = Line No.';
         PurchaseInvoiceLineMatchedErr: Label 'The line is matched to an order line and cannot be modified.';
         PurchaseOrderLineMatchedErr: Label 'The line is matched to an invoice line and cannot be modified.';
+        LineCreatedFromReceiptErr: Label 'Matched order lines are not supported for lines created with the Get Receipt Lines function. Line No.: %1', Comment = '%1 = Line No.';
         InvoiceLineLbl: Label 'Invoice %1 Line %2', Comment = '%1 = Document No., %2 = Line No.';
         OrderLineLbl: Label 'Order %1 Line %2', Comment = '%1 = Document No., %2 = Line No.';
         RcptLineLbl: Label 'Receipt %1 Line %2', Comment = '%1 = Document No., %2 = Line No.';

--- a/src/Layers/W1/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
+++ b/src/Layers/W1/BaseApp/Purchases/Document/PurchInvoiceSubform.Page.al
@@ -333,8 +333,10 @@ page 55 "Purch. Invoice Subform"
 
                     trigger OnDrillDown()
                     var
+                        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                         MatchedOrderLines: Page "Matched Order Lines";
                     begin
+                        MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                         MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                         MatchedOrderLines.RunModal();
                     end;
@@ -1181,8 +1183,10 @@ page 55 "Purch. Invoice Subform"
 
                         trigger OnAction()
                         var
+                            MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
                             MatchedOrderLines: Page "Matched Order Lines";
                         begin
+                            MatchedOrderLineMgmt.CheckLineCanBeMatched(Rec);
                             MatchedOrderLines.InitializePage("Matched Order Line Source"::"Purchase Invoice", false, Rec.SystemId);
                             MatchedOrderLines.RunModal();
                         end;

--- a/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
+++ b/src/Layers/W1/Tests/ERM/ERMMatchedOrderLineTests.Codeunit.al
@@ -4737,6 +4737,108 @@ codeunit 134468 "ERM Matched Order Line Tests"
         LibraryVariableStorage.AssertEmpty();
     end;
 
+    [Test]
+    [Scope('OnPrem')]
+    procedure MatchingRejectedForInvoiceLineCreatedByGetReceiptLines()
+    var
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO] An invoice line created by Get Receipt Lines cannot be opened for order matching.
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 100);
+
+        // [GIVEN] A received purchase order
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        PurchaseLineOrder.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        PurchaseLineOrder.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
+        PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
+        PurchRcptLine.FindFirst();
+
+        // [GIVEN] A purchase invoice line created via Get Receipt Lines (has a Receipt No.)
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
+        PurchGetReceipt.SetPurchHeader(PurchaseHeaderInvoice);
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+
+        PurchaseLineInvoice.SetRange("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.SetRange("Document No.", PurchaseHeaderInvoice."No.");
+        PurchaseLineInvoice.SetFilter("Receipt No.", '<>%1', '');
+        PurchaseLineInvoice.FindFirst();
+
+        // [WHEN] Opening order matching for that invoice line
+        asserterror MatchedOrderLineMgmt.CheckLineCanBeMatched(PurchaseLineInvoice);
+
+        // [THEN] It is rejected because the combination is not supported
+        Assert.ExpectedError('created with the Get Receipt Lines function');
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
+    procedure GetOrderLinesRejectedForInvoiceLineCreatedByGetReceiptLines()
+    var
+        PurchaseHeaderOrder: Record "Purchase Header";
+        PurchaseLineOrder: Record "Purchase Line";
+        PurchaseHeaderInvoice: Record "Purchase Header";
+        PurchaseLineInvoice: Record "Purchase Line";
+        PurchRcptLine: Record "Purch. Rcpt. Line";
+        TempDetailedMatchedOrderLine: Record "Detailed Matched Order Line";
+        Item: Record Item;
+        Vendor: Record Vendor;
+        MatchedOrderLineMgmt: Codeunit "Matched Order Line Mgmt.";
+        PurchGetReceipt: Codeunit "Purch.-Get Receipt";
+        Quantity: Decimal;
+    begin
+        // [SCENARIO] Get Order Lines cannot match order lines to an invoice line created by Get Receipt Lines, even when opened from the header.
+        Initialize();
+        Quantity := LibraryRandom.RandIntInRange(10, 100);
+
+        // [GIVEN] A received purchase order
+        LibraryPurchase.CreateVendor(Vendor);
+        LibraryInventory.CreateItem(Item);
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderOrder, PurchaseHeaderOrder."Document Type"::Order, Vendor."No.");
+        LibraryPurchase.CreatePurchaseLine(PurchaseLineOrder, PurchaseHeaderOrder, PurchaseLineOrder.Type::Item, Item."No.", Quantity);
+        PurchaseLineOrder.Validate("Direct Unit Cost", LibraryRandom.RandDecInRange(10, 100, 2));
+        PurchaseLineOrder.Modify(true);
+        LibraryPurchase.PostPurchaseDocument(PurchaseHeaderOrder, true, false);
+
+        PurchRcptLine.SetRange("Order No.", PurchaseLineOrder."Document No.");
+        PurchRcptLine.SetRange("Order Line No.", PurchaseLineOrder."Line No.");
+        PurchRcptLine.FindFirst();
+
+        // [GIVEN] A purchase invoice line created via Get Receipt Lines (has a Receipt No.)
+        LibraryPurchase.CreatePurchHeader(PurchaseHeaderInvoice, PurchaseHeaderInvoice."Document Type"::Invoice, Vendor."No.");
+        PurchGetReceipt.SetPurchHeader(PurchaseHeaderInvoice);
+        PurchGetReceipt.CreateInvLines(PurchRcptLine);
+
+        PurchaseLineInvoice.SetRange("Document Type", PurchaseHeaderInvoice."Document Type");
+        PurchaseLineInvoice.SetRange("Document No.", PurchaseHeaderInvoice."No.");
+        PurchaseLineInvoice.SetFilter("Receipt No.", '<>%1', '');
+        PurchaseLineInvoice.FindFirst();
+
+        TempDetailedMatchedOrderLine.Init();
+        TempDetailedMatchedOrderLine."Document Line SystemId" := PurchaseLineInvoice.SystemId;
+
+        // [WHEN] Getting order lines for that invoice line
+        asserterror MatchedOrderLineMgmt.GetOrderLines("Matched Order Line Source"::"Purchase Invoice", TempDetailedMatchedOrderLine);
+
+        // [THEN] It is rejected because the combination is not supported
+        Assert.ExpectedError('created with the Get Receipt Lines function');
+    end;
+
     // ============================================================================
     // REGION: Local Helper Functions
     // ============================================================================


### PR DESCRIPTION
Backport of #11339 for [AB#650055](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650055)



