### PR TITLE
[releases/29.x] [Shopify] Fix exchange refund order links, totals, and refund page layout

### DIFF
--- a/src/Apps/W1/Shopify/App/src/Document Links/Codeunits/ShpfyDocumentLinkMgt.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Document Links/Codeunits/ShpfyDocumentLinkMgt.Codeunit.al
@@ -118,7 +118,7 @@ codeunit 30262 "Shpfy Document Link Mgt."
         end;
     end;
 
-    local procedure CreateNewDocumentLink(DocumentType: Enum "Shpfy Shop Document Type"; DocumentId: BigInteger; BCDocumentType: Enum "Shpfy Document Type"; DocumentNo: code[20])
+    internal procedure CreateNewDocumentLink(DocumentType: Enum "Shpfy Shop Document Type"; DocumentId: BigInteger; BCDocumentType: Enum "Shpfy Document Type"; DocumentNo: code[20])
     var
         NewDocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
     begin

--- a/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefund.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order Refunds/Pages/ShpfyRefund.Page.al
@@ -89,6 +89,12 @@ page 30145 "Shpfy Refund"
                     field("Presentment Currency Code"; Rec."Presentment Currency Code") { }
                 }
             }
+            part(Lines; "Shpfy Refund Lines")
+            {
+                ApplicationArea = All;
+                Caption = 'Lines';
+                SubPageLink = "Refund Id" = field("Refund Id");
+            }
             group(Tax)
             {
                 Caption = 'Tax';
@@ -111,12 +117,6 @@ page 30145 "Shpfy Refund"
                     Editable = false;
                     ToolTip = 'Specifies whether the parent order is exempt from tax.';
                 }
-            }
-            part(Lines; "Shpfy Refund Lines")
-            {
-                ApplicationArea = All;
-                Caption = 'Lines';
-                SubPageLink = "Refund Id" = field("Refund Id");
             }
             group(NoteGroup)
             {

--- a/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order Return Refund Processing/Codeunits/ShpfyCreateSalesDocRefund.Codeunit.al
@@ -132,6 +132,10 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                 MapPaymentMethodCode(SalesHeader);
             end;
             SalesHeader."Shpfy Refund Id" := RefundHeader."Refund Id";
+            if RefundHasExchangeItemLines(RefundHeader."Refund Id") then begin
+                SalesHeader."Shpfy Order Id" := OrderHeader."Shopify Order Id";
+                SalesHeader."Shpfy Order No." := OrderHeader."Shopify Order No.";
+            end;
             SalesHeader.Modify(true);
             Clear(DocLinkToBCDoc);
             DocLinkToBCDoc."Document Type" := BCDocumentTypeConvert.Convert(SalesHeader."Document Type");
@@ -203,10 +207,14 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
         GiftCard: Record "Shpfy Gift Card";
         ShopLocation: Record "Shpfy Shop Location";
         ExchangeOrderLine: Record "Shpfy Order Line";
+        OrderHeader: Record "Shpfy Order Header";
         OpenAmount: Decimal;
         LocationId: BigInteger;
+        ShopifyOrderNo: Code[50];
         IsHandled: Boolean;
     begin
+        if OrderHeader.Get(RefundHeader."Order Id") then
+            ShopifyOrderNo := OrderHeader."Shopify Order No.";
         repeat
             case RefundLine."Restock Type" of
                 "Shpfy Restock Type"::"Legacy Restock",
@@ -276,6 +284,10 @@ codeunit 30246 "Shpfy Create Sales Doc. Refund"
                         end;
                         SalesLine."Shpfy Refund Id" := RefundHeader."Refund Id";
                         SalesLine."Shpfy Refund Line Id" := RefundLine."Refund Line Id";
+                        if RefundLine."Is Exchange Item" then begin
+                            SalesLine."Shpfy Order Line Id" := RefundLine."Order Line Id";
+                            SalesLine."Shpfy Order No." := ShopifyOrderNo;
+                        end;
                         SalesLine.Modify();
                         if RefundLine."Gift Card" then begin
                             GiftCard.SetRange("Order Line Id", RefundLine."Order Line Id");

--- a/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyCopySalesDocument.Codeunit.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Codeunits/ShpfyCopySalesDocument.Codeunit.al
@@ -33,4 +33,18 @@ codeunit 30408 "Shpfy Copy Sales Document"
         Clear(ToSalesLine."Shpfy Order No.");
         ToSalesLine.Modify();
     end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Copy Document Mgt.", 'OnAfterCopySalesDocument', '', false, false)]
+    local procedure LinkExchangeInvoiceToShopifyOrder(FromDocumentType: Option; FromDocumentNo: Code[20]; var ToSalesHeader: Record "Sales Header"; FromDocOccurenceNo: Integer; FromDocVersionNo: Integer; IncludeHeader: Boolean; RecalculateLines: Boolean; MoveNegLines: Boolean)
+    var
+        DocumentLinkMgt: Codeunit "Shpfy Document Link Mgt.";
+        DocumentConvert: Codeunit "Shpfy BC Document Type Convert";
+    begin
+        if not MoveNegLines then
+            exit;
+        if (ToSalesHeader."Shpfy Order Id" = 0) or (ToSalesHeader."Shpfy Refund Id" = 0) then
+            exit;
+
+        DocumentLinkMgt.CreateNewDocumentLink("Shpfy Shop Document Type"::"Shopify Shop Order", ToSalesHeader."Shpfy Order Id", DocumentConvert.Convert(ToSalesHeader."Document Type"), ToSalesHeader."No.");
+    end;
 }

--- a/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
+++ b/src/Apps/W1/Shopify/App/src/Order handling/Pages/ShpfyOrderTotalsFactBox.Page.al
@@ -44,12 +44,13 @@ page 30172 "Shpfy Order Totals FactBox"
                     ShowCaption = false;
                     Visible = not PresentmentVisible;
 
-                    field("Subtotal Amount"; Rec."Subtotal Amount")
+                    field("Subtotal Amount"; ShopifySubtotalAmount)
                     {
                         ApplicationArea = All;
+                        Caption = 'Subtotal Amount';
                         AutoFormatExpression = Rec."Currency Code";
                         AutoFormatType = 1;
-                        ToolTip = 'Specifies the subtotal amount of the order.';
+                        ToolTip = 'Specifies the subtotal amount of the order, excluding any exchange items that are invoiced separately.';
                     }
                     field("Shipping Charges Amount"; Rec."Shipping Charges Amount")
                     {
@@ -58,20 +59,21 @@ page 30172 "Shpfy Order Totals FactBox"
                         AutoFormatType = 1;
                         ToolTip = 'Specifies the shipping charges amount of the order.';
                     }
-                    field("Total Amount"; Rec."Total Amount")
+                    field("Total Amount"; ShopifyTotalAmount)
                     {
                         ApplicationArea = All;
+                        Caption = 'Total Amount';
                         AutoFormatExpression = Rec."Currency Code";
                         AutoFormatType = 1;
-                        ToolTip = 'Specifies the total amount of the order.';
+                        ToolTip = 'Specifies the total amount of the order, excluding any exchange items that are invoiced separately.';
                     }
-                    field(VATAmount; Rec."VAT Amount")
+                    field(VATAmount; ShopifyVATAmount)
                     {
                         ApplicationArea = All;
                         AutoFormatExpression = Rec."Currency Code";
                         AutoFormatType = 1;
                         CaptionClass = DocumentTotals.GetTotalVATCaption(Rec."Currency Code");
-                        ToolTip = 'Specifies the sum of tax amounts on all lines in the document.';
+                        ToolTip = 'Specifies the sum of tax amounts on all lines in the document, excluding any exchange items that are invoiced separately.';
                     }
                     field(RoundingAmount; Rec."Payment Rounding Amount")
                     {
@@ -87,12 +89,13 @@ page 30172 "Shpfy Order Totals FactBox"
                     ShowCaption = false;
                     Visible = PresentmentVisible;
 
-                    field("Presentment Subtotal Amount"; Rec."Presentment Subtotal Amount")
+                    field("Presentment Subtotal Amount"; PresentmentSubtotalAmount)
                     {
                         ApplicationArea = All;
+                        Caption = 'Presentment Subtotal Amount';
                         AutoFormatExpression = Rec."Presentment Currency Code";
                         AutoFormatType = 1;
-                        ToolTip = 'Specifies the presentment subtotal amount of the order.';
+                        ToolTip = 'Specifies the presentment subtotal amount of the order, excluding any exchange items that are invoiced separately.';
                     }
                     field("Presentment Shipping Charges Amount"; Rec."Pres. Shipping Charges Amount")
                     {
@@ -101,20 +104,21 @@ page 30172 "Shpfy Order Totals FactBox"
                         AutoFormatType = 1;
                         ToolTip = 'Specifies the presentment shipping charges amount of the order.';
                     }
-                    field("Presentment Total Amount"; Rec."Presentment Total Amount")
+                    field("Presentment Total Amount"; PresentmentTotalAmount)
                     {
                         ApplicationArea = All;
+                        Caption = 'Presentment Total Amount';
                         AutoFormatExpression = Rec."Presentment Currency Code";
                         AutoFormatType = 1;
-                        ToolTip = 'Specifies the presentment total amount of the order.';
+                        ToolTip = 'Specifies the presentment total amount of the order, excluding any exchange items that are invoiced separately.';
                     }
-                    field("Presentment VAT Amount"; Rec."Presentment VAT Amount")
+                    field("Presentment VAT Amount"; PresentmentVATAmount)
                     {
                         ApplicationArea = All;
                         AutoFormatExpression = Rec."Presentment Currency Code";
                         AutoFormatType = 1;
                         CaptionClass = DocumentTotals.GetTotalVATCaption(Rec."Presentment Currency Code");
-                        ToolTip = 'Specifies the sum of presentment tax amounts on all lines in the document.';
+                        ToolTip = 'Specifies the sum of presentment tax amounts on all lines in the document, excluding any exchange items that are invoiced separately.';
                     }
                     field("Presentment Payment Rounding Amount"; Rec."Pres. Payment Rounding Amount")
                     {
@@ -249,6 +253,7 @@ page 30172 "Shpfy Order Totals FactBox"
     trigger OnAfterGetRecord()
     begin
         PresentmentVisible := Rec.IsPresentmentCurrencyOrder();
+        CalcShopifyTotalsExcludingExchange();
         UpdateSalesDocumentInfo();
     end;
 
@@ -267,6 +272,37 @@ page 30172 "Shpfy Order Totals FactBox"
             SalesDocumentType::"Posted Sales Invoice":
                 UpdatePostedSalesInvoiceTotals();
         end;
+    end;
+
+    local procedure CalcShopifyTotalsExcludingExchange()
+    var
+        OrderLine: Record "Shpfy Order Line";
+        OrderTaxLine: Record "Shpfy Order Tax Line";
+        ExchangeSubtotal: Decimal;
+        ExchangePresentmentSubtotal: Decimal;
+        ExchangeTax: Decimal;
+        ExchangePresentmentTax: Decimal;
+    begin
+        // Exclude exchange items from the shown Shopify totals; they are invoiced separately, not on the BC sales doc.
+        OrderLine.SetRange("Shopify Order Id", Rec."Shopify Order Id");
+        OrderLine.SetRange("Is Exchange Item", true);
+        if OrderLine.FindSet() then
+            repeat
+                ExchangeSubtotal += (OrderLine."Unit Price" * OrderLine.Quantity) - OrderLine."Discount Amount";
+                ExchangePresentmentSubtotal += (OrderLine."Presentment Unit Price" * OrderLine.Quantity) - OrderLine."Presentment Discount Amount";
+
+                OrderTaxLine.SetRange("Parent Id", OrderLine."Line Id");
+                OrderTaxLine.CalcSums(Amount, "Presentment Amount");
+                ExchangeTax += OrderTaxLine.Amount;
+                ExchangePresentmentTax += OrderTaxLine."Presentment Amount";
+            until OrderLine.Next() = 0;
+
+        ShopifySubtotalAmount := Rec."Subtotal Amount" - ExchangeSubtotal;
+        ShopifyVATAmount := Rec."VAT Amount" - ExchangeTax;
+        ShopifyTotalAmount := Rec."Total Amount" - (ExchangeSubtotal + ExchangeTax);
+        PresentmentSubtotalAmount := Rec."Presentment Subtotal Amount" - ExchangePresentmentSubtotal;
+        PresentmentVATAmount := Rec."Presentment VAT Amount" - ExchangePresentmentTax;
+        PresentmentTotalAmount := Rec."Presentment Total Amount" - (ExchangePresentmentSubtotal + ExchangePresentmentTax);
     end;
 
     local procedure ResolveSalesDocument(var DocumentType: Enum "Shpfy Document Type"; var ResolvedDocumentNo: Code[20]): Boolean
@@ -402,4 +438,10 @@ page 30172 "Shpfy Order Totals FactBox"
         VATAmount: Decimal;
         TotalAmountExclVAT: Decimal;
         TotalAmountInclVAT: Decimal;
+        ShopifySubtotalAmount: Decimal;
+        ShopifyTotalAmount: Decimal;
+        ShopifyVATAmount: Decimal;
+        PresentmentSubtotalAmount: Decimal;
+        PresentmentTotalAmount: Decimal;
+        PresentmentVATAmount: Decimal;
 }

--- a/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTotalsFBTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Handling/ShpfyOrderTotalsFBTest.Codeunit.al
@@ -338,6 +338,93 @@ codeunit 139587 "Shpfy Order Totals FB Test"
         LibraryAssert.AreEqual(284, OrderTotalsFactBox."Presentment Total Amount".AsDecimal(), 'Presentment Total Amount must be shown.');
     end;
 
+    [Test]
+    procedure TestShopifyTotalsExcludeExchangeItemShopCurrency()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] For a shop-currency order with an exchange item, the Shopify totals exclude the exchange item's
+        // [SCENARIO] contribution, so they reconcile with the BC sales document (which also excludes the exchange item).
+        Initialize();
+
+        // [GIVEN] A shop-currency Shopify order whose totals include an exchange item (subtotal 50, tax 5).
+        CreateShopifyOrderHeader(OrderHeader);
+        OrderHeader."Processed Currency Handling" := "Shpfy Currency Handling"::"Shop Currency";
+        OrderHeader."Subtotal Amount" := 250; // 200 kept + 50 exchange
+        OrderHeader."VAT Amount" := 25;        // 20 kept + 5 exchange
+        OrderHeader."Total Amount" := 275;     // 220 kept + 55 exchange
+        OrderHeader."Shipping Charges Amount" := 0;
+        OrderHeader.Modify();
+
+        // [GIVEN] The order has an exchange item line (unit price 50) with its own tax line (5).
+        CreateExchangeItemWithTax(OrderHeader."Shopify Order Id", 50, 0, 5, 0);
+
+        // [WHEN] Opening the Order Totals factbox
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The shown Shopify totals exclude the exchange item.
+        LibraryAssert.AreEqual(200, OrderTotalsFactBox."Subtotal Amount".AsDecimal(), 'Subtotal must exclude the exchange item.');
+        LibraryAssert.AreEqual(20, OrderTotalsFactBox.VATAmount.AsDecimal(), 'VAT must exclude the exchange item tax.');
+        LibraryAssert.AreEqual(220, OrderTotalsFactBox."Total Amount".AsDecimal(), 'Total must exclude the exchange item subtotal and tax.');
+    end;
+
+    [Test]
+    procedure TestShopifyTotalsExcludeExchangeItemPresentmentCurrency()
+    var
+        OrderHeader: Record "Shpfy Order Header";
+        OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox";
+    begin
+        // [SCENARIO] For a presentment-currency order with an exchange item, the presentment totals exclude the exchange
+        // [SCENARIO] item's contribution.
+        Initialize();
+
+        // [GIVEN] A presentment-currency Shopify order whose presentment totals include an exchange item (subtotal 100, tax 10).
+        CreateShopifyOrderHeader(OrderHeader);
+        OrderHeader."Processed Currency Handling" := "Shpfy Currency Handling"::"Presentment Currency";
+        OrderHeader."Presentment Subtotal Amount" := 500; // 400 kept + 100 exchange
+        OrderHeader."Presentment VAT Amount" := 50;        // 40 kept + 10 exchange
+        OrderHeader."Presentment Total Amount" := 550;     // 440 kept + 110 exchange
+        OrderHeader."Pres. Shipping Charges Amount" := 0;
+        OrderHeader.Modify();
+
+        // [GIVEN] The order has an exchange item line (presentment unit price 100) with its own tax line (presentment 10).
+        CreateExchangeItemWithTax(OrderHeader."Shopify Order Id", 0, 100, 0, 10);
+
+        // [WHEN] Opening the Order Totals factbox
+        OrderTotalsFactBox.OpenView();
+        OrderTotalsFactBox.GoToRecord(OrderHeader);
+
+        // [THEN] The shown presentment totals exclude the exchange item.
+        LibraryAssert.AreEqual(400, OrderTotalsFactBox."Presentment Subtotal Amount".AsDecimal(), 'Presentment Subtotal must exclude the exchange item.');
+        LibraryAssert.AreEqual(40, OrderTotalsFactBox."Presentment VAT Amount".AsDecimal(), 'Presentment VAT must exclude the exchange item tax.');
+        LibraryAssert.AreEqual(440, OrderTotalsFactBox."Presentment Total Amount".AsDecimal(), 'Presentment Total must exclude the exchange item subtotal and tax.');
+    end;
+
+    local procedure CreateExchangeItemWithTax(ShopifyOrderId: BigInteger; UnitPrice: Decimal; PresentmentUnitPrice: Decimal; TaxAmount: Decimal; PresentmentTaxAmount: Decimal)
+    var
+        OrderLine: Record "Shpfy Order Line";
+        OrderTaxLine: Record "Shpfy Order Tax Line";
+        LineId: BigInteger;
+    begin
+        LineId := Any.IntegerInRange(1000000, 2147483647);
+        OrderLine.Init();
+        OrderLine."Shopify Order Id" := ShopifyOrderId;
+        OrderLine."Line Id" := LineId;
+        OrderLine.Quantity := 1;
+        OrderLine."Unit Price" := UnitPrice;
+        OrderLine."Presentment Unit Price" := PresentmentUnitPrice;
+        OrderLine."Is Exchange Item" := true;
+        OrderLine.Insert();
+
+        OrderTaxLine.Init();
+        OrderTaxLine."Parent Id" := LineId;
+        OrderTaxLine.Amount := TaxAmount;
+        OrderTaxLine."Presentment Amount" := PresentmentTaxAmount;
+        OrderTaxLine.Insert(true);
+    end;
+
     local procedure VerifyOpenSalesDocumentSection(var OrderTotalsFactBox: TestPage "Shpfy Order Totals FactBox"; SalesHeader: Record "Sales Header")
     var
         SalesLine: Record "Sales Line";

--- a/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
+++ b/src/Apps/W1/Shopify/Test/Order Refunds/ShpfyOrderRefundTest.Codeunit.al
@@ -10,6 +10,7 @@ using Microsoft.Finance.SalesTax;
 using Microsoft.Integration.Shopify;
 using Microsoft.Inventory.Location;
 using Microsoft.Sales.Document;
+using Microsoft.Utilities;
 using System.TestLibraries.Utilities;
 
 codeunit 139611 "Shpfy Order Refund Test"
@@ -919,6 +920,182 @@ codeunit 139611 "Shpfy Order Refund Test"
         // [THEN] Precondition sanity: Shopify Total Refunded Amount is 0 for this scenario.
         RefundHeader.Get(RefundId);
         LibraryAssert.AreEqual(0, RefundHeader."Total Refunded Amount", 'Total Refunded Amount must be 0 for a more-expensive-exchange refund.');
+
+        // Tear down
+        ResetProcessOnRefund(RefundId);
+    end;
+
+    [Test]
+    procedure UnitTestExchangeCreditMemoCarriesShopifyOrderIdentifiers()
+    var
+        Shop: Record "Shpfy Shop";
+        OrderHeader: Record "Shpfy Order Header";
+        SalesHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        OrderId: BigInteger;
+        OriginalOrderLineId: BigInteger;
+        ExchangeOrderLineId: BigInteger;
+        ReturnId: BigInteger;
+        RefundId: BigInteger;
+        OriginalAmount: Decimal;
+        ExchangeAmount: Decimal;
+        ShopifyOrderNo: Code[50];
+        IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
+    begin
+        // [SCENARIO] A credit memo created from a return-with-exchange refund carries the Shopify order identifiers on the
+        // [SCENARIO] header and on the exchange-item line, so the invoice moved out of it stays linked to the Shopify order.
+        Initialize();
+        Shop := InitializeTest.CreateShop();
+        Shop."Process Returns As" := "Sales Document Type"::"Credit Memo";
+        Shop."Currency Handling" := "Shpfy Currency Handling"::"Shop Currency";
+        Shop.Modify(false);
+
+        OriginalAmount := 200;
+        ExchangeAmount := 50;
+        ShopifyOrderNo := CopyStr(Any.AlphabeticText(10), 1, MaxStrLen(ShopifyOrderNo));
+
+        // [GIVEN] A processed Shopify order (with a Shopify order number) with an original item and an exchange item.
+        OrderRefundsHelper.SetDefaultSeed();
+        OrderId := OrderRefundsHelper.CreateShopifyOrder();
+        OrderHeader.Get(OrderId);
+        OrderHeader."Shop Code" := Shop.Code;
+        OrderHeader."Shopify Order No." := ShopifyOrderNo;
+        OrderHeader."Total Amount" := OriginalAmount;
+        OrderHeader."Subtotal Amount" := OriginalAmount;
+        OrderHeader."VAT Amount" := 0;
+        OrderHeader."Presentment Total Amount" := OriginalAmount;
+        OrderHeader."Presentment Subtotal Amount" := OriginalAmount;
+        OrderHeader."Shipping Charges Amount" := 0;
+        OrderHeader.Processed := true;
+        OrderHeader."Processed Currency Handling" := "Shpfy Currency Handling"::"Shop Currency";
+        OrderHeader.Modify(false);
+        OriginalOrderLineId := OrderRefundsHelper.CreateOrderLineWithUnitPrice(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), OriginalAmount);
+        ExchangeOrderLineId := OrderRefundsHelper.CreateOrderLineWithUnitPrice(OrderId, 20000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), ExchangeAmount);
+        OrderRefundsHelper.MarkOrderLineAsExchangeItem(OrderId, ExchangeOrderLineId);
+        OrderRefundsHelper.ProcessShopifyOrder(OrderId);
+
+        // [GIVEN] A return for the original item and a refund with a returned line and an exchange line.
+        ReturnId := OrderRefundsHelper.CreateReturn(OrderId);
+        OrderRefundsHelper.CreateReturnLine(ReturnId, OriginalOrderLineId, 'DEFECTIVE');
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, OriginalAmount - ExchangeAmount, Shop.Code);
+        OrderRefundsHelper.CreateRefundLineForReturnedItem(RefundId, OriginalOrderLineId, 1, OriginalAmount);
+        OrderRefundsHelper.CreateExchangeRefundLine(RefundId, ExchangeOrderLineId, 1, ExchangeAmount);
+
+        // [WHEN] The credit memo is created through the Auto Create Credit Memo process.
+        IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
+        SalesHeader := IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId);
+
+        // [THEN] The credit memo header carries the Shopify order identifiers.
+        LibraryAssert.AreEqual(OrderHeader."Shopify Order Id", SalesHeader."Shpfy Order Id", 'Credit memo header must carry the Shopify Order Id.');
+        LibraryAssert.AreEqual(ShopifyOrderNo, SalesHeader."Shpfy Order No.", 'Credit memo header must carry the Shopify Order No.');
+
+        // [THEN] The exchange-item line (negative quantity) carries the Shopify order line identifiers.
+        SalesLine.SetRange("Document Type", SalesHeader."Document Type");
+        SalesLine.SetRange("Document No.", SalesHeader."No.");
+        SalesLine.SetRange(Type, SalesLine.Type::Item);
+        SalesLine.SetFilter(Quantity, '<%1', 0);
+        LibraryAssert.IsTrue(SalesLine.FindFirst(), 'The exchange item must be a negative-qty item line.');
+        LibraryAssert.AreEqual(ExchangeOrderLineId, SalesLine."Shpfy Order Line Id", 'Exchange line must carry the Shopify Order Line Id.');
+        LibraryAssert.AreEqual(ShopifyOrderNo, SalesLine."Shpfy Order No.", 'Exchange line must carry the Shopify Order No.');
+
+        // [THEN] The returned-item line (positive quantity) stays a pure credit line without order-line identifiers.
+        SalesLine.SetRange(Quantity);
+        SalesLine.SetFilter(Quantity, '>%1', 0);
+        LibraryAssert.IsTrue(SalesLine.FindFirst(), 'The returned item must be a positive-qty item line.');
+        LibraryAssert.IsTrue(SalesLine."Shpfy Order Line Id" = 0, 'Returned line must not carry a Shopify Order Line Id.');
+
+        // Tear down
+        ResetProcessOnRefund(RefundId);
+    end;
+
+    [Test]
+    procedure UnitTestExchangeInvoiceFromCreditMemoKeepsShopifyLink()
+    var
+        Shop: Record "Shpfy Shop";
+        OrderHeader: Record "Shpfy Order Header";
+        CreditMemoHeader: Record "Sales Header";
+        InvoiceHeader: Record "Sales Header";
+        SalesLine: Record "Sales Line";
+        DocLinkToBCDoc: Record "Shpfy Doc. Link To Doc.";
+        ReleaseSalesDocument: Codeunit "Release Sales Document";
+        CopyDocumentMgt: Codeunit "Copy Document Mgt.";
+        OrderRefundsHelper: Codeunit "Shpfy Order Refunds Helper";
+        OrderId: BigInteger;
+        OriginalOrderLineId: BigInteger;
+        ExchangeOrderLineId: BigInteger;
+        ReturnId: BigInteger;
+        RefundId: BigInteger;
+        OriginalAmount: Decimal;
+        ExchangeAmount: Decimal;
+        ShopifyOrderNo: Code[50];
+        IReturnRefundProcess: Interface "Shpfy IReturnRefund Process";
+    begin
+        // [SCENARIO] Moving the negative exchange-item line out of the refund credit memo produces a sales invoice that keeps
+        // [SCENARIO] the Shopify order identifiers and is linked back to the originating Shopify order (Linked Documents).
+        Initialize();
+        Shop := InitializeTest.CreateShop();
+        Shop."Process Returns As" := "Sales Document Type"::"Credit Memo";
+        Shop."Currency Handling" := "Shpfy Currency Handling"::"Shop Currency";
+        Shop.Modify(false);
+
+        OriginalAmount := 200;
+        ExchangeAmount := 50;
+        ShopifyOrderNo := CopyStr(Any.AlphabeticText(10), 1, MaxStrLen(ShopifyOrderNo));
+
+        // [GIVEN] A processed Shopify order and an exchange refund turned into a credit memo.
+        OrderRefundsHelper.SetDefaultSeed();
+        OrderId := OrderRefundsHelper.CreateShopifyOrder();
+        OrderHeader.Get(OrderId);
+        OrderHeader."Shop Code" := Shop.Code;
+        OrderHeader."Shopify Order No." := ShopifyOrderNo;
+        OrderHeader."Total Amount" := OriginalAmount;
+        OrderHeader."Subtotal Amount" := OriginalAmount;
+        OrderHeader."VAT Amount" := 0;
+        OrderHeader."Presentment Total Amount" := OriginalAmount;
+        OrderHeader."Presentment Subtotal Amount" := OriginalAmount;
+        OrderHeader."Shipping Charges Amount" := 0;
+        OrderHeader.Processed := true;
+        OrderHeader."Processed Currency Handling" := "Shpfy Currency Handling"::"Shop Currency";
+        OrderHeader.Modify(false);
+        OriginalOrderLineId := OrderRefundsHelper.CreateOrderLineWithUnitPrice(OrderId, 10000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), OriginalAmount);
+        ExchangeOrderLineId := OrderRefundsHelper.CreateOrderLineWithUnitPrice(OrderId, 20000, Any.IntegerInRange(100000, 999999), Any.IntegerInRange(100000, 999999), ExchangeAmount);
+        OrderRefundsHelper.MarkOrderLineAsExchangeItem(OrderId, ExchangeOrderLineId);
+        OrderRefundsHelper.ProcessShopifyOrder(OrderId);
+        ReturnId := OrderRefundsHelper.CreateReturn(OrderId);
+        OrderRefundsHelper.CreateReturnLine(ReturnId, OriginalOrderLineId, 'DEFECTIVE');
+        RefundId := OrderRefundsHelper.CreateRefundHeader(OrderId, ReturnId, OriginalAmount - ExchangeAmount, Shop.Code);
+        OrderRefundsHelper.CreateRefundLineForReturnedItem(RefundId, OriginalOrderLineId, 1, OriginalAmount);
+        OrderRefundsHelper.CreateExchangeRefundLine(RefundId, ExchangeOrderLineId, 1, ExchangeAmount);
+        IReturnRefundProcess := Enum::"Shpfy ReturnRefund ProcessType"::"Auto Create Credit Memo";
+        CreditMemoHeader := IReturnRefundProcess.CreateSalesDocument(Enum::"Shpfy Source Document Type"::Refund, RefundId);
+
+        // [GIVEN] The credit memo is reopened so its negative line can be moved.
+        ReleaseSalesDocument.Reopen(CreditMemoHeader);
+
+        // [WHEN] The negative exchange line is moved to a new sales invoice (Move Negative Lines).
+        CopyDocumentMgt.SetProperties(true, false, true, true, true, false, false);
+        InvoiceHeader."Document Type" := InvoiceHeader."Document Type"::Invoice;
+        CopyDocumentMgt.CopySalesDoc(Enum::"Sales Document Type From"::"Credit Memo", CreditMemoHeader."No.", InvoiceHeader);
+        InvoiceHeader.Get(InvoiceHeader."Document Type"::Invoice, InvoiceHeader."No.");
+
+        // [THEN] The created invoice keeps the Shopify order identifiers on the header.
+        LibraryAssert.AreEqual(OrderHeader."Shopify Order Id", InvoiceHeader."Shpfy Order Id", 'Exchange invoice header must keep the Shopify Order Id.');
+        LibraryAssert.AreEqual(ShopifyOrderNo, InvoiceHeader."Shpfy Order No.", 'Exchange invoice header must keep the Shopify Order No.');
+
+        // [THEN] The exchange item line on the invoice keeps the Shopify order line identifiers.
+        SalesLine.SetRange("Document Type", InvoiceHeader."Document Type");
+        SalesLine.SetRange("Document No.", InvoiceHeader."No.");
+        SalesLine.SetRange(Type, SalesLine.Type::Item);
+        LibraryAssert.IsTrue(SalesLine.FindFirst(), 'The moved exchange item must be an item line on the invoice.');
+        LibraryAssert.AreEqual(ExchangeOrderLineId, SalesLine."Shpfy Order Line Id", 'Exchange invoice line must keep the Shopify Order Line Id.');
+
+        // [THEN] The invoice is linked to the Shopify order (visible in the order's Linked Documents).
+        DocLinkToBCDoc.SetRange("Shopify Document Type", "Shpfy Shop Document Type"::"Shopify Shop Order");
+        DocLinkToBCDoc.SetRange("Shopify Document Id", OrderHeader."Shopify Order Id");
+        DocLinkToBCDoc.SetRange("Document Type", "Shpfy Document Type"::"Sales Invoice");
+        DocLinkToBCDoc.SetRange("Document No.", InvoiceHeader."No.");
+        LibraryAssert.IsFalse(DocLinkToBCDoc.IsEmpty(), 'The exchange invoice must be linked to the Shopify order.');
 
         // Tear down
         ResetProcessOnRefund(RefundId);


### PR DESCRIPTION
## Summary
Backport of bugs [AB#647857](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647857), [AB#647858](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647858), [AB#647859](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647859), and [AB#647961](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/647961) to releases/29.x.

Fixes [AB#650070](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650070)

Original PR: #10741

Additional backport: [AB#650014](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650014) from #11407.

Fixes [AB#650014](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650014)





