### PR TITLE
[releases/29.x] [Change Log] Modification entries can contain a NullGuid Changed Record SystemId

### DIFF
--- a/src/Layers/W1/BaseApp/System/ChangeLog/ChangeLogManagement.Codeunit.al
+++ b/src/Layers/W1/BaseApp/System/ChangeLog/ChangeLogManagement.Codeunit.al
@@ -197,8 +197,10 @@ codeunit 423 "Change Log Management"
     procedure InsertLogEntry(var FldRef: FieldRef; var xFldRef: FieldRef; var RecRef: RecordRef; TypeOfChange: Enum "Change Log Entry Type"; IsReadable: Boolean)
     var
         ChangeLogEntry: Record "Change Log Entry";
+        xRecRef: RecordRef;
         KeyFldRef: FieldRef;
         KeyRef1: KeyRef;
+        ChangedRecordSystemId: Guid;
         i: Integer;
     begin
         if RecRef.CurrentCompany <> ChangeLogEntry.CurrentCompany then
@@ -257,8 +259,14 @@ codeunit 423 "Change Log Management"
             end;
         end;
 
+        ChangedRecordSystemId := RecRef.Field(RecRef.SystemIdNo).Value;
+        if IsNullGuid(ChangedRecordSystemId) and IsReadable and (TypeOfChange = TypeOfChange::Modification) then begin
+            xRecRef := xFldRef.Record();
+            ChangedRecordSystemId := xRecRef.Field(xRecRef.SystemIdNo).Value;
+        end;
+
         OnInsertLogEntryOnBeforeChangeLogEntryValidateChangedRecordSystemId(ChangeLogEntry, RecRef, FldRef);
-        ChangeLogEntry.Validate("Changed Record SystemId", RecRef.Field(RecRef.SystemIdNo).Value);
+        ChangeLogEntry.Validate("Changed Record SystemId", ChangedRecordSystemId);
         MonitorSensitiveFieldData.HandleMonitorSensitiveFields(ChangeLogEntry, TempChangeLogSetupField, RecRef, FldRef, IsAlwaysLoggedTable(RecRef.Number), FieldMonitoringSetup."Monitor Status");
 
         ChangeLogEntry.Insert(true);

--- a/src/Layers/W1/Tests/Misc/ChangeLog.Codeunit.al
+++ b/src/Layers/W1/Tests/Misc/ChangeLog.Codeunit.al
@@ -530,6 +530,42 @@ codeunit 139031 "Change Log"
 
     [Test]
     [Scope('OnPrem')]
+    procedure ModifyWithoutLoadedSystemIdLogsStoredSystemId()
+    var
+        ChangeLogEntry: Record "Change Log Entry";
+        CVLedgerEntryBuffer: Record "CV Ledger Entry Buffer";
+        CVLedgerEntryBufferToModify: Record "CV Ledger Entry Buffer";
+    begin
+        // Setup
+        Initialize();
+        SetTableForChangeLog(GlobalTableNo, LogOption::" ", LogOption::"Some Fields", LogOption::" ");
+        SetFieldsForChangeLog(GlobalTableNo, CVLedgerEntryBuffer.FieldNo(Description), false, true, false);
+        CreateItem(CVLedgerEntryBuffer);
+
+        CVLedgerEntryBufferToModify.Init();
+        CVLedgerEntryBufferToModify."Entry No." := CVLedgerEntryBuffer."Entry No.";
+        CVLedgerEntryBufferToModify.Description := LibraryUtility.GenerateGUID();
+        Assert.IsTrue(IsNullGuid(CVLedgerEntryBufferToModify.SystemId), 'SystemId should not be loaded before modifying the record.');
+
+        // Exercise
+        CVLedgerEntryBufferToModify.Modify();
+
+        // Verify
+#pragma warning disable AA0210
+        ChangeLogEntry.SetRange("Table No.", DATABASE::"CV Ledger Entry Buffer");
+        ChangeLogEntry.SetRange("Field No.", CVLedgerEntryBuffer.FieldNo(Description));
+        ChangeLogEntry.SetRange("Type of Change", ChangeLogEntry."Type of Change"::Modification);
+        ChangeLogEntry.SetRange("Record ID", CVLedgerEntryBufferToModify.RecordId);
+#pragma warning restore AA0210
+        ChangeLogEntry.FindFirst();
+        ChangeLogEntry.TestField("Changed Record SystemId", CVLedgerEntryBuffer.SystemId);
+
+        // Tear down
+        TearDown();
+    end;
+
+    [Test]
+    [Scope('OnPrem')]
     procedure ModifyAllFieldsNoLogTmp()
     var
         TempItem: Record Item temporary;


### PR DESCRIPTION
## Summary
Backport of bug [AB#648652](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/648652) to releases/29.x.

Fixes [AB#650071](https://dynamicssmb2.visualstudio.com/1fcb79e7-ab07-432a-a3c6-6cf5a88ba4a5/_workitems/edit/650071)

Original PR: #10927



