### PR TITLE
[Shopify] Handle missing variant mapping in product action

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfySyncProducts.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Codeunits/ShpfySyncProducts.Codeunit.al
@@ -47,6 +47,7 @@ codeunit 30185 "Shpfy Sync Products"
         DialogMsg: Label '#1#########################', Locked = true;
         SyncInformationProgressLbl: Label 'Synchronizing information with Shopify.', Comment = 'Shopify is a product name.';
         FinishSyncProgressLbl: Label 'Finishing up synchronization with Shopify.', Comment = 'Shopify is a product name.';
+        NoProductVariantErr: Label 'No Shopify product variant is linked to this item. Synchronize products with Shopify, refresh the page, and try again.';
 
     /// <summary> 
     /// Export Items To Shopify.
@@ -142,7 +143,8 @@ codeunit 30185 "Shpfy Sync Products"
     var
         ShopifyProduct: Record "Shpfy Product";
     begin
-        ShopifyVariant.FindFirst();
+        if not ShopifyVariant.FindFirst() then
+            Error(NoProductVariantErr);
         ShopifyProduct.Get(ShopifyVariant."Product Id");
         if ShopifyProduct.URL <> '' then
             exit(ShopifyProduct.URL);
@@ -170,7 +172,8 @@ codeunit 30185 "Shpfy Sync Products"
         ShopifyProductsOverview: Page "Shpfy Products Overview";
         ProductIdFilter: Text;
     begin
-        ShopifyVariant.FindSet();
+        if not ShopifyVariant.FindSet() then
+            Error(NoProductVariantErr);
         repeat
             ProductIdFilter += Format(ShopifyVariant."Product Id") + '|';
         until ShopifyVariant.Next() = 0;

--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemCard.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemCard.PageExt.al
@@ -112,33 +112,19 @@ pageextension 30119 "Shpfy Item Card" extends "Item Card"
     local procedure SetIsProductMapped()
     var
         Shop: Record "Shpfy Shop";
-        ShopifyProduct: Record "Shpfy Product";
         ShopifyVariant: Record "Shpfy Variant";
     begin
         IsProductMapped := false;
-        ShopifyProduct.SetLoadFields("Item SystemId", "Shop Code");
-        ShopifyProduct.SetRange("Item SystemId", Rec.SystemId);
-        if ShopifyProduct.FindSet() then
+        ShopifyVariant.SetLoadFields("Item SystemId", "Shop Code");
+        ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
+        if ShopifyVariant.FindSet() then
             repeat
-                if Shop.Get(ShopifyProduct."Shop Code") then
+                if Shop.Get(ShopifyVariant."Shop Code") then
                     if Shop.Enabled then begin
                         IsProductMapped := true;
                         exit;
                     end;
-            until ShopifyProduct.Next() = 0;
-
-        if not IsProductMapped then begin
-            ShopifyVariant.SetLoadFields("Item SystemId", "Shop Code");
-            ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
-            if ShopifyVariant.FindSet() then
-                repeat
-                    if Shop.Get(ShopifyVariant."Shop Code") then
-                        if Shop.Enabled then begin
-                            IsProductMapped := true;
-                            exit;
-                        end;
-                until ShopifyVariant.Next() = 0;
-        end;
+            until ShopifyVariant.Next() = 0;
     end;
 
     local procedure SetAvailableStoresToMap()

--- a/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemList.PageExt.al
+++ b/src/Apps/W1/Shopify/App/src/Products/Page Extensions/ShpfyItemList.PageExt.al
@@ -62,32 +62,18 @@ pageextension 30120 "Shpfy Item List" extends "Item List"
     local procedure SetIsProductMapped()
     var
         Shop: Record "Shpfy Shop";
-        ShopifyProduct: Record "Shpfy Product";
         ShopifyVariant: Record "Shpfy Variant";
     begin
         IsProductMapped := false;
-        ShopifyProduct.SetLoadFields("Item SystemId", "Shop Code");
-        ShopifyProduct.SetRange("Item SystemId", Rec.SystemId);
-        if ShopifyProduct.FindSet() then
+        ShopifyVariant.SetLoadFields("Item SystemId", "Shop Code");
+        ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
+        if ShopifyVariant.FindSet() then
             repeat
-                if Shop.Get(ShopifyProduct."Shop Code") then
+                if Shop.Get(ShopifyVariant."Shop Code") then
                     if Shop.Enabled then begin
                         IsProductMapped := true;
                         exit;
                     end;
-            until ShopifyProduct.Next() = 0;
-
-        if not IsProductMapped then begin
-            ShopifyVariant.SetLoadFields("Item SystemId", "Shop Code");
-            ShopifyVariant.SetRange("Item SystemId", Rec.SystemId);
-            if ShopifyVariant.FindSet() then
-                repeat
-                    if Shop.Get(ShopifyVariant."Shop Code") then
-                        if Shop.Enabled then begin
-                            IsProductMapped := true;
-                            exit;
-                        end;
-                until ShopifyVariant.Next() = 0;
-        end;
+            until ShopifyVariant.Next() = 0;
     end;
 }

--- a/src/Apps/W1/Shopify/Test/Products/ShpfyProductMappingTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Products/ShpfyProductMappingTest.Codeunit.al
@@ -320,4 +320,75 @@ codeunit 139604 "Shpfy Product Mapping Test"
         // [THEN] The facade returns the product's URL
         LibraryAssert.AreEqual(ProductUrlTok, ActualUrl, 'The facade should return the Shopify product URL for the item.');
     end;
+
+    [Test]
+    procedure ShowProductActionDisabledWhenVariantMissingOnItemCard()
+    var
+        Item: Record Item;
+        ItemCard: TestPage "Item Card";
+    begin
+        // [SCENARIO] A mapped product has no Shopify variant linked to the item.
+        CreateMappedProductWithoutVariant(Item);
+
+        // [WHEN] The item card is opened.
+        ItemCard.OpenEdit();
+        ItemCard.GoToRecord(Item);
+
+        // [THEN] The action to show the product in Shopify is disabled.
+        LibraryAssert.IsFalse(ItemCard."Show product in Shopify".Enabled(), 'The action should be disabled when no Shopify variant is linked to the item.');
+    end;
+
+    [Test]
+    procedure ShowProductActionDisabledWhenVariantMissingOnItemList()
+    var
+        Item: Record Item;
+        ItemList: TestPage "Item List";
+    begin
+        // [SCENARIO] A mapped product has no Shopify variant linked to the item.
+        CreateMappedProductWithoutVariant(Item);
+
+        // [WHEN] The item list is opened.
+        ItemList.OpenView();
+        ItemList.GoToRecord(Item);
+
+        // [THEN] The action to show the product in Shopify is disabled.
+        LibraryAssert.IsFalse(ItemList."Show product in Shopify".Enabled(), 'The action should be disabled when no Shopify variant is linked to the item.');
+    end;
+
+    [Test]
+    procedure GetProductsOverviewShowsClearErrorWhenVariantMissing()
+    var
+        Item: Record Item;
+        ShopifyVariant: Record "Shpfy Variant";
+        ShopifyProductMgt: Codeunit "Shpfy Product";
+    begin
+        // [SCENARIO] Product navigation starts after the linked Shopify variant has been deleted.
+        CreateMappedProductWithoutVariant(Item);
+        ShopifyVariant.SetRange("Item SystemId", Item.SystemId);
+
+        // [WHEN] The product overview is requested.
+        asserterror ShopifyProductMgt.GetProductsOverview(ShopifyVariant);
+
+        // [THEN] A clear mapping error is shown.
+        LibraryAssert.ExpectedError('No Shopify product variant is linked to this item. Synchronize products with Shopify, refresh the page, and try again.');
+    end;
+
+    local procedure CreateMappedProductWithoutVariant(var Item: Record Item)
+    var
+        Shop: Record "Shpfy Shop";
+        ShopifyProduct: Record "Shpfy Product";
+        ShopifyVariant: Record "Shpfy Variant";
+        InitializeTest: Codeunit "Shpfy Initialize Test";
+        ProductInitTest: Codeunit "Shpfy Product Init Test";
+    begin
+        Shop := InitializeTest.CreateShop();
+        Item := ProductInitTest.CreateItem();
+        ShopifyVariant := ProductInitTest.CreateStandardProduct(Shop);
+        ShopifyProduct.Get(ShopifyVariant."Product Id");
+        ShopifyProduct."Item SystemId" := Item.SystemId;
+        ShopifyProduct.Modify();
+        ShopifyVariant."Item SystemId" := Item.SystemId;
+        ShopifyVariant.Modify();
+        ShopifyVariant.Delete();
+    end;
 }


### PR DESCRIPTION
## What & why

The **Show product in Shopify** action could remain enabled when an item retained a Shopify Product mapping but its linked Shopify Variant had been deleted. Invoking the action then surfaced a raw database filter error.

This change enables the action only when the item has a Shopify Variant linked through an enabled shop. The shared product navigation methods also show clear guidance if the variant mapping disappears between rendering the page and invoking the action. The same behavior is applied to the Item Card and Item List.

## Linked work

Fixes [AB#649996](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/649996)

## How I validated this

- [x] I read the full diff and it contains only changes I intended.
- [x] I built the affected app(s) locally with no new analyzer warnings.
- [x] I ran the change in Business Central and confirmed it behaves as expected.
- [x] I added or updated tests for the new behavior, or explained below why none are needed.

**What I tested and the outcome**

- Built the Shopify Connector app successfully through the AL MCP build workflow.
- Added regression coverage for the Item Card action, Item List action, and the clear error returned when product navigation finds no linked variant.
- Focused test execution was blocked locally because the AL MCP server restored the v30 Test Toolkit symbols into the application cache instead of the test project cache and returned a generic compilation failure without diagnostics.

## Risk & compatibility

Low. There are no schema or data changes. Items with valid Shopify Variant mappings retain the existing navigation behavior.



