### PR TITLE
[master][Subscription Billing] 1M 'Align to End of Month' line with end date produces a 1-day prorated stub

### DIFF
--- a/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
+++ b/src/Apps/W1/Subscription Billing/App/Service Commitments/Tables/SubscriptionLine.Table.al
@@ -2069,6 +2069,9 @@ table 8059 "Subscription Line"
                     end;
                 end;
         end;
+
+        if (Rec."Period Calculation" = Rec."Period Calculation"::"Align to End of Month") and (Rec."Subscription Line End Date" <> 0D) and (NextToDate < Rec."Subscription Line End Date") and (Rec."Subscription Line End Date" <= CalcDate(PeriodFormula, FromDate)) then
+            NextToDate := Rec."Subscription Line End Date";
     end;
 
     local procedure GetBillingReferenceDate() BillingReferenceDate: Date


### PR DESCRIPTION
**Issue:** For a Vendor contract with 1M Billing Rhythm and Align to End of Month, the billing period ended one day before the Subscription Line End Date, creating an unintended one-day prorated billing line.
**Cause:** The Align to End of Month calculation in CalculateNextToDate incorrectly calculated the period end date, while the end-date handling did not include the Subscription Line End Date in the current billing period.
**Solution:** Updated CalculateNextToDate to cap the calculated period end date at the Subscription Line End Date when it falls within the current monthly period, ensuring the complete period is billed without an extra one-day proration.

Fixes [AB#650068](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650068)
Workitem [Bug 650068](https://dynamicssmb2.visualstudio.com/Dynamics%20SMB/_workitems/edit/650068): [master] [All-E][Subscription Billing] 1M 'Align to End of Month' line with end date produces a 1-day prorated stub




